### PR TITLE
fix: import-masters.jsの環境変数優先順位修正

### DIFF
--- a/scripts/import-masters.js
+++ b/scripts/import-masters.js
@@ -21,8 +21,9 @@ const fs = require('fs');
 const path = require('path');
 
 // プロジェクトID取得（環境変数 > デフォルト）
-const projectId = process.env.GCLOUD_PROJECT
-  || process.env.FIREBASE_PROJECT_ID
+// FIREBASE_PROJECT_IDを最優先（.envrcのGCLOUD_PROJECTより優先させるため）
+const projectId = process.env.FIREBASE_PROJECT_ID
+  || process.env.GCLOUD_PROJECT
   || process.env.CLOUDSDK_CORE_PROJECT
   || 'doc-split-dev';
 


### PR DESCRIPTION
## Summary
- `import-masters.js`の環境変数優先順位を`FIREBASE_PROJECT_ID`最優先に変更
- `.envrc`の`GCLOUD_PROJECT=doc-split-dev`が常に優先され、納品時に指定した`FIREBASE_PROJECT_ID`が無視されるバグを修正
- これにより新規クライアント納品時にマスターデータがdev環境に投入されてしまう問題を防止

## Test plan
- [x] `FIREBASE_PROJECT_ID=docsplit-test`をインライン指定し、`GCLOUD_PROJECT=doc-split-dev`が存在する環境で`FIREBASE_PROJECT_ID`が優先されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted project configuration environment variable resolution to prioritize FIREBASE_PROJECT_ID as the primary source when multiple configuration variables are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->