### PR TITLE
feat: OAuth OOB→loopback方式移行+納品ページ改善

### DIFF
--- a/docs/claude-code-delivery.md
+++ b/docs/claude-code-delivery.md
@@ -186,6 +186,22 @@
 
 ---
 
+## 開発者の前提条件
+
+<div class="warn-box">
+以下がすべて満たされていることを確認してから作業を開始してください。
+</div>
+
+| 条件 | 確認方法 |
+|------|---------|
+| doc-split リポジトリをクローン済み | `ls CLAUDE.md` |
+| `gcloud` CLI 認証済み | `gcloud auth list` |
+| ADC（Application Default Credentials）設定済み | `gcloud auth application-default login` |
+| クライアントGCPプロジェクトのオーナー/編集者権限 | クライアントから招待済み |
+| Python 3 インストール済み | `python3 --version` |
+
+---
+
 ## 事前準備（人間が行う作業）
 
 <div class="step-card">
@@ -200,7 +216,7 @@
   <div class="step-num">2</div>
   <div class="step-content">
     <strong>GCP Console で OAuth クライアントID作成</strong><br>
-    <a href="https://console.cloud.google.com/apis/credentials" target="_blank">認証情報ページ</a> → 「認証情報を作成」→「OAuth クライアント ID」→ 種類: <code>デスクトップアプリ</code><br>
+    <a href="https://console.cloud.google.com/apis/credentials" target="_blank">認証情報ページ</a>（クライアントのプロジェクトを選択）→ 「認証情報を作成」→「OAuth クライアント ID」→ 種類: <code>デスクトップアプリ</code><br>
     → <strong>Client ID</strong> と <strong>Client Secret</strong> をメモ
   </div>
 </div>
@@ -209,8 +225,9 @@
   <div class="step-num">3</div>
   <div class="step-content">
     <strong>OAuth 認証コードを取得</strong><br>
-    下のフォームにClient IDを入力すると認証URLが自動生成されます。<br>
-    ブラウザで開く → Googleログイン → 表示された<strong>認証コード</strong>をコピー
+    doc-split ディレクトリで以下のコマンドを実行:<br>
+    <code>./scripts/setup-gmail-auth.sh --get-code --client-id=&lt;上で取得したClient ID&gt;</code><br>
+    ブラウザが自動で開く → Googleログイン → ターミナルに表示された<strong>認証コード</strong>をコピー
   </div>
 </div>
 
@@ -242,19 +259,8 @@
     <input type="text" id="client-secret" placeholder="GOCSPX-xxxx" oninput="updatePrompts()">
   </div>
   <div class="form-group full-width">
-    <label>認証コード *（上のClient IDを入力すると認証URLが表示されます）</label>
+    <label>認証コード *（<code>./scripts/setup-gmail-auth.sh --get-code --client-id=X</code> で取得）</label>
     <input type="text" id="auth-code" placeholder="4/0AY-xxxx" oninput="updatePrompts()">
-  </div>
-</div>
-<div id="auth-url-box" style="display:none; margin-top:8px;">
-  <div class="info-box">
-    <strong>認証URL:</strong> 以下のURLをブラウザで開いて認証コードを取得してください<br>
-    <div style="margin-top:8px; position:relative;">
-      <code id="auth-url-text" style="word-break:break-all; font-size:12px;"></code>
-      <button onclick="copyAuthUrl()" class="copy-btn" id="auth-url-copy-btn" style="margin-top:8px; font-size:12px; padding:4px 10px;">
-        URL をコピー
-      </button>
-    </div>
   </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -302,26 +302,25 @@
       var csvDoc = _cdVal('csv-documents');
       var csvOff = _cdVal('csv-offices');
       var csvCm = _cdVal('csv-caremanagers');
+      var p = fmt(pid, '<project-id>');
 
