### PR TITLE
feat: 一括操作ボタンの選択/実行状態を視覚的に区別

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -578,19 +578,20 @@ export function DocumentsPage() {
                     }
                   }}
                   disabled={isBulkOperating || (!!selectionMode && selectionMode !== 'reprocess')}
-                  className={`flex items-center gap-1 h-7 text-xs transition-all ${
-                    selectionMode === 'reprocess'
-                      ? 'bg-blue-100 border-blue-400 text-blue-700 ring-1 ring-blue-400'
-                      : selectionMode ? 'opacity-40' : ''
+                  className={`flex items-center gap-1 h-7 text-xs transition-all duration-200 ${
+                    selectionMode === 'reprocess' && selectedIds.size > 0
+                      ? 'bg-blue-600 border-blue-600 text-white shadow-md hover:bg-blue-700'
+                      : selectionMode === 'reprocess'
+                        ? 'bg-blue-100 border-blue-400 text-blue-700 ring-1 ring-blue-400'
+                        : selectionMode ? 'opacity-40' : ''
                   }`}
                 >
                   <RotateCcw className={`h-3.5 w-3.5 ${isBulkOperating && bulkOperation === 'reprocess' ? 'animate-spin' : ''}`} />
                   <span className="hidden sm:inline">再処理</span>
                 </Button>
-                {/* フローティングバッジ（アクティブ時） */}
-                {selectionMode === 'reprocess' && (
-                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-blue-600 text-white text-[10px] font-bold px-1.5 py-0 leading-4 shadow-sm whitespace-nowrap pointer-events-none">
-                    {selectedIds.size}<span className="hidden sm:inline">件選択中</span>
+                {selectionMode === 'reprocess' && selectedIds.size > 0 && (
+                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-white text-blue-700 border border-blue-300 text-[10px] font-bold px-1.5 py-0 leading-4 shadow-sm whitespace-nowrap pointer-events-none">
+                    {selectedIds.size}<span className="hidden sm:inline">件</span>
                   </span>
                 )}
               </div>
@@ -609,18 +610,20 @@ export function DocumentsPage() {
                     }
                   }}
                   disabled={isBulkOperating || (!!selectionMode && selectionMode !== 'verify')}
-                  className={`flex items-center gap-1 h-7 text-xs transition-all ${
-                    selectionMode === 'verify'
-                      ? 'bg-blue-100 border-blue-400 text-blue-700 ring-1 ring-blue-400'
-                      : selectionMode ? 'opacity-40' : ''
+                  className={`flex items-center gap-1 h-7 text-xs transition-all duration-200 ${
+                    selectionMode === 'verify' && selectedIds.size > 0
+                      ? 'bg-blue-600 border-blue-600 text-white shadow-md hover:bg-blue-700'
+                      : selectionMode === 'verify'
+                        ? 'bg-blue-100 border-blue-400 text-blue-700 ring-1 ring-blue-400'
+                        : selectionMode ? 'opacity-40' : ''
                   }`}
                 >
                   <CheckCircle2 className="h-3.5 w-3.5" />
                   <span className="hidden sm:inline">確認済み</span>
                 </Button>
-                {selectionMode === 'verify' && (
-                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-blue-600 text-white text-[10px] font-bold px-1.5 py-0 leading-4 shadow-sm whitespace-nowrap pointer-events-none">
-                    {selectedIds.size}<span className="hidden sm:inline">件選択中</span>
+                {selectionMode === 'verify' && selectedIds.size > 0 && (
+                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-white text-blue-700 border border-blue-300 text-[10px] font-bold px-1.5 py-0 leading-4 shadow-sm whitespace-nowrap pointer-events-none">
+                    {selectedIds.size}<span className="hidden sm:inline">件</span>
                   </span>
                 )}
               </div>
@@ -639,18 +642,20 @@ export function DocumentsPage() {
                     }
                   }}
                   disabled={isBulkOperating || (!!selectionMode && selectionMode !== 'delete')}
-                  className={`flex items-center gap-1 h-7 text-xs transition-all ${
-                    selectionMode === 'delete'
-                      ? 'bg-red-100 border-red-400 text-red-700 ring-1 ring-red-400'
-                      : selectionMode ? 'opacity-40' : 'text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200'
+                  className={`flex items-center gap-1 h-7 text-xs transition-all duration-200 ${
+                    selectionMode === 'delete' && selectedIds.size > 0
+                      ? 'bg-red-600 border-red-600 text-white shadow-md hover:bg-red-700'
+                      : selectionMode === 'delete'
+                        ? 'bg-red-100 border-red-400 text-red-700 ring-1 ring-red-400'
+                        : selectionMode ? 'opacity-40' : 'text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200'
                   }`}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                   <span className="hidden sm:inline">削除</span>
                 </Button>
-                {selectionMode === 'delete' && (
-                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-red-600 text-white text-[10px] font-bold px-1.5 py-0 leading-4 shadow-sm whitespace-nowrap pointer-events-none">
-                    {selectedIds.size}<span className="hidden sm:inline">件選択中</span>
+                {selectionMode === 'delete' && selectedIds.size > 0 && (
+                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 inline-flex items-center rounded-full bg-white text-red-700 border border-red-300 text-[10px] font-bold px-1.5 py-0 leading-4 shadow-sm whitespace-nowrap pointer-events-none">
+                    {selectedIds.size}<span className="hidden sm:inline">件</span>
                   </span>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- 0件選択時: アウトライン表示（モード解除用トグル）、バッジなし
- 1件以上選択時: ソリッド塗りに変化（実行ボタン化）、件数バッジ表示
- 削除=赤ソリッド、再処理/確認済み=青ソリッド
- バッジは白背景に色付きテキストで視認性確保

## Test plan
- [ ] 0件選択時はアウトライン表示、バッジなし
- [ ] 1件以上チェックするとボタンがソリッド塗りに変化
- [ ] バッジに件数が表示される
- [ ] ソリッドボタンクリックで確認ダイアログが表示される
- [ ] 0件のアウトラインボタン再クリックで選択モード解除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced bulk-action buttons with improved visual feedback when items are selected
  * Added selection count indicator badge for reprocess, verify, and delete actions
  * Implemented smoother visual transitions across all bulk actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->