### PR TITLE
fix: CSVテンプレートからisDuplicateカラムを削除

### DIFF
--- a/frontend/src/lib/csvTemplates.ts
+++ b/frontend/src/lib/csvTemplates.ts
@@ -5,9 +5,9 @@
 // テンプレート定義
 export const CSV_TEMPLATES = {
   customers: {
-    headers: ['name', 'furigana', 'isDuplicate', 'careManagerName', 'notes'],
-    headerLabels: ['顧客名', 'フリガナ', '同姓同名フラグ', '担当ケアマネ名', '備考'],
-    example: ['山田太郎', 'ヤマダタロウ', 'false', '佐藤花子', ''],
+    headers: ['name', 'furigana', 'careManagerName', 'notes'],
+    headerLabels: ['顧客名', 'フリガナ', '担当ケアマネ名', '備考'],
+    example: ['山田太郎', 'ヤマダタロウ', '佐藤花子', ''],
     filename: 'customers_template.csv',
   },
   documents: {


### PR DESCRIPTION
## Summary
- 同姓同名/同名フラグはシステムが自動検知するため、CSV入力は不要
- 顧客テンプレートから`isDuplicate`カラムを削除
- 事業所インポートに同名検出ロジックを追加（スキーマ通りに修正）
- 重複検出ロジックを共通関数`detectDuplicateNames`に抽出

## Test plan
- [ ] 顧客CSVテンプレートダウンロード → `isDuplicate`カラムがないことを確認
- [ ] 顧客インポート → 同姓同名が自動検知されることを確認
- [ ] 事業所インポート → 同名が自動検知され`isDuplicate`が設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic detection and logging of duplicate customer and office names during imports.

* **Changes**
  * Simplified customer import template by removing a field now computed automatically by the system.
  * Import process enhanced to intelligently identify duplicate names across data instead of relying on manual CSV input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->