### PR TITLE
feat: OCR結果の編集機能を追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,12 +25,13 @@ service cloud.firestore {
       allow read: if isWhitelisted();
       // 作成: Cloud Functionsのみ（サービスアカウント経由、ルール適用外）
       allow create: if false;
-      // 更新: 顧客解決・事業所解決フィールドのみ許可
+      // 更新: 許可されたフィールドのみ
       allow update: if isWhitelisted()
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
           // 顧客解決フィールド（Phase 7）
           'customerId',
           'customerName',
+          'customerKey',
           'customerConfirmed',
           'needsManualCustomerSelection',
           'confirmedBy',
@@ -39,9 +40,19 @@ service cloud.firestore {
           // 事業所解決フィールド
           'officeId',
           'officeName',
+          'officeKey',
           'officeConfirmed',
           'officeConfirmedBy',
-          'officeConfirmedAt'
+          'officeConfirmedAt',
+          // OCR結果編集フィールド
+          'documentType',
+          'documentTypeKey',
+          'careManagerKey',
+          'fileDate',
+          'fileName',
+          'editedBy',
+          'editedAt',
+          'updatedAt'
         ])
         // confirmedBy は自分のUIDのみ設定可能（事業所解決時は含まれない場合あり）
         && (request.resource.data.confirmedBy == request.auth.uid
@@ -52,7 +63,12 @@ service cloud.firestore {
         && (request.resource.data.officeConfirmedBy == request.auth.uid
             || request.resource.data.officeConfirmedBy == resource.data.officeConfirmedBy
             || request.resource.data.officeConfirmedBy == null
-            || !('officeConfirmedBy' in request.resource.data));
+            || !('officeConfirmedBy' in request.resource.data))
+        // editedBy は自分のUIDのみ設定可能
+        && (request.resource.data.editedBy == request.auth.uid
+            || request.resource.data.editedBy == resource.data.editedBy
+            || request.resource.data.editedBy == null
+            || !('editedBy' in request.resource.data));
       allow delete: if isAdmin();
     }
 
@@ -88,6 +104,21 @@ service cloud.firestore {
         && request.resource.data.newOfficeName.size() > 0
         && request.resource.data.resolvedByEmail is string;
         // resolvedAtはserverTimestamp()で設定されるため、検証はスキップ
+      // 更新・削除は禁止（監査ログは不変）
+      allow update, delete: if false;
+    }
+
+    // ドキュメント編集監査ログ
+    match /editLogs/{logId} {
+      allow read: if isWhitelisted();
+      // 作成: 認証済みユーザー、必須フィールドチェック
+      allow create: if isWhitelisted()
+        && request.resource.data.editedBy == request.auth.uid
+        && request.resource.data.documentId is string
+        && request.resource.data.documentId.size() > 0
+        && request.resource.data.fieldName is string
+        && request.resource.data.fieldName.size() > 0
+        && request.resource.data.editedByEmail is string;
       // 更新・削除は禁止（監査ログは不変）
       allow update, delete: if false;
     }

