### PR TITLE
fix: PDFビューワのフィットモードでコンテナ幅いっぱいに表示

### DIFF
--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -191,7 +191,7 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     )
   }, [documentId, rotation, currentPage, saveRotation, onRotationSaved])
 
-  // フィットスケールを計算（幅にフィット、最大125%）
+  // フィットスケールを計算（コンテナ幅にフィット）
   const calculateFitScale = useCallback(() => {
     if (!pageSize) return 1
 
@@ -199,17 +199,15 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     const isRotated = rotation === 90 || rotation === 270
     const pageWidth = isRotated ? pageSize.height : pageSize.width
 
-    // 幅にフィット（最大125%に制限 - ズーム単位と合わせる）
-    const fitScale = containerSize.width / pageWidth
-    return Math.min(fitScale, 1.25)
+    // コンテナ幅にフィット（上限なし）
+    return containerSize.width / pageWidth
   }, [pageSize, containerSize, rotation])
 
   // 実際の表示幅を計算
   const getDisplayWidth = useCallback(() => {
     if (!pageSize) {
-      // ページサイズ未取得時も125%上限を適用（A4幅595ptを基準に推定）
-      const estimatedMaxWidth = Math.round(595 * 1.25) // ~744px
-      return Math.min(containerSize.width, estimatedMaxWidth)
+      // ページサイズ未取得時はコンテナ幅を使用
+      return containerSize.width
     }
 
     if (zoomMode === 'fit') {


### PR DESCRIPTION
## Summary
- 125%スケール上限を削除
- フィットモードでコンテナ幅いっぱいにPDFを表示

## 背景
125%上限を設けたことで、PDFが小さく表示されモーダルサイズも縮小していた。
ユーザーからのフィードバック：125%時のモーダルサイズがちょうど良いサイズだった。

## 修正内容
- `calculateFitScale`から125%上限を削除
- 初期表示時もコンテナ幅をそのまま使用

## Test plan
- [ ] PDFビューワの初期表示が以前の125%時と同じサイズになること
- [ ] フィットボタンを押した時も同じサイズになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)