### PR TITLE
fix: 事業所キーワードマッチングの施設タイプ汎用語誤判定を修正

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -14,7 +14,6 @@ import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
 import {
   extractDocumentTypeEnhanced,
   extractCustomerCandidates,
-  extractOfficeNameEnhanced,
   extractOfficeCandidates,
   extractDateEnhanced,
   extractFilenameInfo,
@@ -211,7 +210,6 @@ export async function processDocument(
 
   // 事業所候補抽出
   const officeResult = extractOfficeCandidates(ocrResult, officeMasterData, { filenameInfo });
-  const officeResultLegacy = extractOfficeNameEnhanced(ocrResult, officeMasterData);
 
   // ファイル名からの事業所登録提案
   let suggestedNewOffice: string | null = null;
@@ -296,14 +294,14 @@ export async function processDocument(
     extractionScores: {
       documentType: documentTypeResult.score ?? 0,
       customerName: customerResult.bestMatch?.score ?? 0,
-      officeName: officeResultLegacy.score ?? 0,
+      officeName: officeResult.bestMatch?.score ?? 0,
       date: dateResult.confidence ?? 0,
     },
     extractionDetails: {
       documentMatchType: documentTypeResult.matchType ?? 'none',
       documentKeywords: documentTypeResult.keywords ?? [],
       customerMatchType: customerResult.bestMatch?.matchType ?? 'none',
-      officeMatchType: officeResultLegacy.matchType ?? 'none',
+      officeMatchType: officeResult.bestMatch?.matchType ?? 'none',
       datePattern: dateResult.pattern ?? null,
       dateSource: dateResult.source ?? null,
     },


### PR DESCRIPTION
## Summary

- 事業所キーワードマッチングで施設タイプ汎用語（「居宅介護支援」「訪問介護」等）のみでマッチした場合に高スコアが付与される誤判定を修正
- `extractKeywordsForMatching`にひらがな固有名詞の抽出を追加し、`calculateKeywordMatchScore`に施設タイプのみマッチ時のペナルティを追加
- `ocrProcessor.ts`の`extractionScores`/`extractionDetails`を旧エクストラクター(Legacy)から新エクストラクターに統一

## Changes

### `functions/src/utils/extractors.ts`
- `FACILITY_TYPES`定数をモジュールレベルに移動（複数関数から参照可能に）
- `extractKeywordsForMatching`: 3文字以上のひらがな連続パターンをキーワードとして抽出
  - 例: 「みどり居宅介護支援センター」→ `["居宅介護支援", "みどり"]`
- `calculateKeywordMatchScore`: マッチしたキーワードが全て施設タイプの場合にスコアを50%に減衰
  - `[].every()`が常にtrueを返す空配列バグ防止のガード付き

### `functions/src/ocr/ocrProcessor.ts`
- `extractionScores.officeName`: `officeResultLegacy.score` → `officeResult.bestMatch?.score`
- `extractionDetails.officeMatchType`: `officeResultLegacy.matchType` → `officeResult.bestMatch?.matchType`
- 未使用の`officeResultLegacy`呼び出しと`extractOfficeNameEnhanced`インポートを削除

### `functions/test/extractors.test.ts` (+11テスト)
| カテゴリ | テスト内容 |
|---------|-----------|
| 真陽性 (2件) | OCRに完全名がある場合のスコア100、ひらがな+施設タイプ両方マッチ |
| ペナルティ (2件) | 「ひかり通所介護」「あさひ訪問介護ステーション」の偽陽性防止 |
| 識別 (2件) | さくらDS vs たんぽぽDSの正しい区別 |
| 境界条件 (2件) | ひらがな3文字抽出 / 2文字は未抽出 |
| 全ひらがな (1件) | 全ひらがな事業所名の完全一致 |
| 混合キーワード (2件) | 非施設タイプもマッチでペナルティなし / 施設タイプのみでペナルティ有り |

## Test plan

- [x] `cd functions && npm test` で253テスト全パス確認
- [ ] dev環境にFunctionsデプロイ後、「みどり居宅介護支援センター」を含む書類を再処理し誤判定が解消されることを確認
- [ ] 既存の正しくマッチしている事業所の結果がリグレッションしていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)