### PR TITLE
fix: 一括操作ボタンのモバイルアイコン化

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -594,7 +594,7 @@ export function DocumentsPage() {
                 }`}
               >
                 <RotateCcw className={`h-3.5 w-3.5 ${isBulkOperating && bulkOperation === 'reprocess' ? 'animate-spin' : ''}`} />
-                再処理
+                <span className="hidden sm:inline">再処理</span>
               </Button>
               <Button
                 variant="outline"
@@ -615,7 +615,7 @@ export function DocumentsPage() {
                 }`}
               >
                 <CheckCircle2 className="h-3.5 w-3.5" />
-                確認済み
+                <span className="hidden sm:inline">確認済み</span>
               </Button>
               <Button
                 variant="outline"
@@ -636,7 +636,7 @@ export function DocumentsPage() {
                 }`}
               >
                 <Trash2 className="h-3.5 w-3.5" />
-                削除
+                <span className="hidden sm:inline">削除</span>
               </Button>
 
               {/* 選択モード終了ボタン */}


### PR DESCRIPTION
## Summary
- 一括操作ボタン（再処理・確認済み・削除）のラベルをモバイルで非表示にし、アイコンのみ表示
- タブと同じ `hidden sm:inline` パターンを適用

## Test plan
- [ ] モバイル幅でタブ行と操作ボタンが1行に収まる
- [ ] デスクトップ幅ではラベル付きで表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile responsiveness: bulk action buttons now display as icons only on mobile and extra-small screens, while preserving full text labels on small screens and larger devices for improved usability and space efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->