### PR TITLE
feat: PDF分割モーダルにプレビュー機能追加

### DIFF
--- a/frontend/src/components/PdfPageThumbnail.tsx
+++ b/frontend/src/components/PdfPageThumbnail.tsx
@@ -1,0 +1,100 @@
+/**
+ * PDFページサムネイルコンポーネント
+ * PDF分割モーダルで使用するサムネイル表示
+ */
+
+import { useState, memo } from 'react'
+import { Page } from 'react-pdf'
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface PdfPageThumbnailProps {
+  pageNumber: number
+  isSelected?: boolean
+  hasSplitAfter?: boolean
+  onClick?: (pageNumber: number) => void
+  width?: number
+}
+
+/**
+ * PDFページのサムネイル表示
+ * - 選択状態: 青い枠線
+ * - 分割ポイント: 下部に赤い線
+ */
+export const PdfPageThumbnail = memo(function PdfPageThumbnail({
+  pageNumber,
+  isSelected = false,
+  hasSplitAfter = false,
+  onClick,
+  width = 80,
+}: PdfPageThumbnailProps) {
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+
+  const handleClick = () => {
+    onClick?.(pageNumber)
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      {/* サムネイル */}
+      <div
+        onClick={handleClick}
+        className={cn(
+          'relative cursor-pointer rounded border-2 bg-white transition-all hover:shadow-md',
+          isSelected
+            ? 'border-blue-500 shadow-md ring-2 ring-blue-200'
+            : 'border-gray-200 hover:border-gray-300'
+        )}
+      >
+        {/* ローディング表示 */}
+        {isLoading && !hasError && (
+          <div
+            className="absolute inset-0 flex items-center justify-center bg-gray-50"
+            style={{ width, height: width * 1.4 }}
+          >
+            <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+          </div>
+        )}
+
+        {/* エラー表示 */}
+        {hasError && (
+          <div
+            className="flex items-center justify-center bg-gray-100 text-xs text-gray-400"
+            style={{ width, height: width * 1.4 }}
+          >
+            読込失敗
+          </div>
+        )}
+
+        {/* PDFページ */}
+        <Page
+          pageNumber={pageNumber}
+          width={width}
+          renderTextLayer={false}
+          renderAnnotationLayer={false}
+          onLoadSuccess={() => setIsLoading(false)}
+          onLoadError={() => {
+            setIsLoading(false)
+            setHasError(true)
+          }}
+          className={cn(isLoading && 'invisible')}
+        />
+
+        {/* ページ番号バッジ */}
+        <div className="absolute bottom-1 right-1 rounded bg-black/60 px-1.5 py-0.5 text-xs text-white">
+          {pageNumber}
+        </div>
+      </div>
+
+      {/* 分割ポイント（赤線） */}
+      {hasSplitAfter && (
+        <div className="mt-1 flex w-full items-center gap-1">
+          <div className="h-0.5 flex-1 bg-red-500" />
+          <span className="text-[10px] font-medium text-red-500">分割</span>
+          <div className="h-0.5 flex-1 bg-red-500" />
+        </div>
+      )}
+    </div>
+  )
+})

