### PR TITLE
feat: 担当CM別ビューに顧客サブグループ表示を追加

### DIFF
--- a/frontend/src/components/views/CustomerSubGroup.tsx
+++ b/frontend/src/components/views/CustomerSubGroup.tsx
@@ -1,0 +1,227 @@
+/**
+ * 顧客サブグループコンポーネント
+ *
+ * 担当CM別ビューで、ケアマネ配下のドキュメントを顧客ごとにグループ化して表示
+ */
+
+import { useState, useMemo } from 'react';
+import {
+  ChevronRight,
+  ChevronDown,
+  FileText,
+  Users,
+} from 'lucide-react';
+import { Timestamp } from 'firebase/firestore';
+import { Badge } from '@/components/ui/badge';
+import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
+import { getStatusConfig, formatTimestamp } from '@/lib/documentUtils';
+import type { Document } from '@shared/types';
+
+// ============================================
+// 型定義
+// ============================================
+
+interface CustomerSubGroupProps {
+  documents: Document[];
+  onDocumentSelect?: (documentId: string) => void;
+}
+
+interface CustomerGroup {
+  customerKey: string;
+  customerName: string;
+  documents: Document[];
+  latestAt: Timestamp | null;
+}
+
+
+function groupByCustomer(documents: Document[]): CustomerGroup[] {
+  const groupMap = new Map<string, CustomerGroup>();
+
+  for (const doc of documents) {
+    const key = doc.customerKey || doc.customerName || '未判定';
+    const name = doc.customerName || '未判定';
+
+    if (!groupMap.has(key)) {
+      groupMap.set(key, {
+        customerKey: key,
+        customerName: name,
+        documents: [],
+        latestAt: null,
+      });
+    }
+
+    const group = groupMap.get(key)!;
+    group.documents.push(doc);
+
+    // 最新日時を更新
+    if (doc.processedAt) {
+      if (!group.latestAt || doc.processedAt.toMillis() > group.latestAt.toMillis()) {
+        group.latestAt = doc.processedAt;
+      }
+    }
+  }
+
+  // 件数の多い順にソート
+  return Array.from(groupMap.values()).sort((a, b) => b.documents.length - a.documents.length);
+}
+
+// ============================================
+// ドキュメント行コンポーネント
+// ============================================
+
+interface DocumentRowProps {
+  document: Document;
+  onClick: () => void;
+}
+
+function DocumentRow({ document, onClick }: DocumentRowProps) {
+  const statusConfig = getStatusConfig(document.status);
+
+  // 要確認判定
+  const needsCustomerConfirmation = !isCustomerConfirmed(document);
+  const needsOfficeConfirmation =
+    document.officeConfirmed === false &&
+    document.officeCandidates &&
+    document.officeCandidates.length > 0;
+  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation;
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-2 cursor-pointer transition-colors hover:bg-gray-100"
+      onClick={onClick}
+    >
+      <FileText className="h-4 w-4 flex-shrink-0 text-gray-400" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 truncate">
+          {document.fileName}
+        </p>
+        <p className="text-xs text-gray-500 truncate">
+          {document.documentType || '未判定'}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <span className="text-xs text-gray-500 hidden sm:inline">
+          {formatTimestamp(document.fileDate)}
+        </span>
+        {needsReview ? (
+          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
+            要確認
+          </Badge>
+        ) : (
+          <Badge variant={statusConfig.variant} className="text-xs">
+            {statusConfig.label}
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// 顧客グループアイテムコンポーネント
+// ============================================
+
+interface CustomerGroupItemProps {
+  group: CustomerGroup;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onDocumentSelect?: (documentId: string) => void;
+}
+
+function CustomerGroupItem({
+  group,
+  isExpanded,
+  onToggle,
+  onDocumentSelect,
+}: CustomerGroupItemProps) {
+  return (
+    <div className="border-b border-gray-100 last:border-0">
+      {/* 顧客グループヘッダー */}
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-gray-100"
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-4 w-4 flex-shrink-0 text-gray-400" />
+        ) : (
+          <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-400" />
+        )}
+        <Users className="h-4 w-4 flex-shrink-0 text-blue-500" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-800 truncate">
+              {group.customerName}
+            </span>
+            <Badge variant="outline" className="text-xs">
+              {group.documents.length}件
+            </Badge>
+          </div>
+          <div className="text-xs text-gray-400 mt-0.5">
+            最終更新: {formatTimestamp(group.latestAt)}
+          </div>
+        </div>
+      </button>
+
+      {/* 顧客グループ内ドキュメント（展開時） */}
+      {isExpanded && (
+        <div className="bg-white border-t border-gray-50 ml-6">
+          {group.documents.map((doc) => (
+            <DocumentRow
+              key={doc.id}
+              document={doc}
+              onClick={() => onDocumentSelect?.(doc.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================
+// メインコンポーネント
+// ============================================
+
+export function CustomerSubGroup({
+  documents,
+  onDocumentSelect,
+}: CustomerSubGroupProps) {
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  // ドキュメントを顧客ごとにグループ化
+  const customerGroups = useMemo(() => groupByCustomer(documents), [documents]);
+
+  const toggleGroup = (customerKey: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(customerKey)) {
+        next.delete(customerKey);
+      } else {
+        next.add(customerKey);
+      }
+      return next;
+    });
+  };
+
+  if (customerGroups.length === 0) {
+    return (
+      <div className="py-4 text-center text-sm text-gray-500">
+        このグループには書類がありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-gray-100">
+      {customerGroups.map((group) => (
+        <CustomerGroupItem
+          key={group.customerKey}
+          group={group}
+          isExpanded={expandedGroups.has(group.customerKey)}
+          onToggle={() => toggleGroup(group.customerKey)}
+          onDocumentSelect={onDocumentSelect}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/documentUtils.ts
+++ b/frontend/src/lib/documentUtils.ts
@@ -1,0 +1,63 @@
+/**
+ * ドキュメント関連の共通ユーティリティ
+ *
+ * 複数コンポーネントで使用される定数・関数を集約
+ */
+
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { Timestamp } from 'firebase/firestore';
+import type { DocumentStatus } from '@shared/types';
+
+// ============================================
+// ステータス表示設定
+// ============================================
+
+export type BadgeVariant = 'default' | 'secondary' | 'success' | 'warning' | 'destructive';
+
+export interface StatusConfig {
+  label: string;
+  variant: BadgeVariant;
+}
+
+export const DOCUMENT_STATUS_CONFIG: Record<DocumentStatus, StatusConfig> = {
+  pending: { label: '待機中', variant: 'secondary' },
+  processing: { label: '処理中', variant: 'warning' },
+  processed: { label: '完了', variant: 'success' },
+  error: { label: 'エラー', variant: 'destructive' },
+  split: { label: '分割済', variant: 'default' },
+};
+
+export const DEFAULT_STATUS_CONFIG: StatusConfig = {
+  label: '不明',
+  variant: 'secondary',
+};
+
+/**
+ * ドキュメントステータスの表示設定を取得
+ */
+export function getStatusConfig(status: DocumentStatus): StatusConfig {
+  return DOCUMENT_STATUS_CONFIG[status] || DEFAULT_STATUS_CONFIG;
+}
+
+// ============================================
+// 日付フォーマット
+// ============================================
+
+/**
+ * Timestampを日付文字列にフォーマット
+ * @param timestamp Firestore Timestamp
+ * @param formatStr フォーマット文字列（デフォルト: yyyy/MM/dd）
+ * @returns フォーマットされた日付文字列、無効な場合は'-'
+ */
+export function formatTimestamp(
+  timestamp: Timestamp | null | undefined,
+  formatStr = 'yyyy/MM/dd'
+): string {
+  if (!timestamp) return '-';
+  try {
+    return format(timestamp.toDate(), formatStr, { locale: ja });
+  } catch {
+    return '-';
+  }
+}


### PR DESCRIPTION
## Summary
- 担当CM別ビューで、ケアマネ配下のドキュメントを顧客ごとにサブグループ化して表示
- 共通ユーティリティ（documentUtils.ts）を作成しDRY違反を解消

## 変更内容
- `CustomerSubGroup.tsx`: 顧客サブグループコンポーネント新規作成
- `GroupDocumentList.tsx`: careManagerタイプ時にサブグループ表示に切替
- `documentUtils.ts`: STATUS_CONFIG/formatTimestampを共通化

## 表示イメージ
```
担当CM別
└ 飯田 知美（N件）
  └ 顧客Aさん（2件）
  │  └ ドキュメント1
  │  └ ドキュメント2
  └ 顧客Bさん（1件）
     └ ドキュメント3
```

## Test plan
- [ ] dev環境でビルド成功を確認
- [ ] 担当CM別タブで顧客サブグループが表示されることを確認
- [ ] サブグループの展開/折りたたみが動作することを確認
- [ ] 他のグループビュー（顧客別、事業所別、書類種別）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable customer groups view that organizes documents by customer with detailed status and last update information per group.

* **Improvements**
  * Centralized and standardized document status display and timestamp formatting for consistent presentation throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->