-      return 'DocSplitの新規納品を実施してください。\n\n'
-        + '■ クライアント情報\n'
-        + '- プロジェクトID: ' + fmt(pid, '<project-id>') + '\n'
-        + '- 管理者メール: ' + fmt(email, '<admin-email>') + '\n\n'
-        + '■ Gmail OAuth認証情報\n'
-        + '- Client ID: ' + fmt(cid, '<client-id>') + '\n'
-        + '- Client Secret: ' + fmt(csec, '<client-secret>') + '\n'
-        + '- 認証コード: ' + fmt(code, '<auth-code>') + '\n\n'
-        + '■ マスターデータCSV\n'
-        + '- 顧客: ' + fmt(csvCust, '<path/to/customers.csv>') + '\n'
-        + '- 書類種別: ' + fmt(csvDoc, '<path/to/documents.csv>') + '\n'
-        + '- 事業所: ' + fmt(csvOff, '<path/to/offices.csv>') + '\n'
-        + (csvCm ? '- ケアマネ: ' + fmt(csvCm, '') + '\n' : '')
-        + '\n■ 手順\n'
-        + '1. setup-tenant.sh を --with-gmail --yes で実行\n'
-        + '2. verify-setup.sh で検証\n'
-        + '3. import-masters.js でマスターデータ投入\n'
-        + '4. verify-setup.sh で最終確認\n'
+      var lines = 'DocSplitの新規納品を実施してください。\n\n'
+        + '■ 手順（以下のコマンドを順番に実行）\n\n'
+        + '1. セットアップ実行:\n'
+        + '   ./scripts/setup-tenant.sh ' + p + ' ' + fmt(email, '<admin-email>') + ' --with-gmail --client-id=' + fmt(cid, '<client-id>') + ' --client-secret=' + fmt(csec, '<client-secret>') + ' --auth-code=' + fmt(code, '<auth-code>') + ' --yes\n\n'
+        + '2. 中間検証:\n'
+        + '   ./scripts/verify-setup.sh ' + p + '\n\n'
+        + '3. マスターデータ投入:\n'
+        + '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --customers ' + fmt(csvCust, '<customers.csv>') + '\n'
+        + '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --documents ' + fmt(csvDoc, '<documents.csv>') + '\n'
+        + '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --offices ' + fmt(csvOff, '<offices.csv>') + '\n';
+      if (csvCm) {
+        lines += '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --caremanagers ' + fmt(csvCm, '') + '\n';
+      }
+      lines += '\n4. 最終検証:\n'
+        + '   ./scripts/verify-setup.sh ' + p + '\n\n'
         + '5. 結果をサマリーで報告';
