### PR TITLE
fix: AlertDialog内のクリックで親Dialogが閉じる問題を修正

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -697,15 +697,15 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
         className="flex h-[90vh] w-[95vw] max-w-[1100px] flex-col p-0 [&>button.absolute]:hidden"
         aria-describedby={undefined}
         onInteractOutside={(e) => {
-          // ポップアップ表示中やPDF分割モーダル表示中は外側クリックでDialogを閉じない
-          if (mobilePopup !== null || isSplitModalOpen) {
+          // ポップアップ・モーダル・確認ダイアログ表示中は外側クリックでDialogを閉じない
+          if (mobilePopup !== null || isSplitModalOpen || showReprocessDialog || showCloseDialog || showEditCloseDialog || showDownloadDialog) {
             e.preventDefault()
           } else {
             handleOpenChange(false)
           }
         }}
         onPointerDownOutside={(e) => {
-          if (mobilePopup !== null || isSplitModalOpen) {
+          if (mobilePopup !== null || isSplitModalOpen || showReprocessDialog || showCloseDialog || showEditCloseDialog || showDownloadDialog) {
             e.preventDefault()
           }
         }}


### PR DESCRIPTION
## Summary
- `Dialog modal={false}`の場合、AlertDialog内のクリックが`onInteractOutside`として処理され親Dialogが閉じていた
- 全AlertDialogのopen状態を条件に追加し、確認ダイアログ表示中は外部クリック判定から除外

## Root Cause
`Dialog`に`modal={false}`が設定されており、子のAlertDialog内でのクリックイベントが親Dialogの「外側クリック」として検知される。これにより親ダイアログが閉じ、子のAlertDialogもアンマウントされてボタンのonClickが発火しない。

## Test plan
- [ ] エラーステータスのドキュメントをPDFビューワーで開く
- [ ] 再処理ボタン→確認ダイアログ→「再処理を実行」が動作すること
- [ ] 他の確認ダイアログ（閉じる確認、ダウンロード確認）も正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal behavior to prevent unexpected closing when confirmation dialogs are active, ensuring users can safely complete document operations without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->