### PR TITLE
refactor: httpsCallable共通ヘルパー導入（全8箇所にリトライ適用）

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -9,8 +9,8 @@ import { ja } from 'date-fns/locale'
 import { Timestamp } from 'firebase/firestore'
 import { ref, getDownloadURL } from 'firebase/storage'
 import { Download, ExternalLink, Loader2, FileText, User, Building, Calendar, Tag, AlertCircle, Scissors, Pencil, Save, X, BookMarked, History, ChevronUp, ChevronDown, Sparkles, RefreshCw, CheckCircle, XCircle } from 'lucide-react'
-import { httpsCallable } from 'firebase/functions'
-import { storage, functions } from '@/lib/firebase'
+import { storage } from '@/lib/firebase'
+import { callFunction } from '@/lib/callFunction'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   Dialog,
@@ -479,11 +479,9 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
 
     setIsGeneratingSummary(true)
     try {
-      const callable = httpsCallable<{ docId: string }, { success: boolean; summary: string }>(
-        functions,
-        'regenerateSummary'
+      await callFunction<{ docId: string }, { success: boolean; summary: string }>(
+        'regenerateSummary', { docId: documentId }, { timeout: 60_000 }
       )
-      await callable({ docId: documentId })
       // キャッシュを無効化して再取得
       await queryClient.invalidateQueries({ queryKey: ['document', documentId] })
       await refetch()

--- a/frontend/src/hooks/useMasterAlias.ts
+++ b/frontend/src/hooks/useMasterAlias.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import { getFunctions, httpsCallable } from 'firebase/functions';
+import { callFunction } from '@/lib/callFunction';
 
 type MasterType = 'office' | 'customer' | 'document';
 
@@ -38,14 +38,11 @@ export function useMasterAlias() {
       setError(null);
 
       try {
-        const functions = getFunctions(undefined, 'asia-northeast1');
-        const addMasterAlias = httpsCallable<
+        const result = await callFunction<
           { masterType: MasterType; masterId: string; alias: string },
           AddAliasResult
-        >(functions, 'addMasterAlias');
-
-        const result = await addMasterAlias({ masterType, masterId, alias });
-        return result.data.success;
+        >('addMasterAlias', { masterType, masterId, alias }, { timeout: 60_000 });
+        return result.success;
       } catch (err) {
         console.error('Failed to add alias:', err);
         setError(err instanceof Error ? err : new Error('Failed to add alias'));

--- a/frontend/src/hooks/usePdfSplit.ts
+++ b/frontend/src/hooks/usePdfSplit.ts
@@ -4,8 +4,7 @@
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { httpsCallable } from 'firebase/functions'
-import { functions } from '@/lib/firebase'
+import { callFunction } from '@/lib/callFunction'
 import type { SplitSuggestion, SplitSegment } from '@shared/types'
 
 // ============================================
@@ -87,12 +86,9 @@ interface RotatePdfRequest {
 // ============================================
 
 async function detectSplitPoints(documentId: string): Promise<DetectSplitPointsResponse> {
-  const callable = httpsCallable<{ documentId: string }, DetectSplitPointsResponse>(
-    functions,
-    'detectSplitPoints'
+  return callFunction<{ documentId: string }, DetectSplitPointsResponse>(
+    'detectSplitPoints', { documentId }, { timeout: 300_000 }
   )
-  const result = await callable({ documentId })
-  return result.data
 }
 
 export function useDetectSplitPoints() {
@@ -111,12 +107,9 @@ export function useDetectSplitPoints() {
 // ============================================
 
 async function splitPdf(request: SplitPdfRequest): Promise<SplitPdfResponse> {
-  const callable = httpsCallable<SplitPdfRequest, SplitPdfResponse>(
-    functions,
-    'splitPdf'
+  return callFunction<SplitPdfRequest, SplitPdfResponse>(
+    'splitPdf', request, { timeout: 300_000 }
   )
-  const result = await callable(request)
-  return result.data
 }
 
 export function useSplitPdf() {
@@ -136,11 +129,9 @@ export function useSplitPdf() {
 // ============================================
 
 async function rotatePdfPages(request: RotatePdfRequest): Promise<void> {
-  const callable = httpsCallable<RotatePdfRequest, { success: boolean }>(
-    functions,
-    'rotatePdfPages'
+  await callFunction<RotatePdfRequest, { success: boolean }>(
+    'rotatePdfPages', request, { timeout: 300_000 }
   )
-  await callable(request)
 }
 
 export function useRotatePdfPages() {

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -9,11 +9,7 @@
 
 import { useState, useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getFunctions, httpsCallable } from 'firebase/functions';
-import { app } from '@/lib/firebase';
-
-// Cloud Functions インスタンス
-const functions = getFunctions(app, 'asia-northeast1');
+import { callFunction } from '@/lib/callFunction';
 
 /** 検索結果ドキュメント */
 export interface SearchResultDocument {
@@ -59,9 +55,9 @@ interface UseSearchResult {
  * 検索API呼び出し
  */
 async function searchDocumentsApi(request: SearchRequest): Promise<SearchResult> {
-  const searchFn = httpsCallable<SearchRequest, SearchResult>(functions, 'searchDocuments');
-  const result = await searchFn(request);
-  return result.data;
+  return callFunction<SearchRequest, SearchResult>(
+    'searchDocuments', request, { timeout: 30_000 }
+  );
 }
 
 /**

--- a/frontend/src/lib/callFunction.ts
+++ b/frontend/src/lib/callFunction.ts
@@ -1,0 +1,68 @@
+/**
+ * httpsCallable 共通ヘルパー
+ *
+ * モバイルバックグラウンド復帰時の一時的エラーに対して
+ * トークンリフレッシュ + 1回自動リトライを行う。
+ *
+ * リトライ対象:
+ * - unauthenticated: トークン失効
+ * - deadline-exceeded: タイムアウト
+ * - internal: ネットワーク切断
+ */
+
+import { httpsCallable } from 'firebase/functions'
+import { functions, auth } from './firebase'
+
+/** リトライ対象のエラーかどうか判定 */
+function isRetryableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const msg = err.message
+  return msg.includes('unauthenticated') ||
+    msg.includes('deadline-exceeded') ||
+    msg.includes('internal')
+}
+
+/**
+ * Cloud Function を呼び出す（自動リトライ付き）
+ *
+ * @param name - Cloud Function名
+ * @param data - リクエストデータ
+ * @param options.timeout - クライアント側タイムアウト（ms）。Cloud Functions側と合わせること。
+ */
+export async function callFunction<TReq, TRes>(
+  name: string,
+  data: TReq,
+  options?: { timeout?: number }
+): Promise<TRes> {
+  const callable = httpsCallable<TReq, TRes>(
+    functions,
+    name,
+    { timeout: options?.timeout ?? 70_000 }
+  )
+
+  try {
+    const result = await callable(data)
+    return result.data
+  } catch (err) {
+    if (isRetryableError(err) && auth.currentUser) {
+      try {
+        await auth.currentUser.getIdToken(true)
+        const result = await callable(data)
+        return result.data
+      } catch {
+        // リトライも失敗 → 元のエラーをthrow
+      }
+    }
+    throw err
+  }
+}
+
+/** よくあるエラーをユーザー向けメッセージに変換 */
+export function getCallableErrorMessage(err: unknown, defaultMessage = '処理に失敗しました'): string {
+  if (!(err instanceof Error)) return defaultMessage
+  const msg = err.message
+  if (msg.includes('unauthenticated')) return 'ログインセッションが切れました。ページを再読み込みしてください。'
+  if (msg.includes('deadline-exceeded') || msg.includes('internal')) return '通信エラーが発生しました。電波状況を確認して再度お試しください。'
+  if (msg.includes('permission-denied') || msg.includes('not in whitelist')) return '権限がありません。'
+  return defaultMessage
+}


### PR DESCRIPTION
## Summary
- `callFunction` 共通ヘルパーを新規作成（`frontend/src/lib/callFunction.ts`）
- 全8箇所のhttpsCallable呼び出しをヘルパーに統一
- Cloud Functions側タイムアウトとクライアント側タイムアウトを一致させた
- 一時的エラー（unauthenticated/deadline-exceeded/internal）で自動リトライ+トークンリフレッシュ
- PdfUploadModalの個別リトライロジックをヘルパーに委譲し40行削減

## 対象
| Cloud Function | CF側timeout | クライアント側timeout |
|---|---|---|
| uploadPdf | 120s | 120s |
| splitPdf | 300s | 300s |
| detectSplitPoints | 300s | 300s |
| rotatePdfPages | 300s | 300s |
| regenerateSummary | 60s | 60s |
| deleteDocument | 60s | 60s |
| searchDocuments | 30s | 30s |
| addMasterAlias | 60s | 60s |

## Test plan
- [ ] ビルド成功
- [ ] 既存テスト全パス（71/71）
- [ ] PDFアップロードが正常動作すること
- [ ] PDF分割・回転が正常動作すること
- [ ] 検索が正常動作すること
- [ ] 一括削除が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)