### PR TITLE
fix: 書類一覧をページ全体スクロール化し無限スクロールを正常動作させる

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -697,9 +697,9 @@ export function DocumentsPage() {
               </div>
             ) : (
               <>
-              <div className="overflow-auto max-h-[calc(100vh-280px)]">
+              <div className="overflow-x-auto">
                 <table className="w-full">
-                  <thead className="border-b border-gray-200 bg-gray-50 sticky top-0 z-10">
+                  <thead className="border-b border-gray-200 bg-gray-50">
                     <tr>
                       {isAdmin && (
                         <th className="px-2 py-2 sm:px-3 sm:py-3 w-10">
@@ -734,14 +734,14 @@ export function DocumentsPage() {
                     ))}
                   </tbody>
                 </table>
-                {/* 無限スクロール読み込みインジケーター（スクロールコンテナ内に配置） */}
-                <LoadMoreIndicator
-                  ref={loadMoreRef}
-                  hasNextPage={hasNextPage}
-                  isFetchingNextPage={isFetchingNextPage}
-                  className="border-t border-gray-100"
-                />
               </div>
+              {/* 無限スクロール読み込みインジケーター（ページスクロールで検知） */}
+              <LoadMoreIndicator
+                ref={loadMoreRef}
+                hasNextPage={hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                className="border-t border-gray-100"
+              />
             </>
             )}
           </Card>


### PR DESCRIPTION
## Summary
- テーブルの`overflow-auto max-h-[calc(100vh-280px)]`を撤廃し、ページ全体スクロールに変更
- LoadMoreIndicatorをページスクロールで検知される位置に配置
- PR #59の修正では不十分だった問題の根本対応

## Test plan
- [x] E2E確認: 書類一覧でページスクロール＋無限スクロール正常動作
- [x] E2E確認: 処理履歴の無限スクロール引き続き正常
- [x] 全ユニットテスト通過（23/23）
- [x] ビルド成功
- [x] dev/kanameone両環境にデプロイ済み・動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)