### PR TITLE
fix: タブ行の改行を防止

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -542,7 +542,7 @@ export function DocumentsPage() {
 
       {/* ビュー切替タブ */}
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as ViewTab)}>
-        <div className="mb-4 flex items-center gap-3 flex-wrap">
+        <div className="mb-4 flex items-center gap-3">
           <TabsList className="flex-wrap h-auto">
             {VIEW_TABS.map((tab) => (
               <TabsTrigger


### PR DESCRIPTION
## Summary
- タブ＋操作ボタンのラッパーから`flex-wrap`を削除し、1行に強制配置

## Test plan
- [ ] モバイル幅でタブ行が改行されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)