### PR TITLE
fix: E2Eテスト「詳細モーダルを閉じる」のCI失敗を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,9 @@ venv/
 
 # Storage CORS設定（setup-tenant.shが自動生成）
 cors-*.json
+
+# Serena
+.serena/
+
+# Screenshots（開発用スクリーンショット）
+*.png

--- a/frontend/e2e/document-detail.spec.ts
+++ b/frontend/e2e/document-detail.spec.ts
@@ -70,6 +70,14 @@ test.describe('書類詳細モーダル @emulator', () => {
 
     // ESCキーで閉じる
     await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+
+    // 未確認書類の場合、OCR確認ダイアログが表示される
+    const closeWithoutVerify = page.locator('button:has-text("未確認のまま閉じる")');
+    if (await closeWithoutVerify.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await closeWithoutVerify.click();
+      await page.waitForTimeout(500);
+    }
 
     // モーダルが閉じる
     await expect(modal).not.toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Summary
- E2Eテスト `document-detail.spec.ts:63` のCI失敗を修正
- 未確認書類でESC押下時のOCR確認ダイアログ対応を追加（`mobile-pdf-view.spec.ts`の既存パターンを適用）
- `.gitignore`に`.serena/`と`*.png`を追加

## Test plan
- [ ] CI E2Eテストが39/39全パスすること
- [ ] 他のテストに回帰がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project build artifacts configuration.

* **Tests**
  * Enhanced document modal test to handle additional UI confirmation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->