### PR TITLE
fix: 再処理機能の4つのバグを修正

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { doc, writeBatch, serverTimestamp, deleteField } from 'firebase/firestore'
+import { doc, writeBatch, serverTimestamp } from 'firebase/firestore'
 import {
   Filter,
   FileText,
@@ -51,7 +51,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { db } from '@/lib/firebase'
 import { callFunction } from '@/lib/callFunction'
 import { Checkbox } from '@/components/ui/checkbox'
-import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
+import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, getReprocessClearFields, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
 import { DateRangeFilter, type DateRange } from '@/components/DateRangeFilter'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
 import { DocumentDetailModal } from '@/components/DocumentDetailModal'
@@ -472,13 +472,13 @@ export function DocumentsPage() {
 
     setIsBulkOperating(true)
     try {
+      const clearFields = getReprocessClearFields()
       const batch = writeBatch(db)
       for (const docId of selectedIds) {
         const docRef = doc(db, 'documents', docId)
         batch.update(docRef, {
           status: 'pending',
-          ocrResult: deleteField(),
-          error: deleteField(),
+          ...clearFields,
         })
       }
       const count = selectedIds.size


### PR DESCRIPTION
## Summary
- **確認フラグリセット漏れ**: 再処理時に `customerConfirmed`/`officeConfirmed`/`verified` が未確認にリセットされない問題を修正
- **メタ情報クリア漏れ**: 再処理時に `customerName`/`officeName`/`documentType` 等の古い値が残る問題を修正（3箇所すべて）
- **PDFビューアの自動更新**: `useDocument()` に条件付きポーリング（pending/processing時のみ3秒間隔）を追加し、処理完了後にメタ情報が自動反映されるように
- **処理中の進捗表示**: メタ情報セクションに処理中オーバーレイ、ステータスバッジにスピナーアニメーション追加。再処理後の3秒自動クローズを削除

### 技術的変更
- `getReprocessClearFields()` ファクトリ関数を `useDocuments.ts` に追加し、3箇所（DocumentDetailModal/DocumentsPage/useErrors）で共通化（DRY）

## Test plan
- [x] `npm test` 全71テスト通過
- [x] `tsc --noEmit` 型チェック通過
- [x] `npm run build` ビルド成功
- [ ] エラードキュメントを開く → 再処理クリック → メタ情報即座にクリア・確認済みリセット・モーダル開いたまま
- [ ] 処理中オーバーレイ表示 → 完了後に自動で新メタ情報表示
- [ ] テーブルからの一括再処理でも確認フラグ・メタ情報がリセット

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual loader indicator in status badge to show active document processing
  * Added processing overlays across mobile and desktop views during OCR operations

* **Improvements**
  * Implemented automatic status polling (every 3 seconds) for real-time document updates during processing
  * Enhanced document reprocessing to comprehensively reset all relevant fields
  * Improved toast notifications to communicate automatic UI refresh during processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->