### PR TITLE
feat: PDF分割時のOCRマスター照合対応

### DIFF
--- a/frontend/src/components/PdfSplitModal.tsx
+++ b/frontend/src/components/PdfSplitModal.tsx
@@ -147,13 +147,43 @@ export function PdfSplitModal({
 
   // 分割実行
   const handleSplit = async () => {
-    const segmentsData = segments.map((segment) => ({
-      startPage: segment.startPage,
-      endPage: segment.endPage,
-      documentType: segment.documentType,
-      customerName: segment.customerName,
-      officeName: segment.officeName,
-    }))
+    const segmentsData = segments.map((segment) => {
+      // マスターデータからIDを解決
+      const customerMaster = customerMasters?.find(
+        (c) => c.name === segment.customerName
+      )
+      const officeMaster = officeMasters?.find(
+        (o) => o.name === segment.officeName
+      )
+
+      return {
+        startPage: segment.startPage,
+        endPage: segment.endPage,
+        documentType: segment.documentType,
+        customerName: segment.customerName,
+        customerId: segment.customerId || customerMaster?.id || null,
+        officeName: segment.officeName,
+        officeId: segment.officeId || officeMaster?.id || null,
+        // 候補情報（既存のセグメント情報があれば引き継ぐ）
+        customerCandidates: segment.customerCandidates || (customerMaster ? [{
+          id: customerMaster.id,
+          name: customerMaster.name,
+          score: 100,
+          isDuplicate: customerMaster.isDuplicate || false,
+          careManagerName: customerMaster.careManagerName,
+        }] : []),
+        officeCandidates: segment.officeCandidates || (officeMaster ? [{
+          id: officeMaster.id,
+          name: officeMaster.name,
+          score: 100,
+          isDuplicate: officeMaster.isDuplicate || false,
+        }] : []),
+        needsManualCustomerSelection: segment.needsManualCustomerSelection || false,
+        needsManualOfficeSelection: segment.needsManualOfficeSelection || false,
+        isDuplicateCustomer: segment.isDuplicateCustomer || customerMaster?.isDuplicate || false,
+        careManagerName: segment.careManagerName || customerMaster?.careManagerName || null,
+      }
+    })
 
     await splitPdf.mutateAsync({
       documentId: document.id,

--- a/frontend/src/hooks/usePdfSplit.ts
+++ b/frontend/src/hooks/usePdfSplit.ts
@@ -16,16 +16,43 @@ interface DetectSplitPointsResponse {
   suggestions: SplitSuggestion[]
 }
 
+interface SplitPdfSegment {
+  startPage: number
+  endPage: number
+  documentType: string
+  customerName: string
+  customerId?: string | null
+  officeName: string
+  officeId?: string | null
+  /** 顧客候補リスト */
+  customerCandidates?: Array<{
+    id: string
+    name: string
+    score: number
+    isDuplicate: boolean
+    careManagerName?: string
+  }>
+  /** 事業所候補リスト */
+  officeCandidates?: Array<{
+    id: string
+    name: string
+    score: number
+    isDuplicate: boolean
+  }>
+  /** 手動選択が必要か（顧客） */
+  needsManualCustomerSelection?: boolean
+  /** 手動選択が必要か（事業所） */
+  needsManualOfficeSelection?: boolean
+  /** 同姓同名の顧客か */
+  isDuplicateCustomer?: boolean
+  /** 担当ケアマネ名 */
+  careManagerName?: string | null
+}
+
 interface SplitPdfRequest {
   documentId: string
   splitPoints: number[]
-  segments: Array<{
-    startPage: number
-    endPage: number
-    documentType: string
-    customerName: string
-    officeName: string
-  }>
+  segments: SplitPdfSegment[]
 }
 
 interface SplitPdfResponse {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -347,8 +347,33 @@ export interface SplitSegment {
   suggestedFileName: string;
   documentType: string;
   customerName: string;
+  customerId?: string | null;
   officeName: string;
+  officeId?: string | null;
   fileDate: Date | null;
+  /** 顧客候補リスト */
+  customerCandidates?: Array<{
+    id: string;
+    name: string;
+    score: number;
+    isDuplicate: boolean;
+    careManagerName?: string;
+  }>;
+  /** 事業所候補リスト */
+  officeCandidates?: Array<{
+    id: string;
+    name: string;
+    score: number;
+    isDuplicate: boolean;
+  }>;
+  /** 手動選択が必要か（顧客） */
+  needsManualCustomerSelection?: boolean;
+  /** 手動選択が必要か（事業所） */
+  needsManualOfficeSelection?: boolean;
+  /** 同姓同名の顧客か */
+  isDuplicateCustomer?: boolean;
+  /** 担当ケアマネ名 */
+  careManagerName?: string | null;
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- PDF分割処理時にprocessOCRと同等のマスター照合を実装
- 分割後のドキュメントでも同姓同名解決UIやエイリアス学習が正しく機能するようになる
- 事業所候補の複数候補対応（顧客と同様のパターン）

## 主な変更
| ファイル | 内容 |
|----------|------|
| `extractors.ts` | `aggregateOfficeCandidates()`追加 |
| `pdfAnalyzer.ts` | `PdfSegment`に事業所候補関連フィールド追加 |
| `pdfOperations.ts` | マスター取得拡張、候補情報・確定フラグ保存 |
| `usePdfSplit.ts` | リクエスト型拡張 |
| `PdfSplitModal.tsx` | ID解決・候補情報送信 |
| `shared/types.ts` | `SplitSegment`型拡張 |

## Test plan
- [x] `npm run build` 成功
- [x] `npm test` 181 passing
- [x] lint警告なし（今回の変更分）
- [ ] PDF分割後に`customerCandidates`, `officeCandidates`が保存されることを確認
- [ ] 同姓同名顧客で分割し、解決UIが表示されることを確認
- [ ] `customerConfirmed=true`, `officeConfirmed=true`が設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PDF splitting with intelligent candidate matching for customers and offices
  * Added duplicate detection and handling for improved document accuracy
  * Improved manual selection workflows for ambiguous assignments
  * Extended metadata capture including care manager information
  * Multi-page candidate aggregation for more accurate entity matching across document segments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->