### PR TITLE
feat: Gmail過去受信分巻取りスクリプト追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,10 @@ Gmailの添付ファイルを自動取得し、AI OCRでメタ情報を抽出、
   - ドキュメントフィールドマイグレーションスクリプト追加
   - setup-tenant.shにCORS設定を組み込み
   - 納品ガイドに「過去受信分の巻取り対応」セクション追加
+- [x] Gmail過去受信分巻取りスクリプト追加 **完了 2026-01-25**
+  - `import-historical-gmail.js`: 期間指定でGmailから添付PDF取得
+  - 正規スキーマでFirestoreに登録（マイグレーション不要）
+  - dry-runモード対応
 - [ ] 本番運用開始（checkGmailAttachments定期実行）← 次のステップ
 
 ## 未実装（将来対応）

--- a/docs/context/delivery-and-update-guide.md
+++ b/docs/context/delivery-and-update-guide.md
@@ -287,7 +287,30 @@ firebase functions:log -P client-a
 ### 概要
 
 クライアント納品時に、Gmail連携開始前の過去受信分を一括インポートする場合がある。
-この際、以下の点に注意が必要。
+**正式な巻取りスクリプト（`import-historical-gmail.js`）を使用すること。**
+
+### 巻取りスクリプト（推奨）
+
+```bash
+# 使用方法
+node scripts/import-historical-gmail.js <project-id> --after YYYY-MM-DD --before YYYY-MM-DD [--dry-run]
+
+# 例: 2026年1月のメールを取得（dry-runで確認）
+node scripts/import-historical-gmail.js docsplit-kanameone --after 2026-01-01 --before 2026-01-31 --dry-run
+
+# 実行
+node scripts/import-historical-gmail.js docsplit-kanameone --after 2026-01-01 --before 2026-01-31
+```
+
+**前提条件**:
+- `setup-gmail-auth.sh` が完了していること
+- アプリ設定画面でGmailアカウントとラベルが設定済みであること
+
+**処理内容**:
+1. 指定期間・ラベルのGmailを検索
+2. 添付PDFをCloud Storageに保存
+3. 正規スキーマでFirestoreにドキュメント作成（`status: pending`）
+4. 次回の`processOCR`実行時にOCR処理される
 
 ### 必須設定: Storage CORS
 

