### PR TITLE
feat: ローカルPDFアップロード機能

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -180,5 +180,12 @@ service cloud.firestore {
       // 書き込みはCloud Functions（addMasterAlias）のみ
       allow write: if false;
     }
+
+    // アップロードログ
+    match /uploadLogs/{logId} {
+      allow read: if isWhitelisted();
+      // 書き込みはCloud Functions（uploadPdf）のみ
+      allow write: if false;
+    }
   }
 }

--- a/frontend/src/components/PdfUploadModal.tsx
+++ b/frontend/src/components/PdfUploadModal.tsx
@@ -1,0 +1,311 @@
+/**
+ * PDFアップロードモーダル
+ *
+ * ローカルファイルからPDF/画像をアップロードしてOCR処理キューに追加
+ */
+
+import { useState, useRef, useCallback } from 'react'
+import { Upload, FileText, AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
+import { httpsCallable } from 'firebase/functions'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { functions } from '@/lib/firebase'
+
+// 設定
+const MAX_FILE_SIZE_MB = 10
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
+
+// 対象MIMEタイプ
+const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/tiff',
+  'image/gif',
+]
+
+const ALLOWED_EXTENSIONS = '.pdf,.jpg,.jpeg,.png,.tiff,.tif,.gif'
+
+interface PdfUploadModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess?: (documentId: string) => void
+}
+
+interface UploadResult {
+  success: boolean
+  documentId: string
+}
+
+export function PdfUploadModal({ open, onOpenChange, onSuccess }: PdfUploadModalProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [result, setResult] = useState<UploadResult | null>(null)
+  const [dragActive, setDragActive] = useState(false)
+
+  const resetState = useCallback(() => {
+    setSelectedFile(null)
+    setError(null)
+    setResult(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (!uploading) {
+      resetState()
+      onOpenChange(false)
+    }
+  }, [uploading, resetState, onOpenChange])
+
+  const validateFile = useCallback((file: File): string | null => {
+    // MIMEタイプチェック
+    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+      return `対応していないファイル形式です: ${file.type || '不明'}。PDF/JPEG/PNG/TIFF/GIF形式のファイルを選択してください。`
+    }
+
+    // ファイルサイズチェック
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return `ファイルサイズが大きすぎます: ${Math.round(file.size / 1024 / 1024)}MB。最大${MAX_FILE_SIZE_MB}MBまでです。`
+    }
+
+    return null
+  }, [])
+
+  const handleFileSelect = useCallback((file: File) => {
+    setError(null)
+    setResult(null)
+
+    const validationError = validateFile(file)
+    if (validationError) {
+      setError(validationError)
+      setSelectedFile(null)
+      return
+    }
+
+    setSelectedFile(file)
+  }, [validateFile])
+
+  const handleInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) {
+      handleFileSelect(file)
+    }
+  }, [handleFileSelect])
+
+  const handleDrag = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.type === 'dragenter' || e.type === 'dragover') {
+      setDragActive(true)
+    } else if (e.type === 'dragleave') {
+      setDragActive(false)
+    }
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragActive(false)
+
+    const file = e.dataTransfer.files?.[0]
+    if (file) {
+      handleFileSelect(file)
+    }
+  }, [handleFileSelect])
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile) return
+
+    setUploading(true)
+    setError(null)
+
+    try {
+      // ファイルをbase64に変換
+      const base64Data = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => {
+          const result = reader.result as string
+          // data:application/pdf;base64, の部分を除去
+          const base64 = result.split(',')[1]
+          resolve(base64)
+        }
+        reader.onerror = () => reject(new Error('ファイルの読み込みに失敗しました'))
+        reader.readAsDataURL(selectedFile)
+      })
+
+      // Cloud Function呼び出し
+      const uploadPdf = httpsCallable<
+        { fileName: string; mimeType: string; data: string },
+        UploadResult
+      >(functions, 'uploadPdf')
+
+      const response = await uploadPdf({
+        fileName: selectedFile.name,
+        mimeType: selectedFile.type,
+        data: base64Data,
+      })
+
+      setResult(response.data)
+      onSuccess?.(response.data.documentId)
+    } catch (err) {
+      console.error('Upload error:', err)
+
+      // エラーメッセージの抽出
+      let errorMessage = 'アップロードに失敗しました'
+      if (err instanceof Error) {
+        // Firebase Functions のエラーメッセージを解析
+        const message = err.message
+        if (message.includes('already-exists')) {
+          errorMessage = 'このファイルは既にアップロードされています'
+        } else if (message.includes('permission-denied')) {
+          errorMessage = 'アップロード権限がありません'
+        } else if (message.includes('invalid-argument')) {
+          // メッセージから詳細を抽出
+          const match = message.match(/: (.+)$/)
+          errorMessage = match ? match[1] : message
+        } else if (message.includes('unauthenticated')) {
+          errorMessage = 'ログインが必要です'
+        } else {
+          errorMessage = message
+        }
+      }
+      setError(errorMessage)
+    } finally {
+      setUploading(false)
+    }
+  }, [selectedFile, onSuccess])
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>PDFアップロード</DialogTitle>
+          <DialogDescription>
+            PDF/画像ファイルをアップロードしてOCR処理を行います
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* ドラッグ&ドロップエリア */}
+          <div
+            className={`
+              relative border-2 border-dashed rounded-lg p-8 text-center transition-colors
+              ${dragActive ? 'border-blue-500 bg-blue-50' : 'border-gray-300'}
+              ${uploading ? 'opacity-50 pointer-events-none' : 'cursor-pointer hover:border-gray-400'}
+            `}
+            onClick={() => !uploading && fileInputRef.current?.click()}
+            onDragEnter={handleDrag}
+            onDragLeave={handleDrag}
+            onDragOver={handleDrag}
+            onDrop={handleDrop}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ALLOWED_EXTENSIONS}
+              onChange={handleInputChange}
+              className="hidden"
+              disabled={uploading}
+            />
+
+            {selectedFile ? (
+              <div className="flex flex-col items-center gap-2">
+                <FileText className="h-10 w-10 text-blue-500" />
+                <p className="font-medium text-gray-900 truncate max-w-full">
+                  {selectedFile.name}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {formatFileSize(selectedFile.size)}
+                </p>
+                {!uploading && !result && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      resetState()
+                    }}
+                  >
+                    ファイルを変更
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-2">
+                <Upload className="h-10 w-10 text-gray-400" />
+                <p className="text-gray-600">
+                  クリックまたはドラッグ&ドロップでファイルを選択
+                </p>
+                <p className="text-sm text-gray-400">
+                  PDF, JPEG, PNG, TIFF, GIF（最大{MAX_FILE_SIZE_MB}MB）
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* エラー表示 */}
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>エラー</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* 成功メッセージ */}
+          {result && (
+            <Alert className="border-green-200 bg-green-50">
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <AlertTitle className="text-green-800">アップロード完了</AlertTitle>
+              <AlertDescription className="text-green-700">
+                ファイルがアップロードされました。OCR処理は数分後に自動実行されます。
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={handleClose} disabled={uploading}>
+            {result ? '閉じる' : 'キャンセル'}
+          </Button>
+          {!result && (
+            <Button
+              onClick={handleUpload}
+              disabled={!selectedFile || uploading}
+            >
+              {uploading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  アップロード中...
+                </>
+              ) : (
+                <>
+                  <Upload className="mr-2 h-4 w-4" />
+                  アップロード
+                </>
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -12,6 +12,7 @@ import {
   FolderOpen,
   UserCheck,
   History,
+  Upload,
 } from 'lucide-react'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
@@ -31,6 +32,7 @@ import { useDocuments, useDocumentStats, useDocumentMasters, type DocumentFilter
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
 import { DocumentDetailModal } from '@/components/DocumentDetailModal'
 import { AliasLearningHistoryModal } from '@/components/AliasLearningHistoryModal'
+import { PdfUploadModal } from '@/components/PdfUploadModal'
 import { GroupList } from '@/components/views'
 import { SearchBar } from '@/components/SearchBar'
 import type { Document, DocumentStatus } from '@shared/types'
@@ -142,6 +144,9 @@ export function DocumentsPage() {
   // 履歴モーダル
   const [showHistoryModal, setShowHistoryModal] = useState(false)
 
+  // アップロードモーダル
+  const [showUploadModal, setShowUploadModal] = useState(false)
+
   // モーダル状態（URLパラメータと同期）
   const selectedDocumentId = searchParams.get('doc')
 
@@ -180,15 +185,26 @@ export function DocumentsPage() {
       {/* ヘッダー */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl font-bold text-gray-900">書類管理</h1>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setShowHistoryModal(true)}
-          className="flex items-center gap-2"
-        >
-          <History className="h-4 w-4" />
-          学習履歴
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => setShowUploadModal(true)}
+            className="flex items-center gap-2"
+          >
+            <Upload className="h-4 w-4" />
+            PDFアップロード
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowHistoryModal(true)}
+            className="flex items-center gap-2"
+          >
+            <History className="h-4 w-4" />
+            学習履歴
+          </Button>
+        </div>
       </div>
 
       {/* 統計カード */}
@@ -356,6 +372,12 @@ export function DocumentsPage() {
       <AliasLearningHistoryModal
         open={showHistoryModal}
         onOpenChange={setShowHistoryModal}
+      />
+
+      {/* PDFアップロードモーダル */}
+      <PdfUploadModal
+        open={showUploadModal}
+        onOpenChange={setShowUploadModal}
       />
     </div>
   )

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -43,3 +43,6 @@ export { onDocumentWrite } from './triggers/updateDocumentGroups';
 // 検索機能
 export { searchDocuments } from './search/searchDocuments';
 export { onDocumentWriteSearchIndex } from './search/searchIndexer';
+
+// PDFアップロード
+export { uploadPdf } from './upload/uploadPdf';

--- a/functions/src/upload/uploadPdf.ts
+++ b/functions/src/upload/uploadPdf.ts
@@ -1,0 +1,203 @@
+/**
+ * PDFアップロード Cloud Function
+ *
+ * ローカルファイルからPDF/画像をアップロードしてOCR処理キューに追加
+ *
+ * 処理フロー:
+ * 1. 認証チェック（ホワイトリスト確認）
+ * 2. ファイルバリデーション（MIMEタイプ、サイズ）
+ * 3. MD5ハッシュで重複チェック
+ * 4. Cloud Storage保存
+ * 5. uploadLogs + documents (status: pending) 作成
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import * as crypto from 'crypto';
+import { sanitizeFilenameForStorage } from '../utils/fileNaming';
+
+const db = admin.firestore();
+const storage = admin.storage();
+
+// 設定
+const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
+// 対象MIMEタイプ
+const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/tiff',
+  'image/gif',
+];
+
+/**
+ * PDFアップロード Callable Function
+ *
+ * リクエスト: {
+ *   fileName: string,       // オリジナルファイル名
+ *   mimeType: string,       // MIMEタイプ
+ *   data: string,           // base64エンコードされたファイルデータ
+ * }
+ *
+ * レスポンス: {
+ *   success: true,
+ *   documentId: string,     // 作成されたdocumentのID
+ * }
+ */
+export const uploadPdf = onCall(
+  {
+    region: 'asia-northeast1',
+    memory: '512MiB',
+    timeoutSeconds: 120,
+  },
+  async (request) => {
+    // 1. 認証チェック
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Authentication required');
+    }
+
+    const uid = request.auth.uid;
+    const email = request.auth.token.email || '';
+
+    // ホワイトリスト確認
+    const userDoc = await db.doc(`users/${uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+
+    // 2. リクエストバリデーション
+    const { fileName, mimeType, data } = request.data;
+
+    if (!fileName || typeof fileName !== 'string') {
+      throw new HttpsError('invalid-argument', 'fileName is required');
+    }
+    if (!mimeType || typeof mimeType !== 'string') {
+      throw new HttpsError('invalid-argument', 'mimeType is required');
+    }
+    if (!data || typeof data !== 'string') {
+      throw new HttpsError('invalid-argument', 'data is required');
+    }
+
+    // MIMEタイプチェック
+    if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+      throw new HttpsError(
+        'invalid-argument',
+        `Unsupported file type: ${mimeType}. Allowed types: PDF, JPEG, PNG, TIFF, GIF`
+      );
+    }
+
+    // 3. base64デコード
+    let buffer: Buffer;
+    try {
+      buffer = Buffer.from(data, 'base64');
+    } catch {
+      throw new HttpsError('invalid-argument', 'Invalid base64 data');
+    }
+
+    // ファイルサイズチェック
+    if (buffer.length > MAX_FILE_SIZE_BYTES) {
+      throw new HttpsError(
+        'invalid-argument',
+        `File too large: ${Math.round(buffer.length / 1024 / 1024)}MB. Max: ${MAX_FILE_SIZE_MB}MB`
+      );
+    }
+
+    // 4. MD5ハッシュで重複チェック
+    const hash = crypto.createHash('md5').update(buffer).digest('hex');
+
+    // gmailLogsとuploadLogs両方で重複チェック
+    const [existingGmail, existingUpload] = await Promise.all([
+      db.collection('gmailLogs').where('hash', '==', hash).limit(1).get(),
+      db.collection('uploadLogs').where('hash', '==', hash).limit(1).get(),
+    ]);
+
+    if (!existingGmail.empty || !existingUpload.empty) {
+      throw new HttpsError(
+        'already-exists',
+        'This file has already been uploaded'
+      );
+    }
+
+    // 5. Cloud Storageに保存
+    const bucket = storage.bucket();
+    const storagePath = `original/upload_${Date.now()}_${sanitizeFilenameForStorage(fileName)}`;
+    const file = bucket.file(storagePath);
+    const fileSizeKB = Math.round(buffer.length / 1024);
+
+    try {
+      await file.save(buffer, {
+        metadata: {
+          contentType: mimeType,
+          metadata: {
+            originalFilename: fileName,
+            uploadedBy: uid,
+            uploadedByEmail: email,
+            uploadedAt: new Date().toISOString(),
+          },
+        },
+      });
+    } catch (error) {
+      console.error('Storage save error:', error);
+      throw new HttpsError('internal', 'Failed to save file to storage');
+    }
+
+    const fileUrl = `gs://${bucket.name}/${storagePath}`;
+
+    // 6. トランザクションで uploadLogs と documents を同時作成
+    const uploadLogRef = db.collection('uploadLogs').doc();
+    const docRef = db.collection('documents').doc();
+
+    try {
+      await db.runTransaction(async (transaction) => {
+        // uploadLogsに記録
+        transaction.set(uploadLogRef, {
+          fileName,
+          hash,
+          fileSizeKB,
+          uploadedAt: admin.firestore.FieldValue.serverTimestamp(),
+          uploadedBy: uid,
+          uploadedByEmail: email,
+          fileUrl,
+        });
+
+        // documents（status: pending）を作成
+        transaction.set(docRef, {
+          id: docRef.id,
+          processedAt: admin.firestore.FieldValue.serverTimestamp(),
+          fileId: uploadLogRef.id,
+          fileName,
+          mimeType,
+          ocrResult: '',
+          documentType: '',
+          customerName: '',
+          officeName: '',
+          fileUrl,
+          fileDate: null,
+          isDuplicateCustomer: false,
+          totalPages: 0,
+          targetPageNumber: 1,
+          status: 'pending',
+          sourceType: 'upload',
+        });
+      });
+    } catch (error) {
+      console.error('Firestore transaction error:', error);
+      // Storageのファイルを削除（ロールバック）
+      try {
+        await file.delete();
+      } catch {
+        console.error('Failed to delete orphaned file');
+      }
+      throw new HttpsError('internal', 'Failed to create document records');
+    }
+
+    console.log(`Uploaded file: ${fileName} → ${docRef.id}`);
+
+    return {
+      success: true,
+      documentId: docRef.id,
+    };
+  }
+);

--- a/functions/src/utils/fileNaming.ts
+++ b/functions/src/utils/fileNaming.ts
@@ -182,6 +182,26 @@ export function analyzeCustomerEntries(customers: CustomerAttribute[]): Customer
 }
 
 /**
+ * ファイル名を簡易サニタイズ（ストレージパス用）
+ *
+ * Cloud Storage保存時のファイル名サニタイズに使用
+ * - 禁止文字をアンダースコアに置換
+ * - 空白をアンダースコアに置換
+ * - 連続アンダースコアを統一
+ * - 最大200文字に切り詰め
+ *
+ * @param filename ファイル名
+ * @param maxLength 最大長（デフォルト: 200）
+ */
+export function sanitizeFilenameForStorage(filename: string, maxLength: number = 200): string {
+  return filename
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .slice(0, maxLength);
+}
+
+/**
  * ファイル名をサニタイズ
  *
  * 元GAS: sanitizeFileName_()

--- a/functions/test/fileNaming.test.ts
+++ b/functions/test/fileNaming.test.ts
@@ -6,6 +6,7 @@ import { expect } from 'chai';
 import {
   analyzeCustomerEntries,
   sanitizeFileName,
+  sanitizeFilenameForStorage,
   formatDateForFileName,
   shortenDocumentId,
   generateOptimalFileName,
@@ -97,6 +98,41 @@ describe('analyzeCustomerEntries', () => {
     const result = analyzeCustomerEntries(customers);
     expect(result.shouldSplit).to.be.true;
     expect(result.splitReason).to.include('3名を超えています');
+  });
+});
+
+describe('sanitizeFilenameForStorage', () => {
+  it('禁止文字をアンダースコアに置換', () => {
+    expect(sanitizeFilenameForStorage('file<test>.pdf')).to.equal('file_test_.pdf');
+    expect(sanitizeFilenameForStorage('path/to\\file')).to.equal('path_to_file');
+  });
+
+  it('空白をアンダースコアに置換', () => {
+    expect(sanitizeFilenameForStorage('test file name.pdf')).to.equal('test_file_name.pdf');
+  });
+
+  it('連続アンダースコアを統一', () => {
+    expect(sanitizeFilenameForStorage('test___file')).to.equal('test_file');
+  });
+
+  it('デフォルト200文字で切り詰め', () => {
+    const longName = 'a'.repeat(250);
+    const result = sanitizeFilenameForStorage(longName);
+    expect(result.length).to.equal(200);
+  });
+
+  it('カスタム長で切り詰め', () => {
+    const longName = 'a'.repeat(100);
+    const result = sanitizeFilenameForStorage(longName, 50);
+    expect(result.length).to.equal(50);
+  });
+
+  it('日本語ファイル名を保持', () => {
+    expect(sanitizeFilenameForStorage('介護保険被保険者証.pdf')).to.equal('介護保険被保険者証.pdf');
+  });
+
+  it('空文字列を処理', () => {
+    expect(sanitizeFilenameForStorage('')).to.equal('');
   });
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -11,6 +11,9 @@ import { Timestamp } from 'firebase/firestore';
 
 export type DocumentStatus = 'pending' | 'processing' | 'processed' | 'error' | 'split';
 
+/** ドキュメントのソースタイプ */
+export type SourceType = 'gmail' | 'upload';
+
 export interface Document {
   id: string;
   processedAt: Timestamp;
@@ -29,6 +32,7 @@ export interface Document {
   totalPages: number;
   targetPageNumber: number;
   status: DocumentStatus;
+  sourceType?: SourceType;
   careManager?: string;
   category?: string;
 
@@ -273,6 +277,20 @@ export interface GmailLog {
   processedAt: Timestamp;
   fileUrl: string;
   emailBody: string;
+}
+
+// ============================================
+// アップロードログ
+// ============================================
+
+export interface UploadLog {
+  fileName: string;
+  hash: string; // MD5ハッシュ（重複検知用）
+  fileSizeKB: number;
+  uploadedAt: Timestamp;
+  uploadedBy: string; // UID
+  uploadedByEmail: string;
+  fileUrl: string;
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- Gmail添付ファイル経由に加えて、ローカルファイルから直接PDFをアップロードしてOCR処理できる機能を追加
- 書類一覧ページのヘッダーに「PDFアップロード」ボタンを配置
- ドラッグ&ドロップ対応のモーダルUIを実装

## 主な変更点
| ファイル | 変更内容 |
|----------|----------|
| `shared/types.ts` | `SourceType`型、`UploadLog`インターフェース追加 |
| `functions/src/upload/uploadPdf.ts` | 新規Callable Function |
| `frontend/src/components/PdfUploadModal.tsx` | アップロードUI |
| `firestore.rules` | `uploadLogs`コレクションルール追加 |
| `functions/src/utils/fileNaming.ts` | `sanitizeFilenameForStorage`共通化 |

## 機能詳細
- 対応ファイル: PDF, JPEG, PNG, TIFF, GIF（最大10MB）
- MD5ハッシュによる重複チェック（Gmail経由・アップロード両方と照合）
- `sourceType`フィールドでソース識別可能（`gmail` / `upload`）
- アップロード後、既存の`processOCR`で自動処理（5分間隔）

## Test plan
- [ ] ローカル環境でPDFアップロード → documentsにpending状態で作成確認
- [ ] 重複ファイルアップロード → エラー表示確認
- [ ] 10MB超ファイル → クライアント側エラー確認
- [ ] 非対応ファイル形式 → エラー表示確認
- [ ] `npm test` パス確認（188 passing）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now upload PDF and image files (JPEG, PNG, TIFF, GIF) via drag-and-drop or file selection
  * File uploads are validated for supported formats with a 10 MB size limit
  * Real-time upload progress feedback with clear error handling
  
* **Tests**
  * Added comprehensive test coverage for file validation and handling utilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->