### PR TITLE
fix: 確認ステータス変更時のリアルタイム反映を修正

### DIFF
--- a/frontend/src/hooks/useDocumentVerification.ts
+++ b/frontend/src/hooks/useDocumentVerification.ts
@@ -43,6 +43,7 @@ export function useDocumentVerification(
       })
       // 一覧画面のキャッシュも無効化
       queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       onSuccess?.()
       return true
     } catch (err) {
@@ -73,6 +74,7 @@ export function useDocumentVerification(
       })
       // 一覧画面のキャッシュも無効化
       queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       onSuccess?.()
       return true
     } catch (err) {


### PR DESCRIPTION
## Summary
- 確認ステータストグル変更時に一覧のチェックマークがリアルタイムで更新されない問題を修正

## 原因
- `useDocumentVerification`が`['documents']`のみ無効化
- 一覧画面は`useInfiniteDocuments`を使用（queryKey: `['documentsInfinite']`）

## 修正
- `documentsInfinite`クエリも無効化するよう追加

## Test plan
- [ ] 詳細画面で確認トグルをON → 一覧のチェックマークが即座に表示される
- [ ] 詳細画面で確認トグルをOFF → 一覧のチェックマークが即座に消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)