+      return lines;
     }
 
     function _buildFull(fmt) {
@@ -335,53 +334,46 @@
       var csvOff = _cdVal('csv-offices');
       var csvCm = _cdVal('csv-caremanagers');
       var domain = _cdVal('extra-domain');
+      var p = fmt(pid, '<project-id>');
 
-      var stepNum = 4;
-      var extraSteps = '';
-      if (domain) extraSteps += (stepNum++) + '. check-allowed-domains.js --add で許可ドメイン追加\n';
-      extraSteps += (stepNum++) + '. verify-setup.sh で最終検証（全項目合格を確認）\n'
-        + stepNum + '. 結果をサマリーで報告';
+      var stepNum = 1;
+      var lines = 'DocSplitの新規納品を実施してください。\n\n'
+        + '■ 手順（以下のコマンドを順番厳守で実行）\n\n';
 
-      return 'DocSplitの新規納品を実施してください。\n\n'
-        + '■ クライアント情報\n'
-        + '- プロジェクトID: ' + fmt(pid, '<project-id>') + '\n'
-        + '- 管理者メール: ' + fmt(email, '<admin-email>') + '\n'
-        + (domain ? '- 追加許可ドメイン: ' + fmt(domain, '') + '\n' : '')
-        + '\n■ Gmail OAuth認証情報\n'
-        + '- Client ID: ' + fmt(cid, '<client-id>') + '\n'
-        + '- Client Secret: ' + fmt(csec, '<client-secret>') + '\n'
-        + '- 認証コード: ' + fmt(code, '<auth-code>') + '\n\n'
-        + '■ マスターデータCSV\n'
-        + '- 顧客: ' + fmt(csvCust, '<path/to/customers.csv>') + '\n'
-        + '- 書類種別: ' + fmt(csvDoc, '<path/to/documents.csv>') + '\n'
-        + '- 事業所: ' + fmt(csvOff, '<path/to/offices.csv>') + '\n'
-        + (csvCm ? '- ケアマネ: ' + fmt(csvCm, '') + '\n' : '')
-        + '\n■ 手順（順番厳守）\n'
-        + '1. setup-tenant.sh --with-gmail --yes で環境構築\n'
-        + '2. verify-setup.sh で中間検証\n'
-        + '3. import-masters.js でマスターデータ投入\n'
-        + extraSteps + '\n\n'
-        + '■ 禁止事項\n'
+      lines += (stepNum++) + '. セットアップ実行:\n'
+        + '   ./scripts/setup-tenant.sh ' + p + ' ' + fmt(email, '<admin-email>') + ' --with-gmail --client-id=' + fmt(cid, '<client-id>') + ' --client-secret=' + fmt(csec, '<client-secret>') + ' --auth-code=' + fmt(code, '<auth-code>') + ' --yes\n\n';
+
+      lines += (stepNum++) + '. 中間検証:\n'
+        + '   ./scripts/verify-setup.sh ' + p + '\n\n';
+
+      lines += (stepNum++) + '. マスターデータ投入:\n'
+        + '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --customers ' + fmt(csvCust, '<customers.csv>') + '\n'
+        + '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --documents ' + fmt(csvDoc, '<documents.csv>') + '\n'
+        + '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --offices ' + fmt(csvOff, '<offices.csv>') + '\n';
+      if (csvCm) {
+        lines += '   FIREBASE_PROJECT_ID=' + p + ' node scripts/import-masters.js --caremanagers ' + fmt(csvCm, '') + '\n';
+      }
+      lines += '\n';
+
+      if (domain) {
+        lines += (stepNum++) + '. 許可ドメイン追加:\n'
+          + '   node scripts/check-allowed-domains.js ' + p + ' --add ' + fmt(domain, '<domain>') + '\n\n';
+      }
+
+      lines += (stepNum++) + '. 最終検証（全項目合格を確認）:\n'
+        + '   ./scripts/verify-setup.sh ' + p + '\n\n';
+
+      lines += stepNum + '. 結果をサマリーで報告\n\n';
+
+      lines += '■ 禁止事項\n'
         + '- firebase firestore:delete --all-collections は絶対禁止\n'
         + '- 本番環境にサンプルデータを投入しない\n'
         + '- 失敗時は3回まで再試行、それ以上は報告して停止';
+      return lines;
     }
 
     function updatePrompts() {
       if (!document.getElementById('project-id')) return;
-      var cid = _cdVal('client-id');
-
-      // 認証URL生成
-      var urlBox = document.getElementById('auth-url-box');
-      if (urlBox) {
-        if (cid) {
-          var authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?client_id=' + encodeURIComponent(cid) + '&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=https://www.googleapis.com/auth/gmail.readonly&access_type=offline';
-          document.getElementById('auth-url-text').textContent = authUrl;
-          urlBox.style.display = 'block';
-        } else {
-          urlBox.style.display = 'none';
-        }
-      }
 
       var elMin = document.getElementById('prompt-minimal');
       if (elMin) {
@@ -408,15 +400,6 @@
       });
     }
 
-    function copyAuthUrl() {
-      var text = document.getElementById('auth-url-text').textContent;
-      navigator.clipboard.writeText(text).then(function() {
-        var btn = document.getElementById('auth-url-copy-btn');
-        btn.textContent = 'コピーしました!';
-        btn.classList.add('copied');
-        setTimeout(function() { btn.textContent = 'URL をコピー'; btn.classList.remove('copied'); }, 2000);
-      });
-    }
   </script>
 </body>
 </html>

