### PR TITLE
feat: 確認済みをチェックマークアイコンで表示

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -195,20 +195,18 @@ function DocumentRow({
       <td className="px-2 py-2 text-xs text-gray-700 sm:px-4 sm:py-3 sm:text-sm">{formatDateTime(document.processedAt)}</td>
       <td className="hidden px-4 py-3 text-gray-700 md:table-cell">{formatTimestamp(document.fileDate)}</td>
       <td className="px-2 py-2 sm:px-4 sm:py-3">
-        <div className="flex items-center gap-1 flex-wrap">
-          {needsReview ? (
-            <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
-              要確認
-            </Badge>
-          ) : (
-            <Badge variant={statusConfig.variant} className="text-xs sm:text-sm">{statusConfig.label}</Badge>
-          )}
-          {isUnverified && (
-            <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-300 text-xs">
-              未確認
-            </Badge>
-          )}
-        </div>
+        {needsReview ? (
+          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
+            要確認
+          </Badge>
+        ) : (
+          <Badge variant={statusConfig.variant} className="text-xs sm:text-sm">{statusConfig.label}</Badge>
+        )}
+      </td>
+      <td className="px-2 py-2 sm:px-3 sm:py-3 text-center">
+        {!isUnverified && (
+          <CheckCircle2 className="h-5 w-5 text-green-500 inline-block" />
+        )}
       </td>
     </tr>
   )
@@ -748,6 +746,9 @@ export function DocumentsPage() {
                       <SortableHeader label="登録日" field="processedAt" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} />
                       <SortableHeader label="書類日付" field="fileDate" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} hideOnMobile />
                       <SortableHeader label="ステータス" field="status" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} />
+                      <th className="px-2 py-2 text-center text-xs font-medium text-gray-700 sm:px-3 sm:py-3 sm:text-sm w-12">
+                        <CheckCircle2 className="h-4 w-4 text-gray-400 inline-block" />
+                      </th>
                     </tr>
                   </thead>
                   <tbody>


### PR DESCRIPTION
## Summary
- ステータス列の「未確認」バッジを削除してスッキリ
- 右端に確認済みチェックマーク列を追加
- 緑✓で確認済み、空欄で未確認を視覚的に表示

## Before
```
ステータス
[完了] [未確認]  ← 2つのバッジで混雑
```

## After
```
ステータス    ✓
[完了]       ✓   ← スッキリ
```

## Test plan
- [ ] 確認済みドキュメントに緑チェックが表示される
- [ ] 未確認ドキュメントはチェック列が空欄

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified document status badges by consolidating multiple status indicators into a single, streamlined badge displayed per table row
  * Added a new verification check icon column to the documents table to display verification status for each document
  * Reorganized table structure, row layout, and overall visual organization to accommodate the redesigned status display

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->