### PR TITLE
fix: 顧客マッチングの部分一致ロジックを削除

### DIFF
--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -395,17 +395,8 @@ export function extractCustomerCandidates(
       }
     }
 
-    // 3. 部分一致（名前が2文字以上の場合）
-    if (matchType === 'none' && normalizedName.length >= 2) {
-      // 姓のみでの一致（最初の2文字）
-      const lastName = normalizedName.slice(0, 2);
-      if (matchingText.includes(lastName)) {
-        score = 75;
-        matchType = 'partial';
-      }
-    }
-
-    // 4. ファジーマッチ
+    // 3. ファジーマッチ（類似度検索）
+    // GAS版と同様：完全一致・ふりがな一致がない場合のみ類似度で判定
     if (matchType === 'none') {
       const windowSize = Math.min(normalizedName.length + 3, matchingText.length);
       for (let i = 0; i <= matchingText.length - windowSize; i++) {


### PR DESCRIPTION
## Summary
- GAS版にはなかった「部分一致（2文字）」ロジックを削除
- OCRテキスト内の無関係な文字列（医院名、地名等）が顧客名として誤マッチする問題を修正
- GAS版と同様に、完全一致・ふりがな一致・類似度検索（閾値70%）のみで判定

## 問題の詳細
OCRテキストに「三宅医院」があると、マスターの「三宅〇〇」がscore=75で候補に入り、
本来の顧客「最上」（マスター未登録）ではなく「三宅」が選ばれてしまっていた。

## Test plan
- [x] Functions単体テスト: 132件パス
- [x] Firestoreルールテスト: 47件パス
- [x] ビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved customer name matching with a more sophisticated fuzzy matching algorithm to better handle variations and misspellings in customer names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->