### PR TITLE
feat: PDFビューワの表示範囲を拡大

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -669,7 +669,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
     <>
     <Dialog open={open} onOpenChange={handleOpenChange} modal={false}>
       <DialogContent
-        className="flex h-[90vh] w-[95vw] max-w-7xl flex-col p-0 md:w-auto"
+        className="flex h-[90vh] w-[95vw] max-w-[1600px] flex-col p-0 md:w-auto"
         aria-describedby={undefined}
         onInteractOutside={(e) => {
           // ポップアップ表示中やPDF分割モーダル表示中は外側クリックでDialogを閉じない
@@ -807,7 +807,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
 
               {/* メタ情報サイドバー（モバイル: 下部表示・折りたたみ可、デスクトップ: サイドバー） */}
               <div
-                className={`w-full border-t bg-white transition-all duration-200 md:flex md:h-auto md:w-80 md:flex-col md:flex-shrink-0 md:border-l md:border-t-0 md:p-4 ${
+                className={`w-full border-t bg-white transition-all duration-200 md:flex md:h-auto md:w-72 md:flex-col md:flex-shrink-0 md:border-l md:border-t-0 md:p-4 ${
                   isMetadataCollapsed
                     ? 'h-12 flex-shrink-0 overflow-hidden px-3 py-2'
                     : 'min-h-0 max-h-[45vh] flex-shrink-0 overflow-y-auto overscroll-contain p-3 [-webkit-overflow-scrolling:touch] md:max-h-none'


### PR DESCRIPTION
## Summary
PDFビューワの表示エリアをシンプルに拡大

## 変更内容
| 項目 | Before | After | 差分 |
|------|--------|-------|------|
| モーダル最大幅 | 1280px | 1600px | +320px |
| 情報パネル幅 | 320px | 288px | -32px |
| **PDFエリア** | 960px | 1312px | **+352px** |

## Test plan
- [ ] デスクトップでPDFが以前より大きく表示される
- [ ] 情報パネルの内容が読める
- [ ] モバイル表示に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)