### PR TITLE
fix: エラー履歴画面のBE/FEスキーマ不一致修正 + PDFビューワー再処理ボタン追加

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -207,15 +207,15 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "errorDate", "order": "DESCENDING" }
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },
     {
       "collectionGroup": "errors",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "errorType", "order": "ASCENDING" },
-        { "fieldPath": "errorDate", "order": "DESCENDING" }
+        { "fieldPath": "source", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- エラー履歴画面が表示されない問題を修正（BE ErrorLogとFE ErrorRecordのスキーマ不一致を変換レイヤーで吸収）
- PDFビューワーモーダルにエラー時の個別再処理ボタンを追加
- Firestoreインデックスを実際のBEフィールド名（createdAt/source）に修正

## 変更詳細

### useErrors.ts - BE→FE変換レイヤー
- `convertToErrorType(category, source)`: BE分類→日本語エラー種別
- `convertToErrorStatus(status)`: `pending`→`未対応`, `resolved/ignored`→`完了`
- `convertFromErrorStatus(status)`: クエリ用逆変換（`完了`→`in ['resolved','ignored']`）
- `fetchErrors`: `orderBy('createdAt')`, documentIdからドキュメント情報バッチ取得
- `fetchErrorStats`: BE status値(`pending`/`resolved`/`ignored`)でクエリ
- `requestReprocess`: ステータスをBE値`'pending'`で更新

### firestore.indexes.json
- `errors`コレクション: `errorDate`→`createdAt`, `errorType`→`source`

### DocumentDetailModal.tsx
- `document.status === 'error'`時にヘッダーへ再処理ボタン表示
- 確認ダイアログ付き（AlertDialog）
- 再処理: status→pending, ocrResult/errorフィールド削除, キャッシュ無効化

## Test plan
- [ ] dev環境にデプロイし、エラー履歴画面にエラーが表示されることを確認
- [ ] ステータスフィルター（未対応/完了）の動作確認
- [ ] エラー種別フィルターの動作確認
- [ ] PDFビューワーでerrorステータスの書類を開き、再処理ボタンが表示されることを確認
- [ ] 再処理ボタン押下→確認ダイアログ→実行でステータスがpendingに戻ることを確認
- [ ] `--rules`オプション付きデプロイでFirestoreインデックスが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced document reprocessing capability for OCR errors. A new button appears for documents with errors, launching a confirmation dialog before reprocessing with status notifications upon completion.

* **Improvements**
  * Optimized error status tracking, statistics calculations, and indexing for more accurate error filtering and reporting. Enhanced query performance for error-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->