### PR TITLE
fix: 選択件数のモバイルバッジ表示

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -560,13 +560,18 @@ export function DocumentsPage() {
           {/* 一括操作ボタン（管理者のみ） */}
           {isAdmin && (
             <div className="flex items-center gap-1.5 ml-auto">
-              {/* 選択モード中: 件数表示 */}
+              {/* 選択モード中: 件数表示（モバイル:バッジ / デスクトップ:テキスト） */}
               {selectionMode && (
                 <>
                   {isBulkOperating && (
                     <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
                   )}
-                  <span className={`text-sm font-medium whitespace-nowrap mr-1 ${isBulkOperating ? 'text-blue-700' : 'text-blue-800'}`}>
+                  {/* モバイル: コンパクトなバッジ */}
+                  <span className="sm:hidden inline-flex items-center justify-center h-5 min-w-[1.25rem] rounded-full bg-blue-600 text-white text-xs font-bold px-1">
+                    {selectedIds.size}
+                  </span>
+                  {/* デスクトップ: フルテキスト */}
+                  <span className={`hidden sm:inline text-sm font-medium whitespace-nowrap mr-1 ${isBulkOperating ? 'text-blue-700' : 'text-blue-800'}`}>
                     {isBulkOperating
                       ? `${selectedIds.size}件を処理中...`
                       : `${selectedIds.size}件選択中`


### PR DESCRIPTION
## Summary
- モバイル: 選択件数を小さな丸バッジ（数字のみ）で表示し改行を防止
- デスクトップ: 従来通り「N件選択中」テキスト表示

## Test plan
- [ ] モバイル幅で選択モード時にバッジ表示、改行なし
- [ ] デスクトップ幅でフルテキスト表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design in the admin bulk operations interface. Mobile users now see a compact badge displaying the count of selected items, while desktop users view the full-text label for improved usability across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->