### PR TITLE
feat: Google Workspace向けGmail認証セットアップスクリプト追加

### DIFF
--- a/docs/operation/gmail-auth-guide.md
+++ b/docs/operation/gmail-auth-guide.md
@@ -1,0 +1,238 @@
+# DocSplit Gmail認証設定ガイド
+
+DocSplitはGmailの添付ファイルを自動取得するため、Gmail API認証の設定が必要です。
+クライアント環境に応じて適切な認証方式を選択してください。
+
+## 認証方式の選択
+
+```
+┌─────────────────────────────────────────────────┐
+│ クライアントはGoogle Workspaceを使用していますか？ │
+└─────────────────────────────────────────────────┘
+                    │
+        ┌───────────┴───────────┐
+        ▼                       ▼
+       YES                      NO
+        │                       │
+        ▼                       ▼
+┌───────────────────┐   ┌───────────────────┐
+│ Service Account   │   │ OAuth 2.0方式     │
+│ + Domain-wide     │   │                   │
+│ Delegation方式    │   │ 無料Gmailアカウント│
+│                   │   │ 向け              │
+│ 【推奨】          │   │                   │
+└───────────────────┘   └───────────────────┘
+```
+
+### 比較表
+
+| 項目 | OAuth 2.0 | Service Account |
+|------|-----------|-----------------|
+| 対象 | 無料Gmail、個人アカウント | Google Workspace |
+| セキュリティ | 個人の認証情報に依存 | 組織管理下で安全 |
+| トークン更新 | 定期的に必要な場合あり | 不要（自動） |
+| 管理者設定 | 不要 | Admin Console設定が必要 |
+| **推奨度** | 開発・検証環境向け | **本番環境推奨** |
+
+---
+
+## 方式1: OAuth 2.0（無料Gmailアカウント向け）
+
+### 概要
+個人のGmailアカウントを使用する場合の認証方式です。
+OAuth 2.0フローでリフレッシュトークンを取得し、Secret Managerに保存します。
+
+### セットアップ手順
+
+#### 1. OAuth同意画面の設定
+
+1. [GCP Console](https://console.cloud.google.com) > APIs & Services > OAuth consent screen
+2. User Type: 「外部」を選択
+3. アプリ情報を入力:
+   - アプリ名: DocSplit
+   - ユーザーサポートメール: 管理者メールアドレス
+4. スコープを追加: `https://www.googleapis.com/auth/gmail.readonly`
+5. テストユーザーに監視対象のGmailアドレスを追加
+
+#### 2. OAuth クライアントIDの作成
+
+1. GCP Console > APIs & Services > Credentials
+2. 「認証情報を作成」→「OAuth クライアント ID」
+3. アプリケーションの種類: 「デスクトップアプリ」
+4. 作成後、クライアントIDとシークレットをメモ
+
+#### 3. セットアップスクリプトの実行
+
+```bash
+./scripts/setup-gmail-auth.sh <project-id>
+```
+
+スクリプトが以下を実行します:
+- OAuth認証フロー（ブラウザで認証）
+- リフレッシュトークンの取得
+- Secret Managerへの保存
+- Cloud Functionsへの権限付与
+
+#### 4. Firestore設定の更新
+
+アプリの設定画面、または Firebase Console で設定:
+
+**Collection**: `settings`
+**Document**: `gmail`
+
+```json
+{
+  "authMode": "oauth",
+  "oauthClientId": "<your-client-id>"
+}
+```
+
+**Collection**: `settings`
+**Document**: `app`
+
+```json
+{
+  "gmailAccount": "<your-gmail@gmail.com>"
+}
+```
+
+### 注意事項
+
+- リフレッシュトークンは長期間有効ですが、以下の場合に無効化されます:
+  - ユーザーがアクセス権を取り消した場合
+  - 6ヶ月間使用されなかった場合
+  - パスワード変更時
+- トークンが無効になった場合は、再度セットアップスクリプトを実行してください
+
+---
+
+## 方式2: Service Account + Domain-wide Delegation（Google Workspace向け）
+
+### 概要
+Google Workspaceの管理下にあるGmailアカウントを監視する場合の認証方式です。
+Service Accountに対してドメイン全体の委任（Domain-wide Delegation）を設定します。
+
+**本番環境では推奨される方式です。**
+
+### セットアップ手順
+
+#### 1. Google Workspace要件の確認
+
+- Google Workspace管理者権限が必要
+- Admin Console（admin.google.com）へのアクセス権限
+
+#### 2. セットアップスクリプトの実行
+
+```bash
+./scripts/setup-gmail-service-account.sh <project-id> <delegated-email>
+```
+
+例:
+```bash
+./scripts/setup-gmail-service-account.sh my-project-prod admin@company.com
+```
+
+#### 3. Admin Consoleでの設定
+
+スクリプト実行中に表示される手順に従い、Admin Consoleで設定:
+
+1. https://admin.google.com にアクセス
+2. 「セキュリティ」→「アクセスとデータ管理」→「APIの制御」→「ドメイン全体の委任」
+3. 「新しく追加」をクリック
+4. 以下を入力:
+   - **クライアントID**: スクリプトが表示するService AccountのユニークID
+   - **OAuthスコープ**: `https://www.googleapis.com/auth/gmail.readonly`
+5. 「承認」をクリック
+
+#### 4. Firestore設定の確認
+
+スクリプトが自動で設定しますが、以下を確認:
+
+**Collection**: `settings`
+**Document**: `gmail`
+
+```json
+{
+  "authMode": "service_account",
+  "delegatedUserEmail": "<監視対象メール>",
+  "serviceAccountEmail": "gmail-reader@<project-id>.iam.gserviceaccount.com"
+}
+```
+
+### セキュリティ上の利点
+
+- 個人の認証情報に依存しない
+- トークンの手動更新が不要
+- 組織の管理下で権限を制御可能
+- 退職者のアカウント影響を受けない
+
+---
+
+## デプロイと動作確認
+
+### Cloud Functionsの再デプロイ
+
+設定完了後、Cloud Functionsを再デプロイ:
+
+```bash
+firebase deploy --only functions --project <project-id>
+```
+
+### 動作確認
+
+1. Firebase Console > Functions > checkGmailAttachments > Logs を確認
+2. 以下のログが表示されれば成功:
+   - OAuth方式: `Using OAuth 2.0 authentication (development mode)`
+   - Service Account方式: `Using Service Account + Delegation (production mode)`
+
+### 手動実行
+
+Cloud Schedulerから手動実行:
+
+1. GCP Console > Cloud Scheduler
+2. `firebase-schedule-checkGmailAttachments-...` を選択
+3. 「今すぐ実行」
+
+---
+
+## トラブルシューティング
+
+### OAuth方式: 認証エラー
+
+**エラー**: `Error: invalid_grant`
+
+**原因**: リフレッシュトークンが無効
+
+**解決**:
+```bash
+./scripts/setup-gmail-auth.sh <project-id>
+```
+
+### Service Account方式: 403 Forbidden
+
+**エラー**: `Error: Delegation denied for <email>`
+
+**原因**: Domain-wide Delegationが正しく設定されていない
+
+**解決**:
+1. Admin Consoleで設定を確認
+2. クライアントIDが正しいか確認
+3. スコープが正確に入力されているか確認
+4. 設定後、数分待ってから再試行
+
+### 共通: Gmail API not enabled
+
+**エラー**: `Error: Gmail API has not been used in project...`
+
+**解決**:
+```bash
+gcloud services enable gmail.googleapis.com --project=<project-id>
+```
+
+---
+
+## 関連ドキュメント
+
+- [セットアップガイド](./setup-guide.md)
+- [管理者ガイド](./admin-guide.md)
+- [ADR-0003: 認証設計](../adr/0003-authentication-design.md)

--- a/docs/operation/setup-guide.md
+++ b/docs/operation/setup-guide.md
@@ -79,29 +79,27 @@ Firebase Console > プロジェクト設定 > アプリ > Firebase SDK snippet �
 
 ### 4.2 Gmail 認証設定
 
-**開発環境（OAuth 2.0）:**
+クライアント環境に応じて適切な認証方式を選択してください。
+詳細は [Gmail認証設定ガイド](./gmail-auth-guide.md) を参照。
 
-1. GCP Console > APIs & Services > Credentials
-2. OAuth 2.0 Client ID を作成
-3. Secret Manager に保存:
+| クライアント環境 | 認証方式 | セットアップスクリプト |
+|----------------|---------|---------------------|
+| 無料Gmail / 個人アカウント | OAuth 2.0 | `setup-gmail-auth.sh` |
+| Google Workspace | Service Account + Delegation | `setup-gmail-service-account.sh` |
+
+**方式1: OAuth 2.0（無料Gmail向け）**
 
 ```bash
-# OAuth クライアント ID
-echo -n "YOUR_CLIENT_ID" | gcloud secrets create gmail-oauth-client-id --data-file=-
-
-# OAuth クライアントシークレット
-echo -n "YOUR_CLIENT_SECRET" | gcloud secrets create gmail-oauth-client-secret --data-file=-
-
-# リフレッシュトークン（OAuth Playground で取得）
-echo -n "YOUR_REFRESH_TOKEN" | gcloud secrets create gmail-oauth-refresh-token --data-file=-
+./scripts/setup-gmail-auth.sh <project-id>
 ```
 
-**本番環境（Service Account + Domain-wide Delegation）:**
+**方式2: Service Account（Google Workspace向け）【本番推奨】**
 
-1. GCP Console > IAM & Admin > Service Accounts
-2. サービスアカウントを作成
-3. Google Workspace 管理コンソールでドメイン全体の委任を設定
-4. Secret Manager にサービスアカウントキーを保存
+```bash
+./scripts/setup-gmail-service-account.sh <project-id> <監視対象メール>
+```
+
+> **注意**: Google Workspaceの場合は Admin Console での Domain-wide Delegation 設定が必要です。
 
 ## 5. Firestore セットアップ
 

--- a/scripts/setup-gmail-service-account.sh
+++ b/scripts/setup-gmail-service-account.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+#
+# DocSplit Gmail Service Account設定スクリプト
+#
+# Google Workspace向け - Service Account + Domain-wide Delegation方式
+#
+# 使用方法:
+#   ./setup-gmail-service-account.sh <project-id> <delegated-email>
+#
+# 事前準備:
+#   - Google Workspace管理者権限が必要
+#   - Admin Console へのアクセス権限が必要
+#
+
+set -e
+
+# カラー定義
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <project-id> <delegated-email>"
+    echo ""
+    echo "Arguments:"
+    echo "  project-id       GCPプロジェクトID"
+    echo "  delegated-email  Gmail監視対象のメールアドレス（Workspace内）"
+    echo ""
+    echo "Example:"
+    echo "  $0 my-project-prod admin@company.com"
+    exit 1
+fi
+
+PROJECT_ID=$1
+DELEGATED_EMAIL=$2
+SA_NAME="gmail-reader"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+echo ""
+echo -e "${GREEN}=== DocSplit Gmail Service Account設定 ===${NC}"
+echo ""
+echo "Project ID: $PROJECT_ID"
+echo "Delegated Email: $DELEGATED_EMAIL"
+echo "Service Account: $SA_EMAIL"
+echo ""
+
+# ===========================================
+# Service Account作成
+# ===========================================
+log_info "Service Accountを作成中..."
+
+if gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" &>/dev/null; then
+    log_warn "Service Account already exists: $SA_EMAIL"
+else
+    gcloud iam service-accounts create "$SA_NAME" \
+        --display-name="Gmail Reader for DocSplit" \
+        --description="Gmail添付ファイル取得用（Domain-wide Delegation）" \
+        --project="$PROJECT_ID"
+    log_success "Service Account created: $SA_EMAIL"
+fi
+
+# ===========================================
+# Domain-wide Delegation有効化
+# ===========================================
+log_info "Domain-wide Delegationを有効化中..."
+
+# Service AccountのuniqueName取得
+SA_UNIQUE_ID=$(gcloud iam service-accounts describe "$SA_EMAIL" \
+    --project="$PROJECT_ID" \
+    --format="value(uniqueId)")
+
+echo ""
+echo -e "${YELLOW}========================================${NC}"
+echo -e "${YELLOW}  Admin Console で手動設定が必要です  ${NC}"
+echo -e "${YELLOW}========================================${NC}"
+echo ""
+echo "以下の手順でGoogle Workspace Admin Consoleで設定してください:"
+echo ""
+echo "1. Admin Consoleを開く:"
+echo "   https://admin.google.com"
+echo ""
+echo "2. 「セキュリティ」→「アクセスとデータ管理」→「APIの制御」→「ドメイン全体の委任」"
+echo ""
+echo "3. 「新しく追加」をクリック"
+echo ""
+echo "4. 以下の値を入力:"
+echo -e "   ${GREEN}クライアントID:${NC} $SA_UNIQUE_ID"
+echo -e "   ${GREEN}OAuthスコープ:${NC} https://www.googleapis.com/auth/gmail.readonly"
+echo ""
+echo "5. 「承認」をクリック"
+echo ""
+echo -e "${YELLOW}設定完了後、Enterを押して続行してください...${NC}"
+read -p ""
+
+# ===========================================
+# Firestoreに設定保存
+# ===========================================
+log_info "Firestoreに設定を保存中..."
+
+# 一時ファイルで設定
+TEMP_SETTINGS=$(mktemp)
+cat > "$TEMP_SETTINGS" << EOF
+{
+  "authMode": "service_account",
+  "delegatedUserEmail": "$DELEGATED_EMAIL",
+  "serviceAccountEmail": "$SA_EMAIL"
+}
+EOF
+
+# Firebase CLIでFirestoreに書き込み
+# Note: Firebase CLIでは直接書き込みできないため、Node.jsスクリプトを使用
+TEMP_SCRIPT=$(mktemp).js
+cat > "$TEMP_SCRIPT" << 'SCRIPT_EOF'
+const admin = require('firebase-admin');
+const fs = require('fs');
+
+const projectId = process.argv[2];
+const delegatedEmail = process.argv[3];
+const serviceAccountEmail = process.argv[4];
+
+process.env.GCLOUD_PROJECT = projectId;
+process.env.FIREBASE_CONFIG = JSON.stringify({ projectId });
+
+admin.initializeApp({
+  projectId: projectId
+});
+
+const db = admin.firestore();
+
+async function updateSettings() {
+  try {
+    await db.doc('settings/gmail').set({
+      authMode: 'service_account',
+      delegatedUserEmail: delegatedEmail,
+      serviceAccountEmail: serviceAccountEmail,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    console.log('Firestore settings updated successfully');
+  } catch (error) {
+    console.error('Failed to update Firestore:', error.message);
+    process.exit(1);
+  }
+}
+
+updateSettings().then(() => process.exit(0));
+SCRIPT_EOF
+
+# Node.jsスクリプト実行
+cd "$(dirname "$0")/.."
+if [ -f "functions/node_modules/firebase-admin/package.json" ]; then
+    node -e "
+const admin = require('./functions/node_modules/firebase-admin');
+process.env.GCLOUD_PROJECT = '$PROJECT_ID';
+process.env.FIREBASE_CONFIG = JSON.stringify({ projectId: '$PROJECT_ID' });
+admin.initializeApp({ projectId: '$PROJECT_ID' });
+const db = admin.firestore();
+db.doc('settings/gmail').set({
+  authMode: 'service_account',
+  delegatedUserEmail: '$DELEGATED_EMAIL',
+  serviceAccountEmail: '$SA_EMAIL',
+  updatedAt: admin.firestore.FieldValue.serverTimestamp()
+}, { merge: true })
+.then(() => { console.log('Firestore updated'); process.exit(0); })
+.catch(e => { console.error(e); process.exit(1); });
+"
+    log_success "Firestore settings updated"
+else
+    log_warn "firebase-admin not found. Please update Firestore manually:"
+    echo ""
+    echo "Collection: settings"
+    echo "Document: gmail"
+    echo "Fields:"
+    echo "  authMode: 'service_account'"
+    echo "  delegatedUserEmail: '$DELEGATED_EMAIL'"
+    echo "  serviceAccountEmail: '$SA_EMAIL'"
+fi
+
+rm -f "$TEMP_SETTINGS" "$TEMP_SCRIPT" 2>/dev/null || true
+
+# ===========================================
+# Cloud Functionsサービスアカウントに権限付与
+# ===========================================
+log_info "IAM権限を設定中..."
+
+# Cloud Functions実行用サービスアカウント
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)" 2>/dev/null)
+FUNCTIONS_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+
+# Gmail ReaderのService Accountをimpersonateできるようにする
+gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+    --member="serviceAccount:$FUNCTIONS_SA" \
+    --role="roles/iam.serviceAccountTokenCreator" \
+    --project="$PROJECT_ID" 2>/dev/null || true
+
+log_success "IAM権限設定完了"
+
+# ===========================================
+# 完了
+# ===========================================
+echo ""
+echo -e "${GREEN}=== Gmail Service Account設定完了 ===${NC}"
+echo ""
+echo "設定内容:"
+echo "  認証方式: Service Account + Domain-wide Delegation"
+echo "  監視対象: $DELEGATED_EMAIL"
+echo "  Service Account: $SA_EMAIL"
+echo ""
+echo "Cloud Functionsを再デプロイしてください:"
+echo "  firebase deploy --only functions --project $PROJECT_ID"
+echo ""
+echo "デプロイ後、checkGmailAttachments関数がGmailにアクセスできるようになります。"
+echo ""


### PR DESCRIPTION
## Summary
- Google Workspace向けのService Account + Domain-wide Delegation方式セットアップスクリプトを追加
- Gmail認証方式の選択ガイドドキュメントを新規作成
- クライアント環境（無料Gmail / Google Workspace）に応じた認証方式選択が可能に

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `scripts/setup-gmail-service-account.sh` | Service Account方式のセットアップスクリプト（新規） |
| `docs/operation/gmail-auth-guide.md` | 認証方式選択ガイド（フローチャート、比較表付き） |
| `docs/operation/setup-guide.md` | Gmail認証セクションを更新 |

## 認証方式の選択

| クライアント環境 | 認証方式 | スクリプト |
|----------------|---------|-----------|
| 無料Gmail / 個人アカウント | OAuth 2.0 | `setup-gmail-auth.sh` |
| Google Workspace | Service Account + Delegation | `setup-gmail-service-account.sh` |

## Test plan
- [ ] `setup-gmail-service-account.sh` のシンタックスチェック
- [ ] ドキュメントの表示確認
- [ ] 既存のOAuth方式が影響を受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Gmail authentication guide supporting OAuth 2.0 for personal accounts and Service Account authentication for Google Workspace
  * Updated setup guide with clear authentication pathways and references to new setup automation

* **Chores**
  * Added automation script for Gmail Service Account configuration with Domain-wide Delegation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->