### PR TITLE
fix: processOCRに必要なFirestore複合インデックス追加

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,6 +5,14 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "processedAt", "order": "ASCENDING" }
       ]
     },


### PR DESCRIPTION
## Summary
- PR #100で追加した`rescueStuckProcessingDocs()`が必要とする複合インデックス`status + updatedAt`が`firestore.indexes.json`に未定義だった
- processOCRが毎分Fatal errorで即終了し、pendingのPDFが一切処理されない障害が発生
- `firestore.indexes.json`にインデックス定義を追加

## Test plan
- [x] dev環境にインデックスデプロイ済み → processOCR正常稼働確認
- [x] kanameone環境にインデックスデプロイ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)