### PR TITLE
fix: 納品フロードキュメントのコマンド記載を実スクリプト引数に修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,13 @@ frontend/
 
 ### マスターデータ
 ```bash
-# マスターデータインポート
-node scripts/import-masters.js --file scripts/samples/customers.csv --type customers
+# マスターデータインポート（個別）
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --customers scripts/samples/customers.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --documents scripts/samples/documents.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --offices scripts/samples/offices.csv
+
+# 一括インポート（ディレクトリ内のCSVを自動検出）
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --all scripts/samples/
 ```
 
 ## 確定事項

--- a/docs/context/delivery-and-update-guide.md
+++ b/docs/context/delivery-and-update-guide.md
@@ -102,9 +102,11 @@ gcloud config set project <client-project-id>
 # ========================================
 # Step 4: 開発者側作業 - データ投入
 # ========================================
-node scripts/import-masters.js --file <customers.csv> --type customers -P client-x
-node scripts/import-masters.js --file <documents.csv> --type documents -P client-x
-node scripts/import-masters.js --file <offices.csv> --type offices -P client-x
+FIREBASE_PROJECT_ID=<client-project-id> node scripts/import-masters.js --customers <customers.csv>
+FIREBASE_PROJECT_ID=<client-project-id> node scripts/import-masters.js --documents <documents.csv>
+FIREBASE_PROJECT_ID=<client-project-id> node scripts/import-masters.js --offices <offices.csv>
+# ケアマネ（任意）
+# FIREBASE_PROJECT_ID=<client-project-id> node scripts/import-masters.js --caremanagers <caremanagers.csv>
 
 # ========================================
 # Step 5: 検証 & 動作確認
@@ -245,15 +247,20 @@ git push origin main
 ```bash
 # 1. クライアントがGCPプロジェクト作成・課金設定
 
-# 2. セットアップ実行
-./scripts/setup-tenant.sh <new-client-project-id> <admin-email>
-./scripts/setup-gmail-auth.sh
+# 2. セットアップ実行（--with-gmail推奨、.firebasercへのエイリアス追加も自動）
+./scripts/setup-tenant.sh <new-client-project-id> <admin-email> --with-gmail
 
-# 3. .firebasercに追加
-# エディタで .firebaserc を編集し、新クライアントを追加
+# Gmail設定を後から行う場合
+# ./scripts/setup-tenant.sh <new-client-project-id> <admin-email>
+# ./scripts/setup-gmail-auth.sh <new-client-project-id>
 
-# 4. マスターデータ投入
-node scripts/import-masters.js --file <data.csv> --type <type> -P new-client
+# 3. マスターデータ投入
+FIREBASE_PROJECT_ID=<new-client-project-id> node scripts/import-masters.js --customers <customers.csv>
+FIREBASE_PROJECT_ID=<new-client-project-id> node scripts/import-masters.js --documents <documents.csv>
+FIREBASE_PROJECT_ID=<new-client-project-id> node scripts/import-masters.js --offices <offices.csv>
+
+# 4. セットアップ検証
+./scripts/verify-setup.sh <new-client-project-id>
 
 # 5. 動作確認
 ```

--- a/docs/deployment-flow.md
+++ b/docs/deployment-flow.md
@@ -385,11 +385,19 @@
 ### マスターデータ投入
 
 <div class="command-box">
-<code>node scripts/import-masters.js --file customers.csv --type customers -P &lt;alias&gt;</code>
+<code>FIREBASE_PROJECT_ID=&lt;project-id&gt; node scripts/import-masters.js --customers customers.csv</code>
 </div>
 
 <div class="command-box">
-<code>node scripts/import-masters.js --file documents.csv --type documents -P &lt;alias&gt;</code>
+<code>FIREBASE_PROJECT_ID=&lt;project-id&gt; node scripts/import-masters.js --documents documents.csv</code>
+</div>
+
+<div class="command-box">
+<code>FIREBASE_PROJECT_ID=&lt;project-id&gt; node scripts/import-masters.js --offices offices.csv</code>
+</div>
+
+<div class="command-box">
+<code>FIREBASE_PROJECT_ID=&lt;project-id&gt; node scripts/import-masters.js --all ./data/</code>
 </div>
 
 </div>

--- a/docs/operation/setup-guide.md
+++ b/docs/operation/setup-guide.md
@@ -57,7 +57,10 @@ gcloud services enable \
   pubsub.googleapis.com \
   aiplatform.googleapis.com \
   secretmanager.googleapis.com \
