### PR TITLE
fix: 再処理確認ダイアログのボタンが動作しない問題を修正

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -1483,11 +1483,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
           <AlertDialogCancel disabled={isReprocessing}>
             キャンセル
           </AlertDialogCancel>
-          <AlertDialogAction
-            onClick={(e) => {
-              e.preventDefault()
-              handleReprocess()
-            }}
+          <Button
+            onClick={handleReprocess}
             disabled={isReprocessing}
             className="bg-blue-600 hover:bg-blue-700"
           >
@@ -1497,7 +1494,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
               <RefreshCw className="mr-1 h-4 w-4" />
             )}
             {isReprocessing ? '処理中...' : '再処理を実行'}
-          </AlertDialogAction>
+          </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>


### PR DESCRIPTION
## Summary
- AlertDialogActionが内部でダイアログを閉じるため、async処理と競合して無反応だった
- 通常のButtonコンポーネントに置き換えて動作するように修正

## Test plan
- [ ] エラーステータスのドキュメントをPDFビューワーで開く
- [ ] 再処理ボタン→確認ダイアログ→「再処理を実行」でローディング→トースト表示→モーダル閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal implementation of the document reprocessing functionality with no changes to user-facing behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->