### PR TITLE
feat: メタ情報編集時の楽観的UI更新

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -465,7 +465,6 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       setRememberDocTypeNotation(false)
       setRememberCustomerNotation(false)
       setRememberOfficeNotation(false)
-      refetch()
       // 学習履歴を更新
       if (rememberCustomerNotation || rememberOfficeNotation || rememberDocTypeNotation) {
         invalidateHistory()


### PR DESCRIPTION
## Summary
- メタ情報（顧客名・事業所・書類種別等）の編集保存後、一覧ビューに即座に反映されるよう楽観的UI更新（Optimistic Update）を実装
- Firestore書き込み失敗時は自動ロールバックでデータ整合性を保証
- `updateDocumentInListCache` 共通ユーティリティを導入し、`useDocumentVerification` と `useDocumentEdit` のキャッシュ更新ロジックをDRY化

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `useDocuments.ts` | `updateDocumentInListCache` 共通ユーティリティ追加 |
| `useDocumentEdit.ts` | 楽観的更新 + ロールバック + invalidateQueries |
| `useDocumentVerification.ts` | 共通ユーティリティ使用にリファクタ（DRY） |
| `DocumentDetailModal.tsx` | 不要な `refetch()` 削除 |

## Before / After
| 操作 | Before | After |
|------|--------|-------|
| メタ情報編集→保存 | 一覧は30秒待ち or リロード必要 | 即座に一覧に反映 |
| 保存失敗時 | エラー表示のみ | 自動ロールバック + エラー表示 |

## Test plan
- [x] TypeScript型チェック通過（既存エラーのみ）
- [x] フロントエンドテスト通過（71/71）
- [x] ビルド成功
- [x] `/safe-refactor` 実行済み
- [ ] 手動確認: 顧客名を編集→保存→一覧に即反映されること
- [ ] 手動確認: 書類種別を編集→保存→一覧に即反映されること
- [ ] 手動確認: ネットワーク切断時に保存→ロールバックされること
- [ ] 手動確認: 確認ステータスの楽観的更新が引き続き動作すること（リグレッション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized document editing with immediate UI responsiveness via optimistic updates
  * Enhanced error handling with automatic rollback on failed edits
  * Refined cache synchronization for improved data consistency across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->