### PR TITLE
feat: ファイル名から事業所マスター登録を提案する機能

### DIFF
--- a/frontend/src/components/OfficeSameNameResolveModal.tsx
+++ b/frontend/src/components/OfficeSameNameResolveModal.tsx
@@ -141,8 +141,9 @@ export function OfficeSameNameResolveModal({
   // 候補リスト
   const candidates = getCandidates(document);
 
-  // OCRから抽出された事業所名（初期値として提案）
-  const suggestedOfficeName = document.officeName || '';
+  // ファイル名から抽出された事業所名（優先）またはOCRから抽出された事業所名
+  const suggestedNewOffice = document.suggestedNewOffice;
+  const suggestedOfficeName = suggestedNewOffice || document.officeName || '';
 
   // モーダル開閉時にリセット
   useEffect(() => {
@@ -359,7 +360,22 @@ export function OfficeSameNameResolveModal({
                 該当する事業所がマスターに登録されていない可能性があります。
                 新しい事業所として登録しますか？
               </p>
-              {suggestedOfficeName && suggestedOfficeName !== '不明事業所' && (
+              {suggestedNewOffice && (
+                <Card className="bg-green-50 border-green-200">
+                  <CardContent className="p-3">
+                    <div className="flex items-center gap-2">
+                      <Building2 className="h-4 w-4 text-green-600" />
+                      <span className="text-sm">
+                        ファイル名から抽出: <strong className="text-green-700">{suggestedNewOffice}</strong>
+                      </span>
+                    </div>
+                    <p className="text-xs text-green-600 mt-1">
+                      ※ファイル名とOCRテキスト両方に存在を確認済み
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+              {!suggestedNewOffice && suggestedOfficeName && suggestedOfficeName !== '不明事業所' && suggestedOfficeName !== '未判定' && (
                 <Card className="bg-muted/50">
                   <CardContent className="p-3">
                     <div className="flex items-center gap-2">
@@ -406,7 +422,7 @@ export function OfficeSameNameResolveModal({
         type="office"
         isOpen={registrationPrompt === 'registering'}
         onClose={() => setRegistrationPrompt('prompt')}
-        suggestedName={suggestedOfficeName !== '不明事業所' ? suggestedOfficeName : ''}
+        suggestedName={suggestedNewOffice || (suggestedOfficeName !== '不明事業所' && suggestedOfficeName !== '未判定' ? suggestedOfficeName : '')}
         onRegistered={handleMasterRegistered}
       />
     </Dialog>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -55,6 +55,7 @@ export interface Document {
   officeConfirmed?: boolean;                     // 確定済みフラグ（デフォルト: true）
   officeConfirmedBy?: string | null;             // 確定者UID（システム自動確定時はnull）
   officeConfirmedAt?: Timestamp | null;          // 確定日時（システム自動確定時はnull）
+  suggestedNewOffice?: string | null;            // ファイル名から抽出された事業所名（登録提案用）
 
   // Phase 8: グループ化用正規化キー（Cloud Functionsで自動設定）
   customerKey?: string;       // customerName正規化版


### PR DESCRIPTION
## Summary
- ファイル名から事業所名が抽出でき、OCRテキストにも存在し、マスター未登録の場合に新規登録を提案
- 確認待ち画面で「ファイル名から抽出: xxx」として緑色で強調表示

## 背景
ファイル名には送信元FAXの事業所名が含まれることが多い。
この情報をOCRテキストと照合し、マスター未登録の場合は登録を提案することで、
マスターデータの充実とOCR精度向上の両方を実現。

## 変更内容

### functions/src/ocr/processOCR.ts
- `suggestedNewOffice`フィールドを追加
- 条件: ファイル名が事業所名タイプ + OCRテキストにも存在 + マスター未登録（スコア80未満）

### frontend/src/components/OfficeSameNameResolveModal.tsx
- `suggestedNewOffice`がある場合、緑色のカードで強調表示
- 「※ファイル名とOCRテキスト両方に存在を確認済み」のメッセージ追加

### shared/types.ts
- `Document`型に`suggestedNewOffice`フィールド追加

## Test plan
- [x] `npm run build` 成功
- [x] `npm test` 132件パス
- [ ] dev環境デプロイ
- [ ] クライアント環境で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting office names from uploaded filenames and suggesting them for registration
  * New highlighted indicator displays file-derived office suggestions with improved priority handling over previously extracted values
  * Enhanced office name resolution with fallback logic for incomplete data scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->