### PR TITLE
docs: クライアント別ステータス管理ドキュメントを追加

### DIFF
--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -1,0 +1,17 @@
+# クライアント管理
+
+DocSplitの全クライアント環境の一覧と現在のステータス。
+
+## クライアント一覧
+
+| クライアント | プロジェクトID | 認証方式 | 運用状態 | 詳細 |
+|-------------|--------------|---------|---------|------|
+| dev | doc-split-dev | 個人アカウント | 開発環境 | [dev.md](dev.md) |
+| kanameone | docsplit-kanameone | 個人アカウント | 運用中 | [kanameone.md](kanameone.md) |
+| cocoro | docsplit-cocoro | サービスアカウント | セットアップ完了・認証待ち | [cocoro.md](cocoro.md) |
+
+## 関連ドキュメント
+
+- [クライアント定義ファイル](../../scripts/clients/) - `*.env` による環境設定
+- [納品・アップデート運用ガイド](../context/delivery-and-update-guide.md)
+- [クライアント向けセットアップガイド](../client/client-setup.md)

--- a/docs/clients/cocoro.md
+++ b/docs/clients/cocoro.md
@@ -1,0 +1,53 @@
+# cocoro（ココロマネジメント）
+
+## 基本情報
+
+| 項目 | 値 |
+|------|-----|
+| プロジェクトID | `docsplit-cocoro` |
+| gcloud構成 | `doc-split-cocoro` |
+| 認証方式 | サービスアカウント |
+| アカウント | `docsplit-deployer@docsplit-cocoro.iam.gserviceaccount.com` |
+| 管理者 | `a.itagaki@cocoro-mgnt.com` |
+| 許可ドメイン | `cocoro-mgnt.com` |
+| URL | https://docsplit-cocoro.web.app |
+| PITR | ENABLED（7日間） |
+
+## セットアップ状態
+
+- [x] GCPプロジェクト作成
+- [x] Firebase初期化
+- [x] Cloud Functions デプロイ（19関数 ACTIVE）
+- [x] Firestore Rules デプロイ
+- [x] Hosting デプロイ
+- [x] Storage CORS設定
+- [x] settings/app 設定（gmailAccount: a.itagaki@cocoro-mgnt.com）
+- [x] settings/auth 設定（allowedDomains: cocoro-mgnt.com）
+- [x] settings/gmail 設定（authMode: oauth, clientId設定済み）
+- [x] Secret Manager（client-id/client-secret 保存済み）
+- [x] Gmail API 有効化
+- [x] マスターデータ投入（顧客5, 書類種別5, 事業所5, ケアマネ2）
+- [x] 管理者ユーザー登録（a.itagaki@cocoro-mgnt.com）
+- [x] PITR有効化
+- [ ] **Gmail OAuth認証（先方操作待ち）**
+- [ ] **Gmail監視ラベル設定（先方操作待ち）**
+
+## 運用開始に必要な先方操作
+
+1. `https://docsplit-cocoro.web.app` にアクセス
+2. Googleアカウント（`a.itagaki@cocoro-mgnt.com`）でログイン
+3. 設定画面 → Gmail連携ボタン → OAuthポップアップで認証
+4. Gmail監視対象ラベルを設定
+5. → 運用開始
+
+## 注意事項
+
+- OAuth同意画面は `orgInternalOnly: true`（cocoro-mgnt.com組織内ユーザーのみ認証可能）
+- SAキーファイルの安全管理に注意
+
+## 履歴
+
+| 日付 | 内容 |
+|------|------|
+| 2026-02-11 | setup-tenant.sh実行、Firestore設定投入、マスターデータ投入、Secret Manager設定 |
+| 2026-02-13 | インフラ構築完了確認。開発者側作業完了、先方のOAuth認証待ち |

--- a/docs/clients/dev.md
+++ b/docs/clients/dev.md
@@ -1,0 +1,34 @@
+# dev（開発環境）
+
+## 基本情報
+
+| 項目 | 値 |
+|------|-----|
+| プロジェクトID | `doc-split-dev` |
+| gcloud構成 | `doc-split` |
+| 認証方式 | 個人アカウント |
+| アカウント | `hy.unimail.11@gmail.com` |
+| URL | https://doc-split-dev.web.app |
+| PITR | DISABLED（開発環境のため） |
+
+## セットアップ状態
+
+- [x] GCPプロジェクト作成
+- [x] Firebase初期化
+- [x] Cloud Functions デプロイ
+- [x] Firestore Rules デプロイ
+- [x] Hosting デプロイ
+- [x] settings/app 設定
+- [x] settings/auth 設定
+- [x] settings/gmail 設定
+- [x] Gmail OAuth認証
+- [x] マスターデータ投入（サンプル）
+- [ ] PITR有効化（開発環境のため無効）
+
+**verify-setup.sh**: 9/10（PITRのみDISABLED）
+
+## 履歴
+
+| 日付 | 内容 |
+|------|------|
+| 2026-02-13 | マルチクライアント安全運用機構テスト完了（Phase 1-8全通過） |

--- a/docs/clients/kanameone.md
+++ b/docs/clients/kanameone.md
@@ -1,0 +1,40 @@
+# kanameone（カナメワン）
+
+## 基本情報
+
+| 項目 | 値 |
+|------|-----|
+| プロジェクトID | `docsplit-kanameone` |
+| gcloud構成 | `doc-split` |
+| 認証方式 | 個人アカウント |
+| アカウント | `hy.unimail.11@gmail.com` |
+| URL | https://docsplit-kanameone.web.app |
+| PITR | ENABLED（7日間） |
+
+## セットアップ状態
+
+- [x] GCPプロジェクト作成
+- [x] Firebase初期化
+- [x] Cloud Functions デプロイ
+- [x] Firestore Rules デプロイ
+- [x] Hosting デプロイ
+- [x] Storage CORS設定
+- [x] settings/app 設定
+- [x] settings/auth 設定
+- [x] settings/gmail 設定
+- [x] Gmail OAuth認証
+- [x] 監視ラベル設定
+- [x] マスターデータ投入
+- [x] PITR有効化
+
+**verify-setup.sh**: 16/16（全項目通過）
+
+## 運用状態
+
+運用中
+
+## 履歴
+
+| 日付 | 内容 |
+|------|------|
+| 2026-02-13 | マルチクライアント安全運用機構テスト完了（verify-setup 16/16） |


### PR DESCRIPTION
## Summary
- `docs/clients/` にクライアント別ステータス管理ドキュメントを新設
- 各クライアント（dev/kanameone/cocoro）の基本情報、セットアップチェックリスト、履歴を記録
- README.md に全クライアント一覧サマリーを配置

## Test plan
- [ ] 各mdファイルのリンクが正しいことを確認
- [ ] GitHub上でマークダウンが正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive client environment documentation with an overview page and three new client project guides.
  * Documentation includes project details, setup status, operational information, and change history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->