### PR TITLE
fix: 抽出理由ポップオーバーのmatchType=none表示修正

### DIFF
--- a/frontend/src/components/ExtractionInfoPopover.tsx
+++ b/frontend/src/components/ExtractionInfoPopover.tsx
@@ -27,7 +27,7 @@ function matchTypeLabel(matchType: string | undefined): string {
     case 'exact': return '完全一致'
     case 'partial': return '部分一致'
     case 'fuzzy': return 'あいまい一致'
-    case 'none': return '一致なし'
+    case 'none': return 'マスター未登録'
     default: return '不明'
   }
 }
@@ -115,10 +115,16 @@ function getReasonMessage(info: ReturnType<typeof getFieldInfo>): string {
     }
   } else if (matchType === 'fuzzy') {
     parts.push(`OCRテキストの表記がマスターデータの「${currentValue}」と類似していると判定されました（あいまい一致）。`)
+  } else if (matchType === 'none') {
+    parts.push(`OCRテキストから「${currentValue}」を読み取りましたが、マスターデータに一致する候補が見つかりませんでした。マスターへの登録をご検討ください。`)
   }
 
   if (score !== undefined && score > 0) {
     parts.push(`確信度: ${score}点`)
+  }
+
+  if (parts.length === 0) {
+    parts.push(`OCRテキストから「${currentValue}」が抽出されました。`)
   }
 
   return parts.join(' ')


### PR DESCRIPTION
## Summary
- マスター未登録の値でPopoverの理由メッセージが空白になる問題を修正
- matchType=noneのケースで「マスターに一致する候補が見つかりませんでした」メッセージを表示
- フォールバックメッセージを追加（matchTypeが未設定の場合）
- 「一致なし」→「マスター未登録」に表記変更

## Test plan
- [x] TypeCheckパス
- [x] ビルド成功
- [ ] dev環境で再処理後のドキュメントでPopover表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Japanese label for "no match" status to provide clearer indication of missing master data.
  * Added explanatory messages for cases where no master data match is found.
  * Implemented fallback message when extraction data is unavailable, improving user experience in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->