### PR TITLE
feat: 書類一覧に一括操作機能を追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -56,7 +56,11 @@ service cloud.firestore {
           // OCR結果確認ステータスフィールド
           'verified',
           'verifiedBy',
-          'verifiedAt'
+          'verifiedAt',
+          // 再処理用フィールド（一括再処理）
+          'status',
+          'ocrResult',
+          'error'
         ])
         // confirmedBy は自分のUIDのみ設定可能（事業所解決時は含まれない場合あり）
         && (request.resource.data.confirmedBy == request.auth.uid


### PR DESCRIPTION
## Summary
- 書類一覧画面にチェックボックスによる複数選択機能を追加（管理者のみ）
- 一括確認済み / 一括再処理 / 一括削除の3つの一括操作を実装
- Firestoreルールにstatus/ocrResult/errorフィールドの更新権限を追加

## Test plan
- [ ] 書類一覧で複数選択できることを確認
- [ ] 「確認済み」ボタンで選択した書類がverified=trueになることを確認
- [ ] 「再処理」ボタンで選択した書類がstatus=pendingになりOCR再実行されることを確認
- [ ] 「削除」ボタンで選択した書類が削除されることを確認（管理者のみ）
- [ ] 非管理者ユーザーにはチェックボックスが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk selection capabilities with per-document checkboxes (admin-only) to select multiple documents.
  * Enabled batch operations to verify, reprocess, or delete selected documents simultaneously.
  * Implemented confirmation dialogs for all bulk actions to ensure intentional execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->