### PR TITLE
fix: 検索機能の改善 - 検索窓統一と日付パース強化

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useCallback } from 'react'
 import {
-  Search,
   Filter,
   FileText,
   ChevronDown,
@@ -18,7 +17,6 @@ import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import { Timestamp } from 'firebase/firestore'
 import { Card, CardContent } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -126,7 +124,6 @@ export function DocumentsPage() {
   const [activeTab, setActiveTab] = useState<ViewTab>('list')
 
   // フィルター状態（一覧ビュー用）
-  const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<DocumentStatus | 'all'>('all')
   const [documentTypeFilter, setDocumentTypeFilter] = useState<string>('all')
   const [showFilters, setShowFilters] = useState(false)
@@ -139,8 +136,7 @@ export function DocumentsPage() {
   const filters: DocumentFilters = useMemo(() => ({
     status: statusFilter === 'all' ? undefined : statusFilter,
     documentType: documentTypeFilter === 'all' ? undefined : documentTypeFilter,
-    searchText: searchQuery || undefined,
-  }), [statusFilter, documentTypeFilter, searchQuery])
+  }), [statusFilter, documentTypeFilter])
 
   // データ取得
   const { data: documentsData, isLoading, isError, error } = useDocuments({ filters })
@@ -207,19 +203,9 @@ export function DocumentsPage() {
 
         {/* 書類一覧タブ */}
         <TabsContent value="list" className="space-y-4">
-          {/* 検索・フィルターバー */}
+          {/* フィルターバー */}
           <div className="space-y-4">
-            <div className="flex gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
-                <Input
-                  type="text"
-                  placeholder="書類名、顧客名で検索..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10"
-                />
-              </div>
+            <div className="flex justify-end">
               <Button
                 variant="outline"
                 onClick={() => setShowFilters(!showFilters)}
@@ -300,7 +286,7 @@ export function DocumentsPage() {
                 <FileText className="mb-4 h-12 w-12 text-gray-300" />
                 <p className="text-lg font-medium">書類がありません</p>
                 <p className="mt-1 text-sm">
-                  {searchQuery || statusFilter !== 'all' || documentTypeFilter !== 'all'
+                  {statusFilter !== 'all' || documentTypeFilter !== 'all'
                     ? '条件に一致する書類がありません'
                     : 'Gmailから添付ファイルが取得されると、ここに表示されます'}
                 </p>

--- a/functions/src/utils/tokenizer.ts
+++ b/functions/src/utils/tokenizer.ts
@@ -135,7 +135,7 @@ export function generateDateTokens(date: Date | null): string[] {
 /**
  * 日付文字列からトークンを生成
  *
- * @param dateStr 日付文字列（YYYY/MM/DD, YYYY-MM-DD など）
+ * @param dateStr 日付文字列（YYYY/MM/DD, YYYY-MM-DD, YYYY年MM月, YYYY年MM月DD日 など）
  * @returns 日付トークン配列
  */
 export function generateDateTokensFromString(dateStr: string | null): string[] {
@@ -151,12 +151,37 @@ export function generateDateTokensFromString(dateStr: string | null): string[] {
   }
 
   // YYYY年MM月DD日 形式
-  const jpMatch = dateStr.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
-  if (jpMatch) {
-    const year = parseInt(jpMatch[1]!, 10);
-    const month = parseInt(jpMatch[2]!, 10);
-    const day = parseInt(jpMatch[3]!, 10);
+  const jpFullMatch = dateStr.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
+  if (jpFullMatch) {
+    const year = parseInt(jpFullMatch[1]!, 10);
+    const month = parseInt(jpFullMatch[2]!, 10);
+    const day = parseInt(jpFullMatch[3]!, 10);
     return generateDateTokens(new Date(year, month - 1, day));
+  }
+
+  // YYYY年MM月 形式（日なし）- 月の最初の日として扱う
+  const jpMonthMatch = dateStr.match(/(\d{4})年(\d{1,2})月/);
+  if (jpMonthMatch) {
+    const year = parseInt(jpMonthMatch[1]!, 10);
+    const month = parseInt(jpMonthMatch[2]!, 10);
+    // 年月トークンを直接生成（日は含まない）
+    const monthStr = String(month).padStart(2, '0');
+    return [
+      String(year),  // YYYY
+      `${year}-${monthStr}`,  // YYYY-MM
+    ];
+  }
+
+  // YYYY/MM 形式（日なし）
+  const slashMonthMatch = dateStr.match(/(\d{4})\/(\d{1,2})(?!\/\d)/);
+  if (slashMonthMatch) {
+    const year = parseInt(slashMonthMatch[1]!, 10);
+    const month = parseInt(slashMonthMatch[2]!, 10);
+    const monthStr = String(month).padStart(2, '0');
+    return [
+      String(year),  // YYYY
+      `${year}-${monthStr}`,  // YYYY-MM
+    ];
   }
 
   return [];

--- a/scripts/migrate-search-index.js
+++ b/scripts/migrate-search-index.js
@@ -118,8 +118,10 @@ function generateDateTokens(date) {
   const month = String(dateObj.getMonth() + 1).padStart(2, '0');
   const day = String(dateObj.getDate()).padStart(2, '0');
 
-  // 各種形式のトークン
+  // 各種形式のトークン（検索クエリとマッチするように複数形式を生成）
   tokens.push(`${year}`);               // 2024
+  tokens.push(`${year}-${month}`);      // 2024-01（YYYY-MM形式）
+  tokens.push(`${year}-${month}-${day}`); // 2024-01-15（YYYY-MM-DD形式）
   tokens.push(`${year}${month}`);       // 202401
   tokens.push(`${year}${month}${day}`); // 20240115
   tokens.push(`${year}/${month}`);      // 2024/01


### PR DESCRIPTION
## Summary
- 検索窓を1つに統一（ヘッダーのグローバル検索に集約）
- 日付パースを強化（「2025年4月」「2025/04」形式をサポート）
- マイグレーションスクリプトの日付トークン生成を改善

## 変更内容

### 検索窓の統一
- `DocumentsPage`からタブ内のローカル検索（Input）を削除
- ヘッダーの`SearchBar`（バックエンドAPI検索）に統一
- 不要なimportとstateを削除

### 日付パースの強化
- `tokenizer.ts`: 「YYYY年MM月」「YYYY/MM」形式のサポートを追加
- `migrate-search-index.js`: `YYYY-MM`形式のトークン生成を追加

## Test plan
- [x] フロントエンドビルド確認
- [x] Functionsビルド確認
- [x] テスト実行（169テストパス）
- [x] dev環境デプロイ確認

## 注意事項
既存ドキュメントへの検索インデックス適用には、マイグレーションスクリプトの実行が必要:
```bash
node scripts/migrate-search-index.js --project=<project-id>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed search functionality from the Documents page; the filter panel now focuses exclusively on status and document type filtering options.

* **Bug Fixes**
  * Enhanced date format recognition for document indexing and queries to support multiple date format variations, improving search and filtering accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->