### PR TITLE
feat: Gmail監視に送信元メールアドレスフィルター追加

### DIFF
--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -21,6 +21,7 @@ import type { AppSettings, User, UserRole } from '@shared/types'
 
 const DEFAULT_SETTINGS: AppSettings = {
   targetLabels: [],
+  targetSenders: [],
   labelSearchOperator: 'OR',
   errorNotificationEmails: [],
   gmailAccount: '',
@@ -37,6 +38,7 @@ async function fetchSettings(): Promise<AppSettings> {
   const data = docSnap.data()
   return {
     targetLabels: data.targetLabels || [],
+    targetSenders: data.targetSenders || [],
     labelSearchOperator: data.labelSearchOperator || 'OR',
     errorNotificationEmails: data.errorNotificationEmails || [],
     gmailAccount: data.gmailAccount || '',

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -310,6 +310,7 @@ export type LabelSearchOperator = 'AND' | 'OR';
 
 export interface AppSettings {
   targetLabels: string[]; // 監視対象Gmailラベル
+  targetSenders: string[]; // 監視対象送信元メールアドレス
   labelSearchOperator: LabelSearchOperator;
   errorNotificationEmails: string[];
   gmailAccount?: string; // 監視対象Gmailアカウント


### PR DESCRIPTION
## Summary
- Gmail監視設定に「監視対象送信元」フィールドを追加
- 送信元メールアドレスを指定して、そこから届いたメールの添付ファイルを取得可能に
- ラベルと送信元の併用をサポート（OR条件）

## 変更内容
- `shared/types.ts`: `AppSettings`に`targetSenders`追加
- `functions/src/gmail/checkGmailAttachments.ts`: `buildSearchQuery`を拡張
- `frontend/src/hooks/useSettings.ts`: 設定の読み書き対応
- `frontend/src/pages/SettingsPage.tsx`: 送信元入力UI追加

## 動作
| 設定 | 結果 |
|------|------|
| ラベルのみ | そのラベルのメールを取得 |
| 送信元のみ | その送信元からのメールを取得 |
| 両方設定 | いずれかに該当するメールを取得（OR） |

## Test plan
- [ ] ローカルで設定画面を開き、送信元メールアドレスを追加・削除できることを確認
- [ ] 保存後、Firestoreに`targetSenders`が保存されることを確認
- [ ] Cloud Functionsログで正しいクエリが生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to filter and monitor emails by sender addresses in addition to labels.
  * New settings interface for adding and managing multiple target senders with add/remove actions.
  * Added informational panel displaying active filter combinations and their behavioral impact.
  * Introduced confirmation dialog for pending sender entries before saving settings.
  * Conditional AND/OR toggle now appears only when multiple labels are configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->