### PR TITLE
fix: Firestoreルールに再処理用フィールドを追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -57,10 +57,25 @@ service cloud.firestore {
           'verified',
           'verifiedBy',
           'verifiedAt',
-          // 再処理用フィールド（一括再処理）
+          // 再処理用フィールド（getReprocessClearFields対応）
           'status',
           'ocrResult',
-          'error'
+          'ocrResultUrl',
+          'summary',
+          'ocrExtraction',
+          'pageResults',
+          'fileDateFormatted',
+          'careManager',
+          'category',
+          'customerCandidates',
+          'officeCandidates',
+          'extractionScores',
+          'extractionDetails',
+          'allCustomerCandidates',
+          'suggestedNewOffice',
+          'error',
+          'lastErrorMessage',
+          'lastErrorId'
         ])
         // confirmedBy は自分のUIDのみ設定可能（事業所解決時は含まれない場合あり）
         && (request.resource.data.confirmedBy == request.auth.uid


### PR DESCRIPTION
## Summary
- `getReprocessClearFields()` が使用する15フィールドがFirestoreルールの `affectedKeys().hasOnly()` に含まれておらず、フロントエンドからの再処理がPERMISSION_DENIEDで失敗していた
- PR #129 で導入した `getReprocessClearFields()` に対応するルール更新が漏れていた
- ルールテストに `deleteField()` を使った全フィールド再処理テストを追加

## Changes
- `firestore.rules`: 再処理セクションに15フィールド追加（ocrResultUrl, summary, ocrExtraction, pageResults, fileDateFormatted, careManager, category, customerCandidates, officeCandidates, extractionScores, extractionDetails, allCustomerCandidates, suggestedNewOffice, lastErrorMessage, lastErrorId）
- `functions/test/firestore.rules.test.ts`: `getReprocessClearFields()` の全フィールド更新テスト追加

## Test plan
- [x] Firestoreルールテスト 55件パス（新規1件含む）
- [x] フロントエンドテスト 71件パス
- [ ] デプロイ後にE2E環境で再処理の実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended document update capabilities with additional field support including processing metadata and extraction details.

* **Tests**
  * Added test coverage for document field clearing during reprocessing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->