--- a/scripts/import-historical-gmail.js
+++ b/scripts/import-historical-gmail.js
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+/**
+ * Gmail過去受信分 巻取りスクリプト
+ *
+ * 指定期間のGmailから添付PDFを取得し、正規スキーマでFirestoreに登録
+ *
+ * 使用方法:
+ *   node import-historical-gmail.js <project-id> --after YYYY-MM-DD --before YYYY-MM-DD [--dry-run]
+ *
+ * 例:
+ *   node import-historical-gmail.js docsplit-kanameone --after 2026-01-01 --before 2026-01-20
+ *   node import-historical-gmail.js docsplit-kanameone --after 2026-01-01 --before 2026-01-20 --dry-run
+ */
+
+const admin = require('firebase-admin');
+const { google } = require('googleapis');
+const crypto = require('crypto');
+const { SecretManagerServiceClient } = require('@google-cloud/secret-manager');
+
+// 引数パース
+const args = process.argv.slice(2);
+const projectId = args[0];
+const afterIndex = args.indexOf('--after');
+const beforeIndex = args.indexOf('--before');
+const dryRun = args.includes('--dry-run');
+
+if (!projectId || afterIndex === -1 || beforeIndex === -1) {
+  console.error('Usage: node import-historical-gmail.js <project-id> --after YYYY-MM-DD --before YYYY-MM-DD [--dry-run]');
+  console.error('');
+  console.error('Example:');
+  console.error('  node import-historical-gmail.js docsplit-kanameone --after 2026-01-01 --before 2026-01-20');
+  process.exit(1);
+}
+
+const afterDate = args[afterIndex + 1];
+const beforeDate = args[beforeIndex + 1];
+
+// 日付フォーマット検証
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+if (!dateRegex.test(afterDate) || !dateRegex.test(beforeDate)) {
+  console.error('Error: 日付はYYYY-MM-DD形式で指定してください');
+  process.exit(1);
+}
+
+// 環境設定
+process.env.GOOGLE_CLOUD_PROJECT = projectId;
+
+admin.initializeApp({
+  projectId: projectId,
+  storageBucket: `${projectId}.firebasestorage.app`
+});
+
+const db = admin.firestore();
+const storage = admin.storage();
+
+// 統計
+const stats = {
+  messagesFound: 0,
+  attachmentsProcessed: 0,
+  duplicatesSkipped: 0,
+  errors: 0
+};
+
+/**
+ * Secret Managerから値を取得
+ */
+async function getSecret(secretName) {
+  const client = new SecretManagerServiceClient();
+  const name = `projects/${projectId}/secrets/${secretName}/versions/latest`;
+  const [version] = await client.accessSecretVersion({ name });
+  return version.payload.data.toString();
+}
+
+/**
+ * Gmail APIクライアントを取得（OAuth方式）
+ */
+async function getGmailClient() {
+  console.log('Gmail認証を取得中...');
+
+  const clientId = await getSecret('gmail-oauth-client-id');
+  const clientSecret = await getSecret('gmail-oauth-client-secret');
+  const refreshToken = await getSecret('gmail-oauth-refresh-token');
+
+  const oauth2Client = new google.auth.OAuth2(clientId, clientSecret);
+  oauth2Client.setCredentials({ refresh_token: refreshToken });
+
+  return google.gmail({ version: 'v1', auth: oauth2Client });
+}
+
+/**
+ * 検索クエリを構築
+ */
+function buildSearchQuery(labels, afterDate, beforeDate) {
+  const labelQuery = labels.map(l => `label:${l}`).join(' OR ');
+  return `(${labelQuery}) has:attachment after:${afterDate} before:${beforeDate}`;
+}
+
+/**
+ * 対象のMIMEタイプかチェック
+ */
+function isTargetMimeType(mimeType) {
+  const targets = [
+    'application/pdf',
+    'image/jpeg',
+    'image/png',
+    'image/tiff',
+    'image/gif',
+  ];
+  return targets.includes(mimeType);
+}
+
+/**
+ * ファイル名をサニタイズ
+ */
+function sanitizeFilename(filename) {
+  return filename
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .slice(0, 200);
+}
+
+/**
+ * マルチパートメッセージから全てのパートを再帰的に取得
+ */
+function getAllParts(payload) {
+  const parts = [];
+
+  if (payload.filename && payload.body?.attachmentId) {
+    parts.push(payload);
+  }
+
+  if (payload.parts) {
+    for (const part of payload.parts) {
+      parts.push(...getAllParts(part));
+    }
+  }
+
+  return parts;
+}
+
+/**
+ * ヘッダーから値を取得
+ */
+function getHeader(headers, name) {
+  const header = headers.find(h => h.name?.toLowerCase() === name.toLowerCase());
+  return header?.value;
+}
+
+/**
+ * 添付ファイルを処理
+ */
+async function processAttachment(gmail, userId, messageId, part, subject, emailBody) {
+  const attachmentId = part.body?.attachmentId;
+  const filename = part.filename || 'unknown';
+  const mimeType = part.mimeType || 'application/octet-stream';
+
+  if (!attachmentId) return 'error';
+
+  // 添付ファイル取得
+  const attachment = await gmail.users.messages.attachments.get({
+    userId,
+    messageId,
+    id: attachmentId,
+  });
+
+  const data = attachment.data.data;
+  if (!data) return 'error';
+
+  const buffer = Buffer.from(data, 'base64');
+
+  // ファイルサイズチェック（10MB上限）
+  const fileSizeKB = Math.round(buffer.length / 1024);
+  if (fileSizeKB > 10240) {
+    console.log(`  ⏭️ スキップ（ファイルサイズ超過）: ${filename} (${fileSizeKB}KB)`);
+    return 'skipped';
+  }
+
+  // MD5ハッシュで重複チェック
+  const hash = crypto.createHash('md5').update(buffer).digest('hex');
+
+  const existingLog = await db
+    .collection('gmailLogs')
+    .where('hash', '==', hash)
+    .limit(1)
+    .get();
+
+  if (!existingLog.empty) {
+    console.log(`  ⏭️ スキップ（重複）: ${filename}`);
+    return 'skipped';
+  }
+
+  if (dryRun) {
+    console.log(`  📄 [DRY-RUN] 処理対象: ${filename} (${fileSizeKB}KB)`);
+    return 'processed';
+  }
+
+  // Cloud Storageに保存
+  const bucket = storage.bucket();
+  const storagePath = `original/${Date.now()}_${sanitizeFilename(filename)}`;
+  const file = bucket.file(storagePath);
+
+  await file.save(buffer, {
+    metadata: {
+      contentType: mimeType,
+      metadata: {
+        originalFilename: filename,
+        emailSubject: subject,
+        uploadedAt: new Date().toISOString(),
+        source: 'historical-import'
+      },
+    },
+  });
+
+  const fileUrl = `gs://${bucket.name}/${storagePath}`;
+
+  // トランザクションで gmailLogs と documents を同時作成
+  const logRef = db.collection('gmailLogs').doc();
+  const docRef = db.collection('documents').doc();
+
+  await db.runTransaction(async (transaction) => {
+    // gmailLogsに記録
+    transaction.set(logRef, {
+      fileName: filename,
+      hash,
+      fileSizeKB,
+      emailSubject: subject,
+      processedAt: admin.firestore.FieldValue.serverTimestamp(),
+      fileUrl,
+      emailBody,
+      source: 'historical-import'
+    });
+
+    // 正規スキーマでdocumentsを作成
+    transaction.set(docRef, {
+      id: docRef.id,
+      processedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      fileId: logRef.id,
+      fileName: filename,               // 正規フィールド名
+      mimeType,
+      ocrResult: '',
+      documentType: '',
+      customerName: '',
+      officeName: '',
+      fileUrl,                          // 正規フィールド名
+      fileDate: null,
+      isDuplicateCustomer: false,
+      totalPages: 0,                    // 正規フィールド名
+      targetPageNumber: 1,
+      status: 'pending',
+      source: 'historical-import',
+      // グループキー（初期値）
+      customerKey: '',
+      officeKey: '',
+      documentTypeKey: '',
+      careManagerKey: '',
+      // 顧客・事業所確定フラグ
+      customerConfirmed: false,
+      customerCandidates: [],
+      officeConfirmed: false,
+      officeCandidates: []
+    });
+  });
+
+  console.log(`  ✅ 保存完了: ${filename} → ${docRef.id}`);
+  return 'processed';
+}
+
+/**
+ * メッセージを処理して添付ファイルを保存
+ */
+async function processMessage(gmail, userId, messageId) {
+  let processed = 0;
+  let skipped = 0;
+
+  const message = await gmail.users.messages.get({
+    userId,
+    id: messageId,
+    format: 'full',
+  });
+
+  const payload = message.data.payload;
+  if (!payload) return { processed, skipped };
+
+  const headers = payload.headers || [];
+  const subject = getHeader(headers, 'Subject') || 'No Subject';
+  const emailBody = message.data.snippet || '';
+
+  console.log(`📧 メール: ${subject}`);
+
+  // 添付ファイルを再帰的に処理（マルチパート対応）
+  const parts = getAllParts(payload);
+
+  for (const part of parts) {
+    if (!part.filename || !part.body?.attachmentId) continue;
+
+    // PDF/画像ファイルのみ処理
+    const mimeType = part.mimeType || '';
+    if (!isTargetMimeType(mimeType)) continue;
+
+    try {
+      const result = await processAttachment(
+        gmail,
+        userId,
+        messageId,
+        part,
+        subject,
+        emailBody
+      );
+
+      if (result === 'processed') {
+        processed++;
+      } else if (result === 'skipped') {
+        skipped++;
+      }
+    } catch (error) {
+      console.error(`  ❌ エラー: ${part.filename}`, error.message);
+      stats.errors++;
+    }
+  }
+
+  return { processed, skipped };
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  console.log('');
+  console.log('╔════════════════════════════════════════════╗');
+  console.log('║   Gmail過去受信分 巻取りインポート          ║');
+  console.log('╚════════════════════════════════════════════╝');
+  console.log('');
+  console.log(`Project:  ${projectId}`);
+  console.log(`期間:     ${afterDate} 〜 ${beforeDate}`);
+  console.log(`Dry Run:  ${dryRun}`);
+  console.log('');
+
+  // 設定を取得
+  const settingsDoc = await db.doc('settings/app').get();
+  if (!settingsDoc.exists) {
+    console.error('Error: 設定（settings/app）が見つかりません');
+    console.error('先にアプリで設定を保存してください');
+    process.exit(1);
+  }
+
+  const settings = settingsDoc.data();
+  const targetLabels = settings?.targetLabels || [];
+  const gmailAccount = settings?.gmailAccount;
+
+  if (!gmailAccount || targetLabels.length === 0) {
+    console.error('Error: Gmail設定が不完全です');
+    console.error(`  gmailAccount: ${gmailAccount || '未設定'}`);
+    console.error(`  targetLabels: ${targetLabels.length > 0 ? targetLabels.join(', ') : '未設定'}`);
+    process.exit(1);
+  }
+
+  console.log(`Gmail:    ${gmailAccount}`);
+  console.log(`Labels:   ${targetLabels.join(', ')}`);
+  console.log('---');
+
+  // Gmail APIクライアント取得
+  const gmail = await getGmailClient();
+
+  // 検索クエリ構築
+  const query = buildSearchQuery(targetLabels, afterDate, beforeDate);
+  console.log(`検索クエリ: ${query}`);
+  console.log('');
+
+  // メッセージ検索（ページネーション対応）
+  let pageToken = undefined;
+  let allMessages = [];
+
+  do {
+    const response = await gmail.users.messages.list({
+      userId: gmailAccount,
+      q: query,
+      maxResults: 100,
+      pageToken: pageToken
+    });
+
+    const messages = response.data.messages || [];
+    allMessages = allMessages.concat(messages);
+    pageToken = response.data.nextPageToken;
+
+    console.log(`メッセージ取得中... ${allMessages.length}件`);
+  } while (pageToken);
+
+  stats.messagesFound = allMessages.length;
+  console.log(`合計 ${allMessages.length} 件のメッセージが見つかりました`);
+  console.log('---');
+
+  if (allMessages.length === 0) {
+    console.log('処理対象のメッセージがありません');
+    return;
+  }
+
+  // 各メッセージを処理
+  for (const message of allMessages) {
+    if (!message.id) continue;
+
+    try {
+      const result = await processMessage(gmail, gmailAccount, message.id);
+      stats.attachmentsProcessed += result.processed;
+      stats.duplicatesSkipped += result.skipped;
+    } catch (error) {
+      stats.errors++;
+      console.error(`Error processing message ${message.id}:`, error.message);
+    }
+  }
+
+  console.log('');
+  console.log('===================================');
+  console.log('📊 処理結果サマリー');
+  console.log('===================================');
+  console.log(`メッセージ数:     ${stats.messagesFound}`);
+  console.log(`処理した添付:     ${stats.attachmentsProcessed}`);
+  console.log(`スキップ（重複）: ${stats.duplicatesSkipped}`);
+  console.log(`エラー:           ${stats.errors}`);
+  console.log('');
+
+  if (dryRun) {
+    console.log('⚠️  DRY-RUNモードのため、実際の保存は行われていません');
+    console.log('   実行するには --dry-run を外して再実行してください');
+  } else if (stats.attachmentsProcessed > 0) {
+    console.log('✅ インポート完了');
+    console.log('');
+    console.log('次のステップ:');
+    console.log('  1. processOCR を手動実行してOCR処理を開始');
+    console.log('     firebase functions:call processOCR -P ' + projectId);
+    console.log('  2. または次回の定期実行（5分間隔）を待つ');
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(e => {
+    console.error('Fatal error:', e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Gmail過去受信分の巻取りスクリプト（`import-historical-gmail.js`）を追加
- 正規スキーマでFirestoreに登録するため、マイグレーション不要
- 納品ガイドに使用方法を追記

## 背景

クライアント納品時に過去受信分の巻取り対応が必要。
これまでは一時的なスクリプトで対応していたが、スキーマの不整合が発生していた。
正式なスクリプトを作成し、正規スキーマで登録することで問題を解消。

## 使用方法

```bash
# dry-runで確認
node scripts/import-historical-gmail.js <project-id> --after 2026-01-01 --before 2026-01-31 --dry-run

# 実行
node scripts/import-historical-gmail.js <project-id> --after 2026-01-01 --before 2026-01-31
```

## 機能

- 期間指定（after/before）
- dry-runモード
- ページネーション対応（大量メール対応）
- 重複チェック（MD5ハッシュ）
- 正規スキーマでFirestore登録

## Test plan

- [ ] dry-runモードで動作確認
- [ ] 実際のGmailからインポートテスト
- [ ] PDF閲覧確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to import historical Gmail attachments with configurable date ranges
  * Includes dry-run mode for testing before permanent ingestion
  * Automatic duplicate detection and file size validation

* **Documentation**
  * Expanded guide with step-by-step usage examples and prerequisites
  * Detailed configuration requirements and processing workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->