### PR TITLE
fix: 全Callable関数の認証・権限チェックを統一

### DIFF
--- a/functions/src/admin/masterOperations.ts
+++ b/functions/src/admin/masterOperations.ts
@@ -34,10 +34,18 @@ export const addMasterAlias = onCall(
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Authentication required');
     }
+    // 2. ホワイトリスト + adminロール確認
+    const userDoc = await getFirestore().doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+    if (userDoc.data()?.role !== 'admin') {
+      throw new HttpsError('permission-denied', 'Admin permission required');
+    }
 
     const { masterType, masterId, alias } = request.data;
 
-    // 2. パラメータ検証
+    // 3. パラメータ検証
     if (!masterType || !['office', 'customer', 'document'].includes(masterType)) {
       throw new HttpsError('invalid-argument', 'Invalid masterType. Must be office, customer, or document');
     }
@@ -110,10 +118,18 @@ export const removeMasterAlias = onCall(
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Authentication required');
     }
+    // 2. ホワイトリスト + adminロール確認
+    const userDoc = await getFirestore().doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+    if (userDoc.data()?.role !== 'admin') {
+      throw new HttpsError('permission-denied', 'Admin permission required');
+    }
 
     const { masterType, masterId, alias } = request.data;
 
-    // 2. パラメータ検証
+    // 3. パラメータ検証
     if (!masterType || !['office', 'customer', 'document'].includes(masterType)) {
       throw new HttpsError('invalid-argument', 'Invalid masterType');
     }

--- a/functions/src/ocr/getOcrText.ts
+++ b/functions/src/ocr/getOcrText.ts
@@ -23,6 +23,10 @@ export const getOcrText = onCall(
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Authentication required');
     }
+    const userDoc = await getFirestore().doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
 
     const { documentId } = request.data;
     if (!documentId || typeof documentId !== 'string') {

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -36,6 +36,10 @@ export const regenerateSummary = functions.https.onCall(
     if (!request.auth) {
       throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
     }
+    const userDoc = await db.doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new functions.https.HttpsError('permission-denied', 'User not in whitelist');
+    }
 
     const { docId } = request.data as RegenerateSummaryRequest;
 

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -45,6 +45,15 @@ export const detectSplitPoints = onCall(
     memory: '512MiB',
   },
   async (request) => {
+    // 認証チェック
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Authentication required');
+    }
+    const userDoc = await db.doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+
     const { documentId, useEnhanced = true } = request.data;
     console.log(`detectSplitPoints called: documentId=${documentId}, useEnhanced=${useEnhanced}`);
 
@@ -256,6 +265,15 @@ export const splitPdf = onCall(
     timeoutSeconds: 300,
   },
   async (request) => {
+    // 認証チェック
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Authentication required');
+    }
+    const userDoc = await db.doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+
     const { documentId, splitPoints, segments } = request.data as SplitRequest;
 
     if (!documentId || !splitPoints || !segments) {
@@ -457,6 +475,15 @@ export const rotatePdfPages = onCall(
     memory: '512MiB',
   },
   async (request) => {
+    // 認証チェック
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Authentication required');
+    }
+    const userDoc = await db.doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
+
     const { documentId, rotations } = request.data as RotateRequest;
     console.log('rotatePdfPages called:', { documentId, rotations });
 

--- a/functions/src/search/searchDocuments.ts
+++ b/functions/src/search/searchDocuments.ts
@@ -135,6 +135,10 @@ export const searchDocuments = onCall<SearchRequest>(
     if (!request.auth) {
       throw new HttpsError('unauthenticated', '認証が必要です');
     }
+    const userDoc = await db.doc(`users/${request.auth.uid}`).get();
+    if (!userDoc.exists) {
+      throw new HttpsError('permission-denied', 'User not in whitelist');
+    }
 
     const { query, limit = 20, offset = 0 } = request.data;
 


### PR DESCRIPTION
## Summary
- PDF系Callable 3関数（detectSplitPoints/splitPdf/rotatePdfPages）に認証+ホワイトリスト確認を追加（未認証ユーザーによるPDF操作を防止）
- OCR/検索系Callable 3関数（getOcrText/regenerateSummary/searchDocuments）にホワイトリスト確認を追加（uploadPdf.tsパターンに統一）
- マスター操作Callable 2関数（addMasterAlias/removeMasterAlias）にホワイトリスト+adminロール確認を追加
- initTenant系onRequest 2関数（initTenantSettings/registerAdminUser）に初回セットアップ限定ガードを追加（setup-tenant.shフロー維持）

## 背景
納品前セキュリティレビューで、PDF系Callableに認証チェックが無く未認証ユーザーからの呼び出しが可能であることが判明。他のCallableも権限レベルに不統一があったため、一括で修正。

## 変更パターン

| 関数 | 変更前 | 変更後 |
|------|--------|--------|
| detectSplitPoints/splitPdf/rotatePdfPages | 認証なし | 認証+ホワイトリスト |
| getOcrText/regenerateSummary/searchDocuments | 認証のみ | 認証+ホワイトリスト |
| addMasterAlias/removeMasterAlias | 認証のみ | 認証+ホワイトリスト+admin |
| initTenantSettings | ガードなし | 設定既存時は403 |
| registerAdminUser | ガードなし | admin既存時は403 |

## Test plan
- [x] `npm run build` (functions) 成功
- [x] `npm test` (functions) 227テスト全パス
- [ ] デプロイ後、認証済みユーザーでPDF分割・回転・検索等が正常動作すること
- [ ] 未認証状態でのCallable呼び出しがunauthenticatedエラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security & Access Control**
  * First-time setup is now protected—cannot be reconfigured after initial configuration
  * Admin operations require verified administrative authorization
  * OCR text extraction and PDF manipulation operations restricted to whitelisted users
  * Search functionality now enforces user whitelist verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->