### PR TITLE
fix: エラー詳細ダイアログのテキストはみ出し修正

### DIFF
--- a/frontend/src/pages/ErrorsPage.tsx
+++ b/frontend/src/pages/ErrorsPage.tsx
@@ -419,7 +419,7 @@ function ErrorRow({ error }: ErrorRowProps) {
 
             <div>
               <p className="text-sm text-gray-500">エラー詳細</p>
-              <pre className="mt-1 p-3 bg-gray-100 rounded-md text-sm overflow-auto max-h-48">
+              <pre className="mt-1 p-3 bg-gray-100 rounded-md text-sm overflow-auto max-h-48 whitespace-pre-wrap break-all">
                 {error.errorDetails}
               </pre>
             </div>


### PR DESCRIPTION
## Summary
- エラー詳細ダイアログで長いURL等がダイアログ外にはみ出す問題を修正
- `<pre>`タグに`whitespace-pre-wrap break-all`を追加

## Test plan
- [ ] エラー詳細ダイアログで長いエラーメッセージが折り返し表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)