### PR TITLE
feat: ネットワーク状態バナー＋一括削除の楽観的UI更新

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, Link, useLocation } from 'react-router-dom'
 import { FileText, Settings, LogOut, AlertCircle, Database, History, HelpCircle } from 'lucide-react'
 import { useAuthStore } from '@/stores/authStore'
+import { NetworkStatusBar } from '@/components/NetworkStatusBar'
 
 export function Layout() {
   const location = useLocation()
@@ -66,6 +67,8 @@ export function Layout() {
           </div>
         </div>
       </header>
+
+      <NetworkStatusBar />
 
       {/* Main content */}
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">

--- a/frontend/src/components/NetworkStatusBar.tsx
+++ b/frontend/src/components/NetworkStatusBar.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react'
+import { WifiOff } from 'lucide-react'
+import { useNetworkStatus } from '@/hooks/useNetworkStatus'
+
+export function NetworkStatusBar() {
+  const { isOnline } = useNetworkStatus()
+  const [showRecovered, setShowRecovered] = useState(false)
+  const [wasOffline, setWasOffline] = useState(false)
+
+  useEffect(() => {
+    if (!isOnline) {
+      setWasOffline(true)
+    } else if (wasOffline) {
+      setShowRecovered(true)
+      const timer = setTimeout(() => {
+        setShowRecovered(false)
+        setWasOffline(false)
+      }, 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [isOnline, wasOffline])
+
+  if (isOnline && !showRecovered) return null
+
+  return (
+    <div
+      className={`flex items-center justify-center gap-2 px-4 py-1.5 text-sm font-medium ${
+        isOnline
+          ? 'bg-green-600 text-white'
+          : 'bg-amber-500 text-white'
+      }`}
+    >
+      {isOnline ? (
+        'ネットワークが回復しました'
+      ) : (
+        <>
+          <WifiOff className="h-4 w-4" />
+          ネットワークに接続されていません — 操作が反映されない場合があります
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+
+export function useNetworkStatus() {
+  const [isOnline, setIsOnline] = useState(navigator.onLine)
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  return { isOnline }
+}


### PR DESCRIPTION
## Summary
- オフライン時にヘッダー下に黄色バナー表示（「ネットワークに接続されていません」）、復帰時に緑バナーで3秒間通知
- 一括削除で即座にリストから非表示にする楽観的UI更新を実装。バックエンド失敗時はロールバック
- 既存バグ修正: `invalidateQueries({ queryKey: ['documents'] })`が`['documentsInfinite']`にマッチせず、削除後のリスト更新が30秒のrefetchInterval頼みだった

## 変更ファイル（4ファイル）
| ファイル | 変更内容 |
|---------|---------|
| `hooks/useNetworkStatus.ts` | 新規: navigator.onLine監視hook |
| `components/NetworkStatusBar.tsx` | 新規: オフラインバナー＋復帰通知 |
| `components/Layout.tsx` | import追加＋NetworkStatusBar配置 |
| `pages/DocumentsPage.tsx` | handleBulkDeleteを楽観的UI更新に変更 |

## Test plan
- [ ] オフライン時にバナーが表示されること（DevTools Network → Offline）
- [ ] オンライン復帰時に緑バナーが3秒間表示されること
- [ ] 通常時はバナー非表示であること
- [ ] 一括削除で即座にリストから消えること
- [ ] 削除失敗時にリストが元に戻ること
- [ ] ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network connectivity indicator: A status bar now displays real-time network connectivity with distinct visual feedback for offline states and recovery confirmations
  * Enhanced bulk delete experience: Documents are immediately removed from view when bulk-deleted, with automatic restoration if any deletions fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->