### PR TITLE
fix: デスクトップの件数テキスト・×ボタンを左側に移動

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -560,6 +560,26 @@ export function DocumentsPage() {
           {/* 一括操作ボタン（管理者のみ） */}
           {isAdmin && (
             <div className="flex items-center gap-1.5 ml-auto">
+              {/* デスクトップ: 件数テキスト＋×ボタン（操作ボタンの左側に配置） */}
+              {selectionMode && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearSelection}
+                    disabled={isBulkOperating}
+                    className="hidden sm:flex h-7 w-7 p-0"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </Button>
+                  <span className={`hidden sm:inline text-sm font-medium whitespace-nowrap ${
+                    selectedIds.size > 0 ? 'text-blue-800' : 'text-gray-500'
+                  }`}>
+                    {selectedIds.size}件選択中
+                  </span>
+                </>
+              )}
+
               {/* 処理中スピナー */}
               {selectionMode && isBulkOperating && (
                 <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
@@ -661,25 +681,6 @@ export function DocumentsPage() {
                 )}
               </div>
 
-              {/* デスクトップ: 件数テキスト＋×ボタン */}
-              {selectionMode && (
-                <>
-                  <span className={`hidden sm:inline text-sm font-medium whitespace-nowrap ${
-                    selectedIds.size > 0 ? 'text-blue-800' : 'text-gray-500'
-                  }`}>
-                    {selectedIds.size}件選択中
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={clearSelection}
-                    disabled={isBulkOperating}
-                    className="hidden sm:flex h-7 w-7 p-0"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </Button>
-                </>
-              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- デスクトップ表示の「N件選択中」テキストと×ボタンを、操作ボタン（再処理・確認済み・削除）の**左側**に移動
- 選択モードのON/OFFで操作ボタンの位置が動かなくなり、レイアウトが安定

## Test plan
- [ ] デスクトップ: 操作ボタンクリック時に「N件選択中」と×が左側に表示される
- [ ] デスクトップ: 操作ボタンの位置がモード切替前後で変わらない
- [ ] モバイル: 変更なし（従来通りバッジのみ表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)