### PR TITLE
fix: CIのE2Eテストをchromiumプロジェクトに限定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
              cd frontend && \
              npx vite --port 5173 & sleep 5 && \
              cd frontend && \
-             E2E_BASE_URL=http://localhost:5173 CI=true npx playwright test --grep @emulator'
+             E2E_BASE_URL=http://localhost:5173 CI=true npx playwright test --grep @emulator --project=chromium'
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           VITE_USE_FIREBASE_EMULATOR: 'true'


### PR DESCRIPTION
## Summary
- CIの`npx playwright test --grep @emulator`に`--project=chromium`を追加
- PR #121で追加された`dev`プロジェクト(`baseURL: doc-split-dev.web.app`)がCIでも実行され、本番ビルドではViteソースファイルが存在しないため`import('/src/lib/firebase.ts')`が全テスト(38件)で失敗していた
- `dev`プロジェクトは手動テスト用のため、CIではchromiumプロジェクト(localhost Viteサーバー)のみ実行する

## Test plan
- [ ] CIの`lint-build-test`ジョブが全ステップpassすることを確認
- [ ] E2Eテストがchromiumプロジェクトのみで実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration pipeline to refine test execution scope for automated browser testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->