### PR TITLE
fix: 残りのinvalidateQueries queryKeyミスマッチを全箇所修正

### DIFF
--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -263,7 +263,7 @@ export function useUpdateDocument() {
     mutationFn: updateDocument,
     onSuccess: (_, { documentId }) => {
       // 関連キャッシュを無効化
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['document', documentId] })
     },
   })

--- a/frontend/src/hooks/useErrors.ts
+++ b/frontend/src/hooks/useErrors.ts
@@ -172,7 +172,7 @@ export function useReprocessError() {
     mutationFn: requestReprocess,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['errors'] })
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
     },
   })
 }

--- a/frontend/src/hooks/usePdfSplit.ts
+++ b/frontend/src/hooks/usePdfSplit.ts
@@ -125,7 +125,7 @@ export function useSplitPdf() {
   return useMutation({
     mutationFn: splitPdf,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['document'] })
     },
   })

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -329,7 +329,7 @@ export function DocumentsPage() {
   // アップロード成功時のハンドラ
   const handleUploadSuccess = useCallback(() => {
     // ドキュメント一覧と統計をリフレッシュ
-    queryClient.invalidateQueries({ queryKey: ['documents'] })
+    queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
     queryClient.invalidateQueries({ queryKey: ['documentStats'] })
   }, [queryClient])
 


### PR DESCRIPTION
## Summary
- PR #71, #72に続き、残りの`invalidateQueries({ queryKey: ['documents'] })`を全て`['documentsInfinite']`に修正
- 対象4箇所: アップロード成功後、ドキュメント編集後、PDF分割後、エラー再処理後
- これで全箇所が`useInfiniteDocuments`のqueryKey`['documentsInfinite']`と一致

## 変更箇所
| ファイル | 操作 |
|---------|------|
| `DocumentsPage.tsx:332` | アップロード成功後のリスト更新 |
| `useDocuments.ts:266` | ドキュメント編集後のリスト更新 |
| `usePdfSplit.ts:128` | PDF分割後のリスト更新 |
| `useErrors.ts:175` | エラー再処理後のリスト更新 |

## Test plan
- [ ] PDFアップロード後にリストが即時更新されること
- [ ] ドキュメント編集後にリストが即時更新されること
- [ ] PDF分割後にリストが即時更新されること
- [ ] ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)