### PR TITLE
fix: 再処理トースト表示時間の延長

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -626,8 +626,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       queryClient.invalidateQueries({ queryKey: ['document', documentId] })
       queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       setShowReprocessDialog(false)
-      toast.success('再処理をリクエストしました。ステータスが「処理待ち」に変わります。')
-      setTimeout(() => onOpenChange(false), 1500)
+      toast.success('再処理をリクエストしました。ステータスが「処理待ち」に変わります。', { duration: 5000 })
+      setTimeout(() => onOpenChange(false), 3000)
     } catch (err) {
       console.error('Failed to reprocess:', err)
       toast.error('再処理リクエストに失敗しました')


### PR DESCRIPTION
## Summary
- 再処理リクエスト後のトースト通知が早く消える問題を修正
- トースト表示時間: 4秒 → 5秒
- モーダル自動閉じ: 1.5秒 → 3秒

## Test plan
- [x] TypeScript型チェック通過
- [ ] 再処理ボタンクリック後、トーストが十分な時間表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended modal auto-close delay to provide users more time to see confirmation messages during document reprocessing
  * Increased success notification display duration for better visibility of action confirmation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->