### PR TITLE
fix: PDFフィットモードのスケール上限を130%に設定

### DIFF
--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -191,7 +191,7 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     )
   }, [documentId, rotation, currentPage, saveRotation, onRotationSaved])
 
-  // フィットスケールを計算（幅にフィット）
+  // フィットスケールを計算（幅にフィット、最大130%）
   const calculateFitScale = useCallback(() => {
     if (!pageSize) return 1
 
@@ -199,8 +199,9 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     const isRotated = rotation === 90 || rotation === 270
     const pageWidth = isRotated ? pageSize.height : pageSize.width
 
-    // 幅にフィット（モバイルでも横幅いっぱいに表示）
-    return containerSize.width / pageWidth
+    // 幅にフィット（最大130%に制限）
+    const fitScale = containerSize.width / pageWidth
+    return Math.min(fitScale, 1.3)
   }, [pageSize, containerSize, rotation])
 
   // 実際の表示幅を計算


### PR DESCRIPTION
## Summary
PDFビューワの「フィット」モードで過度に拡大される問題を修正

## 問題
- ビューワ幅が広くなると、フィットモードで200%以上に拡大される
- 拡大後に「フィット」を押しても過度な拡大状態に戻る

## 修正
- フィットスケールに上限130%を設定
- 幅が広くても適切なサイズで表示

## Test plan
- [ ] フィットモードでPDFが130%以上に拡大されない
- [ ] 拡大/縮小後に「フィット」を押すと130%以下で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF viewer zoom scaling has been improved when using fit-to-width mode. The maximum zoom level is now capped at 130%, preventing content from being magnified excessively and ensuring pages display at appropriate proportions for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->