### PR TITLE
fix: キャッシュヘッダー設定を追加し古いビルド問題を解決

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,26 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
+    ],
     "rewrites": [
       {
         "source": "**",


### PR DESCRIPTION
## Summary
- index.htmlにno-cache設定を追加（デプロイ後は常に最新を取得）
- /assets/**にimmutable設定を追加（ハッシュ付きファイルは長期キャッシュ）

## 背景
ユーザーが「Cannot access 'A' before initialization」エラーで使用できない問題が発生。
原因は古いindex.htmlがブラウザにキャッシュされ、削除済みの古いJSファイルを参照していたため。

## 効果
デプロイ後にユーザーが古いビルドを参照し続ける問題を防止。

## Test plan
- [ ] デプロイ後、シークレットモードで動作確認
- [ ] 通常モードでハードリフレッシュなしで最新が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching strategy to enable faster app updates and improve asset loading performance on repeat visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->