### PR TITLE
refactor(e2e): loginWithTestUser を共通ヘルパーに抽出

### DIFF
--- a/frontend/e2e/auth-and-documents.spec.ts
+++ b/frontend/e2e/auth-and-documents.spec.ts
@@ -9,25 +9,8 @@
  *   3. テスト実行: cd frontend && npx playwright test e2e/auth-and-documents.spec.ts
  */
 
-import { test, expect, Page } from '@playwright/test';
-
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
-
-async function loginWithTestUser(page: Page) {
-  await page.goto('/');
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
-}
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser } from './helpers';
 
 // ============================================
 // 基本テスト（認証不要）

--- a/frontend/e2e/document-detail.spec.ts
+++ b/frontend/e2e/document-detail.spec.ts
@@ -9,25 +9,8 @@
  *   3. テスト実行: cd frontend && npx playwright test e2e/document-detail.spec.ts
  */
 
-import { test, expect, Page } from '@playwright/test';
-
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
-
-async function loginWithTestUser(page: Page) {
-  await page.goto('/');
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
-}
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser } from './helpers';
 
 // ============================================
 // Emulator環境テスト（認証必要 + シードデータ必要）

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,32 @@
+/**
+ * E2Eテスト共通ヘルパー
+ */
+
+import { Page } from '@playwright/test';
+
+export const TEST_USER = {
+  email: 'test@example.com',
+  password: 'testpassword123',
+};
+
+/**
+ * Emulator環境でメール/パスワードログイン
+ * @param waitSelector ログイン後の待機セレクタ（モバイルでは 'h1:has-text("書類管理")' を指定）
+ */
+export async function loginWithTestUser(page: Page, waitSelector = 'text=書類一覧') {
+  await page.goto('/');
+  await page.evaluate(
+    async ({ email, password }) => {
+      // @ts-expect-error - Vite devサーバー経由でモジュール解決
+      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
+      await signInWithEmailAndPassword(auth, email, password);
+    },
+    { email: TEST_USER.email, password: TEST_USER.password }
+  );
+  await page.waitForSelector(waitSelector, { timeout: 10000 });
+}
+
+/** タブをクリック */
+export async function clickTab(page: Page, tabName: string) {
+  await page.locator('[role="tab"]').filter({ hasText: tabName }).click();
+}

--- a/frontend/e2e/kana-filter.spec.ts
+++ b/frontend/e2e/kana-filter.spec.ts
@@ -10,34 +10,15 @@
  */
 
 import { test, expect, Page } from '@playwright/test';
-
-// テストユーザー情報（seed-e2e-data.jsと同じ）
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
+import { loginWithTestUser, clickTab } from './helpers';
 
 // ============================================
 // ヘルパー
 // ============================================
 
-async function loginWithTestUser(page: Page) {
-  await page.goto('/');
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
-}
-
 /** 「顧客別」タブに移動 */
 async function navigateToCustomerTab(page: Page) {
-  // タブをクリック
-  await page.locator('[role="tab"]').filter({ hasText: '顧客別' }).click();
+  await clickTab(page, '顧客別');
   // グループデータが表示されるまで待機（CIでは時間がかかる場合がある）
   await page.waitForTimeout(2000);
 }

--- a/frontend/e2e/mobile-pdf-view.spec.ts
+++ b/frontend/e2e/mobile-pdf-view.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { test, expect, Page } from '@playwright/test';
+import { loginWithTestUser as _loginWithTestUser } from './helpers';
 
 // モバイルViewport設定（CIではChromiumのみのため、devices[]ではなくviewport直指定）
 test.use({
@@ -15,23 +16,9 @@ test.use({
   baseURL: process.env.E2E_BASE_URL || 'http://localhost:5173',
 });
 
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
-
+/** モバイルではタブラベルが hidden sm:inline で非表示のため、h1ヘッダーで判定 */
 async function loginWithTestUser(page: Page) {
-  await page.goto('/');
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-  // モバイルではタブラベルが hidden sm:inline で非表示のため、h1ヘッダーで判定
-  await page.waitForSelector('h1:has-text("書類管理")', { timeout: 10000 });
+  await _loginWithTestUser(page, 'h1:has-text("書類管理")');
 }
 
 test.describe('モバイルPDFビュー @emulator', () => {

--- a/frontend/e2e/office-resolution.spec.ts
+++ b/frontend/e2e/office-resolution.spec.ts
@@ -9,43 +9,8 @@
  *   3. テスト実行: npm run test:e2e:emulator
  */
 
-import { test, expect, Page } from '@playwright/test';
-
-// テストユーザー情報（seed-e2e-data.jsと同じ）
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
-
-// ============================================
-// 認証ヘルパー
-// ============================================
-
-/**
- * Emulator環境でメール/パスワードログイン
- * Firebase Auth Emulatorではメール/パスワード認証が使用可能
- */
-async function loginWithTestUser(page: Page) {
-  // ログインページにアクセス
-  await page.goto('/');
-
-  // Emulator環境ではGoogleログインの代わりに
-  // Firebase UIのメール/パスワードフォームを使用するか、
-  // または直接FirebaseのsignInWithEmailAndPassword APIを呼び出す
-
-  // ここではページ内でFirebase認証を直接実行
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-
-  // ログイン後、書類一覧ページが表示されるまで待機
-  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
-}
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser } from './helpers';
 
 // ============================================
 // 基本テスト（認証不要）

--- a/frontend/e2e/pdf-upload.spec.ts
+++ b/frontend/e2e/pdf-upload.spec.ts
@@ -11,25 +11,8 @@
  *   3. テスト実行: cd frontend && npx playwright test e2e/pdf-upload.spec.ts
  */
 
-import { test, expect, Page } from '@playwright/test';
-
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
-
-async function loginWithTestUser(page: Page) {
-  await page.goto('/');
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
-}
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser } from './helpers';
 
 // ============================================
 // Emulator環境テスト（認証必要）

--- a/frontend/e2e/search.spec.ts
+++ b/frontend/e2e/search.spec.ts
@@ -11,25 +11,8 @@
  *   3. テスト実行: cd frontend && npx playwright test e2e/search.spec.ts
  */
 
-import { test, expect, Page } from '@playwright/test';
-
-const TEST_USER = {
-  email: 'test@example.com',
-  password: 'testpassword123',
-};
-
-async function loginWithTestUser(page: Page) {
-  await page.goto('/');
-  await page.evaluate(
-    async ({ email, password }) => {
-      // @ts-expect-error - Vite devサーバー経由でモジュール解決
-      const { auth, signInWithEmailAndPassword } = await import('/src/lib/firebase.ts');
-      await signInWithEmailAndPassword(auth, email, password);
-    },
-    { email: TEST_USER.email, password: TEST_USER.password }
-  );
-  await page.waitForSelector('text=書類一覧', { timeout: 10000 });
-}
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser } from './helpers';
 
 // ============================================
 // Emulator環境テスト（認証必要）


### PR DESCRIPTION
## Summary
- 7ファイルで重複していた `loginWithTestUser`, `TEST_USER` を `e2e/helpers.ts` に集約
- `clickTab` ヘルパーも追加（タブクリック操作の共通化）
- -150行の重複を除去し、E2Eテストの保守性を向上

## 影響範囲
- プロダクションコード変更: **なし**（テストコードのみ）
- dev/クライアント環境への再デプロイ: **不要**
- テスト数: 45件（変化なし）

## Test plan
- [ ] CIのE2Eテスト全パス（39件 @emulator）
- [ ] Playwrightテスト一覧が45件/8ファイルで正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test authentication utilities into a shared helper module to improve maintainability across end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->