-  gmail.googleapis.com
+  gmail.googleapis.com \
+  cloudscheduler.googleapis.com \
+  cloudbuild.googleapis.com \
+  identitytoolkit.googleapis.com
 ```
 
 ## 4. 環境設定
@@ -70,7 +73,7 @@ gcloud services enable \
 VITE_FIREBASE_API_KEY=<your-api-key>
 VITE_FIREBASE_AUTH_DOMAIN=<your-project-id>.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=<your-project-id>
-VITE_FIREBASE_STORAGE_BUCKET=<your-project-id>.appspot.com
+VITE_FIREBASE_STORAGE_BUCKET=<your-project-id>.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=<your-sender-id>
 VITE_FIREBASE_APP_ID=<your-app-id>
 ```
@@ -125,7 +128,14 @@ CSVファイルを `scripts/samples/` に配置:
 - `caremanagers.csv`: ケアマネマスター
 
 ```bash
-node scripts/import-masters.js
+# 一括インポート（ディレクトリ内のCSVを自動検出）
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --all scripts/samples/
+
+# 個別インポート
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --customers scripts/samples/customers.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --documents scripts/samples/documents.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --offices scripts/samples/offices.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --caremanagers scripts/samples/caremanagers.csv
 ```
 
 ## 6. Storage セットアップ

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -32,27 +32,39 @@ gcloud billing projects link <project-id> --billing-account=<billing-account-id>
 firebase projects:addfirebase <project-id>
 ```
 
-### Step 3: テナントセットアップ実行
+### Step 3: テナントセットアップ実行（Gmail込みで一括）
 
 ```bash
-./scripts/setup-tenant.sh <project-id> <admin-email> [gmail-account]
+./scripts/setup-tenant.sh <project-id> <admin-email> --with-gmail
 ```
 
 **例:**
 ```bash
-./scripts/setup-tenant.sh my-docsplit admin@example.com docs@example.com
+./scripts/setup-tenant.sh my-docsplit admin@example.com --with-gmail
 ```
 
-### Step 4: Gmail認証設定
+Gmail設定を後から行う場合:
+```bash
+./scripts/setup-tenant.sh <project-id> <admin-email>
+./scripts/setup-gmail-auth.sh <project-id>
+```
+
+### Step 4: セットアップ検証
 
 ```bash
-./scripts/setup-gmail-auth.sh <project-id>
+./scripts/verify-setup.sh <project-id>
 ```
 
 ### Step 5: マスターデータ投入（任意）
 
 ```bash
-node scripts/import-masters.js --all scripts/samples/
+# 一括インポート（ディレクトリ内のCSVを自動検出）
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --all scripts/samples/
+
+# 個別インポート
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --customers customers.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --documents documents.csv
+FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --offices offices.csv
 ```
 
 ## 手動セットアップ
@@ -72,6 +84,7 @@ gcloud services enable \
   gmail.googleapis.com \
   cloudscheduler.googleapis.com \
   cloudbuild.googleapis.com \
+  identitytoolkit.googleapis.com \
   --project=<project-id>
 ```
 
@@ -94,7 +107,7 @@ Firebase Consoleで以下を有効化:
 VITE_FIREBASE_API_KEY=<api-key>
 VITE_FIREBASE_AUTH_DOMAIN=<project-id>.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=<project-id>
-VITE_FIREBASE_STORAGE_BUCKET=<project-id>.appspot.com
+VITE_FIREBASE_STORAGE_BUCKET=<project-id>.firebasestorage.app
 VITE_FIREBASE_MESSAGING_SENDER_ID=<sender-id>
 VITE_FIREBASE_APP_ID=<app-id>
 ```


### PR DESCRIPTION
## Summary
- `import-masters.js` のコマンド引数が4箇所で間違っていた（`--file`/`--type`/`-P` → `--customers`等の正しい形式）
- `setup-tenant.sh` の引数、API一覧、Storageバケット名等の不整合を修正
- Claude Codeで納品フローを実行する前提で、全ドキュメントのコマンドがそのまま実行可能な状態に統一

## 修正対象（5ファイル）

| ファイル | 修正内容 |
|---------|---------|
| CLAUDE.md | import-masters.js引数修正 |
| docs/deployment-flow.md | import-masters.js引数修正 |
| docs/context/delivery-and-update-guide.md | import-masters.js + setup-gmail-auth.sh引数 + .firebaserc自動追加の矛盾解消 |
| docs/setup-guide.md | setup-tenant.sh引数 + API一覧 + import-masters.js + Storageバケット名 |
| docs/operation/setup-guide.md | API一覧 + import-masters.js + Storageバケット名 |

## Test plan
- [x] `npm run build` 成功
- [x] `/safe-refactor` 実行済み（問題なし）
- [x] 全コマンドがスクリプト実引数と一致していることを確認
- [ ] GitHub Pagesの表示確認（マージ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated master data import commands to use environment variables with support for per-entity imports (customers, documents, offices) and bulk directory imports
  * Bundled Gmail authentication configuration into tenant setup process
  * Added automated setup verification step to validate configuration
  * Updated Firebase Storage bucket endpoint from appspot.com to firebasestorage.app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->