--- a/scripts/setup-gmail-auth.sh
+++ b/scripts/setup-gmail-auth.sh
@@ -4,16 +4,22 @@
 #
 # 使用方法:
 #   ./setup-gmail-auth.sh <project-id> [OPTIONS]
+#   ./setup-gmail-auth.sh --get-code --client-id=X   # 認証コード取得のみ
 #
 # オプション:
 #   --client-id=X      OAuth Client ID（省略時は対話入力）
 #   --client-secret=X  OAuth Client Secret（省略時は対話入力）
-#   --auth-code=X      OAuth 認証コード（省略時は対話入力）
+#   --auth-code=X      OAuth 認証コード（省略時はloopbackで自動取得）
+#   --get-code         認証コードの取得のみ行う（Secret Manager保存なし）
 #
 # 3つすべて指定すると非対話モードで実行（CI/Claude Code用）
 #
 # 事前準備:
 #   GCP Console で OAuth 2.0 クライアントIDを作成済みであること
+#   （種類: デスクトップアプリ）
+#
+# 注意: Google OAuth OOBフローは2023年に廃止済み。
+#       本スクリプトはloopback方式（http://localhost）を使用します。
 #
 
 set -e
@@ -30,34 +36,142 @@ log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+# OAuth loopback設定
+LOOPBACK_PORT=18234
+REDIRECT_URI="http://localhost:${LOOPBACK_PORT}"
+
 usage() {
     echo "Usage: $0 <project-id> [OPTIONS]"
+    echo "       $0 --get-code --client-id=X"
     echo ""
     echo "Options:"
     echo "  --client-id=X      OAuth Client ID（省略時は対話入力）"
     echo "  --client-secret=X  OAuth Client Secret（省略時は対話入力）"
-    echo "  --auth-code=X      OAuth 認証コード（省略時は対話入力）"
+    echo "  --auth-code=X      OAuth 認証コード（省略時はloopbackで自動取得）"
+    echo "  --get-code         認証コードの取得のみ（Secret Manager保存なし）"
     echo ""
     echo "3つすべて指定すると非対話モードで実行（CI/Claude Code用）"
     echo ""
     echo "Examples:"
     echo "  $0 my-project"
     echo "  $0 my-project --client-id=XXX --client-secret=YYY --auth-code=ZZZ"
+    echo "  $0 --get-code --client-id=XXX"
     exit 1
 }
 
