### PR TITLE
feat: 顧客名・事業所名のエイリアス学習UI追加

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -137,6 +137,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
   // エイリアス登録
   const { addAlias, isAdding: isAddingAlias } = useMasterAlias()
   const [rememberDocTypeNotation, setRememberDocTypeNotation] = useState(false)
+  const [rememberCustomerNotation, setRememberCustomerNotation] = useState(false)
+  const [rememberOfficeNotation, setRememberOfficeNotation] = useState(false)
 
   // マスターデータをMasterSelectField用に変換
   const customerItems = (customers || []).map(c => ({
@@ -156,6 +158,34 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
 
   // 編集保存成功時
   const handleSave = async () => {
+    // 顧客エイリアス登録（チェックが入っている場合）
+    if (rememberCustomerNotation && document && editedFields.customerName) {
+      const originalCustomer = document.customerName || ''
+      const newCustomerName = editedFields.customerName
+      const selectedCustomer = customers?.find(c => c.name === newCustomerName)
+      if (selectedCustomer && originalCustomer !== newCustomerName) {
+        try {
+          await addAlias('customer', selectedCustomer.id, originalCustomer)
+        } catch (err) {
+          console.error('Failed to add customer alias:', err)
+        }
+      }
+    }
+
+    // 事業所エイリアス登録（チェックが入っている場合）
+    if (rememberOfficeNotation && document && editedFields.officeName) {
+      const originalOffice = document.officeName || ''
+      const newOfficeName = editedFields.officeName
+      const selectedOffice = offices?.find(o => o.name === newOfficeName)
+      if (selectedOffice && originalOffice !== newOfficeName) {
+        try {
+          await addAlias('office', selectedOffice.id, originalOffice)
+        } catch (err) {
+          console.error('Failed to add office alias:', err)
+        }
+      }
+    }
+
     // 書類種別エイリアス登録（チェックが入っている場合）
     if (rememberDocTypeNotation && document && editedFields.documentType) {
       const originalDocType = document.documentType || ''
@@ -174,6 +204,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
     const success = await saveChanges()
     if (success) {
       setRememberDocTypeNotation(false)
+      setRememberCustomerNotation(false)
+      setRememberOfficeNotation(false)
       refetch()
     }
   }
@@ -421,6 +453,35 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                             items={customerItems}
                             onChange={(v) => updateField('customerName', v)}
                           />
+                          {/* 顧客名エイリアス学習オプション */}
+                          {editedFields.customerName &&
+                           document.customerName &&
+                           editedFields.customerName !== document.customerName &&
+                           document.customerName !== '不明顧客' &&
+                           document.customerName !== '未判定' && (
+                            <div className="mt-2 rounded bg-blue-50 p-2 border border-blue-200">
+                              <div className="flex items-start gap-2">
+                                <Checkbox
+                                  id="remember-customer-notation"
+                                  checked={rememberCustomerNotation}
+                                  onCheckedChange={(checked) => setRememberCustomerNotation(checked === true)}
+                                  className="mt-0.5"
+                                />
+                                <div className="flex-1">
+                                  <label
+                                    htmlFor="remember-customer-notation"
+                                    className="text-xs font-medium cursor-pointer flex items-center gap-1"
+                                  >
+                                    <BookMarked className="h-3 w-3 text-blue-600" />
+                                    この表記を記憶する
+                                  </label>
+                                  <p className="text-xs text-muted-foreground mt-0.5">
+                                    「{document.customerName}」を「{editedFields.customerName}」の許容表記として登録
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+                          )}
                         </div>
                       ) : (
                         <div className="flex items-center gap-2">
@@ -447,6 +508,34 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                             items={officeItems}
                             onChange={(v) => updateField('officeName', v)}
                           />
+                          {/* 事業所エイリアス学習オプション */}
+                          {editedFields.officeName &&
+                           document.officeName &&
+                           editedFields.officeName !== document.officeName &&
+                           document.officeName !== '未判定' && (
+                            <div className="mt-2 rounded bg-blue-50 p-2 border border-blue-200">
+                              <div className="flex items-start gap-2">
+                                <Checkbox
+                                  id="remember-office-notation"
+                                  checked={rememberOfficeNotation}
+                                  onCheckedChange={(checked) => setRememberOfficeNotation(checked === true)}
+                                  className="mt-0.5"
+                                />
+                                <div className="flex-1">
+                                  <label
+                                    htmlFor="remember-office-notation"
+                                    className="text-xs font-medium cursor-pointer flex items-center gap-1"
+                                  >
+                                    <BookMarked className="h-3 w-3 text-blue-600" />
+                                    この表記を記憶する
+                                  </label>
+                                  <p className="text-xs text-muted-foreground mt-0.5">
+                                    「{document.officeName}」を「{editedFields.officeName}」の許容表記として登録
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+                          )}
                         </div>
                       ) : (
                         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- 顧客名変更時に「この表記を記憶する」チェックボックスを追加
- 事業所名変更時に「この表記を記憶する」チェックボックスを追加
- 修正前の値を新マスターのエイリアスとして登録し、次回のOCRマッチング精度を向上

## 動作
1. 書類詳細モーダルで編集モードに入る
2. 顧客名または事業所名を変更
3. 「この表記を記憶する」チェックボックスが表示される
4. チェックを入れて保存 → 元の表記がエイリアスとして登録

## 対応ケース
- **正解フィードバック**: 表記ゆれ修正（「田中太郎」→「田中　太郎」）
- **間違いフィードバック**: 誤認識修正（「山田太郎」→「田中太郎」）

## Test plan
- [ ] ローカルで編集モードに入り、顧客名を変更してチェックボックスが表示されることを確認
- [ ] チェックを入れて保存し、Firestoreにエイリアスが登録されることを確認
- [ ] 事業所名でも同様の動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document detail editor now supports automatic alias learning for customers and offices. When editing document information, users can opt-in to remember these aliases through new checkbox options. Enabled aliases are automatically saved during the document save process, enhancing efficiency in future document management workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->