### PR TITLE
fix: 再処理E2Eテストを#129仕様変更に合わせて修正

### DIFF
--- a/frontend/e2e/reprocess-button.spec.ts
+++ b/frontend/e2e/reprocess-button.spec.ts
@@ -103,7 +103,8 @@ test.describe('再処理ボタン @emulator', () => {
     // 成功トーストが表示される
     await expect(page.locator('text=再処理をリクエストしました')).toBeVisible({ timeout: 5000 });
 
-    // モーダルが自動で閉じる（1.5秒後）
-    await expect(modal).not.toBeVisible({ timeout: 5000 });
+    // モーダルは開いたまま、ステータスが「待機中」に変わる（#129: 自動クローズ削除、進捗表示対応）
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('text=待機中')).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary
- PR #129 でモーダルの自動クローズを削除したが、E2Eテストが旧仕様（自動クローズ）を期待していたため失敗していた
- 初回試行でreprocessが実行されてdocument statusが`pending`に変わった後、リトライ時に「エラー」フィルターでドキュメントが見つからず `openErrorDocument` が失敗していた

## Root Cause
1. テスト line 107: `expect(modal).not.toBeVisible()` → モーダルが閉じないためタイムアウト
2. Playwright retry時: 初回でstatusが`error`→`pending`に変わっているため、エラーフィルターに一致するドキュメントが0件

## Fix
- `expect(modal).not.toBeVisible()` → `expect(modal).toBeVisible()` + `expect('待機中').toBeVisible()`
- モーダルが開いたまま、ステータスバッジが「待機中」に変わることを検証

## Test plan
- [ ] CI E2Eテスト全件パス（reprocess-button.spec.ts:91 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)