### PR TITLE
feat: ドメイン許可リストによる自動ログイン機能

### DIFF
--- a/scripts/setup-tenant.sh
+++ b/scripts/setup-tenant.sh
@@ -253,6 +253,9 @@ const db = getFirestore();
 const auth = getAuth();
 
 async function main() {
+    // 許可ドメインを管理者メールアドレスから抽出
+    const adminDomain = '$ADMIN_EMAIL'.split('@')[1];
+
     // アプリ設定を投入（ラベルは空で初期化、管理者が設定画面で追加）
     await db.doc('settings/app').set({
         targetLabels: [],
@@ -263,6 +266,14 @@ async function main() {
         updatedAt: new Date()
     });
     console.log('✓ settings/app を作成');
+
+    // 認証設定（許可ドメインリスト）
+    await db.doc('settings/auth').set({
+        allowedDomains: [adminDomain],
+        createdAt: new Date(),
+        updatedAt: new Date()
+    });
+    console.log('✓ settings/auth を作成 (許可ドメイン: ' + adminDomain + ')');
 
     // Gmail認証設定（Service Account方式 - Google Workspace向け）
     await db.doc('settings/gmail').set({


### PR DESCRIPTION
## Summary
- 許可ドメインのユーザーは自動的にログイン可能（ホワイトリスト個別登録不要）
- 初回ログイン時に `users` コレクションへ自動登録（権限: user）
- `setup-tenant.sh` で管理者メールアドレスのドメインを自動設定

## 動作フロー
```
ログイン → usersコレクション確認 → なければ許可ドメイン確認 → 許可なら自動登録
```

## Firestore設定
```
settings/auth
├── allowedDomains: ["kanameone.com"]
├── createdAt
└── updatedAt
```

## 変更ファイル
- `frontend/src/stores/authStore.ts`: ドメインチェック＆自動登録ロジック
- `scripts/setup-tenant.sh`: 許可ドメイン設定を追加

## 設定済み環境
- kanameone: `kanameone.com`
- dev: `gmail.com`（テスト用）

## Test plan
- [ ] @kanameone.com の新規ユーザーがログインできることを確認
- [ ] 自動で users コレクションに登録されることを確認
- [ ] 権限が `user` で登録されることを確認
- [ ] 許可ドメイン外のユーザーはログイン拒否されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added domain-based access control: users can now automatically register if their email domain is on the approval list; non-approved domains are denied access during sign-up.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->