### PR TITLE
feat: 一覧のステータス列に「要確認」バッジを表示

### DIFF
--- a/frontend/src/components/views/GroupDocumentList.tsx
+++ b/frontend/src/components/views/GroupDocumentList.tsx
@@ -16,6 +16,7 @@ import {
   useGroupDocuments,
   type GroupType,
 } from '@/hooks/useDocumentGroups';
+import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
 import type { Document, DocumentStatus } from '@shared/types';
 
 // ============================================
@@ -72,6 +73,14 @@ function DocumentRow({ document, groupType, onClick }: DocumentRowProps) {
     variant: 'secondary' as const,
   };
 
+  // 要確認判定（顧客・事業所）
+  const needsCustomerConfirmation = !isCustomerConfirmed(document);
+  const needsOfficeConfirmation =
+    document.officeConfirmed === false &&
+    document.officeCandidates &&
+    document.officeCandidates.length > 0;
+  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation;
+
   // グループタイプに応じて表示するサブ情報を変更
   const getSubInfo = () => {
     switch (groupType) {
@@ -104,9 +113,15 @@ function DocumentRow({ document, groupType, onClick }: DocumentRowProps) {
         <span className="text-xs text-gray-500 hidden sm:inline">
           {formatTimestamp(document.fileDate)}
         </span>
-        <Badge variant={statusConfig.variant} className="text-xs">
-          {statusConfig.label}
-        </Badge>
+        {needsReview ? (
+          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
+            要確認
+          </Badge>
+        ) : (
+          <Badge variant={statusConfig.variant} className="text-xs">
+            {statusConfig.label}
+          </Badge>
+        )}
         <Button
           variant="ghost"
           size="sm"


### PR DESCRIPTION
## Summary
- 顧客または事業所が未確定の書類に「要確認」バッジを一覧画面で表示
- 詳細モーダルを開かなくても確認が必要な書類を識別可能に
- 既存の詳細モーダルと同じ判定ロジックを使用

## Test plan
- [ ] 顧客未確定の書類が一覧で「要確認」と表示されること
- [ ] 事業所未確定の書類が一覧で「要確認」と表示されること
- [ ] 確定済みの書類は従来通り「完了」と表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a visual confirmation indicator for documents requiring review. Documents needing customer or office confirmation now display an orange-outlined "要確認" badge.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->