### PR TITLE
feat: 顧客別あいうえお順ソート＋あかさたなフィルター対応

### DIFF
--- a/frontend/src/components/KanaFilterBar.tsx
+++ b/frontend/src/components/KanaFilterBar.tsx
@@ -1,0 +1,50 @@
+/**
+ * あかさたなフィルターバー
+ *
+ * 顧客別グループビューで、ふりがなの行で絞り込むフィルターUI
+ */
+
+import { KANA_ROWS, type KanaRow } from '@/lib/kanaUtils';
+import { cn } from '@/lib/utils';
+
+interface KanaFilterBarProps {
+  selected: KanaRow | null;
+  onSelect: (row: KanaRow | null) => void;
+}
+
+export function KanaFilterBar({ selected, onSelect }: KanaFilterBarProps) {
+  return (
+    <div className="flex gap-1 overflow-x-auto pb-1 -mx-1 px-1">
+      {/* 全ボタン */}
+      <button
+        data-active={selected === null ? 'true' : 'false'}
+        className={cn(
+          'flex-shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+          selected === null
+            ? 'bg-gray-800 text-white'
+            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+        )}
+        onClick={() => onSelect(null)}
+      >
+        全
+      </button>
+
+      {/* あかさたな行ボタン */}
+      {KANA_ROWS.map((row) => (
+        <button
+          key={row}
+          data-active={selected === row ? 'true' : 'false'}
+          className={cn(
+            'flex-shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+            selected === row
+              ? 'bg-gray-800 text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          )}
+          onClick={() => onSelect(selected === row ? null : row)}
+        >
+          {row}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/KanaFilterBar.test.tsx
+++ b/frontend/src/components/__tests__/KanaFilterBar.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * KanaFilterBar 単体テスト
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KanaFilterBar } from '../KanaFilterBar';
+
+describe('KanaFilterBar', () => {
+  it('「全」ボタンと10行のボタンを表示', () => {
+    render(<KanaFilterBar selected={null} onSelect={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '全' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'あ' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'か' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'さ' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'た' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'な' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'は' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'ま' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'や' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'ら' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'わ' })).toBeDefined();
+  });
+
+  it('selected=nullのとき「全」がアクティブ', () => {
+    render(<KanaFilterBar selected={null} onSelect={vi.fn()} />);
+    const allButton = screen.getByRole('button', { name: '全' });
+    expect(allButton.getAttribute('data-active')).toBe('true');
+  });
+
+  it('selected="か"のとき「か」がアクティブ', () => {
+    render(<KanaFilterBar selected="か" onSelect={vi.fn()} />);
+    const kaButton = screen.getByRole('button', { name: 'か' });
+    expect(kaButton.getAttribute('data-active')).toBe('true');
+    const allButton = screen.getByRole('button', { name: '全' });
+    expect(allButton.getAttribute('data-active')).toBe('false');
+  });
+
+  it('行ボタンクリックでonSelectが行を返す', () => {
+    const onSelect = vi.fn();
+    render(<KanaFilterBar selected={null} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'さ' }));
+    expect(onSelect).toHaveBeenCalledWith('さ');
+  });
+
+  it('「全」クリックでonSelect(null)を返す', () => {
+    const onSelect = vi.fn();
+    render(<KanaFilterBar selected="か" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '全' }));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('既に選択中の行をクリックするとnullを返す（トグル）', () => {
+    const onSelect = vi.fn();
+    render(<KanaFilterBar selected="た" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'た' }));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/src/components/views/GroupDocumentList.tsx
+++ b/frontend/src/components/views/GroupDocumentList.tsx
@@ -25,6 +25,7 @@ import type { Document } from '@shared/types';
 interface GroupDocumentListProps {
   groupType: GroupType;
   groupKey: string;
+  furiganaMap?: Map<string, string>;
   onDocumentSelect?: (documentId: string) => void;
 }
 
@@ -111,6 +112,7 @@ function DocumentRow({ document, groupType, onClick }: DocumentRowProps) {
 export function GroupDocumentList({
   groupType,
   groupKey,
+  furiganaMap,
   onDocumentSelect,
 }: GroupDocumentListProps) {
   const {
@@ -164,6 +166,7 @@ export function GroupDocumentList({
       <div className="max-h-[500px] overflow-y-auto">
         <CustomerSubGroup
           documents={allDocuments}
+          furiganaMap={furiganaMap}
           onDocumentSelect={onDocumentSelect}
         />
 

--- a/frontend/src/hooks/useDocumentGroups.ts
+++ b/frontend/src/hooks/useDocumentGroups.ts
@@ -46,7 +46,7 @@ export interface DocumentGroup {
 
 export interface UseDocumentGroupsOptions {
   groupType: GroupType;
-  sortBy?: 'count' | 'latestAt';
+  sortBy?: 'count' | 'latestAt' | 'none';
   limitCount?: number;
   enabled?: boolean;
 }
@@ -75,15 +75,21 @@ const GROUP_KEY_FIELD: Record<GroupType, string> = {
 
 async function fetchDocumentGroups(
   groupType: GroupType,
-  sortBy: 'count' | 'latestAt',
+  sortBy: 'count' | 'latestAt' | 'none',
   limitCount: number
 ): Promise<DocumentGroup[]> {
-  const q = query(
-    collection(db, 'documentGroups'),
-    where('groupType', '==', groupType),
-    orderBy(sortBy, 'desc'),
-    limit(limitCount)
-  );
+  // 顧客別はクライアントソート（あいうえお順）のため orderBy/limit なしで全件取得
+  const q = sortBy === 'none'
+    ? query(
+        collection(db, 'documentGroups'),
+        where('groupType', '==', groupType)
+      )
+    : query(
+        collection(db, 'documentGroups'),
+        where('groupType', '==', groupType),
+        orderBy(sortBy, 'desc'),
+        limit(limitCount)
+      );
 
   const snapshot = await getDocs(q);
 

--- a/frontend/src/lib/__tests__/kanaUtils.test.ts
+++ b/frontend/src/lib/__tests__/kanaUtils.test.ts
@@ -1,0 +1,303 @@
+/**
+ * kanaUtils テスト
+ * あかさたな分類・ふりがなソートのユーティリティ
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  KANA_ROWS,
+  getKanaRow,
+  buildFuriganaMap,
+  sortGroupsByFurigana,
+  filterGroupsByKanaRow,
+} from '../kanaUtils';
+import type { CustomerMaster } from '@shared/types';
+
+// ============================================
+// getKanaRow
+// ============================================
+
+describe('getKanaRow', () => {
+  it('ひらがな「あ」行を正しく分類', () => {
+    expect(getKanaRow('あ')).toBe('あ');
+    expect(getKanaRow('い')).toBe('あ');
+    expect(getKanaRow('う')).toBe('あ');
+    expect(getKanaRow('え')).toBe('あ');
+    expect(getKanaRow('お')).toBe('あ');
+  });
+
+  it('ひらがな「か」行を正しく分類', () => {
+    expect(getKanaRow('か')).toBe('か');
+    expect(getKanaRow('き')).toBe('か');
+    expect(getKanaRow('く')).toBe('か');
+    expect(getKanaRow('け')).toBe('か');
+    expect(getKanaRow('こ')).toBe('か');
+  });
+
+  it('ひらがな「さ」行を正しく分類', () => {
+    expect(getKanaRow('さ')).toBe('さ');
+    expect(getKanaRow('し')).toBe('さ');
+    expect(getKanaRow('す')).toBe('さ');
+    expect(getKanaRow('せ')).toBe('さ');
+    expect(getKanaRow('そ')).toBe('さ');
+  });
+
+  it('ひらがな「た」行を正しく分類', () => {
+    expect(getKanaRow('た')).toBe('た');
+    expect(getKanaRow('ち')).toBe('た');
+    expect(getKanaRow('つ')).toBe('た');
+    expect(getKanaRow('て')).toBe('た');
+    expect(getKanaRow('と')).toBe('た');
+  });
+
+  it('ひらがな「な」行を正しく分類', () => {
+    expect(getKanaRow('な')).toBe('な');
+    expect(getKanaRow('に')).toBe('な');
+    expect(getKanaRow('ぬ')).toBe('な');
+    expect(getKanaRow('ね')).toBe('な');
+    expect(getKanaRow('の')).toBe('な');
+  });
+
+  it('ひらがな「は」行を正しく分類', () => {
+    expect(getKanaRow('は')).toBe('は');
+    expect(getKanaRow('ひ')).toBe('は');
+    expect(getKanaRow('ふ')).toBe('は');
+    expect(getKanaRow('へ')).toBe('は');
+    expect(getKanaRow('ほ')).toBe('は');
+  });
+
+  it('ひらがな「ま」行を正しく分類', () => {
+    expect(getKanaRow('ま')).toBe('ま');
+    expect(getKanaRow('み')).toBe('ま');
+    expect(getKanaRow('む')).toBe('ま');
+    expect(getKanaRow('め')).toBe('ま');
+    expect(getKanaRow('も')).toBe('ま');
+  });
+
+  it('ひらがな「や」行を正しく分類', () => {
+    expect(getKanaRow('や')).toBe('や');
+    expect(getKanaRow('ゆ')).toBe('や');
+    expect(getKanaRow('よ')).toBe('や');
+  });
+
+  it('ひらがな「ら」行を正しく分類', () => {
+    expect(getKanaRow('ら')).toBe('ら');
+    expect(getKanaRow('り')).toBe('ら');
+    expect(getKanaRow('る')).toBe('ら');
+    expect(getKanaRow('れ')).toBe('ら');
+    expect(getKanaRow('ろ')).toBe('ら');
+  });
+
+  it('ひらがな「わ」行を正しく分類', () => {
+    expect(getKanaRow('わ')).toBe('わ');
+    expect(getKanaRow('を')).toBe('わ');
+    expect(getKanaRow('ん')).toBe('わ');
+  });
+
+  it('カタカナをひらがなに変換して分類', () => {
+    expect(getKanaRow('ア')).toBe('あ');
+    expect(getKanaRow('カ')).toBe('か');
+    expect(getKanaRow('サ')).toBe('さ');
+    expect(getKanaRow('タ')).toBe('た');
+    expect(getKanaRow('ナ')).toBe('な');
+    expect(getKanaRow('ハ')).toBe('は');
+    expect(getKanaRow('マ')).toBe('ま');
+    expect(getKanaRow('ヤ')).toBe('や');
+    expect(getKanaRow('ラ')).toBe('ら');
+    expect(getKanaRow('ワ')).toBe('わ');
+    expect(getKanaRow('ン')).toBe('わ');
+  });
+
+  it('濁音・半濁音を清音として分類', () => {
+    expect(getKanaRow('が')).toBe('か');
+    expect(getKanaRow('ざ')).toBe('さ');
+    expect(getKanaRow('だ')).toBe('た');
+    expect(getKanaRow('ば')).toBe('は');
+    expect(getKanaRow('ぱ')).toBe('は');
+    // カタカナ濁音
+    expect(getKanaRow('ガ')).toBe('か');
+    expect(getKanaRow('ザ')).toBe('さ');
+    expect(getKanaRow('ダ')).toBe('た');
+    expect(getKanaRow('バ')).toBe('は');
+    expect(getKanaRow('パ')).toBe('は');
+  });
+
+  it('小文字かなを正しく分類', () => {
+    expect(getKanaRow('ぁ')).toBe('あ');
+    expect(getKanaRow('ぃ')).toBe('あ');
+    expect(getKanaRow('ぅ')).toBe('あ');
+    expect(getKanaRow('ぇ')).toBe('あ');
+    expect(getKanaRow('ぉ')).toBe('あ');
+    expect(getKanaRow('っ')).toBe('た');
+    expect(getKanaRow('ゃ')).toBe('や');
+    expect(getKanaRow('ゅ')).toBe('や');
+    expect(getKanaRow('ょ')).toBe('や');
+  });
+
+  it('かな以外はnullを返す', () => {
+    expect(getKanaRow('田')).toBeNull();
+    expect(getKanaRow('A')).toBeNull();
+    expect(getKanaRow('1')).toBeNull();
+    expect(getKanaRow('')).toBeNull();
+  });
+});
+
+// ============================================
+// KANA_ROWS
+// ============================================
+
+describe('KANA_ROWS', () => {
+  it('10行が定義されている', () => {
+    expect(KANA_ROWS).toEqual(['あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ']);
+  });
+});
+
+// ============================================
+// buildFuriganaMap
+// ============================================
+
+describe('buildFuriganaMap', () => {
+  const customers: CustomerMaster[] = [
+    { id: '1', name: '田中太郎', furigana: 'たなかたろう', isDuplicate: false },
+    { id: '2', name: '鈴木花子', furigana: 'すずきはなこ', isDuplicate: false },
+    { id: '3', name: '佐藤一郎', furigana: 'さとういちろう', isDuplicate: false },
+  ];
+
+  it('顧客名→ふりがなのMapを構築', () => {
+    const map = buildFuriganaMap(customers);
+    expect(map.get('田中太郎')).toBe('たなかたろう');
+    expect(map.get('鈴木花子')).toBe('すずきはなこ');
+    expect(map.get('佐藤一郎')).toBe('さとういちろう');
+  });
+
+  it('存在しない名前はundefined', () => {
+    const map = buildFuriganaMap(customers);
+    expect(map.get('山田次郎')).toBeUndefined();
+  });
+
+  it('空配列でも動作', () => {
+    const map = buildFuriganaMap([]);
+    expect(map.size).toBe(0);
+  });
+
+  it('furiganaが空文字の場合もマップに含まれる', () => {
+    const customersWithEmpty: CustomerMaster[] = [
+      { id: '1', name: '不明者', furigana: '', isDuplicate: false },
+    ];
+    const map = buildFuriganaMap(customersWithEmpty);
+    expect(map.get('不明者')).toBe('');
+  });
+});
+
+// ============================================
+// sortGroupsByFurigana
+// ============================================
+
+describe('sortGroupsByFurigana', () => {
+  const furiganaMap = new Map([
+    ['田中太郎', 'たなかたろう'],
+    ['鈴木花子', 'すずきはなこ'],
+    ['佐藤一郎', 'さとういちろう'],
+    ['安藤美咲', 'あんどうみさき'],
+    ['渡辺健太', 'わたなべけんた'],
+  ]);
+
+  const groups = [
+    { id: '1', displayName: '渡辺健太' },
+    { id: '2', displayName: '田中太郎' },
+    { id: '3', displayName: '鈴木花子' },
+    { id: '4', displayName: '佐藤一郎' },
+    { id: '5', displayName: '安藤美咲' },
+  ];
+
+  it('ふりがな順（あいうえお順）にソートされる', () => {
+    const sorted = sortGroupsByFurigana(groups, furiganaMap);
+    expect(sorted.map((g) => g.displayName)).toEqual([
+      '安藤美咲',   // あんどうみさき
+      '佐藤一郎',   // さとういちろう
+      '鈴木花子',   // すずきはなこ
+      '田中太郎',   // たなかたろう
+      '渡辺健太',   // わたなべけんた
+    ]);
+  });
+
+  it('ふりがながないグループは末尾に配置', () => {
+    const groupsWithUnknown = [
+      ...groups,
+      { id: '6', displayName: '未登録者' },
+    ];
+    const sorted = sortGroupsByFurigana(groupsWithUnknown, furiganaMap);
+    expect(sorted[sorted.length - 1].displayName).toBe('未登録者');
+  });
+
+  it('元の配列を変更しない（イミュータブル）', () => {
+    const original = [...groups];
+    sortGroupsByFurigana(groups, furiganaMap);
+    expect(groups).toEqual(original);
+  });
+
+  it('空配列でも動作', () => {
+    expect(sortGroupsByFurigana([], furiganaMap)).toEqual([]);
+  });
+
+  it('空のふりがなマップでもクラッシュしない', () => {
+    const sorted = sortGroupsByFurigana(groups, new Map());
+    expect(sorted).toHaveLength(groups.length);
+  });
+});
+
+// ============================================
+// filterGroupsByKanaRow
+// ============================================
+
+describe('filterGroupsByKanaRow', () => {
+  const furiganaMap = new Map([
+    ['田中太郎', 'たなかたろう'],
+    ['鈴木花子', 'すずきはなこ'],
+    ['佐藤一郎', 'さとういちろう'],
+    ['安藤美咲', 'あんどうみさき'],
+    ['高橋裕子', 'たかはしゆうこ'],
+  ]);
+
+  const groups = [
+    { id: '1', displayName: '田中太郎' },
+    { id: '2', displayName: '鈴木花子' },
+    { id: '3', displayName: '佐藤一郎' },
+    { id: '4', displayName: '安藤美咲' },
+    { id: '5', displayName: '高橋裕子' },
+  ];
+
+  it('null（全て）を指定すると全グループを返す', () => {
+    const result = filterGroupsByKanaRow(groups, null, furiganaMap);
+    expect(result).toHaveLength(5);
+  });
+
+  it('「た」行でフィルター → た行の顧客のみ', () => {
+    const result = filterGroupsByKanaRow(groups, 'た', furiganaMap);
+    expect(result.map((g) => g.displayName)).toEqual(['田中太郎', '高橋裕子']);
+  });
+
+  it('「さ」行でフィルター → さ行の顧客のみ', () => {
+    const result = filterGroupsByKanaRow(groups, 'さ', furiganaMap);
+    expect(result.map((g) => g.displayName)).toEqual(['鈴木花子', '佐藤一郎']);
+  });
+
+  it('「あ」行でフィルター → あ行の顧客のみ', () => {
+    const result = filterGroupsByKanaRow(groups, 'あ', furiganaMap);
+    expect(result.map((g) => g.displayName)).toEqual(['安藤美咲']);
+  });
+
+  it('該当なしの行は空配列を返す', () => {
+    const result = filterGroupsByKanaRow(groups, 'ま', furiganaMap);
+    expect(result).toEqual([]);
+  });
+
+  it('ふりがながないグループはフィルターに含まれない', () => {
+    const groupsWithUnknown = [
+      ...groups,
+      { id: '6', displayName: '未登録者' },
+    ];
+    const result = filterGroupsByKanaRow(groupsWithUnknown, 'た', furiganaMap);
+    expect(result.map((g) => g.displayName)).toEqual(['田中太郎', '高橋裕子']);
+  });
+});

--- a/frontend/src/lib/kanaUtils.ts
+++ b/frontend/src/lib/kanaUtils.ts
@@ -1,0 +1,150 @@
+/**
+ * かなユーティリティ
+ * あかさたな分類・ふりがなソートの共通関数
+ */
+
+import type { CustomerMaster } from '@shared/types';
+
+// ============================================
+// 定数
+// ============================================
+
+/** あかさたな行の定義 */
+export const KANA_ROWS = ['あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ'] as const;
+
+export type KanaRow = (typeof KANA_ROWS)[number];
+
+/**
+ * ひらがな→行マッピング
+ * 清音・濁音・半濁音・小文字すべてを清音の行に分類
+ */
+const HIRAGANA_TO_ROW: Record<string, KanaRow> = {};
+
+// あ行: あいうえお + 小文字
+const A_ROW = 'ぁあぃいぅうぇえぉお';
+// か行: かきくけこ + 濁音
+const KA_ROW = 'かがきぎくぐけげこご';
+// さ行: さしすせそ + 濁音
+const SA_ROW = 'さざしじすずせぜそぞ';
+// た行: たちつてと + 濁音 + 小文字っ
+const TA_ROW = 'ただちぢっつづてでとど';
+// な行
+const NA_ROW = 'なにぬねの';
+// は行: はひふへほ + 濁音・半濁音
+const HA_ROW = 'はばぱひびぴふぶぷへべぺほぼぽ';
+// ま行
+const MA_ROW = 'まみむめも';
+// や行 + 小文字
+const YA_ROW = 'ゃやゅゆょよ';
+// ら行
+const RA_ROW = 'らりるれろ';
+// わ行 + ゐゑをん
+const WA_ROW = 'ゎわゐゑをん';
+
+const ROW_DEFS: Array<[string, KanaRow]> = [
+  [A_ROW, 'あ'],
+  [KA_ROW, 'か'],
+  [SA_ROW, 'さ'],
+  [TA_ROW, 'た'],
+  [NA_ROW, 'な'],
+  [HA_ROW, 'は'],
+  [MA_ROW, 'ま'],
+  [YA_ROW, 'や'],
+  [RA_ROW, 'ら'],
+  [WA_ROW, 'わ'],
+];
+
+for (const [chars, row] of ROW_DEFS) {
+  for (const ch of chars) {
+    HIRAGANA_TO_ROW[ch] = row;
+  }
+}
+
+// ============================================
+// 関数
+// ============================================
+
+/**
+ * カタカナをひらがなに変換
+ */
+function katakanaToHiragana(char: string): string {
+  const code = char.charCodeAt(0);
+  // カタカナ範囲: 0x30A0-0x30FF → ひらがな: 0x3040-0x309F (差分: 0x60)
+  if (code >= 0x30a1 && code <= 0x30f6) {
+    return String.fromCharCode(code - 0x60);
+  }
+  // 特殊: ヮ(0x30EE)→ゎ, ヰ(0x30F0)→ゐ, ヱ(0x30F1)→ゑ, ヲ(0x30F2)→を, ン(0x30F3)→ん
+  if (code === 0x30ee) return 'ゎ';
+  if (code === 0x30f0) return 'ゐ';
+  if (code === 0x30f1) return 'ゑ';
+  if (code === 0x30f2) return 'を';
+  if (code === 0x30f3) return 'ん';
+  return char;
+}
+
+/**
+ * 文字の先頭からあかさたな行を判定
+ * @returns 行（'あ'〜'わ'）またはnull（かな以外）
+ */
+export function getKanaRow(text: string): KanaRow | null {
+  if (!text) return null;
+  const firstChar = text[0];
+  // ひらがなチェック
+  const row = HIRAGANA_TO_ROW[firstChar];
+  if (row) return row;
+  // カタカナ→ひらがな変換してチェック
+  const hiragana = katakanaToHiragana(firstChar);
+  return HIRAGANA_TO_ROW[hiragana] ?? null;
+}
+
+/**
+ * 顧客マスターから名前→ふりがなのMapを構築
+ */
+export function buildFuriganaMap(customers: CustomerMaster[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const customer of customers) {
+    map.set(customer.name, customer.furigana);
+  }
+  return map;
+}
+
+/**
+ * グループをふりがな順（あいうえお順）にソート
+ * ふりがながないグループは末尾に配置
+ */
+export function sortGroupsByFurigana<T extends { displayName: string }>(
+  groups: T[],
+  furiganaMap: Map<string, string>
+): T[] {
+  return [...groups].sort((a, b) => {
+    const readingA = furiganaMap.get(a.displayName) ?? '';
+    const readingB = furiganaMap.get(b.displayName) ?? '';
+    // ふりがながある方を優先
+    if (readingA && !readingB) return -1;
+    if (!readingA && readingB) return 1;
+    if (!readingA && !readingB) {
+      // 両方なし → displayNameで比較
+      return a.displayName.localeCompare(b.displayName, 'ja');
+    }
+    // 両方あり → ふりがなで比較
+    return readingA.localeCompare(readingB, 'ja');
+  });
+}
+
+/**
+ * あかさたな行でグループをフィルター
+ * @param kanaRow null = 全て表示
+ */
+export function filterGroupsByKanaRow<T extends { displayName: string }>(
+  groups: T[],
+  kanaRow: KanaRow | null,
+  furiganaMap: Map<string, string>
+): T[] {
+  if (kanaRow === null) return groups;
+
+  return groups.filter((group) => {
+    const reading = furiganaMap.get(group.displayName);
+    if (!reading) return false;
+    return getKanaRow(reading) === kanaRow;
+  });
+}


### PR DESCRIPTION
## Summary
- **顧客別タブ**: 件数順ソートを廃止し、ふりがな（CustomerMaster.furigana）によるあいうえお順ソート＋あかさたなフィルターバーを実装
- **担当CM別タブ**: 顧客サブグループのソートを件数順からあいうえお順に変更
- 事業所別・書類種別タブは変更なし（既存の件数順を維持）

## 変更内容

### 新規ファイル
| ファイル | 内容 |
|---------|------|
| `lib/kanaUtils.ts` | あかさたな行分類・ふりがなソート・フィルターユーティリティ |
| `lib/__tests__/kanaUtils.test.ts` | kanaUtils テスト（30件） |
| `components/KanaFilterBar.tsx` | あかさたなフィルターバーUI（全/あ/か/さ/た/な/は/ま/や/ら/わ） |
| `components/__tests__/KanaFilterBar.test.tsx` | KanaFilterBar テスト（6件） |

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `hooks/useDocumentGroups.ts` | 顧客別: `sortBy='none'`で全件取得対応（orderBy/limit なし） |
| `components/views/GroupList.tsx` | 顧客別: あいうえお順ソート＋フィルター統合、CM別: furiganaMap伝搬 |
| `components/views/GroupDocumentList.tsx` | furiganaMap props追加→CustomerSubGroupへ伝搬 |
| `components/views/CustomerSubGroup.tsx` | furiganaMapによるあいうえお順ソート対応 |

## 技術ポイント
- バックエンド変更なし（フロントエンドのみ）
- CustomerMaster.furiganaを活用（useCustomersフック、5分キャッシュ済み）
- 濁音・半濁音・小文字かな・カタカナすべてを清音行に正規化して分類
- ふりがな未登録の顧客はソート末尾に配置、フィルター時は非表示

## Test plan
- [x] kanaUtils テスト 30件パス
- [x] KanaFilterBar テスト 6件パス
- [x] 既存テスト全59件パス
- [x] `npm run build` 成功
- [ ] dev環境で顧客別タブのあいうえお順を確認
- [ ] dev環境であかさたなフィルターの動作確認
- [ ] dev環境で担当CM別タブの顧客サブグループ順序を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kana filter bar to the customer view, allowing users to filter groups by Japanese Kana rows (あ, か, さ, た, etc.).
  * Implemented client-side sorting of customer groups by Japanese reading with dynamic result counts displayed when filters are active.
  * Added "no results" messaging when applied Kana filters match no groups.

* **Tests**
  * Added comprehensive test coverage for Kana filtering and sorting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->