### PR TITLE
feat: メタ情報の抽出理由を表示するInfoポップオーバーを追加

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -28,6 +28,7 @@ import { Switch } from '@/components/ui/switch'
 import { PdfViewer } from '@/components/PdfViewer'
 import { PdfSplitModal } from '@/components/PdfSplitModal'
 import { MasterSelectField } from '@/components/MasterSelectField'
+import { ExtractionInfoPopover } from '@/components/ExtractionInfoPopover'
 import { useDocument } from '@/hooks/useDocuments'
 import { useDocumentEdit } from '@/hooks/useDocumentEdit'
 import { useCustomers, useOffices, useDocumentTypes } from '@/hooks/useMasters'
@@ -1033,6 +1034,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                       ) : (
                         <div className="flex items-center gap-2">
                           <span className="truncate text-sm text-gray-900">{document.customerName || '未判定'}</span>
+                          <ExtractionInfoPopover fieldType="customer" document={document} />
                           {needsCustomerConfirmation && (
                             <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
                               選択待ち
@@ -1104,6 +1106,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                       ) : (
                         <div className="flex items-center gap-2">
                           <span className="truncate text-sm text-gray-900">{document.officeName || '未判定'}</span>
+                          <ExtractionInfoPopover fieldType="office" document={document} />
                           {needsOfficeConfirmation && (
                             <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
                               選択待ち
@@ -1164,7 +1167,10 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                           )}
                         </div>
                       ) : (
-                        <p className="truncate text-sm text-gray-900">{document.documentType || '未判定'}</p>
+                        <div className="flex items-center gap-2">
+                          <span className="truncate text-sm text-gray-900">{document.documentType || '未判定'}</span>
+                          <ExtractionInfoPopover fieldType="documentType" document={document} />
+                        </div>
                       )}
                     </div>
                   </div>

--- a/frontend/src/components/ExtractionInfoPopover.tsx
+++ b/frontend/src/components/ExtractionInfoPopover.tsx
@@ -1,0 +1,215 @@
+/**
+ * 抽出理由ポップオーバー
+ * メタ情報（顧客名・事業所名・書類種別）がなぜその値に設定されたかを表示
+ */
+
+import { Info } from 'lucide-react'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type {
+  Document,
+  OcrFieldExtraction,
+} from '@shared/types'
+
+type FieldType = 'customer' | 'office' | 'documentType'
+
+interface ExtractionInfoPopoverProps {
+  fieldType: FieldType
+  document: Document
+}
+
+/** マッチタイプを日本語に変換 */
+function matchTypeLabel(matchType: string | undefined): string {
+  switch (matchType) {
+    case 'exact': return '完全一致'
+    case 'partial': return '部分一致'
+    case 'fuzzy': return 'あいまい一致'
+    case 'none': return '一致なし'
+    default: return '不明'
+  }
+}
+
+/** フィールドごとの抽出情報を取得 */
+function getFieldInfo(fieldType: FieldType, document: Document): {
+  fieldLabel: string
+  currentValue: string
+  ocrField: OcrFieldExtraction | undefined
+  matchType: string | undefined
+  score: number | undefined
+  candidates: Array<{ name: string; score: number; matchType: string; isCurrent: boolean }> | undefined
+  keywords: string[] | undefined
+} {
+  const extraction = document.ocrExtraction
+  const details = document.extractionDetails
+  const scores = document.extractionScores
+
+  switch (fieldType) {
+    case 'customer': {
+      const candidates = document.customerCandidates?.map(c => ({
+        name: c.customerName,
+        score: c.score,
+        matchType: c.matchType,
+        isCurrent: c.customerName === document.customerName,
+      }))
+      return {
+        fieldLabel: '顧客名',
+        currentValue: document.customerName || '未判定',
+        ocrField: extraction?.customer,
+        matchType: details?.customerMatchType ?? extraction?.customer?.matchType,
+        score: scores?.customerName ?? extraction?.customer?.confidence,
+        candidates,
+        keywords: undefined,
+      }
+    }
+    case 'office': {
+      const candidates = document.officeCandidates?.map(c => ({
+        name: c.officeName,
+        score: c.score,
+        matchType: c.matchType,
+        isCurrent: c.officeName === document.officeName,
+      }))
+      return {
+        fieldLabel: '事業所名',
+        currentValue: document.officeName || '未判定',
+        ocrField: extraction?.office,
+        matchType: details?.officeMatchType ?? extraction?.office?.matchType,
+        score: scores?.officeName ?? extraction?.office?.confidence,
+        candidates,
+        keywords: undefined,
+      }
+    }
+    case 'documentType': {
+      return {
+        fieldLabel: '書類種別',
+        currentValue: document.documentType || '未判定',
+        ocrField: extraction?.documentType,
+        matchType: details?.documentMatchType ?? extraction?.documentType?.matchType,
+        score: scores?.documentType ?? extraction?.documentType?.confidence,
+        candidates: undefined,
+        keywords: details?.documentKeywords,
+      }
+    }
+  }
+}
+
+/** 抽出理由のメッセージを生成 */
+function getReasonMessage(info: ReturnType<typeof getFieldInfo>): string {
+  const { currentValue, matchType, score, keywords } = info
+
+  if (currentValue === '未判定' || currentValue === '不明顧客' || currentValue === '不明文書') {
+    return 'OCRテキストからマスターデータに一致する情報が見つかりませんでした。'
+  }
+
+  const parts: string[] = []
+
+  if (matchType === 'exact') {
+    parts.push(`OCRテキスト内の表記がマスターデータの「${currentValue}」と完全に一致しました。`)
+  } else if (matchType === 'partial') {
+    if (keywords && keywords.length > 0) {
+      parts.push(`OCRテキスト内のキーワード「${keywords.join('」「')}」がマスターデータの「${currentValue}」と部分的に一致しました。`)
+    } else {
+      parts.push(`OCRテキストの一部がマスターデータの「${currentValue}」と部分的に一致しました。`)
+    }
+  } else if (matchType === 'fuzzy') {
+    parts.push(`OCRテキストの表記がマスターデータの「${currentValue}」と類似していると判定されました（あいまい一致）。`)
+  }
+
+  if (score !== undefined && score > 0) {
+    parts.push(`確信度: ${score}点`)
+  }
+
+  return parts.join(' ')
+}
+
+export function ExtractionInfoPopover({ fieldType, document }: ExtractionInfoPopoverProps) {
+  const info = getFieldInfo(fieldType, document)
+
+  // 表示する情報がない場合はアイコンを表示しない
+  const hasInfo = info.ocrField || info.matchType || info.score !== undefined ||
+    (info.candidates && info.candidates.length > 0) || info.keywords
+
+  if (!hasInfo) return null
+
+  const reasonMessage = getReasonMessage(info)
+  const candidates = info.candidates?.filter(c => !c.isCurrent)
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full p-0.5 text-gray-400 hover:text-blue-500 hover:bg-blue-50 transition-colors"
+          aria-label={`${info.fieldLabel}の抽出理由を表示`}
+        >
+          <Info className="h-3.5 w-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-80 text-sm"
+        side="left"
+        align="start"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-3">
+          {/* ヘッダー */}
+          <p className="font-medium text-gray-700">
+            なぜこの{info.fieldLabel}？
+          </p>
+
+          {/* 抽出理由 */}
+          <div className="rounded bg-gray-50 p-2.5 text-xs leading-relaxed text-gray-600">
+            {reasonMessage}
+          </div>
+
+          {/* マッチ情報サマリー */}
+          {info.matchType && (
+            <div className="flex items-center gap-3 text-xs text-gray-500">
+              <span className="flex items-center gap-1">
+                判定: <span className="font-medium text-gray-700">{matchTypeLabel(info.matchType)}</span>
+              </span>
+              {info.score !== undefined && info.score > 0 && (
+                <span className="flex items-center gap-1">
+                  確信度: <span className="font-medium text-gray-700">{info.score}点</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* 書類種別: マッチしたキーワード */}
+          {info.keywords && info.keywords.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-gray-500">マッチしたキーワード</p>
+              <div className="flex flex-wrap gap-1">
+                {info.keywords.map((kw, i) => (
+                  <span key={i} className="inline-block rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700">
+                    {kw}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* 顧客・事業所: 他の候補 */}
+          {candidates && candidates.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-gray-500">他の候補</p>
+              <div className="space-y-0.5">
+                {candidates.slice(0, 4).map((c, i) => (
+                  <div key={i} className="flex items-center justify-between text-xs text-gray-500">
+                    <span className="truncate">{c.name}</span>
+                    <span className="ml-2 flex-shrink-0 text-gray-400">
+                      {c.score}点・{matchTypeLabel(c.matchType)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -106,6 +106,11 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     officeKey: data.officeKey as string | undefined,
     documentTypeKey: data.documentTypeKey as string | undefined,
     careManagerKey: data.careManagerKey as string | undefined,
+    // OCR抽出スナップショット
+    ocrExtraction: data.ocrExtraction as Document['ocrExtraction'],
+    // 抽出スコア・詳細
+    extractionScores: data.extractionScores as Document['extractionScores'],
+    extractionDetails: data.extractionDetails as Document['extractionDetails'],
     // OCR結果確認ステータス
     verified: data.verified as boolean | undefined,
     verifiedBy: data.verifiedBy as string | null | undefined,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -71,6 +71,11 @@ export interface Document {
   // Phase 9: OCR抽出スナップショット（正解フィードバック用）
   ocrExtraction?: OcrExtraction;
 
+  // 抽出スコア（各フィールドの信頼度）
+  extractionScores?: ExtractionScores;
+  // 抽出詳細（マッチ方法・キーワード等）
+  extractionDetails?: ExtractionDetails;
+
   // OCR結果確認ステータス（人によるチェック状態）
   verified?: boolean;           // 確認済みフラグ（デフォルト: false）
   verifiedBy?: string | null;   // 確認者UID
@@ -96,6 +101,28 @@ export interface OcrExtraction {
   customer?: OcrFieldExtraction;
   office?: OcrFieldExtraction;
   documentType?: OcrFieldExtraction;
+}
+
+// ============================================
+// 抽出スコア・詳細情報
+// ============================================
+
+/** 各フィールドの抽出信頼度スコア */
+export interface ExtractionScores {
+  documentType: number;   // 書類種別スコア (0-100)
+  customerName: number;   // 顧客名スコア (0-100)
+  officeName: number;     // 事業所名スコア (0-100)
+  date: number;           // 日付スコア (0-100)
+}
+
+/** 抽出方法の詳細情報 */
+export interface ExtractionDetails {
+  documentMatchType: string;     // 書類種別のマッチタイプ
+  documentKeywords?: string[];   // マッチしたキーワード
+  customerMatchType: string;     // 顧客名のマッチタイプ
+  officeMatchType: string;       // 事業所名のマッチタイプ
+  datePattern?: string | null;   // 日付の抽出パターン
+  dateSource?: string | null;    // 日付の抽出元
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- 各メタ情報（顧客名・事業所名・書類種別）の横にℹアイコンを追加
- クリックで「なぜこの値が設定されたか」をPopoverで表示
  - マッチタイプ（完全一致/部分一致/あいまい一致）
  - 確信度スコア
  - 他の候補一覧（顧客・事業所の場合）
  - マッチしたキーワード（書類種別の場合）
- `ExtractionScores`/`ExtractionDetails`型を`shared/types.ts`に追加
- `firestoreToDocument`に`ocrExtraction`/`extractionScores`/`extractionDetails`マッピングを追加

## Test plan
- [x] TypeCheckパス
- [x] ビルド成功
- [x] フロントエンドテスト全71件パス
- [x] Functionsテスト全241件パス
- [ ] dev環境でInfoアイコンクリック→Popover表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explanatory popovers to document extraction fields, displaying match details, confidence scores, and alternative suggestions for customer name, office name, and document type fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->