### PR TITLE
fix: 書類一覧の無限スクロールが動作しない問題を修正

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -734,15 +734,14 @@ export function DocumentsPage() {
                     ))}
                   </tbody>
                 </table>
+                {/* 無限スクロール読み込みインジケーター（スクロールコンテナ内に配置） */}
+                <LoadMoreIndicator
+                  ref={loadMoreRef}
+                  hasNextPage={hasNextPage}
+                  isFetchingNextPage={isFetchingNextPage}
+                  className="border-t border-gray-100"
+                />
               </div>
-
-              {/* 無限スクロール読み込みインジケーター */}
-              <LoadMoreIndicator
-                ref={loadMoreRef}
-                hasNextPage={hasNextPage}
-                isFetchingNextPage={isFetchingNextPage}
-                className="border-t border-gray-100"
-              />
             </>
             )}
           </Card>


### PR DESCRIPTION
## Summary
- LoadMoreIndicatorが`overflow-auto`スクロールコンテナの外に配置されていたため、IntersectionObserverが発火しなかった
- コンテナ内（tableの直後）に移動して修正

## Test plan
- [ ] 書類一覧: スクロール末尾で自動読み込みされること
- [ ] 処理履歴: 引き続き正常動作すること
- [x] 全テスト通過（23/23）
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)