### PR TITLE
feat: 未判定時にエイリアス登録ヒントを表示

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -977,6 +977,13 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                               </div>
                             </div>
                           )}
+                          {/* 未判定時のエイリアス登録ヒント */}
+                          {editedFields.customerName &&
+                           document.customerName === '未判定' && (
+                            <p className="mt-1.5 text-xs text-muted-foreground">
+                              表記揺れで未判定になる場合は、<a href="/masters" className="text-blue-600 underline">マスター管理</a>で別表記を登録すると次回から自動マッチします
+                            </p>
+                          )}
                         </div>
                       ) : (
                         <div className="flex items-center gap-2">
@@ -1041,6 +1048,13 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                               </div>
                             </div>
                           )}
+                          {/* 未判定時のエイリアス登録ヒント */}
+                          {editedFields.officeName &&
+                           document.officeName === '未判定' && (
+                            <p className="mt-1.5 text-xs text-muted-foreground">
+                              表記揺れで未判定になる場合は、<a href="/masters" className="text-blue-600 underline">マスター管理</a>で別表記を登録すると次回から自動マッチします
+                            </p>
+                          )}
                         </div>
                       ) : (
                         <div className="flex items-center gap-2">
@@ -1095,6 +1109,13 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                                 </div>
                               </div>
                             </div>
+                          )}
+                          {/* 未判定時のエイリアス登録ヒント */}
+                          {editedFields.documentType &&
+                           document.documentType === '未判定' && (
+                            <p className="mt-1.5 text-xs text-muted-foreground">
+                              表記揺れで未判定になる場合は、<a href="/masters" className="text-blue-600 underline">マスター管理</a>で別表記を登録すると次回から自動マッチします
+                            </p>
                           )}
                         </div>
                       ) : (


### PR DESCRIPTION
## Summary
- 書類詳細モーダルで「未判定」からマスターを選択した際、マスター管理画面でのエイリアス登録を案内するヒントを表示
- 顧客名・事業所・書類種別の3箇所に同パターンで追加
- 表記揺れによる未判定の再発防止をユーザーに誘導

## Changes
- **DocumentDetailModal.tsx**: 3箇所に「未判定」時のヒントテキスト追加（+21行）

## Test plan
- [ ] ビルド成功確認済み
- [ ] 顧客名が「未判定」の書類で編集→マスター選択時にヒントが表示される
- [ ] 事業所が「未判定」の書類で同様にヒントが表示される
- [ ] 書類種別が「未判定」の書類で同様にヒントが表示される
- [ ] 「未判定」以外の値から変更した場合は従来通り学習チェックボックスが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)