### PR TITLE
fix: PDFビューワの初期表示サイズをフィットと一致させる

### DIFF
--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -191,7 +191,7 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     )
   }, [documentId, rotation, currentPage, saveRotation, onRotationSaved])
 
-  // フィットスケールを計算（幅にフィット、最大130%）
+  // フィットスケールを計算（幅にフィット、最大125%）
   const calculateFitScale = useCallback(() => {
     if (!pageSize) return 1
 
@@ -206,7 +206,11 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
 
   // 実際の表示幅を計算
   const getDisplayWidth = useCallback(() => {
-    if (!pageSize) return containerSize.width
+    if (!pageSize) {
+      // ページサイズ未取得時も125%上限を適用（A4幅595ptを基準に推定）
+      const estimatedMaxWidth = Math.round(595 * 1.25) // ~744px
+      return Math.min(containerSize.width, estimatedMaxWidth)
+    }
 
     if (zoomMode === 'fit') {
       const fitScale = calculateFitScale()


### PR DESCRIPTION
## Summary
- PDFビューワの初期表示時にも125%上限を適用
- ページサイズ未取得時はA4幅（595pt）を基準に最大幅を推定

## 問題
初期表示時は `pageSize` が null のため `containerSize.width` がそのまま使われ、フィットボタンを押した後のサイズより大きく表示されていた。

## 修正内容
`getDisplayWidth()` でページサイズ未取得時も125%上限を適用するよう修正。

## Test plan
- [ ] PDFビューワを開いた初期表示がフィットボタンを押した時と同じサイズになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF scaling behavior to consistently enforce a 125% maximum zoom level, ensuring uniform display quality throughout document loading and viewing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->