### PR TITLE
feat: ドキュメント削除機能を追加

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,29 +1,29 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
       },
     },
     defaultVariants: {

--- a/functions/src/documents/deleteDocument.ts
+++ b/functions/src/documents/deleteDocument.ts
@@ -1,0 +1,142 @@
+/**
+ * ドキュメント削除 Cloud Function
+ *
+ * 管理者のみがドキュメントを完全削除可能
+ *
+ * 処理フロー:
+ * 1. 認証チェック（管理者のみ）
+ * 2. documentId検証
+ * 3. Cloud Storage ファイル削除
+ * 4. gmailLogs または uploadLogs 削除（sourceType判定）
+ * 5. documents 削除
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+
+const db = admin.firestore();
+const storage = admin.storage();
+
+/**
+ * ドキュメント削除 Callable Function
+ *
+ * リクエスト: {
+ *   documentId: string,  // 削除対象のドキュメントID
+ * }
+ *
+ * レスポンス: {
+ *   success: true,
+ * }
+ */
+export const deleteDocument = onCall(
+  {
+    region: 'asia-northeast1',
+    memory: '256MiB',
+    timeoutSeconds: 60,
+  },
+  async (request) => {
+    // 1. 認証チェック
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Authentication required');
+    }
+
+    const uid = request.auth.uid;
+
+    // 管理者チェック
+    const userDoc = await db.doc(`users/${uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+
+    const userData = userDoc.data();
+    if (userData?.role !== 'admin') {
+      throw new HttpsError('permission-denied', 'Admin permission required');
+    }
+
+    // 2. リクエストバリデーション
+    const { documentId } = request.data;
+
+    if (!documentId || typeof documentId !== 'string') {
+      throw new HttpsError('invalid-argument', 'documentId is required');
+    }
+
+    // 3. ドキュメント取得
+    const docRef = db.collection('documents').doc(documentId);
+    const docSnapshot = await docRef.get();
+
+    if (!docSnapshot.exists) {
+      throw new HttpsError('not-found', 'Document not found');
+    }
+
+    const docData = docSnapshot.data()!;
+    const { fileUrl, fileId, sourceType } = docData;
+
+    const errors: string[] = [];
+
+    // 4. Cloud Storage ファイル削除
+    if (fileUrl && typeof fileUrl === 'string') {
+      try {
+        // gs://bucket-name/path/to/file 形式からパスを抽出
+        const match = fileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/);
+        if (match) {
+          const bucketName = match[1];
+          const filePath = match[2];
+          const bucket = storage.bucket(bucketName);
+          const file = bucket.file(filePath);
+
+          const [exists] = await file.exists();
+          if (exists) {
+            await file.delete();
+            console.log(`Deleted storage file: ${filePath}`);
+          } else {
+            console.log(`Storage file not found (already deleted?): ${filePath}`);
+          }
+        }
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        console.error('Failed to delete storage file:', errMsg);
+        errors.push(`Storage deletion failed: ${errMsg}`);
+      }
+    }
+
+    // 5. gmailLogs または uploadLogs 削除
+    if (fileId && typeof fileId === 'string') {
+      try {
+        const logCollection = sourceType === 'upload' ? 'uploadLogs' : 'gmailLogs';
+        const logRef = db.collection(logCollection).doc(fileId);
+        const logSnapshot = await logRef.get();
+
+        if (logSnapshot.exists) {
+          await logRef.delete();
+          console.log(`Deleted ${logCollection}/${fileId}`);
+        } else {
+          console.log(`Log not found (already deleted?): ${logCollection}/${fileId}`);
+        }
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        console.error('Failed to delete log:', errMsg);
+        errors.push(`Log deletion failed: ${errMsg}`);
+      }
+    }
+
+    // 6. documents 削除
+    try {
+      await docRef.delete();
+      console.log(`Deleted document: ${documentId}`);
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error('Failed to delete document:', errMsg);
+      throw new HttpsError('internal', `Failed to delete document: ${errMsg}`);
+    }
+
+    // 部分的なエラーがあっても、ドキュメント自体は削除成功とする
+    if (errors.length > 0) {
+      console.warn('Deletion completed with warnings:', errors);
+    }
+
+    return {
+      success: true,
+      warnings: errors.length > 0 ? errors : undefined,
+    };
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,3 +46,6 @@ export { onDocumentWriteSearchIndex } from './search/searchIndexer';
 
 // PDFアップロード
 export { uploadPdf } from './upload/uploadPdf';
+
+// ドキュメント削除
+export { deleteDocument } from './documents/deleteDocument';

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "name": "@docsplit/frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -3159,6 +3160,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",


### PR DESCRIPTION
## Summary
- 管理者が書類一覧からドキュメントを削除できる機能を追加
- 重複ファイルエラー時に既存ファイルを削除して再アップロード可能に

## Changes
- `deleteDocument` Callable Function追加
  - 管理者認証チェック
  - Cloud Storage ファイル削除
  - gmailLogs/uploadLogs エントリー削除
  - documents レコード削除
- フロントエンド削除UI
  - 管理者のみ表示されるアクションメニュー（...ボタン）
  - 削除確認ダイアログ（AlertDialog）
  - 削除後の自動リフレッシュ

## Test plan
- [ ] 管理者でログインし、書類一覧でアクションメニューが表示されることを確認
- [ ] 削除ボタンをクリックし、確認ダイアログが表示されることを確認
- [ ] 削除を実行し、ドキュメントが一覧から消えることを確認
- [ ] 同じファイルを再アップロードできることを確認
- [ ] 非管理者ユーザーではアクションメニューが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can delete documents via dropdown menu with confirmation dialog.

* **Style**
  * Enhanced button focus rings for improved keyboard navigation visibility.
  * Adjusted button sizes and hover states for consistent appearance across variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->