### PR TITLE
feat: セットアップスクリプトに非対話モード追加（Claude Code自動納品対応）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,14 @@ Gmailの添付ファイルを自動取得し、AI OCRでメタ情報を抽出、
 # 一括セットアップ（Gmail OAuth込み）※推奨
 ./scripts/setup-tenant.sh <project-id> <admin-email> --with-gmail
 
+# Claude Code / CI用（非対話モード）
+./scripts/setup-tenant.sh <project-id> <admin-email> --yes
+./scripts/setup-tenant.sh <project-id> <admin-email> --with-gmail --client-id=X --client-secret=Y --auth-code=Z --yes
+
 # 段階的セットアップ
 ./scripts/setup-tenant.sh <project-id> <admin-email>
 ./scripts/setup-gmail-auth.sh <project-id>
+./scripts/setup-gmail-auth.sh <project-id> --client-id=X --client-secret=Y --auth-code=Z
 
 # セットアップ検証
 ./scripts/verify-setup.sh <project-id>
@@ -407,8 +412,8 @@ doc-split/
 │   ├── test/                    # テスト
 │   └── package.json
 ├── scripts/                     # 運用・セットアップスクリプト
-│   ├── setup-tenant.sh          # テナント初期設定（推奨: --with-gmail）
-│   ├── setup-gmail-auth.sh      # Gmail OAuth認証設定
+│   ├── setup-tenant.sh          # テナント初期設定（推奨: --with-gmail --yes）
+│   ├── setup-gmail-auth.sh      # Gmail OAuth認証設定（--client-id/secret/auth-code で非対話モード）
 │   ├── verify-setup.sh          # セットアップ検証
 │   ├── deploy-to-project.sh     # マルチ環境デプロイ
 │   ├── deploy-all-clients.sh    # 全クライアント一括デプロイ

--- a/docs/context/delivery-and-update-guide.md
+++ b/docs/context/delivery-and-update-guide.md
@@ -84,9 +84,14 @@ gcloud config set project <client-project-id>
 # 2-2. セットアップスクリプト実行（Gmail OAuth込みで一括）
 ./scripts/setup-tenant.sh <client-project-id> <admin-email> --with-gmail
 
+# Claude Code / CI用（非対話モード）
+./scripts/setup-tenant.sh <client-project-id> <admin-email> --yes
+./scripts/setup-tenant.sh <client-project-id> <admin-email> --with-gmail --client-id=X --client-secret=Y --auth-code=Z --yes
+
 # または、Gmail設定を後から行う場合
 ./scripts/setup-tenant.sh <client-project-id> <admin-email>
 ./scripts/setup-gmail-auth.sh <client-project-id>
+./scripts/setup-gmail-auth.sh <client-project-id> --client-id=X --client-secret=Y --auth-code=Z
 
 # ※ .firebasercへのエイリアス追加は自動で行われます
 
@@ -250,9 +255,13 @@ git push origin main
 # 2. セットアップ実行（--with-gmail推奨、.firebasercへのエイリアス追加も自動）
 ./scripts/setup-tenant.sh <new-client-project-id> <admin-email> --with-gmail
 
+# Claude Code / CI用（非対話モード）
+./scripts/setup-tenant.sh <new-client-project-id> <admin-email> --with-gmail --client-id=X --client-secret=Y --auth-code=Z --yes
+
 # Gmail設定を後から行う場合
 # ./scripts/setup-tenant.sh <new-client-project-id> <admin-email>
 # ./scripts/setup-gmail-auth.sh <new-client-project-id>
+# ./scripts/setup-gmail-auth.sh <new-client-project-id> --client-id=X --client-secret=Y --auth-code=Z
 
 # 3. マスターデータ投入
 FIREBASE_PROJECT_ID=<new-client-project-id> node scripts/import-masters.js --customers <customers.csv>

--- a/docs/deployment-flow.md
+++ b/docs/deployment-flow.md
@@ -325,6 +325,12 @@
 <code>./scripts/setup-tenant.sh &lt;project-id&gt; &lt;admin-email&gt; --with-gmail</code>
 </div>
 
