### PR TITLE
fix: あかさたなフィルター空結果バグ修正＋E2Eテスト追加

### DIFF
--- a/frontend/e2e/kana-filter.spec.ts
+++ b/frontend/e2e/kana-filter.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * あかさたなフィルター E2Eテスト
+ *
+ * 顧客別グループビューのフィルター挙動を検証
+ *
+ * 実行方法:
+ *   1. Firebase Emulator起動: firebase emulators:start
+ *   2. シードデータ投入: FIRESTORE_EMULATOR_HOST=localhost:8085 node scripts/seed-e2e-data.js
+ *   3. テスト実行: cd frontend && npx playwright test e2e/kana-filter.spec.ts
+ */
+
+import { test, expect, Page } from '@playwright/test';
+
+// テストユーザー情報（seed-e2e-data.jsと同じ）
+const TEST_USER = {
+  email: 'test@example.com',
+  password: 'testpassword123',
+};
+
+// ============================================
+// ヘルパー
+// ============================================
+
+async function loginWithTestUser(page: Page) {
+  await page.goto('/');
+  await page.evaluate(
+    async ({ email, password }) => {
+      // @ts-expect-error - Firebase SDKはグローバルに存在
+      const { auth } = await import('/src/lib/firebase.ts');
+      // @ts-expect-error - Firebase SDKはグローバルに存在
+      const { signInWithEmailAndPassword } = await import('firebase/auth');
+      await signInWithEmailAndPassword(auth, email, password);
+    },
+    { email: TEST_USER.email, password: TEST_USER.password }
+  );
+  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
+}
+
+/** 「顧客別」タブに移動 */
+async function navigateToCustomerTab(page: Page) {
+  // タブをクリック
+  await page.locator('[role="tab"]').filter({ hasText: '顧客別' }).click();
+  // グループデータが表示されるまで待機
+  await page.waitForTimeout(1000);
+}
+
+/** フィルターバーの存在確認 */
+function getFilterBar(page: Page) {
+  return page.locator('button:has-text("全")').first();
+}
+
+/** 特定のかな行ボタンを取得 */
+function getKanaButton(page: Page, kana: string) {
+  return page.locator(`button:text-is("${kana}")`);
+}
+
+// ============================================
+// 基本テスト（認証不要）
+// ============================================
+
+test.describe('あかさたなフィルター - 基本', () => {
+  test('ログインページが表示される', async ({ page }) => {
+    await page.goto('/');
+    // 「Googleでログイン」ボタンまたは「書類管理ビューアー」テキストを確認
+    const hasLoginButton = await page
+      .locator('text=Googleでログイン')
+      .isVisible({ timeout: 10000 })
+      .catch(() => false);
+    const hasTitle = await page
+      .locator('text=書類管理ビューアー')
+      .isVisible()
+      .catch(() => false);
+    expect(hasLoginButton || hasTitle).toBeTruthy();
+  });
+});
+
+// ============================================
+// Emulator環境テスト（認証必要 + シードデータ必要）
+// ============================================
+
+test.describe('あかさたなフィルター @emulator', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginWithTestUser(page);
+  });
+
+  test('顧客別タブにフィルターバーが表示される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    // フィルターバーが表示される
+    const filterBar = getFilterBar(page);
+    await expect(filterBar).toBeVisible({ timeout: 10000 });
+
+    // 「全」ボタンが存在
+    await expect(filterBar).toHaveText('全');
+
+    // 各行ボタンが存在
+    for (const kana of ['あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ']) {
+      await expect(getKanaButton(page, kana)).toBeVisible();
+    }
+  });
+
+  test('他のタブにフィルターバーが表示されない', async ({ page }) => {
+    // 事業所別タブ
+    await page.locator('[role="tab"]').filter({ hasText: '事業所別' }).click();
+    await page.waitForTimeout(500);
+
+    // 「全あかさたな...」のフィルターバーが存在しないことを確認
+    // 事業所別にも「全」テキストは他の箇所にある可能性があるため、
+    // data-active属性でフィルターバーのボタンを特定
+    const kanaButton = getKanaButton(page, 'あ');
+    await expect(kanaButton).not.toBeVisible();
+  });
+
+  test('「か」行でフィルターすると該当顧客のみ表示される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    // フィルターバーが使用可能になるまで待機
+    await expect(getKanaButton(page, 'か')).toBeEnabled({ timeout: 10000 });
+
+    // 「か」行ボタンをクリック
+    await getKanaButton(page, 'か').click();
+
+    // 加藤次郎が表示される
+    await expect(page.locator('text=加藤次郎')).toBeVisible({ timeout: 5000 });
+
+    // 他の行の顧客が表示されない
+    await expect(page.locator('text=阿部太郎')).not.toBeVisible();
+    await expect(page.locator('text=佐藤三郎')).not.toBeVisible();
+  });
+
+  test('「さ」行でフィルターすると該当顧客のみ表示される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    await expect(getKanaButton(page, 'さ')).toBeEnabled({ timeout: 10000 });
+    await getKanaButton(page, 'さ').click();
+
+    await expect(page.locator('text=佐藤三郎')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=田中四郎')).not.toBeVisible();
+  });
+
+  test('「全」ボタンでフィルターをリセットできる', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    // まず「た」行でフィルター
+    await expect(getKanaButton(page, 'た')).toBeEnabled({ timeout: 10000 });
+    await getKanaButton(page, 'た').click();
+    await expect(page.locator('text=田中四郎')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=阿部太郎')).not.toBeVisible();
+
+    // 「全」でリセット
+    await getFilterBar(page).click();
+
+    // 全顧客が表示される
+    await expect(page.locator('text=阿部太郎')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=田中四郎')).toBeVisible();
+  });
+
+  test('同じ行をもう一度クリックするとフィルターが解除される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    await expect(getKanaButton(page, 'な')).toBeEnabled({ timeout: 10000 });
+    // 「な」行をクリック（フィルター適用）
+    await getKanaButton(page, 'な').click();
+    await expect(page.locator('text=中村五郎')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=阿部太郎')).not.toBeVisible();
+
+    // 「な」行を再クリック（フィルター解除）
+    await getKanaButton(page, 'な').click();
+    await expect(page.locator('text=阿部太郎')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('該当なしの行では「〜行の顧客はいません」と表示される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    // シードデータに「ら」行の顧客はいない
+    await expect(getKanaButton(page, 'ら')).toBeEnabled({ timeout: 10000 });
+    await getKanaButton(page, 'ら').click();
+
+    await expect(page.locator('text=行の顧客はいません')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('フィルター適用時に件数が表示される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    await expect(getKanaButton(page, 'あ')).toBeEnabled({ timeout: 10000 });
+    await getKanaButton(page, 'あ').click();
+
+    // 件数表示（例: 「2件 / 11件」）
+    const countDisplay = page.locator('text=/\\d+件 \\/ \\d+件/');
+    await expect(countDisplay).toBeVisible({ timeout: 5000 });
+  });
+
+  test('フィルターバーはcustomersロード完了まで無効化される', async ({ page }) => {
+    // ページに直接アクセスして顧客別タブへ
+    await navigateToCustomerTab(page);
+
+    // フィルターバーが表示される時点で、disabled=falseであることを確認
+    // （customersがロードされた後にenableされる）
+    const kanaButton = getKanaButton(page, 'か');
+    await expect(kanaButton).toBeEnabled({ timeout: 10000 });
+  });
+});
+
+// ============================================
+// タブ切り替えテスト
+// ============================================
+
+test.describe('タブ切り替え時のフィルター挙動 @emulator', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginWithTestUser(page);
+  });
+
+  test('タブ切り替え後にフィルター状態が保持される', async ({ page }) => {
+    await navigateToCustomerTab(page);
+
+    // 「か」行でフィルター
+    await expect(getKanaButton(page, 'か')).toBeEnabled({ timeout: 10000 });
+    await getKanaButton(page, 'か').click();
+    await expect(page.locator('text=加藤次郎')).toBeVisible({ timeout: 5000 });
+
+    // 事業所別タブに切り替え
+    await page.locator('[role="tab"]').filter({ hasText: '事業所別' }).click();
+    await page.waitForTimeout(500);
+
+    // 顧客別タブに戻る
+    await page.locator('[role="tab"]').filter({ hasText: '顧客別' }).click();
+    await page.waitForTimeout(1000);
+
+    // フィルターバーが再表示される
+    await expect(getFilterBar(page)).toBeVisible();
+  });
+});