--- a/frontend/src/hooks/useDocumentEdit.ts
+++ b/frontend/src/hooks/useDocumentEdit.ts
@@ -1,0 +1,235 @@
+import { useState, useCallback } from 'react'
+import { doc, updateDoc, collection, addDoc, serverTimestamp, Timestamp } from 'firebase/firestore'
+import { db, auth } from '../lib/firebase'
+import type { Document } from '../../../shared/types'
+
+export interface EditLogEntry {
+  documentId: string
+  fieldName: string
+  oldValue: string | null
+  newValue: string | null
+  editedBy: string
+  editedByEmail: string
+  editedAt: Timestamp
+}
+
+export interface EditableFields {
+  customerName?: string
+  customerId?: string
+  customerKey?: string
+  officeName?: string
+  officeId?: string
+  officeKey?: string
+  documentType?: string
+  documentTypeKey?: string
+  careManagerKey?: string
+  fileDate?: Date | null
+  fileName?: string
+}
+
+interface UseDocumentEditResult {
+  isEditing: boolean
+  isSaving: boolean
+  editedFields: EditableFields
+  startEditing: () => void
+  cancelEditing: () => void
+  updateField: <K extends keyof EditableFields>(field: K, value: EditableFields[K]) => void
+  saveChanges: () => Promise<boolean>
+  error: string | null
+}
+
+export function useDocumentEdit(document: Document | null | undefined): UseDocumentEditResult {
+  const [isEditing, setIsEditing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [editedFields, setEditedFields] = useState<EditableFields>({})
+
+  const startEditing = useCallback(() => {
+    if (!document) return
+    setEditedFields({
+      customerName: document.customerName || '',
+      customerId: document.customerId || '',
+      customerKey: document.customerKey || '',
+      officeName: document.officeName || '',
+      officeId: document.officeId || '',
+      officeKey: document.officeKey || '',
+      documentType: document.documentType || '',
+      documentTypeKey: document.documentTypeKey || '',
+      careManagerKey: document.careManagerKey || '',
+      fileDate: document.fileDate instanceof Timestamp
+        ? document.fileDate.toDate()
+        : document.fileDate ? new Date(document.fileDate) : null,
+      fileName: document.fileName || '',
+    })
+    setIsEditing(true)
+    setError(null)
+  }, [document])
+
+  const cancelEditing = useCallback(() => {
+    setIsEditing(false)
+    setEditedFields({})
+    setError(null)
+  }, [])
+
+  const updateField = useCallback(<K extends keyof EditableFields>(
+    field: K,
+    value: EditableFields[K]
+  ) => {
+    setEditedFields(prev => ({ ...prev, [field]: value }))
+  }, [])
+
+  const saveChanges = useCallback(async (): Promise<boolean> => {
+    if (!document || !auth.currentUser) {
+      setError('認証情報がありません')
+      return false
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      const docRef = doc(db, 'documents', document.id)
+      const editLogsRef = collection(db, 'editLogs')
+
+      // 変更されたフィールドを特定
+      const changes: { field: string; oldValue: string | null; newValue: string | null }[] = []
+
+      // 顧客名
+      if (editedFields.customerName !== (document.customerName || '')) {
+        changes.push({
+          field: 'customerName',
+          oldValue: document.customerName || null,
+          newValue: editedFields.customerName || null,
+        })
+      }
+
+      // 事業所名
+      if (editedFields.officeName !== (document.officeName || '')) {
+        changes.push({
+          field: 'officeName',
+          oldValue: document.officeName || null,
+          newValue: editedFields.officeName || null,
+        })
+      }
+
+      // 書類種別
+      if (editedFields.documentType !== (document.documentType || '')) {
+        changes.push({
+          field: 'documentType',
+          oldValue: document.documentType || null,
+          newValue: editedFields.documentType || null,
+        })
+      }
+
+      // 担当ケアマネ
+      if (editedFields.careManagerKey !== (document.careManagerKey || '')) {
+        changes.push({
+          field: 'careManagerKey',
+          oldValue: document.careManagerKey || null,
+          newValue: editedFields.careManagerKey || null,
+        })
+      }
+
+      // ファイル名
+      if (editedFields.fileName !== (document.fileName || '')) {
+        changes.push({
+          field: 'fileName',
+          oldValue: document.fileName || null,
+          newValue: editedFields.fileName || null,
+        })
+      }
+
+      // 日付（比較が複雑なため文字列化して比較）
+      const oldDate = document.fileDate instanceof Timestamp
+        ? document.fileDate.toDate().toISOString().split('T')[0]
+        : document.fileDate ? new Date(document.fileDate).toISOString().split('T')[0] : null
+      const newDate = editedFields.fileDate
+        ? editedFields.fileDate.toISOString().split('T')[0]
+        : null
+      if (oldDate !== newDate) {
+        changes.push({
+          field: 'fileDate',
+          oldValue: oldDate,
+          newValue: newDate,
+        })
+      }
+
+      if (changes.length === 0) {
+        setIsEditing(false)
+        return true
+      }
+
+      // ドキュメント更新
+      const updateData: Record<string, unknown> = {
+        editedBy: auth.currentUser.uid,
+        editedAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      }
+
+      // 変更されたフィールドを追加
+      if (editedFields.customerName !== undefined) {
+        updateData.customerName = editedFields.customerName
+        updateData.customerKey = editedFields.customerName // グループキーも更新
+      }
+      if (editedFields.customerId !== undefined) {
+        updateData.customerId = editedFields.customerId
+      }
+      if (editedFields.officeName !== undefined) {
+        updateData.officeName = editedFields.officeName
+        updateData.officeKey = editedFields.officeName // グループキーも更新
+      }
+      if (editedFields.officeId !== undefined) {
+        updateData.officeId = editedFields.officeId
+      }
+      if (editedFields.documentType !== undefined) {
+        updateData.documentType = editedFields.documentType
+        updateData.documentTypeKey = editedFields.documentType // グループキーも更新
+      }
+      if (editedFields.careManagerKey !== undefined) {
+        updateData.careManagerKey = editedFields.careManagerKey
+      }
+      if (editedFields.fileName !== undefined) {
+        updateData.fileName = editedFields.fileName
+      }
+      if (editedFields.fileDate !== undefined) {
+        updateData.fileDate = editedFields.fileDate
+      }
+
+      await updateDoc(docRef, updateData)
+
+      // 監査ログを記録
+      for (const change of changes) {
+        await addDoc(editLogsRef, {
+          documentId: document.id,
+          fieldName: change.field,
+          oldValue: change.oldValue,
+          newValue: change.newValue,
+          editedBy: auth.currentUser.uid,
+          editedByEmail: auth.currentUser.email || '',
+          editedAt: serverTimestamp(),
+        })
+      }
+
+      setIsEditing(false)
+      setEditedFields({})
+      return true
+    } catch (err) {
+      console.error('Failed to save changes:', err)
+      setError(err instanceof Error ? err.message : '保存に失敗しました')
+      return false
+    } finally {
+      setIsSaving(false)
+    }
+  }, [document, editedFields])
+
+  return {
+    isEditing,
+    isSaving,
+    editedFields,
+    startEditing,
+    cancelEditing,
+    updateField,
+    saveChanges,
+    error,
+  }
+}


### PR DESCRIPTION
## Summary
- OCR処理後のドキュメント情報を手動で編集可能にする機能を追加
- 編集履歴は監査ログ（editLogs）として記録

## 変更内容
- **useDocumentEdit.ts**: ドキュメント編集フック（監査ログ記録付き）
- **DocumentDetailModal.tsx**: 編集モードUI追加
- **firestore.rules**: 編集フィールド許可、editLogsコレクション追加
- **firestore.rules.test.ts**: 12件のテスト追加

## 編集可能フィールド
- 顧客名（customerName）
- 事業所（officeName）
- 書類種別（documentType）
- 担当ケアマネ（careManagerKey）
- 書類日付（fileDate）
- ファイル名（fileName）

## テスト結果
- Firestoreルール: 47件パス
- Functions: 132件パス
- フロントエンド: 11件パス

## Test plan
- [ ] dev環境で編集機能の動作確認
- [ ] 監査ログが正しく記録されることを確認
- [ ] クライアント環境へのデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added inline editing capability for document metadata fields (customer name, office name, document type, file date)
  - Implemented edit/save/cancel controls in the document detail interface
  - Introduced comprehensive audit trail logging for all document changes

* **Tests**
  - Added test coverage for document editing and audit logging functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->