### PR TITLE
fix: モーダルサイズを固定し、PDF拡大時はスクロールで対応

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -669,7 +669,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
     <>
     <Dialog open={open} onOpenChange={handleOpenChange} modal={false}>
       <DialogContent
-        className="flex h-[90vh] w-[95vw] max-w-[1600px] flex-col p-0 md:w-auto [&>button.absolute]:hidden"
+        className="flex h-[90vh] w-[95vw] max-w-[1100px] flex-col p-0 [&>button.absolute]:hidden"
         aria-describedby={undefined}
         onInteractOutside={(e) => {
           // ポップアップ表示中やPDF分割モーダル表示中は外側クリックでDialogを閉じない

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -191,7 +191,7 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     )
   }, [documentId, rotation, currentPage, saveRotation, onRotationSaved])
 
-  // フィットスケールを計算（コンテナ幅にフィット）
+  // フィットスケールを計算（コンテナ幅にフィット、最大125%）
   const calculateFitScale = useCallback(() => {
     if (!pageSize) return 1
 
@@ -199,15 +199,17 @@ export function PdfViewer({ fileUrl, totalPages, documentId, onRotationSaved }: 
     const isRotated = rotation === 90 || rotation === 270
     const pageWidth = isRotated ? pageSize.height : pageSize.width
 
-    // コンテナ幅にフィット（上限なし）
-    return containerSize.width / pageWidth
+    // コンテナ幅にフィット（最大125%に制限）
+    const fitScale = containerSize.width / pageWidth
+    return Math.min(fitScale, 1.25)
   }, [pageSize, containerSize, rotation])
 
   // 実際の表示幅を計算
   const getDisplayWidth = useCallback(() => {
     if (!pageSize) {
-      // ページサイズ未取得時はコンテナ幅を使用
-      return containerSize.width
+      // ページサイズ未取得時も125%上限を適用（A4幅595ptを基準）
+      const estimatedMaxWidth = Math.round(595 * 1.25) // ~744px
+      return Math.min(containerSize.width, estimatedMaxWidth)
     }
 
     if (zoomMode === 'fit') {


### PR DESCRIPTION
## Summary
- モーダルサイズを固定（125%時のサイズ）
- PDF拡大時はモーダル内でスクロール

## 修正内容
- `md:w-auto` を削除してモーダルがコンテンツに追従しないよう変更
- モーダル幅を `max-w-[1100px]` に固定（PDF 744px + サイドバー 288px + パディング）
- PDFフィットモードは125%上限を維持

## Test plan
- [ ] モーダルの初期サイズが125%時と同じこと
- [ ] PDF拡大時にモーダルが大きくならずスクロールすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the maximum width constraint of the document detail modal for improved layout
  * Implemented a 125% scaling cap for the PDF viewer fit-to-width feature
  * Enhanced display width calculation for improved PDF viewing boundaries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->