--- a/frontend/src/components/KanaFilterBar.tsx
+++ b/frontend/src/components/KanaFilterBar.tsx
@@ -10,14 +10,19 @@ import { cn } from '@/lib/utils';
 interface KanaFilterBarProps {
   selected: KanaRow | null;
   onSelect: (row: KanaRow | null) => void;
+  disabled?: boolean;
 }
 
-export function KanaFilterBar({ selected, onSelect }: KanaFilterBarProps) {
+export function KanaFilterBar({ selected, onSelect, disabled = false }: KanaFilterBarProps) {
   return (
-    <div className="flex gap-1 overflow-x-auto pb-1 -mx-1 px-1">
+    <div className={cn(
+      'flex gap-1 overflow-x-auto pb-1 -mx-1 px-1',
+      disabled && 'opacity-50 pointer-events-none'
+    )}>
       {/* 全ボタン */}
       <button
         data-active={selected === null ? 'true' : 'false'}
+        disabled={disabled}
         className={cn(
           'flex-shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
           selected === null
@@ -34,6 +39,7 @@ export function KanaFilterBar({ selected, onSelect }: KanaFilterBarProps) {
         <button
           key={row}
           data-active={selected === row ? 'true' : 'false'}
+          disabled={disabled}
           className={cn(
             'flex-shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
             selected === row

--- a/frontend/src/components/__tests__/KanaFilterBar.test.tsx
+++ b/frontend/src/components/__tests__/KanaFilterBar.test.tsx
@@ -60,4 +60,30 @@ describe('KanaFilterBar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'た' }));
     expect(onSelect).toHaveBeenCalledWith(null);
   });
+
+  it('disabled=trueのとき全ボタンが無効化される', () => {
+    const onSelect = vi.fn();
+    render(<KanaFilterBar selected={null} onSelect={onSelect} disabled={true} />);
+
+    const allButton = screen.getByRole('button', { name: '全' });
+    expect(allButton.hasAttribute('disabled')).toBe(true);
+
+    const kaButton = screen.getByRole('button', { name: 'か' });
+    expect(kaButton.hasAttribute('disabled')).toBe(true);
+
+    // クリックしてもonSelectが呼ばれない
+    fireEvent.click(kaButton);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('disabled=falseのとき通常動作する', () => {
+    const onSelect = vi.fn();
+    render(<KanaFilterBar selected={null} onSelect={onSelect} disabled={false} />);
+
+    const kaButton = screen.getByRole('button', { name: 'か' });
+    expect(kaButton.hasAttribute('disabled')).toBe(false);
+
+    fireEvent.click(kaButton);
+    expect(onSelect).toHaveBeenCalledWith('か');
+  });
 });

--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -179,18 +179,21 @@ export function GroupList({ groupType, onDocumentSelect }: GroupListProps) {
 
   // 顧客マスター（顧客別・担当CM別のみ取得）
   const { data: customers } = useCustomers();
+  const isFuriganaReady = needsFurigana ? !!customers : true;
   const furiganaMap = useMemo(
     () => (needsFurigana && customers ? buildFuriganaMap(customers) : new Map<string, string>()),
     [needsFurigana, customers]
   );
 
   // 顧客別: あいうえお順ソート + フィルター
+  // furiganaMap未準備時はソート・フィルターをスキップ（空結果防止）
   const displayGroups = useMemo(() => {
     if (!groups) return [];
     if (!isCustomerView) return groups;
+    if (!isFuriganaReady) return groups;
     const sorted = sortGroupsByFurigana(groups, furiganaMap);
     return filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
-  }, [groups, isCustomerView, furiganaMap, selectedKanaRow]);
+  }, [groups, isCustomerView, isFuriganaReady, furiganaMap, selectedKanaRow]);
 
   const config = GROUP_TYPE_CONFIG[groupType];
 
@@ -265,7 +268,11 @@ export function GroupList({ groupType, onDocumentSelect }: GroupListProps) {
 
       {/* あかさたなフィルター（顧客別のみ） */}
       {isCustomerView && (
-        <KanaFilterBar selected={selectedKanaRow} onSelect={setSelectedKanaRow} />
+        <KanaFilterBar
+          selected={selectedKanaRow}
+          onSelect={setSelectedKanaRow}
+          disabled={!isFuriganaReady}
+        />
       )}
 
       {/* グループ一覧 */}

--- a/scripts/seed-e2e-data.js
+++ b/scripts/seed-e2e-data.js
@@ -4,6 +4,7 @@
  * Firebase Emulator環境で実行
  * - テストユーザー作成
  * - 事業所未確定テストドキュメント作成
+ * - あかさたなフィルターテスト用の顧客マスター・書類データ作成
  *
  * 使用方法:
  *   FIRESTORE_EMULATOR_HOST=localhost:8085 node scripts/seed-e2e-data.js
@@ -119,12 +120,107 @@ async function seedTestDocuments() {
   }
 }
 
+/**
+ * あかさたなフィルターテスト用の顧客マスター作成
+ * 各行に1名以上の顧客を配置
+ */
+async function seedCustomerMasters() {
+  console.log('\n👥 顧客マスターを作成中...');
+
+  const customers = [
+    { id: 'e2e-cust-a', name: '阿部太郎', furigana: 'あべたろう', notes: '' },
+    { id: 'e2e-cust-i', name: '伊藤花子', furigana: 'いとうはなこ', notes: '' },
+    { id: 'e2e-cust-ka', name: '加藤次郎', furigana: 'かとうじろう', notes: '' },
+    { id: 'e2e-cust-sa', name: '佐藤三郎', furigana: 'さとうさぶろう', notes: '' },
+    { id: 'e2e-cust-ta', name: '田中四郎', furigana: 'たなかしろう', notes: '' },
+    { id: 'e2e-cust-na', name: '中村五郎', furigana: 'なかむらごろう', notes: '' },
+    { id: 'e2e-cust-ha', name: '浜田六郎', furigana: 'はまだろくろう', notes: '' },
+    { id: 'e2e-cust-ma', name: '松本七郎', furigana: 'まつもとしちろう', notes: '' },
+    { id: 'e2e-cust-ya', name: '山本八郎', furigana: 'やまもとはちろう', notes: '' },
+    { id: 'e2e-cust-wa', name: '渡辺九郎', furigana: 'わたなべくろう', notes: '' },
+    // ふりがな空の顧客（フィルター除外テスト用）
+    { id: 'e2e-cust-nofuri', name: 'テスト株式会社', furigana: '', notes: '' },
+  ];
+
+  for (const cust of customers) {
+    await db.collection('masters').doc('customers').collection('items').doc(cust.id).set({
+      name: cust.name,
+      furigana: cust.furigana,
+      notes: cust.notes,
+      createdAt: Timestamp.now(),
+    });
+  }
+  console.log(`✅ 顧客マスター ${customers.length}件作成`);
+  return customers;
+}
+
+/**
+ * あかさたなフィルターテスト用の書類データ作成
+ * 各顧客に1件ずつ書類を紐付け
+ */
+async function seedFilterTestDocuments(customers) {
+  console.log('\n📄 フィルターテスト用書類を作成中...');
+
+  const docs = customers
+    .filter((c) => c.furigana) // ふりがなありのみ書類作成
+    .map((cust, i) => ({
+      id: `e2e-filter-doc-${String(i + 1).padStart(3, '0')}`,
+      data: {
+        fileName: `E2E_フィルターテスト_${cust.name}.pdf`,
+        fileUrl: `gs://doc-split-dev-documents/test/e2e-filter-${i + 1}.pdf`,
+        mimeType: 'application/pdf',
+        totalPages: 1,
+        status: 'processed',
+        customerId: cust.id,
+        customerName: cust.name,
+        customerConfirmed: true,
+        officeId: 'office-001',
+        officeName: 'テスト第一事業所',
+        officeConfirmed: true,
+        documentType: '請求書',
+        processedAt: Timestamp.now(),
+        createdAt: Timestamp.now(),
+      },
+    }));
+
+  // ふりがな空の顧客にも書類を紐付け
+  const nofuriCust = customers.find((c) => !c.furigana);
+  if (nofuriCust) {
+    docs.push({
+      id: 'e2e-filter-doc-nofuri',
+      data: {
+        fileName: `E2E_フィルターテスト_${nofuriCust.name}.pdf`,
+        fileUrl: 'gs://doc-split-dev-documents/test/e2e-filter-nofuri.pdf',
+        mimeType: 'application/pdf',
+        totalPages: 1,
+        status: 'processed',
+        customerId: nofuriCust.id,
+        customerName: nofuriCust.name,
+        customerConfirmed: true,
+        officeId: 'office-001',
+        officeName: 'テスト第一事業所',
+        officeConfirmed: true,
+        documentType: '請求書',
+        processedAt: Timestamp.now(),
+        createdAt: Timestamp.now(),
+      },
+    });
+  }
+
+  for (const doc of docs) {
+    await db.collection('documents').doc(doc.id).set(doc.data);
+  }
+  console.log(`✅ フィルターテスト用書類 ${docs.length}件作成`);
+}
+
 async function main() {
   console.log('🚀 E2Eテスト用シードデータ作成開始');
   console.log(`プロジェクト: ${projectId}\n`);
 
   await createTestUser();
   await seedTestDocuments();
+  const customers = await seedCustomerMasters();
+  await seedFilterTestDocuments(customers);
 
   console.log('\n✅ シードデータ作成完了');
   console.log('\nテストユーザー情報:');


### PR DESCRIPTION
## Summary
- 顧客マスター未ロード時にフィルター操作すると結果0件になるバグを修正
- KanaFilterBarにdisabled制御を追加し、ロード完了まで操作を無効化
- E2Eテスト11ケース＋単体テスト2件を追加

## 修正内容
| ファイル | 変更 |
|---------|------|
| `KanaFilterBar.tsx` | `disabled` prop追加 |
| `GroupList.tsx` | `isFuriganaReady` ガード追加 |
| `KanaFilterBar.test.tsx` | disabled状態テスト2件追加 |
| `kana-filter.spec.ts` | E2Eテスト11ケース（Emulator環境用） |
| `seed-e2e-data.js` | フィルターテスト用シードデータ追加 |

## Test plan
- [x] 単体テスト 61/61 パス
- [x] バックエンドテスト 227/227 パス
- [x] ビルド成功
- [x] E2E基本テスト（ログインページ表示）パス
- [ ] Emulator環境でのE2Eテスト実行（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive e2e test suite for the Kana filter UI, covering login flows, tab navigation, filter interactions, and state persistence.

* **New Features**
  * Kana filter bar now supports a disabled state, preventing interaction while furigana data loads. Filter becomes available automatically once data is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->