### PR TITLE
fix: CIでのTypeScriptエラーを修正

### DIFF
--- a/functions/test/ocrProcessor.test.ts
+++ b/functions/test/ocrProcessor.test.ts
@@ -140,7 +140,7 @@ describe('ocrProcessor', () => {
 
     it('処理完了後は再処理できない', () => {
       // Given: 処理が完了したドキュメント
-      const currentStatus = 'processed';
+      const currentStatus: string = 'processed';
 
       // 新しいリクエストが来た場合
       const canProcess = currentStatus === 'pending';


### PR DESCRIPTION
## Summary
- ocrProcessor.test.ts: リテラル型推論によるTS2367エラーを回避

## 背景
PR #37マージ後のCIで`const currentStatus = 'processed'`がリテラル型として推論され、`'pending'`との比較でTypeScriptエラー発生。

## Test plan
- [x] npm test 通過（225件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced type safety in test suite to improve code robustness and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->