### PR TITLE
feat: 一括操作の完了トースト通知を追加

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "react-dom": "^18.3.1",
     "react-pdf": "^9.1.1",
     "react-router-dom": "^6.28.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.1"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
+import { Toaster } from 'sonner'
 import { useAuthStore } from '@/stores/authStore'
 import { LoginPage } from '@/pages/LoginPage'
 import { DocumentsPage } from '@/pages/DocumentsPage'
@@ -53,6 +54,7 @@ function AdminRoute({ children }: { children: React.ReactNode }) {
 export default function App() {
   return (
     <AuthInitializer>
+      <Toaster position="top-center" richColors />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -23,6 +23,7 @@ import {
   CheckCircle2,
   X,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import { Timestamp } from 'firebase/firestore'
@@ -442,6 +443,7 @@ export function DocumentsPage() {
           verifiedAt: serverTimestamp(),
         })
       }
+      const count = selectedIds.size
       await batch.commit()
 
       // 一覧をリフレッシュ
@@ -449,9 +451,10 @@ export function DocumentsPage() {
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
       clearSelection()
       setBulkOperation(null)
+      toast.success(`${count}件を確認済みにしました`)
     } catch (error) {
       console.error('Bulk verify error:', error)
-      alert('一括確認に失敗しました')
+      toast.error('一括確認に失敗しました')
     } finally {
       setIsBulkOperating(false)
     }
@@ -472,6 +475,7 @@ export function DocumentsPage() {
           error: deleteField(),
         })
       }
+      const count = selectedIds.size
       await batch.commit()
 
       // 一覧をリフレッシュ
@@ -479,9 +483,10 @@ export function DocumentsPage() {
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
       clearSelection()
       setBulkOperation(null)
+      toast.success(`${count}件を再処理キューに追加しました`)
     } catch (error) {
       console.error('Bulk reprocess error:', error)
-      alert('一括再処理に失敗しました')
+      toast.error('一括再処理に失敗しました')
     } finally {
       setIsBulkOperating(false)
     }
@@ -529,15 +534,17 @@ export function DocumentsPage() {
 
       if (failed > 0) {
         // 部分失敗: サーバーの実際の状態で一覧を更新
-        alert(`${results.length - failed}件削除、${failed}件失敗しました`)
+        toast.warning(`${results.length - failed}件削除、${failed}件失敗しました`)
         queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
+      } else {
+        toast.success(`${results.length}件を削除しました`)
       }
 
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
       queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
     } catch (error) {
       console.error('Bulk delete error:', error)
-      alert('一括削除に失敗しました')
+      toast.error('一括削除に失敗しました')
       // ロールバック: 元のデータを復元
       previousPages.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data)

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-dom": "^18.3.1",
         "react-pdf": "^9.1.1",
         "react-router-dom": "^6.28.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.1"
@@ -15083,6 +15084,16 @@
       "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",


### PR DESCRIPTION
## Summary
- 一括操作（削除・確認済み・再処理）完了後にトースト通知を表示
- 成功時: 「X件を削除しました」等の件数付きメッセージ
- エラー時: `alert()` → `toast.error()` に置換（非ブロッキング化）
- 部分失敗時: `toast.warning()` で成功/失敗件数を表示

## Test plan
- [ ] 一括削除 → 「X件を削除しました」トースト表示
- [ ] 一括確認済み → 「X件を確認済みにしました」トースト表示
- [ ] 一括再処理 → 「X件を再処理キューに追加しました」トースト表示
- [ ] エラー時 → alert()ではなくトーストで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added toast notifications for bulk operations (verify, reprocess, delete). Success messages display operation counts, partial failure warnings show affected items, and error messages alert users to any issues during these actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->