+Claude Code / CI用（非対話モード）:
+
+<div class="command-box">
+<code>./scripts/setup-tenant.sh &lt;project-id&gt; &lt;admin-email&gt; --with-gmail --client-id=X --client-secret=Y --auth-code=Z --yes</code>
+</div>
+
 このコマンド1つで以下が**すべて自動実行**されます：
 
 <div class="timeline">

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -43,10 +43,17 @@ firebase projects:addfirebase <project-id>
 ./scripts/setup-tenant.sh my-docsplit admin@example.com --with-gmail
 ```
 
+Claude Code / CI用（非対話モード）:
+```bash
+./scripts/setup-tenant.sh <project-id> <admin-email> --yes
+./scripts/setup-tenant.sh <project-id> <admin-email> --with-gmail --client-id=X --client-secret=Y --auth-code=Z --yes
+```
+
 Gmail設定を後から行う場合:
 ```bash
 ./scripts/setup-tenant.sh <project-id> <admin-email>
 ./scripts/setup-gmail-auth.sh <project-id>
+./scripts/setup-gmail-auth.sh <project-id> --client-id=X --client-secret=Y --auth-code=Z
 ```
 
 ### Step 4: セットアップ検証

--- a/scripts/setup-gmail-auth.sh
+++ b/scripts/setup-gmail-auth.sh
@@ -3,7 +3,14 @@
 # DocSplit Gmail認証設定スクリプト
 #
 # 使用方法:
-#   ./setup-gmail-auth.sh <project-id>
+#   ./setup-gmail-auth.sh <project-id> [OPTIONS]
+#
+# オプション:
+#   --client-id=X      OAuth Client ID（省略時は対話入力）
+#   --client-secret=X  OAuth Client Secret（省略時は対話入力）
+#   --auth-code=X      OAuth 認証コード（省略時は対話入力）
+#
+# 3つすべて指定すると非対話モードで実行（CI/Claude Code用）
 #
 # 事前準備:
 #   GCP Console で OAuth 2.0 クライアントIDを作成済みであること
@@ -23,12 +30,56 @@ log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-if [ $# -lt 1 ]; then
-    echo "Usage: $0 <project-id>"
+usage() {
+    echo "Usage: $0 <project-id> [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --client-id=X      OAuth Client ID（省略時は対話入力）"
+    echo "  --client-secret=X  OAuth Client Secret（省略時は対話入力）"
+    echo "  --auth-code=X      OAuth 認証コード（省略時は対話入力）"
+    echo ""
+    echo "3つすべて指定すると非対話モードで実行（CI/Claude Code用）"
+    echo ""
+    echo "Examples:"
+    echo "  $0 my-project"
+    echo "  $0 my-project --client-id=XXX --client-secret=YYY --auth-code=ZZZ"
     exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
 fi
 
 PROJECT_ID=$1
+
+# オプション解析
+CLIENT_ID=""
+CLIENT_SECRET=""
+AUTH_CODE=""
+
+shift
+for arg in "$@"; do
+    case $arg in
+        --client-id=*)
+            CLIENT_ID="${arg#*=}"
+            ;;
+        --client-secret=*)
+            CLIENT_SECRET="${arg#*=}"
+            ;;
+        --auth-code=*)
+            AUTH_CODE="${arg#*=}"
+            ;;
+        *)
+            log_warn "不明なオプション: $arg"
+            ;;
+    esac
+done
+
+# 非対話モード判定
+NON_INTERACTIVE=false
+if [ -n "$CLIENT_ID" ] && [ -n "$CLIENT_SECRET" ] && [ -n "$AUTH_CODE" ]; then
+    NON_INTERACTIVE=true
+fi
 
 echo ""
 echo -e "${GREEN}=== DocSplit Gmail認証設定 ===${NC}"
@@ -39,15 +90,19 @@ echo ""
 # ===========================================
 # OAuth クライアント情報の入力
 # ===========================================
-echo -e "${YELLOW}GCP Console で OAuth 2.0 クライアントIDを作成してください:${NC}"
-echo "  1. https://console.cloud.google.com/apis/credentials?project=$PROJECT_ID"
-echo "  2. 「認証情報を作成」→「OAuth クライアント ID」"
-echo "  3. アプリケーションの種類: 「デスクトップアプリ」"
-echo "  4. 作成後、クライアントIDとシークレットをコピー"
-echo ""
+if [ "$NON_INTERACTIVE" = true ]; then
+    log_info "非対話モード: 引数からOAuth情報を使用します"
+else
+    echo -e "${YELLOW}GCP Console で OAuth 2.0 クライアントIDを作成してください:${NC}"
+    echo "  1. https://console.cloud.google.com/apis/credentials?project=$PROJECT_ID"
+    echo "  2. 「認証情報を作成」→「OAuth クライアント ID」"
+    echo "  3. アプリケーションの種類: 「デスクトップアプリ」"
+    echo "  4. 作成後、クライアントIDとシークレットをコピー"
+    echo ""
 
-read -p "OAuth Client ID: " CLIENT_ID
-read -p "OAuth Client Secret: " CLIENT_SECRET
+    read -p "OAuth Client ID: " CLIENT_ID
+    read -p "OAuth Client Secret: " CLIENT_SECRET
+fi
 
 if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
     log_error "Client ID と Client Secret は必須です"
@@ -59,19 +114,24 @@ fi
 # ===========================================
 echo ""
 log_info "リフレッシュトークンを取得します..."
-echo ""
-echo -e "${YELLOW}以下のURLをブラウザで開いてください:${NC}"
-echo ""
 
-AUTH_URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/gmail.readonly&response_type=code&access_type=offline&prompt=consent"
+if [ "$NON_INTERACTIVE" = true ]; then
+    log_info "非対話モード: 引数から認証コードを使用します"
+else
+    echo ""
+    echo -e "${YELLOW}以下のURLをブラウザで開いてください:${NC}"
+    echo ""
 
-echo "$AUTH_URL"
-echo ""
-echo "Googleアカウントでログインし、アクセスを許可してください。"
-echo "表示された認証コードをコピーしてください。"
-echo ""
+    AUTH_URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/gmail.readonly&response_type=code&access_type=offline&prompt=consent"
 
-read -p "認証コード: " AUTH_CODE
+    echo "$AUTH_URL"
+    echo ""
+    echo "Googleアカウントでログインし、アクセスを許可してください。"
+    echo "表示された認証コードをコピーしてください。"
+    echo ""
+
+    read -p "認証コード: " AUTH_CODE
+fi
 
 if [ -z "$AUTH_CODE" ]; then
     log_error "認証コードは必須です"


### PR DESCRIPTION
## Summary
- `setup-tenant.sh` に `--yes` / `-y` フラグを追加し、確認プロンプトを自動承認
- `setup-gmail-auth.sh` に `--client-id` / `--client-secret` / `--auth-code` オプションを追加し、3つ全指定で非対話モード実行
- `setup-tenant.sh` からのGmail OAuth引数パススルー対応
- CLAUDE.md + ドキュメント4ファイルに非対話コマンド例を追記

## Background
新規納品フローをClaude Codeで完全自動実行する際、`read -p` の対話プロンプトがブロッカーとなっていた。

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `scripts/setup-tenant.sh` | `--yes`, `--client-id/secret/auth-code` オプション追加 |
| `scripts/setup-gmail-auth.sh` | `--client-id/secret/auth-code` で非対話モード |
| `CLAUDE.md` | 非対話コマンド例追記 |
| `docs/setup-guide.md` | 同上 |
| `docs/deployment-flow.md` | 同上 |
| `docs/context/delivery-and-update-guide.md` | 同上 |

## Claude Code納品フロー（改修後）
```
[自動] setup-tenant.sh <project-id> <admin-email> --yes       ← 全確認スキップ
[人間] ブラウザでOAuth認証コード取得
[自動] setup-gmail-auth.sh <project-id> --client-id=X --client-secret=Y --auth-code=Z
[自動] verify-setup.sh / import-masters.js / deploy-to-project.sh
```

## Test plan
- [x] `setup-tenant.sh` usage表示で新オプションが出る
- [x] `setup-gmail-auth.sh` usage表示で新オプションが出る
- [x] 引数パースのドライテスト（変数が正しく設定される）
- [x] 後方互換性: 既存の引数のみでも動作する
- [x] `/safe-refactor` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Non-interactive setup mode: Use the `--yes` flag with setup commands for automated execution without prompts.
  * Gmail authentication now accepts credentials via CLI parameters (`--client-id`, `--client-secret`, `--auth-code`) for CI/automation workflows.

* **Documentation**
  * Updated setup guides with non-interactive command examples for CI and automation use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->