### PR TITLE
fix: OCRマスター照合でエイリアスが機能しないバグを修正

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -178,6 +178,7 @@ export async function processDocument(
     name: d.data().name as string,
     category: d.data().category as string | undefined,
     keywords: d.data().keywords as string[] | undefined,
+    aliases: d.data().aliases as string[] | undefined,
   }));
 
   const custMasterData: CustomerMaster[] = customerMasters.docs.map((d) => ({
@@ -187,6 +188,7 @@ export async function processDocument(
     isDuplicate: d.data().isDuplicate as boolean | undefined,
     careManagerName: d.data().careManagerName as string | undefined,
     notes: d.data().notes as string | undefined,
+    aliases: d.data().aliases as string[] | undefined,
   }));
 
   const officeMasterData: OfficeMaster[] = officeMasters.docs.map((d) => ({
@@ -195,6 +197,7 @@ export async function processDocument(
     shortName: d.data().shortName as string | undefined,
     isDuplicate: d.data().isDuplicate as boolean | undefined,
     notes: d.data().notes as string | undefined,
+    aliases: d.data().aliases as string[] | undefined,
   }));
 
   // 情報抽出（強化版エクストラクター使用）


### PR DESCRIPTION
## Summary
- `ocrProcessor.ts`でFirestoreからマスターデータを読み込む際に`aliases`フィールドが含まれていなかったバグを修正
- 顧客・書類種別・事業所の3マスター全てのマッピングに`aliases`フィールドを追加
- これにより`extractors.ts`のエイリアス照合ロジック（スコア98）が正しく機能するようになる

## Background
PR #93でUI側のエイリアス管理を実装し、PR #94で未判定時のヒントを追加したが、OCR処理のバックエンドでエイリアスデータがFirestoreから読み込まれていなかったため、エイリアス照合が完全に非機能だった。

## Test plan
- [x] Functionsビルド成功
- [x] Functionsテスト全227件パス
- [x] フロントエンドビルド成功
- [ ] 手動E2E: エイリアス登録済みマスターでOCR再処理し、エイリアスでマッチすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)