### PR TITLE
fix: 一括確認・再処理のinvalidateQueries queryKey修正

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -369,7 +369,7 @@ export function DocumentsPage() {
       await batch.commit()
 
       // 一覧をリフレッシュ
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
       clearSelection()
       setBulkOperation(null)
@@ -399,7 +399,7 @@ export function DocumentsPage() {
       await batch.commit()
 
       // 一覧をリフレッシュ
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
       clearSelection()
       setBulkOperation(null)


### PR DESCRIPTION
## Summary
- 一括確認（handleBulkVerify）と一括再処理（handleBulkReprocess）の`invalidateQueries`のqueryKeyを`['documents']`→`['documentsInfinite']`に修正
- `useInfiniteDocuments`のqueryKey `['documentsInfinite']`にマッチしておらず、操作後のリスト更新が30秒のrefetchInterval頼みだった既存バグの修正
- PR #71で削除のみ修正済み、本PRで残り2箇所を修正

## Test plan
- [ ] 一括確認後にリストが即時更新されること
- [ ] 一括再処理後にリストが即時更新されること
- [ ] ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the refresh behavior for the documents list when performing bulk operations, ensuring the infinite scrolling list updates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->