### PR TITLE
fix: 再処理時に書類の確認ステータスをリセット

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -622,6 +622,13 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
         status: 'pending',
         ocrResult: deleteField(),
         error: deleteField(),
+        // 確認ステータスをリセット（OCR再実行で抽出結果が変わるため）
+        customerConfirmed: false,
+        confirmedBy: null,
+        confirmedAt: null,
+        officeConfirmed: false,
+        officeConfirmedBy: null,
+        officeConfirmedAt: null,
       })
       queryClient.invalidateQueries({ queryKey: ['document', documentId] })
       queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })


### PR DESCRIPTION
## Summary
- 再処理（OCR再実行）時に、顧客・事業所の確認ステータスをリセットする
- OCR結果が変わるため、以前の確認は無効になるべき

## リセット対象フィールド
| フィールド | リセット値 |
|-----------|-----------|
| `customerConfirmed` | `false` |
| `confirmedBy` | `null` |
| `confirmedAt` | `null` |
| `officeConfirmed` | `false` |
| `officeConfirmedBy` | `null` |
| `officeConfirmedAt` | `null` |

## Test plan
- [x] TypeScript型チェック通過
- [ ] エラー書類の再処理後、確認ステータスが未確認に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where confirmation data from previous processing attempts persisted when reprocessing documents. All customer and office approval statuses are now properly cleared during reprocessing to ensure accurate, fresh results and prevent outdated confirmations from interfering with subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->