### PR TITLE
fix: SPAのキャッシュヘッダー設定を修正

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,20 +15,20 @@
     ],
     "headers": [
       {
-        "source": "/index.html",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache, no-store, must-revalidate"
-          }
-        ]
-      },
-      {
         "source": "/assets/**",
         "headers": [
           {
             "key": "Cache-Control",
             "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      },
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- `/index.html` → `**` に変更（SPAのrewriteに対応）
- `/assets/**`を先に定義し、それ以外を`**`でキャッチ

## 背景
PR #55 でキャッシュヘッダーを追加したが、SPAのrewrite動作により`/index.html`にマッチしなかった。
Firebase Hostingではrewriteされてもヘッダーはオリジナルのリクエストパスに基づいて適用される。

## 確認結果（修正前）
```
$ curl -sI https://doc-split-dev.web.app/ | grep cache-control
cache-control: max-age=3600  # ← デフォルトのまま
```

## Test plan
- [ ] デプロイ後、`curl -sI https://doc-split-dev.web.app/ | grep cache-control` で `no-cache` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized browser caching configuration to improve page load speeds
  * Static resources now benefit from extended caching for faster repeat visits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->