### PR TITLE
fix: タブ行の折り返しを完全に防止

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -542,8 +542,8 @@ export function DocumentsPage() {
 
       {/* ビュー切替タブ */}
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as ViewTab)}>
-        <div className="mb-4 flex items-center gap-3">
-          <TabsList className="flex-wrap h-auto">
+        <div className="mb-4 flex items-center gap-2 overflow-x-auto">
+          <TabsList className="shrink-0">
             {VIEW_TABS.map((tab) => (
               <TabsTrigger
                 key={tab.value}


### PR DESCRIPTION
## Summary
- TabsListから`flex-wrap h-auto`を削除し`shrink-0`に変更
- 外側コンテナを`overflow-x-auto`で横スクロール可能に
- タブ5つ＋操作ボタン3つが常に1行で表示される

## Test plan
- [ ] モバイル幅でタブ・ボタンが1行に収まる（折り返しなし）
- [ ] 幅が足りない場合は横スクロールで対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)