### PR TITLE
fix: switch-client.shのdirenv環境変数上書き問題を修正

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 # ===========================================
-# doc-split direnv設定（dev環境専用）
+# doc-split direnv設定
 # ===========================================
 # クライアント環境への切り替え: ./scripts/switch-client.sh <alias>
 # クライアント定義: scripts/clients/*.env
@@ -7,13 +7,17 @@
 # GitHub CLI認証（プロジェクト分離）
 export GH_CONFIG_DIR="$(pwd)/.gh"
 
-# GCP設定（dev環境固定）
-export CLOUDSDK_ACTIVE_CONFIG_NAME="doc-split"
-export GCLOUD_PROJECT="doc-split-dev"
-
-# Firebase設定（dev環境固定）
-export FIREBASE_PROJECT="doc-split-dev"
+# クライアント設定（.envrc.client から読み込み）
+# switch-client.sh が .envrc.client を生成・更新する
+if [ -f .envrc.client ]; then
+    source .envrc.client
+else
+    # デフォルト: dev環境
+    export CLOUDSDK_ACTIVE_CONFIG_NAME="doc-split"
+    export GCLOUD_PROJECT="doc-split-dev"
+    export FIREBASE_PROJECT="doc-split-dev"
+    export _expected_gcp_account="hy.unimail.11@gmail.com"
+fi
 
 # 期待するアカウント（Claude Code確認用）
 export _expected_gh_user="yasushi-honda"
-export _expected_gcp_account="hy.unimail.11@gmail.com"

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ venv/
 # GitHub CLI認証（プロジェクト分離）
 .gh/
 
+# クライアント切替設定（switch-client.shが生成）
+.envrc.client
+
 # Storage CORS設定（setup-tenant.shが自動生成）
 cors-*.json
 

--- a/scripts/verify-setup.sh
+++ b/scripts/verify-setup.sh
@@ -67,6 +67,12 @@ PROJECT_ID=$1
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# .envrc.client からクライアント設定を読み込み（direnv未発火時の対策）
+ENVRC_CLIENT="$ROOT_DIR/.envrc.client"
+if [ -f "$ENVRC_CLIENT" ]; then
+    source "$ENVRC_CLIENT"
+fi
+
 echo ""
 echo -e "${GREEN}╔════════════════════════════════════════════╗${NC}"
 echo -e "${GREEN}║   DocSplit 納品検証                        ║${NC}"


### PR DESCRIPTION
## Summary
- `.envrc`が`CLOUDSDK_ACTIVE_CONFIG_NAME`を固定しており、`switch-client.sh`のgcloud構成切替（特にcocoro SA方式）が無効化されていた問題を修正
- `.envrc.client`ファイルによる動的切替方式を導入し、全3環境（dev/kanameone/cocoro）での切替・認証チェックの動作を確認済み

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `.envrc` | `.envrc.client`から動的にクライアント設定を読み込み |
| `.gitignore` | `.envrc.client`を追加 |
| `switch-client.sh` | 切替時に`.envrc.client`生成 + `direnv allow`実行 |
| `deploy-to-project.sh` | `CLOUDSDK_ACTIVE_CONFIG_NAME`環境変数を優先チェック |
| `verify-setup.sh` | `.envrc.client`読み込みでdirenv未発火時も動作 |

## Test plan
- [x] `switch-client.sh cocoro` → SA認証でcocoro環境に切替成功
- [x] `switch-client.sh dev` → dev環境に復帰成功
- [x] `deploy-to-project.sh cocoro`（cocoro切替後）→ 認証チェック通過
- [x] `deploy-to-project.sh cocoro`（dev環境のまま）→ 構成不一致でブロック
- [x] `deploy-to-project.sh dev` → 認証チェック通過
- [x] `deploy-to-project.sh kanameone` → 認証チェック通過
- [x] `verify-setup.sh docsplit-cocoro` → 8/14合格（Firestore設定未完了は運用範疇）

🤖 Generated with [Claude Code](https://claude.com/claude-code)