### PR TITLE
feat: 納品フロー成功率改善（jq除去/CSV堅牢化/バリデーション追加）

### DIFF
--- a/docs/claude-code-delivery.md
+++ b/docs/claude-code-delivery.md
@@ -177,6 +177,16 @@
   color: #1e3a5f;
 }
 .info-box strong { color: #1e40af; }
+/* バリデーションエラー */
+.input-error {
+  border-color: #ef4444 !important;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
+}
+.copy-btn:disabled, .copy-btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 </style>
 
 <div class="success-box">
@@ -302,6 +312,8 @@
     <input type="text" id="extra-domain" placeholder="example.com" oninput="updatePrompts()">
   </div>
 </div>
+
+<div id="validation-errors"></div>
 </div>
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -230,6 +230,30 @@
       background: rgba(6, 78, 59, 0.1) !important;
       color: #064e3b !important;
     }
+    /* バリデーションエラー */
+    .input-error {
+      border-color: #ef4444 !important;
+      box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15) !important;
+    }
+    #validation-errors {
+      display: none;
+      background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
+      border-radius: 8px;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-left: 4px solid #ef4444;
+      color: #991b1b;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    #validation-errors strong {
+      color: #7f1d1d;
+    }
+    .copy-btn-disabled {
+      opacity: 0.5 !important;
+      cursor: not-allowed !important;
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
@@ -376,8 +400,69 @@
       return lines;
     }
 
