### PR TITLE
fix: PdfUploadModalのresetState参照エラーを修正

### DIFF
--- a/frontend/src/components/PdfUploadModal.tsx
+++ b/frontend/src/components/PdfUploadModal.tsx
@@ -82,6 +82,18 @@ export function PdfUploadModal({ open, onOpenChange, onSuccess }: PdfUploadModal
     suggestedFileName: string
   } | null>(null)
 
+  // 状態リセット関数（useEffectより前に定義）
+  const resetState = useCallback(() => {
+    setSelectedFile(null)
+    setError(null)
+    setCurrentStep('idle')
+    setDocumentId(null)
+    setDuplicateInfo(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }, [])
+
   // OCR処理完了を監視
   useEffect(() => {
     if (!documentId || currentStep === 'processed' || currentStep === 'error') {
@@ -126,17 +138,6 @@ export function PdfUploadModal({ open, onOpenChange, onSuccess }: PdfUploadModal
       return () => clearTimeout(timer)
     }
   }, [currentStep, onOpenChange, resetState])
-
-  const resetState = useCallback(() => {
-    setSelectedFile(null)
-    setError(null)
-    setCurrentStep('idle')
-    setDocumentId(null)
-    setDuplicateInfo(null)
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ''
-    }
-  }, [])
 
   const handleClose = useCallback(() => {
     if (currentStep !== 'uploading') {


### PR DESCRIPTION
## Summary
- `PdfUploadModal`で`ReferenceError: Cannot access 'resetState' before initialization`エラーが発生していた問題を修正
- kanameone環境でアプリが正常に動作しない原因となっていた

## Root Cause
- `resetState`が`useCallback`で定義される前に、`useEffect`の依存配列で参照されていた
- JavaScriptのTemporal Dead Zone (TDZ)により、`const`変数が宣言前にアクセスされるとエラーになる

## Changes
- `resetState`の定義を`useEffect`より前に移動

## Test plan
- [ ] kanameone環境でアプリが正常に起動することを確認
- [ ] PDFアップロードモーダルが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for better maintainability in the PDF upload modal component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->