--- a/frontend/src/components/PdfSplitModal.tsx
+++ b/frontend/src/components/PdfSplitModal.tsx
@@ -8,8 +8,6 @@ import {
   Scissors,
   Plus,
   Trash2,
-  ChevronLeft,
-  ChevronRight,
   RotateCw,
   AlertCircle,
   CheckCircle2,
@@ -17,7 +15,6 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
   Dialog,
@@ -43,6 +40,7 @@ import {
   generateSplitPreview,
 } from '@/hooks/usePdfSplit'
 import { useDocumentMasters, useCustomerMasters, useOfficeMasters } from '@/hooks/useDocuments'
+import { PdfSplitPreview } from './PdfSplitPreview'
 import type { Document, SplitSuggestion, SplitSegment } from '@shared/types'
 
 interface PdfSplitModalProps {
@@ -209,7 +207,7 @@ export function PdfSplitModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-5xl max-h-[90vh] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Scissors className="h-5 w-5" />
@@ -223,68 +221,34 @@ export function PdfSplitModal({
         {!isConfirmStep ? (
           // ステップ1: 分割ポイント設定
           <div className="flex-1 overflow-hidden flex gap-4">
-            {/* 左側: ページプレビュー */}
-            <div className="w-1/2 flex flex-col">
+            {/* 左側: PDFプレビュー */}
+            <div className="w-1/2 flex flex-col min-h-[400px]">
+              {/* 回転ボタン */}
               <div className="flex items-center justify-between mb-2">
-                <span className="text-sm font-medium">
-                  ページ {currentPage} / {document.totalPages}
+                <span className="text-sm font-medium text-gray-600">
+                  サムネイルをクリックでページ選択
                 </span>
-                <div className="flex gap-1">
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => handleRotatePage(90)}
-                    disabled={rotatePdf.isPending}
-                    title="90度回転"
-                  >
-                    <RotateCw className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-
-              {/* ページサムネイル表示エリア */}
-              <div className="flex-1 bg-gray-100 rounded-lg flex items-center justify-center min-h-[300px]">
-                <div className="text-gray-500 text-center">
-                  <p>ページ {currentPage}</p>
-                  <p className="text-xs mt-1">
-                    (プレビューは実装予定)
-                  </p>
-                </div>
-              </div>
-
-              {/* ページナビゲーション */}
-              <div className="flex items-center justify-center gap-2 mt-2">
                 <Button
                   variant="outline"
-                  size="icon"
-                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                  disabled={currentPage === 1}
+                  size="sm"
+                  onClick={() => handleRotatePage(90)}
+                  disabled={rotatePdf.isPending}
+                  title="選択中のページを90度回転"
                 >
-                  <ChevronLeft className="h-4 w-4" />
+                  <RotateCw className="h-4 w-4 mr-1" />
+                  回転
                 </Button>
-                <Input
-                  type="number"
-                  min={1}
-                  max={document.totalPages}
-                  value={currentPage}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value)
-                    if (val >= 1 && val <= document.totalPages) {
-                      setCurrentPage(val)
-                    }
-                  }}
-                  className="w-20 text-center"
+              </div>
+
+              {/* PDFプレビュー（サムネイル一覧 + 拡大表示） */}
+              <div className="flex-1 border rounded-lg overflow-hidden">
+                <PdfSplitPreview
+                  fileUrl={document.fileUrl}
+                  totalPages={document.totalPages}
+                  currentPage={currentPage}
+                  splitPoints={splitPoints}
+                  onPageSelect={setCurrentPage}
                 />
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={() =>
-                    setCurrentPage((p) => Math.min(document.totalPages, p + 1))
-                  }
-                  disabled={currentPage === document.totalPages}
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
               </div>
 
               {/* 現在ページの後に分割ポイント追加 */}

--- a/frontend/src/components/PdfSplitPreview.tsx
+++ b/frontend/src/components/PdfSplitPreview.tsx
@@ -1,0 +1,195 @@
+/**
+ * PDF分割プレビューコンポーネント
+ * サムネイル一覧 + 選択ページ拡大表示
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { Document, Page, pdfjs } from 'react-pdf'
+import { Loader2, ZoomIn, ZoomOut } from 'lucide-react'
+import { PdfPageThumbnail } from './PdfPageThumbnail'
+import { Button } from '@/components/ui/button'
+
+// PDF.js worker設定
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
+
+interface PdfSplitPreviewProps {
+  fileUrl: string
+  totalPages: number
+  currentPage: number
+  splitPoints: number[]
+  onPageSelect: (pageNumber: number) => void
+}
+
+// 拡大表示のスケールオプション
+const PREVIEW_SCALES = [300, 400, 500]
+
+/**
+ * PDF分割用プレビュー
+ * - 上部: サムネイル一覧（グリッド表示、分割ポイント赤線付き）
+ * - 下部: 選択ページ拡大表示
+ */
+export function PdfSplitPreview({
+  fileUrl,
+  totalPages,
+  currentPage,
+  splitPoints,
+  onPageSelect,
+}: PdfSplitPreviewProps) {
+  const [numPages, setNumPages] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [previewWidth, setPreviewWidth] = useState(PREVIEW_SCALES[1])
+  const thumbnailContainerRef = useRef<HTMLDivElement>(null)
+  const selectedThumbnailRef = useRef<HTMLDivElement>(null)
+
+  const onDocumentLoadSuccess = useCallback(
+    ({ numPages }: { numPages: number }) => {
+      setNumPages(numPages)
+      setIsLoading(false)
+    },
+    []
+  )
+
+  // 選択ページが変わったらサムネイルをスクロール
+  useEffect(() => {
+    if (selectedThumbnailRef.current && thumbnailContainerRef.current) {
+      selectedThumbnailRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'center',
+      })
+    }
+  }, [currentPage])
+
+  // 分割ポイントかどうかをチェック
+  const hasSplitAfter = (pageNumber: number) => {
+    return splitPoints.includes(pageNumber)
+  }
+
+  // ズームイン
+  const handleZoomIn = () => {
+    const currentIndex = PREVIEW_SCALES.indexOf(previewWidth)
+    if (currentIndex < PREVIEW_SCALES.length - 1) {
+      setPreviewWidth(PREVIEW_SCALES[currentIndex + 1])
+    }
+  }
+
+  // ズームアウト
+  const handleZoomOut = () => {
+    const currentIndex = PREVIEW_SCALES.indexOf(previewWidth)
+    if (currentIndex > 0) {
+      setPreviewWidth(PREVIEW_SCALES[currentIndex - 1])
+    }
+  }
+
+  const pages = numPages || totalPages
+
+  return (
+    <div className="flex h-full flex-col">
+      <Document
+        file={fileUrl}
+        onLoadSuccess={onDocumentLoadSuccess}
+        loading={
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+            <span className="ml-2 text-gray-500">PDFを読み込み中...</span>
+          </div>
+        }
+        error={
+          <div className="flex h-full items-center justify-center text-red-500">
+            PDFの読み込みに失敗しました
+          </div>
+        }
+      >
+        {!isLoading && (
+          <>
+            {/* サムネイル一覧 */}
+            <div className="border-b bg-gray-50 p-2">
+              <div className="mb-1 text-xs font-medium text-gray-600">
+                ページ一覧（クリックで選択）
+              </div>
+              <div
+                ref={thumbnailContainerRef}
+                className="flex gap-2 overflow-x-auto pb-2"
+                style={{ maxHeight: '180px' }}
+              >
+                {Array.from({ length: pages }, (_, i) => i + 1).map((pageNum) => (
+                  <div
+                    key={pageNum}
+                    ref={pageNum === currentPage ? selectedThumbnailRef : null}
+                    className="flex-shrink-0"
+                  >
+                    <PdfPageThumbnail
+                      pageNumber={pageNum}
+                      isSelected={pageNum === currentPage}
+                      hasSplitAfter={hasSplitAfter(pageNum)}
+                      onClick={onPageSelect}
+                      width={70}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 選択ページ拡大表示 */}
+            <div className="flex-1 overflow-auto bg-gray-100 p-2">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">
+                  ページ {currentPage} / {pages}
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleZoomOut}
+                    disabled={previewWidth === PREVIEW_SCALES[0]}
+                  >
+                    <ZoomOut className="h-4 w-4" />
+                  </Button>
+                  <span className="min-w-[50px] text-center text-xs text-gray-500">
+                    {previewWidth}px
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleZoomIn}
+                    disabled={previewWidth === PREVIEW_SCALES[PREVIEW_SCALES.length - 1]}
+                  >
+                    <ZoomIn className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex justify-center">
+                <div className="rounded bg-white shadow-lg">
+                  <Page
+                    pageNumber={currentPage}
+                    width={previewWidth}
+                    renderTextLayer={false}
+                    renderAnnotationLayer={false}
+                    loading={
+                      <div
+                        className="flex items-center justify-center bg-white"
+                        style={{ width: previewWidth, height: previewWidth * 1.4 }}
+                      >
+                        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                      </div>
+                    }
+                  />
+                </div>
+              </div>
+
+              {/* 分割ポイント表示 */}
+              {hasSplitAfter(currentPage) && (
+                <div className="mt-3 flex items-center justify-center gap-2 rounded bg-red-50 p-2 text-sm text-red-600">
+                  <div className="h-0.5 w-8 bg-red-500" />
+                  <span>このページの後で分割</span>
+                  <div className="h-0.5 w-8 bg-red-500" />
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </Document>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- PDF分割モーダルにサムネイル一覧 + 拡大表示のプレビュー機能を追加
- 分割ポイントを赤い境界線で視覚化
- 既存のプレースホルダー（「プレビューは実装予定」）を実装に置き換え

## 変更内容
| ファイル | 変更 |
|---------|------|
| `PdfPageThumbnail.tsx` | 新規: サムネイル単体コンポーネント |
| `PdfSplitPreview.tsx` | 新規: プレビューレイアウト（サムネイル一覧 + 拡大表示） |
| `PdfSplitModal.tsx` | 修正: プレビューコンポーネント統合 |

## 機能
- サムネイルクリックでページ選択（青枠でハイライト）
- 選択ページの拡大表示（ズーム可能: 300px/400px/500px）
- 分割ポイントはサムネイル下に赤線で表示
- 自動スクロール（選択ページのサムネイルが見える位置に）

## Test plan
- [ ] PDF分割モーダルを開く
- [ ] サムネイル一覧が表示される
- [ ] サムネイルクリックでページ選択できる
- [ ] 選択ページが拡大表示される
- [ ] 「自動検出」で分割ポイントが赤線で表示される
- [ ] ズームイン/アウトが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF split preview now includes thumbnail-based page selection
  * Added zoom controls for enhanced preview visibility
  * Split points are visually indicated on thumbnails

* **Improvements**
  * Streamlined page rotation controls in split modal
  * Enhanced modal layout and navigation interface
  * Improved visual feedback for selected pages and loading states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->