### PR TITLE
fix: PDFビューワー再処理ボタンのフィードバック改善

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -625,9 +625,9 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       })
       queryClient.invalidateQueries({ queryKey: ['document', documentId] })
       queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      toast.success('再処理をリクエストしました')
       setShowReprocessDialog(false)
-      onOpenChange(false)
+      toast.success('再処理をリクエストしました。ステータスが「処理待ち」に変わります。')
+      setTimeout(() => onOpenChange(false), 1500)
     } catch (err) {
       console.error('Failed to reprocess:', err)
       toast.error('再処理リクエストに失敗しました')
@@ -1484,7 +1484,10 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
             キャンセル
           </AlertDialogCancel>
           <AlertDialogAction
-            onClick={handleReprocess}
+            onClick={(e) => {
+              e.preventDefault()
+              handleReprocess()
+            }}
             disabled={isReprocessing}
             className="bg-blue-600 hover:bg-blue-700"
           >


### PR DESCRIPTION
## Summary
- 再処理ボタンのローディングスピナーが表示されない問題を修正
- AlertDialogActionの自動クローズをpreventDefaultで防止
- トーストメッセージを改善し、モーダルを1.5秒後に閉じるように変更

## Test plan
- [ ] 再処理ボタンクリック→確認ダイアログで「再処理を実行」→ローディング表示→トースト→モーダル閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)