### PR TITLE
feat: 顧客確定時にケアマネージャーを自動設定

### DIFF
--- a/frontend/src/components/SameNameResolveModal.tsx
+++ b/frontend/src/components/SameNameResolveModal.tsx
@@ -182,6 +182,7 @@ export function SameNameResolveModal({
           selectedCustomerId: selection.candidate.customerId,
           selectedCustomerName: selection.candidate.customerName,
           selectedCustomerIsDuplicate: selection.candidate.isDuplicate,
+          selectedCareManagerName: selection.candidate.careManagerName,
         });
         onResolved?.();
         onClose();
@@ -209,13 +210,14 @@ export function SameNameResolveModal({
   // 新規登録後のコールバック
   const handleMasterRegistered = useCallback(
     async (result: RegisteredMasterInfo) => {
-      // 登録後、その顧客で確定する
+      // 登録後、その顧客で確定する（新規顧客なのでcareManagerはなし）
       try {
         await resolveCustomer({
           documentId: document.id,
           selectedCustomerId: result.id || result.name, // IDがない場合は名前で代用
           selectedCustomerName: result.name,
           selectedCustomerIsDuplicate: false,
+          selectedCareManagerName: null, // 新規登録時はケアマネ未設定
         });
         onResolved?.();
         onClose();

--- a/frontend/src/hooks/useSameNameResolution.ts
+++ b/frontend/src/hooks/useSameNameResolution.ts
@@ -30,6 +30,7 @@ export interface ResolveCustomerParams {
   selectedCustomerId: string;
   selectedCustomerName: string;
   selectedCustomerIsDuplicate: boolean;
+  selectedCareManagerName?: string | null;
 }
 
 export interface ResolveAsUnknownParams {
@@ -75,6 +76,7 @@ async function resolveCustomer({
   selectedCustomerId,
   selectedCustomerName,
   selectedCustomerIsDuplicate,
+  selectedCareManagerName,
 }: ResolveCustomerParams): Promise<void> {
   const user = auth.currentUser;
   if (!user) throw new Error('Not authenticated');
@@ -87,7 +89,7 @@ async function resolveCustomer({
 
     const previousCustomerId = docSnap.data().customerId ?? null;
 
-    // 1. documentsを更新
+    // 1. documentsを更新（careManagerも設定）
     transaction.update(docRef, {
       customerId: selectedCustomerId,
       customerName: selectedCustomerName,
@@ -96,6 +98,7 @@ async function resolveCustomer({
       confirmedBy: user.uid,
       confirmedAt: serverTimestamp(),
       isDuplicateCustomer: selectedCustomerIsDuplicate,
+      careManager: selectedCareManagerName || null,
     });
 
     // 2. 監査ログを作成

--- a/functions/src/ocr/processOCR.ts
+++ b/functions/src/ocr/processOCR.ts
@@ -237,6 +237,7 @@ async function processDocument(
     name: d.data().name as string,
     furigana: d.data().furigana as string | undefined,
     isDuplicate: d.data().isDuplicate as boolean | undefined,
+    careManagerName: d.data().careManagerName as string | undefined,
   }));
 
   const officeMasterData: OfficeMaster[] = officeMasters.docs.map((d) => ({
@@ -280,6 +281,8 @@ async function processDocument(
     documentType: documentTypeResult.documentType || '未判定',
     customerName: customerResult.bestMatch?.name || '不明顧客',
     customerId: customerResult.bestMatch?.id || null,
+    // 顧客に紐づくケアマネを設定
+    careManager: customerResult.bestMatch?.careManagerName || null,
     officeName: officeResult.bestMatch?.name || '未判定',
     officeId: officeResult.bestMatch?.id || null,
     fileDate: dateResult.date || null,
@@ -298,6 +301,7 @@ async function processDocument(
       isDuplicate: c.isDuplicate || false,
       score: c.score,
       matchType: c.matchType,
+      careManagerName: c.careManagerName || null,
     })),
     // 事業所確定フィールド
     officeConfirmed: !officeResult.needsManualSelection,

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -42,6 +42,7 @@ export interface CustomerCandidate {
   matchType: MatchType;
   isDuplicate: boolean;
   pageNumbers?: number[];
+  careManagerName?: string;
 }
 
 /** 書類抽出結果 */
@@ -106,6 +107,7 @@ export interface CustomerMaster {
   name: string;
   furigana?: string;
   isDuplicate?: boolean;
+  careManagerName?: string;
 }
 
 export interface OfficeMaster {
@@ -426,6 +428,7 @@ export function extractCustomerCandidates(
         matchType,
         isDuplicate: customer.isDuplicate || false,
         pageNumbers: pageNumber !== undefined ? [pageNumber] : undefined,
+        careManagerName: customer.careManagerName,
       });
     }
   }


### PR DESCRIPTION
## Summary
- 顧客マスターの`careManagerName`を、OCR処理時および顧客解決時にドキュメントの`careManager`フィールドに自動設定
- これにより「担当CM別」タブにデータが表示されるようになる

## 変更内容
- `extractors.ts`: CustomerMaster/CustomerCandidateにcareManagerName追加
- `processOCR.ts`: 顧客マッチ時にcareManagerを設定、customerCandidatesにも含める
- `useSameNameResolution.ts`: 顧客解決時にcareManagerを設定
- `SameNameResolveModal.tsx`: careManagerNameをパラメータに追加

## Test plan
- [ ] Functions単体テスト: 132テストパス
- [ ] Firestoreルールテスト: 47テストパス
- [ ] 顧客マスターにcareManagerNameを設定してOCR処理を実行
- [ ] 「担当CM別」タブにデータが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Care manager information is now tracked and associated with customer records during registration and conflict resolution, ensuring accurate care manager assignments are maintained when resolving duplicate customers and creating new profiles.
  * Care manager details are now captured and propagated throughout the customer matching and OCR processing workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->