### PR TITLE
fix: セレクションモードで行全体をタップ可能に

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -239,7 +239,13 @@ function DocumentRow({
   }`
 
   return (
-    <tr className={rowClassName} onClick={onClick}>
+    <tr className={rowClassName} onClick={() => {
+      if (showCheckbox && !isProcessing) {
+        onSelectChange(!isSelected)
+      } else {
+        onClick()
+      }
+    }}>
       {showCheckbox && (
         <td className="px-2 py-2 sm:px-3 sm:py-3" onClick={(e) => e.stopPropagation()}>
           <Checkbox


### PR DESCRIPTION
## Summary
- セレクションモード中、チェックボックスだけでなく行全体のクリック/タップで選択トグル可能に
- 通常時は従来通り行クリックで詳細モーダルを開く
- チェックボックス直接クリック時の二重トグル防止（stopPropagation）は維持

## Test plan
- [ ] セレクションモードで行クリック→チェックが切り替わること
- [ ] セレクションモードでチェックボックス直接クリック→正常にトグルすること
- [ ] 通常時の行クリック→詳細モーダルが開くこと
- [ ] モバイルでの行タップ操作が快適であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced row click interaction in the document list to properly handle selection toggling when applicable, while maintaining original row activation behavior in other scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->