### PR TITLE
feat: マスター未登録時の登録提案UI追加

### DIFF
--- a/frontend/src/components/RegisterNewMasterModal.tsx
+++ b/frontend/src/components/RegisterNewMasterModal.tsx
@@ -1,0 +1,336 @@
+/**
+ * 新規マスター登録モーダル
+ *
+ * 同名解決モーダルで「該当なし」選択時に、
+ * マスターデータへの新規登録を提案するモーダル
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, AlertCircle, Plus, UserPlus, Building2 } from 'lucide-react';
+import {
+  useAddCustomer,
+  useAddOffice,
+  checkCustomerDuplicate,
+  checkOfficeDuplicate,
+  DuplicateError,
+} from '@/hooks/useMasters';
+
+// ============================================
+// 型定義
+// ============================================
+
+export type MasterType = 'customer' | 'office';
+
+interface RegisterNewMasterModalProps {
+  type: MasterType;
+  isOpen: boolean;
+  onClose: () => void;
+  /** OCRで抽出された名前（初期値） */
+  suggestedName?: string;
+  /** 登録成功時のコールバック */
+  onRegistered?: (result: RegisteredMasterInfo) => void;
+}
+
+export interface RegisteredMasterInfo {
+  type: MasterType;
+  id: string;
+  name: string;
+}
+
+// ============================================
+// メインコンポーネント
+// ============================================
+
+export function RegisterNewMasterModal({
+  type,
+  isOpen,
+  onClose,
+  suggestedName = '',
+  onRegistered,
+}: RegisterNewMasterModalProps) {
+  // フォーム状態
+  const [name, setName] = useState(suggestedName);
+  const [furigana, setFurigana] = useState('');
+  const [shortName, setShortName] = useState('');
+
+  // 同名チェック状態
+  const [isDuplicateChecking, setIsDuplicateChecking] = useState(false);
+  const [showDuplicateConfirm, setShowDuplicateConfirm] = useState(false);
+
+  // エラー状態
+  const [error, setError] = useState<string | null>(null);
+
+  // ミューテーション
+  const addCustomer = useAddCustomer();
+  const addOffice = useAddOffice();
+
+  const isLoading = addCustomer.isPending || addOffice.isPending;
+
+  // モーダル開閉時に初期化
+  useEffect(() => {
+    if (isOpen) {
+      setName(suggestedName);
+      setFurigana('');
+      setShortName('');
+      setError(null);
+      setShowDuplicateConfirm(false);
+    }
+  }, [isOpen, suggestedName]);
+
+  // 同名チェック
+  const checkDuplicate = useCallback(async (): Promise<boolean> => {
+    if (!name.trim()) return false;
+
+    setIsDuplicateChecking(true);
+    try {
+      if (type === 'customer') {
+        return await checkCustomerDuplicate(name);
+      } else {
+        return await checkOfficeDuplicate(name);
+      }
+    } finally {
+      setIsDuplicateChecking(false);
+    }
+  }, [name, type]);
+
+  // 登録処理
+  const handleRegister = useCallback(
+    async (force = false) => {
+      if (!name.trim()) {
+        setError('名前を入力してください');
+        return;
+      }
+
+      setError(null);
+
+      try {
+        // 強制追加でない場合は同名チェック
+        if (!force) {
+          const isDuplicate = await checkDuplicate();
+          if (isDuplicate) {
+            setShowDuplicateConfirm(true);
+            return;
+          }
+        }
+
+        if (type === 'customer') {
+          await addCustomer.mutateAsync({
+            name: name.trim(),
+            furigana: furigana.trim(),
+            isDuplicate: force,
+            force,
+          });
+        } else {
+          await addOffice.mutateAsync({
+            name: name.trim(),
+            shortName: shortName.trim() || undefined,
+            force,
+          });
+        }
+
+        // 成功時のコールバック
+        onRegistered?.({
+          type,
+          id: '', // 新規登録時はIDは取得できないが、名前で検索可能
+          name: name.trim(),
+        });
+
+        onClose();
+      } catch (err) {
+        if (err instanceof DuplicateError) {
+          setShowDuplicateConfirm(true);
+        } else {
+          setError(err instanceof Error ? err.message : '登録に失敗しました');
+        }
+      }
+    },
+    [name, furigana, shortName, type, checkDuplicate, addCustomer, addOffice, onRegistered, onClose]
+  );
+
+  // 同名確認後の強制登録
+  const handleForceRegister = useCallback(() => {
+    setShowDuplicateConfirm(false);
+    handleRegister(true);
+  }, [handleRegister]);
+
+  // タイプに応じたラベル
+  const typeLabel = type === 'customer' ? '顧客' : '事業所';
+  const TypeIcon = type === 'customer' ? UserPlus : Building2;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <TypeIcon className="h-5 w-5" />
+            新規{typeLabel}を登録
+          </DialogTitle>
+          <DialogDescription>
+            マスターデータに新しい{typeLabel}を登録します。
+            登録後、この書類に自動的に紐付けられます。
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* 同名確認ダイアログ */}
+        {showDuplicateConfirm ? (
+          <div className="space-y-4">
+            <Card className="border-yellow-500 bg-yellow-50">
+              <CardContent className="p-4">
+                <div className="flex items-start gap-3">
+                  <AlertCircle className="h-5 w-5 text-yellow-600 mt-0.5" />
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-yellow-800">
+                      同名の{typeLabel}が既に存在します
+                    </p>
+                    <p className="text-sm text-yellow-700">
+                      「{name}」という名前の{typeLabel}は既に登録されています。
+                      同名で登録しますか？
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <DialogFooter className="gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setShowDuplicateConfirm(false)}
+                disabled={isLoading}
+              >
+                戻る
+              </Button>
+              <Button
+                variant="default"
+                onClick={handleForceRegister}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    登録中...
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4 mr-2" />
+                    同名で登録する
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* 名前入力 */}
+            <div className="space-y-2">
+              <Label htmlFor="name">
+                {typeLabel}名 <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={`${typeLabel}名を入力`}
+                disabled={isLoading}
+              />
+              {suggestedName && name !== suggestedName && (
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="h-auto p-0 text-xs"
+                  onClick={() => setName(suggestedName)}
+                >
+                  OCR抽出値「{suggestedName}」を使用
+                </Button>
+              )}
+            </div>
+
+            {/* 顧客の場合: フリガナ入力 */}
+            {type === 'customer' && (
+              <div className="space-y-2">
+                <Label htmlFor="furigana">
+                  フリガナ
+                  <Badge variant="secondary" className="ml-2 text-xs">
+                    任意
+                  </Badge>
+                </Label>
+                <Input
+                  id="furigana"
+                  value={furigana}
+                  onChange={(e) => setFurigana(e.target.value)}
+                  placeholder="フリガナを入力"
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+
+            {/* 事業所の場合: 短縮名入力 */}
+            {type === 'office' && (
+              <div className="space-y-2">
+                <Label htmlFor="shortName">
+                  短縮名
+                  <Badge variant="secondary" className="ml-2 text-xs">
+                    任意
+                  </Badge>
+                </Label>
+                <Input
+                  id="shortName"
+                  value={shortName}
+                  onChange={(e) => setShortName(e.target.value)}
+                  placeholder="短縮名を入力"
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+
+            {/* エラー表示 */}
+            {error && (
+              <Card className="border-destructive bg-destructive/10">
+                <CardContent className="p-3">
+                  <div className="flex items-center gap-2 text-destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <span className="text-sm">{error}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={onClose} disabled={isLoading}>
+                キャンセル
+              </Button>
+              <Button
+                onClick={() => handleRegister(false)}
+                disabled={isLoading || isDuplicateChecking || !name.trim()}
+              >
+                {isLoading || isDuplicateChecking ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    {isDuplicateChecking ? 'チェック中...' : '登録中...'}
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4 mr-2" />
+                    登録する
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/SameNameResolveModal.tsx
+++ b/frontend/src/components/SameNameResolveModal.tsx
@@ -21,8 +21,9 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Loader2, AlertCircle, FileText, User, Calendar, Check } from 'lucide-react';
+import { Loader2, AlertCircle, FileText, User, Calendar, Check, UserPlus } from 'lucide-react';
 import { useSameNameResolution } from '@/hooks/useSameNameResolution';
+import { RegisterNewMasterModal, type RegisteredMasterInfo } from '@/components/RegisterNewMasterModal';
 import type { Document, CustomerCandidateInfo } from '@shared/types';
 
 // ============================================
@@ -42,6 +43,9 @@ interface Selection {
   type: SelectionType;
   candidate?: CustomerCandidateInfo;
 }
+
+// 登録提案ダイアログの状態
+type RegistrationPromptState = 'none' | 'prompt' | 'registering';
 
 // ============================================
 // マッチタイプ表示
@@ -137,14 +141,21 @@ export function SameNameResolveModal({
   // 選択状態
   const [selection, setSelection] = useState<Selection>({ type: null });
 
+  // 登録提案ダイアログの状態
+  const [registrationPrompt, setRegistrationPrompt] = useState<RegistrationPromptState>('none');
+
   // 候補リスト
   const candidates = getCandidates(document);
+
+  // OCRから抽出された顧客名（初期値として提案）
+  const suggestedCustomerName = document.customerName || '';
 
   // モーダル開閉時にOCR取得・リセット
   useEffect(() => {
     if (isOpen) {
       loadOcrText(document);
       setSelection({ type: null });
+      setRegistrationPrompt('none');
     } else {
       resetOcrText();
     }
@@ -172,17 +183,48 @@ export function SameNameResolveModal({
           selectedCustomerName: selection.candidate.customerName,
           selectedCustomerIsDuplicate: selection.candidate.isDuplicate,
         });
+        onResolved?.();
+        onClose();
       } else if (selection.type === 'unknown') {
-        await resolveAsUnknown({ documentId: document.id });
+        // 「該当なし」選択時は登録提案ダイアログを表示
+        setRegistrationPrompt('prompt');
       }
-
-      onResolved?.();
-      onClose();
     } catch (err) {
       // エラーはresolveErrorで表示
       console.error('Resolution failed:', err);
     }
-  }, [selection, document.id, resolveCustomer, resolveAsUnknown, onResolved, onClose]);
+  }, [selection, document.id, resolveCustomer, onResolved, onClose]);
+
+  // 登録せずに確定（不明顧客として登録）
+  const handleSkipRegistration = useCallback(async () => {
+    try {
+      await resolveAsUnknown({ documentId: document.id });
+      onResolved?.();
+      onClose();
+    } catch (err) {
+      console.error('Resolution failed:', err);
+    }
+  }, [document.id, resolveAsUnknown, onResolved, onClose]);
+
+  // 新規登録後のコールバック
+  const handleMasterRegistered = useCallback(
+    async (result: RegisteredMasterInfo) => {
+      // 登録後、その顧客で確定する
+      try {
+        await resolveCustomer({
+          documentId: document.id,
+          selectedCustomerId: result.id || result.name, // IDがない場合は名前で代用
+          selectedCustomerName: result.name,
+          selectedCustomerIsDuplicate: false,
+        });
+        onResolved?.();
+        onClose();
+      } catch (err) {
+        console.error('Resolution after registration failed:', err);
+      }
+    },
+    [document.id, resolveCustomer, onResolved, onClose]
+  );
 
   // 書類日付フォーマット
   const formattedDate = document.fileDate
@@ -339,6 +381,69 @@ export function SameNameResolveModal({
           </Button>
         </DialogFooter>
       </DialogContent>
+
+      {/* 登録提案ダイアログ */}
+      {registrationPrompt === 'prompt' && (
+        <Dialog open={true} onOpenChange={() => setRegistrationPrompt('none')}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>新規顧客の登録</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                該当する顧客がマスターに登録されていない可能性があります。
+                新しい顧客として登録しますか？
+              </p>
+              {suggestedCustomerName && suggestedCustomerName !== '不明顧客' && (
+                <Card className="bg-muted/50">
+                  <CardContent className="p-3">
+                    <div className="flex items-center gap-2">
+                      <User className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm">
+                        OCR抽出値: <strong>{suggestedCustomerName}</strong>
+                      </span>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+            <DialogFooter className="flex-col sm:flex-row gap-2">
+              <Button
+                variant="outline"
+                onClick={handleSkipRegistration}
+                disabled={isResolving}
+                className="w-full sm:w-auto"
+              >
+                {isResolving ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    処理中...
+                  </>
+                ) : (
+                  '登録せずに確定'
+                )}
+              </Button>
+              <Button
+                onClick={() => setRegistrationPrompt('registering')}
+                disabled={isResolving}
+                className="w-full sm:w-auto"
+              >
+                <UserPlus className="h-4 w-4 mr-2" />
+                新規登録する
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* 新規マスター登録モーダル */}
+      <RegisterNewMasterModal
+        type="customer"
+        isOpen={registrationPrompt === 'registering'}
+        onClose={() => setRegistrationPrompt('prompt')}
+        suggestedName={suggestedCustomerName !== '不明顧客' ? suggestedCustomerName : ''}
+        onRegistered={handleMasterRegistered}
+      />
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- 「該当なし」選択時に新規マスター登録を提案するUIを追加
- RegisterNewMasterModal: 新規マスター登録モーダル（顧客/事業所共通）
- 顧客・事業所の同名解決モーダルに登録提案機能を統合

## Changes
- `RegisterNewMasterModal.tsx`: 新規マスター登録用モーダルコンポーネント
- `SameNameResolveModal.tsx`: 顧客の登録提案機能追加
- `OfficeSameNameResolveModal.tsx`: 事業所の登録提案機能追加

## Features
- OCRで抽出された名前を初期値として提案
- 同名チェック機能（重複時は確認ダイアログ表示）
- 登録後は自動的にドキュメントに紐付け
- 「登録せずに確定」オプションも提供

## Test plan
- [ ] 顧客解決モーダルで「該当なし」→登録提案ダイアログが表示される
- [ ] 事業所解決モーダルで「該当なし」→登録提案ダイアログが表示される
- [ ] 「新規登録する」→RegisterNewMasterModalが開く
- [ ] 「登録せずに確定」→不明顧客/事業所として確定
- [ ] 登録成功後、ドキュメントに新規登録したマスターが紐付く
- [ ] 同名チェックで重複検出時、確認ダイアログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added registration workflows for unknown offices with OCR-suggested names
  * Introduced registration prompts when customer matches are uncertain
  * New modal for registering new customers and offices
  * Built-in duplicate detection with override capability during registration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->