-if [ $# -lt 1 ]; then
-    usage
-fi
+# ===========================================
+# Loopback認証コード取得関数
+# ===========================================
+get_auth_code_via_loopback() {
+    local client_id="$1"
 
-PROJECT_ID=$1
+    # Python3チェック
+    if ! command -v python3 &> /dev/null; then
+        log_error "python3 が見つかりません。Python 3をインストールしてください。"
+        exit 1
+    fi
 
+    # ポート使用チェック
+    if lsof -i ":${LOOPBACK_PORT}" &> /dev/null; then
+        log_error "ポート ${LOOPBACK_PORT} が使用中です。使用中のプロセスを終了してから再実行してください。"
+        exit 1
+    fi
+
+    local auth_url="https://accounts.google.com/o/oauth2/v2/auth?client_id=${client_id}&redirect_uri=${REDIRECT_URI}&response_type=code&scope=https://www.googleapis.com/auth/gmail.readonly&access_type=offline&prompt=consent"
+
+    echo ""
+    log_info "ブラウザで Google 認証画面を開きます..."
+    echo ""
+
+    # ブラウザを開く
+    if command -v open &> /dev/null; then
+        open "$auth_url"
+    elif command -v xdg-open &> /dev/null; then
+        xdg-open "$auth_url"
+    else
+        echo -e "${YELLOW}以下のURLをブラウザで開いてください:${NC}"
+        echo "$auth_url"
+    fi
+
+    echo "認証が完了するまで待機中... (ブラウザで Google アカウントを認証してください)"
+    echo ""
+
+    # Python loopback サーバーで認証コードを受け取る
+    AUTH_CODE=$(python3 << PYEOF
+import http.server
+import urllib.parse
+import sys
+
+LISTEN_PORT = ${LOOPBACK_PORT}
+
+class OAuthHandler(http.server.BaseHTTPRequestHandler):
+    auth_code = None
+
+    def do_GET(self):
+        query = urllib.parse.urlparse(self.path).query
+        params = urllib.parse.parse_qs(query)
+        if 'code' in params:
+            OAuthHandler.auth_code = params['code'][0]
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html; charset=utf-8')
+            self.end_headers()
+            html = '''<!DOCTYPE html><html><head><meta charset="utf-8">
+            <style>body{font-family:sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f0fdf4;}
+            .card{text-align:center;padding:40px;background:white;border-radius:12px;box-shadow:0 4px 6px rgba(0,0,0,0.1);}
+            h1{color:#065f46;}</style></head>
+            <body><div class="card"><h1>認証成功</h1><p>このタブを閉じてターミナルに戻ってください。</p></div></body></html>'''
+            self.wfile.write(html.encode())
+        elif 'error' in params:
+            error = params.get('error', ['unknown'])[0]
+            self.send_response(400)
+            self.send_header('Content-type', 'text/html; charset=utf-8')
+            self.end_headers()
+            self.wfile.write('<html><body><h1>認証エラー</h1><p>{}</p></body></html>'.format(error).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+try:
+    server = http.server.HTTPServer(('localhost', LISTEN_PORT), OAuthHandler)
+    server.timeout = 300
+    server.handle_request()
+    if OAuthHandler.auth_code:
+        print(OAuthHandler.auth_code)
+        sys.exit(0)
+    else:
+        sys.exit(1)
+except Exception as e:
+    sys.stderr.write("Error: {}\n".format(e))
+    sys.exit(1)
+PYEOF
+)
+
+    if [ -z "$AUTH_CODE" ]; then
+        log_error "認証コードの取得に失敗しました（タイムアウトまたはエラー）"
+        exit 1
+    fi
+
+    log_success "認証コードを取得しました"
+}
+
+# ===========================================
 # オプション解析
+# ===========================================
 CLIENT_ID=""
 CLIENT_SECRET=""
 AUTH_CODE=""
+GET_CODE_ONLY=false
+PROJECT_ID=""
 
-shift
+# 第1引数がオプションでなければ project-id
+if [ $# -ge 1 ] && [[ "$1" != --* ]]; then
+    PROJECT_ID=$1
+    shift
+fi
+
 for arg in "$@"; do
     case $arg in
         --client-id=*)
@@ -69,11 +183,43 @@ for arg in "$@"; do
         --auth-code=*)
             AUTH_CODE="${arg#*=}"
             ;;
+        --get-code)
+            GET_CODE_ONLY=true
+            ;;
         *)
             log_warn "不明なオプション: $arg"
             ;;
     esac
 done
+
+# ===========================================
+# --get-code モード: 認証コード取得のみ
+# ===========================================
+if [ "$GET_CODE_ONLY" = true ]; then
+    if [ -z "$CLIENT_ID" ]; then
+        echo -e "${YELLOW}OAuth Client IDを入力してください:${NC}"
+        read -p "Client ID: " CLIENT_ID
+    fi
+    if [ -z "$CLIENT_ID" ]; then
+        log_error "Client ID は必須です"
+        exit 1
+    fi
+
+    get_auth_code_via_loopback "$CLIENT_ID"
+    echo ""
+    echo -e "${GREEN}=== 認証コード ===${NC}"
+    echo "$AUTH_CODE"
+    echo ""
+    echo "この認証コードを GitHub Pages のフォームまたは --auth-code= オプションに使用してください。"
+    exit 0
+fi
+
+# ===========================================
+# 通常モード: project-id 必須チェック
+# ===========================================
+if [ -z "$PROJECT_ID" ]; then
+    usage
+fi
 
 # 非対話モード判定
 NON_INTERACTIVE=false