+    function _validateForm() {
+      var required = [
+        { id: 'project-id', label: 'プロジェクトID' },
+        { id: 'admin-email', label: '管理者メール', type: 'email' },
+        { id: 'client-id', label: 'Client ID' },
+        { id: 'client-secret', label: 'Client Secret' },
+        { id: 'auth-code', label: '認証コード' },
+        { id: 'csv-customers', label: '顧客CSV' },
+        { id: 'csv-documents', label: '書類種別CSV' },
+        { id: 'csv-offices', label: '事業所CSV' }
+      ];
+      var errors = [];
+      var emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+      for (var i = 0; i < required.length; i++) {
+        var el = document.getElementById(required[i].id);
+        if (!el) continue;
+        var val = el.value.trim();
+        if (!val) {
+          errors.push(required[i].label + ' を入力してください');
+          el.classList.add('input-error');
+        } else if (required[i].type === 'email' && !emailRe.test(val)) {
+          errors.push(required[i].label + ' の形式が正しくありません');
+          el.classList.add('input-error');
+        } else {
+          el.classList.remove('input-error');
+        }
+      }
+
+      var errDiv = document.getElementById('validation-errors');
+      if (errDiv) {
+        if (errors.length > 0) {
+          errDiv.innerHTML = '<strong>未入力の項目があります:</strong><br>' + errors.join('<br>');
+          errDiv.style.display = 'block';
+        } else {
+          errDiv.innerHTML = '';
+          errDiv.style.display = 'none';
+        }
+      }
+
+      return errors.length === 0;
+    }
+
+    function _setCopyBtnsDisabled(disabled) {
+      var btns = ['copy-minimal', 'copy-full'];
+      for (var i = 0; i < btns.length; i++) {
+        var btn = document.getElementById(btns[i]);
+        if (btn) {
+          btn.disabled = disabled;
+          if (disabled) {
+            btn.classList.add('copy-btn-disabled');
+          } else {
+            btn.classList.remove('copy-btn-disabled');
+          }
+        }
+      }
+    }
+
     function updatePrompts() {
       if (!document.getElementById('project-id')) return;
+
+      var isValid = _validateForm();
+      _setCopyBtnsDisabled(!isValid);
 
       var elMin = document.getElementById('prompt-minimal');
       if (elMin) {
@@ -393,6 +478,7 @@
     }
 
     function copyPrompt(type) {
+      if (!_validateForm()) return;
       var el = document.getElementById('prompt-' + type);
       if (!el) return;
       var text = el.getAttribute('data-raw');

--- a/scripts/deploy-to-project.sh
+++ b/scripts/deploy-to-project.sh
@@ -87,22 +87,13 @@ if [ ! -f "$ROOT_DIR/.firebaserc" ]; then
     exit 1
 fi
 
-# jqがなければgrep/sedで代用
-if command -v jq &> /dev/null; then
-    PROJECT_ID=$(jq -r ".projects.\"$PROJECT_ALIAS\"" "$ROOT_DIR/.firebaserc")
-else
-    PROJECT_ID=$(grep -A 20 '"projects"' "$ROOT_DIR/.firebaserc" | grep "\"$PROJECT_ALIAS\"" | sed 's/.*: *"\([^"]*\)".*/\1/')
-fi
+PROJECT_ID=$(node "$SCRIPT_DIR/helpers/firebaserc-helper.js" get-project "$PROJECT_ALIAS" 2>/dev/null)
 
-if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
+if [ -z "$PROJECT_ID" ]; then
     log_error "プロジェクト '$PROJECT_ALIAS' が .firebaserc に見つかりません"
     echo ""
     echo "利用可能なプロジェクト:"
-    if command -v jq &> /dev/null; then
-        jq -r '.projects | keys[]' "$ROOT_DIR/.firebaserc"
-    else
-        grep -E '^\s+"[a-z]' "$ROOT_DIR/.firebaserc" | sed 's/.*"\([^"]*\)".*/  \1/'
-    fi
+    node "$SCRIPT_DIR/helpers/firebaserc-helper.js" list-aliases 2>/dev/null | sed 's/^/  /'
     exit 1
 fi
 

--- a/scripts/helpers/firebaserc-helper.js
+++ b/scripts/helpers/firebaserc-helper.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * .firebaserc 操作ヘルパー（jq依存除去用）
+ *
+ * Usage:
+ *   node firebaserc-helper.js get-project <alias>
+ *   node firebaserc-helper.js add-alias <alias> <project-id>
+ *   node firebaserc-helper.js list-aliases
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FIREBASERC_PATH = path.resolve(__dirname, '../../.firebaserc');
+
+function readFirebaserc() {
+  if (!fs.existsSync(FIREBASERC_PATH)) {
+    console.error('ERROR: .firebaserc not found at ' + FIREBASERC_PATH);
+    process.exit(1);
+  }
+  return JSON.parse(fs.readFileSync(FIREBASERC_PATH, 'utf8'));
+}
+
+function writeFirebaserc(data) {
+  fs.writeFileSync(FIREBASERC_PATH, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+const command = process.argv[2];
+
+switch (command) {
+  case 'get-project': {
+    const alias = process.argv[3];
+    if (!alias) {
+      console.error('Usage: firebaserc-helper.js get-project <alias>');
+      process.exit(1);
+    }
+    const rc = readFirebaserc();
+    const projectId = rc.projects && rc.projects[alias];
+    if (!projectId) {
+      console.error('ERROR: Alias not found: ' + alias);
+      process.exit(1);
+    }
+    console.log(projectId);
+    break;
+  }
+
+  case 'add-alias': {
+    const alias = process.argv[3];
+    const projectId = process.argv[4];
+    if (!alias || !projectId) {
+      console.error('Usage: firebaserc-helper.js add-alias <alias> <project-id>');
+      process.exit(1);
+    }
+    const rc = readFirebaserc();
+    if (!rc.projects) {
+      rc.projects = {};
+    }
+    rc.projects[alias] = projectId;
+    writeFirebaserc(rc);
+    break;
+  }
+
+  case 'list-aliases': {
+    const rc = readFirebaserc();
+    const projects = rc.projects || {};
+    Object.keys(projects).forEach(function (alias) {
+      console.log(alias);
+    });
+    break;
+  }
+
+  default:
+    console.error('Unknown command: ' + command);
+    console.error('Available: get-project, add-alias, list-aliases');
+    process.exit(1);
+}

--- a/scripts/helpers/json-helper.js
+++ b/scripts/helpers/json-helper.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * JSON変換ヘルパー（jq依存除去用）
+ *
+ * Usage:
+ *   node json-helper.js array-from-csv "a,b,c"
+ *   → ["a","b","c"]
+ */
+
+const command = process.argv[2];
+
+switch (command) {
+  case 'array-from-csv': {
+    const csv = process.argv[3];
+    if (csv === undefined) {
+      console.error('Usage: json-helper.js array-from-csv "a,b,c"');
+      process.exit(1);
+    }
+    if (!csv) {
+      console.log('[]');
+      break;
+    }
+    const items = csv.split(',')
+      .map(function (s) { return s.trim(); })
+      .filter(function (s) { return s.length > 0; });
+    // Remove duplicates
+    const unique = items.filter(function (v, i, a) { return a.indexOf(v) === i; });
+    console.log(JSON.stringify(unique));
+    break;
+  }
+
+  default:
+    console.error('Unknown command: ' + command);
+    console.error('Available: array-from-csv');
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

- **jq依存除去**: `setup-tenant.sh`/`deploy-to-project.sh`からjq依存を完全除去し、Node.jsヘルパー（`scripts/helpers/`）に統一。macOS環境でjq未インストールでも動作可能に
- **CSV解析堅牢化**: `import-masters.js`のparseCSVをRFC 4180準拠に置換。BOM除去、クォートフィールド対応、カラム数不一致/クォート未閉じ検出、必須フィールドバリデーション、`--dry-run`オプション追加
- **Gmail OAuth事前チェック**: Client ID形式検証、Secret空チェック、Secret Manager API有効化確認を`setup-tenant.sh`に追加。失敗時にGCP Console URLつきの対処手順を表示
- **フォームバリデーション**: GitHub Pages納品フォームで必須フィールド未入力時にコピーボタン無効化、赤枠表示、エラーメッセージ表示

## Test plan

- [x] `node scripts/helpers/firebaserc-helper.js get-project dev` → `doc-split-dev` 出力確認
- [x] `node scripts/helpers/json-helper.js array-from-csv "a,b,a,c"` → 重複除去JSON配列出力確認
- [x] `node scripts/import-masters.js --dry-run --all scripts/samples/` → 全サンプルCSV解析+バリデーション通過
- [x] クォート含みCSV・バリデーションエラーCSV・クォート未閉じCSVの各パターンでエラーハンドリング確認
- [ ] jq未インストール環境で `setup-tenant.sh` / `deploy-to-project.sh` の正常動作確認
- [ ] ブラウザでGitHub Pages納品フォームを開き、空欄でコピーボタン無効化・赤枠表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added form validation with error display for required fields
  * Added dry-run mode for data imports to preview changes before committing

* **Improvements**
  * Enhanced CSV parsing with improved validation and error detection
  * Strengthened error handling and messaging for setup and deployment processes
  * Copy buttons now disabled when form validation fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->