### PR TITLE
perf: 確認ステータスの楽観的更新で即時反映

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -345,13 +345,13 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
 
   const queryClient = useQueryClient()
 
-  // 確認ステータス管理
+  // 確認ステータス管理（楽観的更新で即時反映）
   const {
     isUpdating: isVerifying,
     error: verifyError,
     markAsVerified,
     markAsUnverified,
-  } = useDocumentVerification(document, refetch)
+  } = useDocumentVerification(document)
 
   // 編集機能
   const {
@@ -851,8 +851,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                             markAsUnverified()
                           }
                         }}
-                        disabled={isEditing}
-                        className="data-[state=checked]:bg-green-500 cursor-pointer"
+                        disabled={isEditing || isVerifying}
+                        className={`data-[state=checked]:bg-green-500 cursor-pointer ${isVerifying ? 'opacity-50' : ''}`}
                       />
                       <span className={`text-xs font-medium ${document.verified ? 'text-green-700' : 'text-gray-500'}`}>
                         {document.verified ? '確認済み' : '未確認'}

--- a/frontend/src/hooks/useDocumentVerification.ts
+++ b/frontend/src/hooks/useDocumentVerification.ts
@@ -1,10 +1,11 @@
 /**
  * ドキュメント確認ステータス管理フック
  * OCR結果の人的確認状態を管理
+ * 楽観的更新でUIの即時反映を実現
  */
 
 import { useState, useCallback } from 'react'
-import { doc, updateDoc, serverTimestamp } from 'firebase/firestore'
+import { doc, updateDoc, serverTimestamp, Timestamp } from 'firebase/firestore'
 import { useQueryClient } from '@tanstack/react-query'
 import { db, auth } from '../lib/firebase'
 import type { Document } from '../../../shared/types'
@@ -17,12 +18,45 @@ interface UseDocumentVerificationResult {
 }
 
 export function useDocumentVerification(
-  document: Document | null | undefined,
-  onSuccess?: () => void
+  document: Document | null | undefined
 ): UseDocumentVerificationResult {
   const [isUpdating, setIsUpdating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const queryClient = useQueryClient()
+
+  // 楽観的更新: キャッシュを即座に更新
+  const optimisticUpdate = useCallback((verified: boolean) => {
+    if (!document) return
+
+    const newData = {
+      verified,
+      verifiedBy: verified ? auth.currentUser?.uid : null,
+      verifiedAt: verified ? Timestamp.now() : null,
+    }
+
+    // 個別ドキュメントのキャッシュを更新
+    queryClient.setQueryData(['document', document.id], (old: Document | undefined) => {
+      if (!old) return old
+      return { ...old, ...newData }
+    })
+
+    // 一覧のキャッシュも更新（無限スクロール）
+    queryClient.setQueriesData<{ pages: { documents: Document[] }[] }>(
+      { queryKey: ['documentsInfinite'] },
+      (old) => {
+        if (!old) return old
+        return {
+          ...old,
+          pages: old.pages.map(page => ({
+            ...page,
+            documents: page.documents.map(doc =>
+              doc.id === document.id ? { ...doc, ...newData } : doc
+            ),
+          })),
+        }
+      }
+    )
+  }, [document, queryClient])
 
   const markAsVerified = useCallback(async (): Promise<boolean> => {
     if (!document || !auth.currentUser) {
@@ -33,6 +67,10 @@ export function useDocumentVerification(
     setIsUpdating(true)
     setError(null)
 
+    // 楽観的更新（即座にUIに反映）
+    const previousVerified = document.verified
+    optimisticUpdate(true)
+
     try {
       const docRef = doc(db, 'documents', document.id)
       await updateDoc(docRef, {
@@ -41,19 +79,17 @@ export function useDocumentVerification(
         verifiedAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       })
-      // 一覧画面のキャッシュも無効化
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      onSuccess?.()
       return true
     } catch (err) {
       console.error('Failed to mark as verified:', err)
       setError(err instanceof Error ? err.message : '確認済みにできませんでした')
+      // エラー時はロールバック
+      optimisticUpdate(previousVerified || false)
       return false
     } finally {
       setIsUpdating(false)
     }
-  }, [document, onSuccess, queryClient])
+  }, [document, optimisticUpdate])
 
   const markAsUnverified = useCallback(async (): Promise<boolean> => {
     if (!document || !auth.currentUser) {
@@ -64,6 +100,10 @@ export function useDocumentVerification(
     setIsUpdating(true)
     setError(null)
 
+    // 楽観的更新（即座にUIに反映）
+    const previousVerified = document.verified
+    optimisticUpdate(false)
+
     try {
       const docRef = doc(db, 'documents', document.id)
       await updateDoc(docRef, {
@@ -72,19 +112,17 @@ export function useDocumentVerification(
         verifiedAt: null,
         updatedAt: serverTimestamp(),
       })
-      // 一覧画面のキャッシュも無効化
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      onSuccess?.()
       return true
     } catch (err) {
       console.error('Failed to mark as unverified:', err)
       setError(err instanceof Error ? err.message : '未確認に戻せませんでした')
+      // エラー時はロールバック
+      optimisticUpdate(previousVerified || false)
       return false
     } finally {
       setIsUpdating(false)
     }
-  }, [document, onSuccess, queryClient])
+  }, [document, optimisticUpdate])
 
   return {
     isUpdating,


### PR DESCRIPTION
## Summary
- 確認ステータスの切り替えで楽観的更新を実装
- トグル操作時に即座にUIが反映されるよう改善
- 不要なネットワークリクエスト（refetchコールバック）を削除

## 問題
確認ステータスの更新時に以下の問題があった：
1. Firestore更新完了を待ってからUIに反映
2. クエリ無効化による再取得を待機
3. 不要なrefetchコールバックによる二重取得

## 修正内容
- `setQueryData`で即座にキャッシュを更新（楽観的更新）
- エラー時はロールバックで整合性を担保
- 更新中は視覚的なフィードバック（opacity）を追加

## Test plan
- [ ] 確認トグルを切り替えた時に即座にUIが反映されること
- [ ] 一覧のチェックマークも即座に更新されること
- [ ] 閉じる時の確認ダイアログが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)