@@ -100,8 +246,12 @@ else
     echo "  4. 作成後、クライアントIDとシークレットをコピー"
     echo ""
 
-    read -p "OAuth Client ID: " CLIENT_ID
-    read -p "OAuth Client Secret: " CLIENT_SECRET
+    if [ -z "$CLIENT_ID" ]; then
+        read -p "OAuth Client ID: " CLIENT_ID
+    fi
+    if [ -z "$CLIENT_SECRET" ]; then
+        read -p "OAuth Client Secret: " CLIENT_SECRET
+    fi
 fi
 
 if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
@@ -110,27 +260,15 @@ if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
 fi
 
 # ===========================================
-# リフレッシュトークンの取得
+# 認証コードの取得
 # ===========================================
 echo ""
 log_info "リフレッシュトークンを取得します..."
 
 if [ "$NON_INTERACTIVE" = true ]; then
     log_info "非対話モード: 引数から認証コードを使用します"
-else
-    echo ""
-    echo -e "${YELLOW}以下のURLをブラウザで開いてください:${NC}"
-    echo ""
-
-    AUTH_URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=https://www.googleapis.com/auth/gmail.readonly&response_type=code&access_type=offline&prompt=consent"
-
-    echo "$AUTH_URL"
-    echo ""
-    echo "Googleアカウントでログインし、アクセスを許可してください。"
-    echo "表示された認証コードをコピーしてください。"
-    echo ""
-
-    read -p "認証コード: " AUTH_CODE
+elif [ -z "$AUTH_CODE" ]; then
+    get_auth_code_via_loopback "$CLIENT_ID"
 fi
 
 if [ -z "$AUTH_CODE" ]; then
@@ -146,7 +284,7 @@ TOKEN_RESPONSE=$(curl -s -X POST "https://oauth2.googleapis.com/token" \
     -d "client_secret=$CLIENT_SECRET" \
     -d "code=$AUTH_CODE" \
     -d "grant_type=authorization_code" \
-    -d "redirect_uri=urn:ietf:wg:oauth:2.0:oob")
+    -d "redirect_uri=$REDIRECT_URI")
 
 REFRESH_TOKEN=$(echo "$TOKEN_RESPONSE" | grep -o '"refresh_token": "[^"]*"' | cut -d'"' -f4)
 


### PR DESCRIPTION
## Summary
- `setup-gmail-auth.sh`: Google OAuth OOB(2023年廃止済み)からloopback方式(`http://localhost:18234`)に移行。Python HTTPサーバーで認証コード自動取得、`--get-code`モード追加
- `docs/claude-code-delivery.md`: 開発者の前提条件セクション追加、OAuth認証手順をloopback方式に更新
- `docs/index.html`: プロンプトジェネレーターを正確なコマンド形式（値埋め込み）に改善

## Test plan
- [ ] `./scripts/setup-gmail-auth.sh --get-code --client-id=<test-id>` でブラウザが開きloopbackサーバーが起動することを確認
- [ ] GitHub Pages (`docs/claude-code-delivery.md`) のフォーム入力→プロンプト生成が正しいコマンドを出力することを確認
- [ ] 生成されたプロンプトをClaude Codeに貼り付けて納品フローが完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup documentation with new developer prerequisites section.
  * Restructured setup instructions into clearly labeled, numbered steps.

* **New Features**
  * Implemented browser-based OAuth authentication loopback flow, replacing manual code entry process.
  * Added `--get-code` option for automated authentication code retrieval.

* **Improvements**
  * Enhanced setup prompts with conditional steps for additional configurations (caremanagers, domain handling).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->