### PR TITLE
fix: タブレット/スマホ横向きで右サイドバーがスクロールできない問題を修正

### DIFF
--- a/frontend/e2e/tablet-landscape-sidebar.spec.ts
+++ b/frontend/e2e/tablet-landscape-sidebar.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * タブレット横向き - サイドバースクロール E2Eテスト
+ * タブレット/スマホ横向き（md:以上）で右サイドバーがスクロール可能であることを確認
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser } from './helpers';
+
+// タブレット横向きViewport設定（iPad横向き相当）
+test.use({
+  viewport: { width: 1024, height: 600 },
+  baseURL: process.env.E2E_BASE_URL || 'http://localhost:5173',
+});
+
+test.describe('タブレット横向き サイドバー @emulator', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginWithTestUser(page);
+  });
+
+  test('書類詳細モーダルの右サイドバーが表示される', async ({ page }) => {
+    await page.waitForSelector('table tbody tr', { timeout: 10000 });
+    const firstDoc = page.locator('table tbody tr').first();
+    await firstDoc.click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // デスクトップレイアウトでは hidden md:flex 内の書類情報ヘッダーが表示
+    // モバイル用(md:hidden)とデスクトップ用(hidden md:flex)の2つがあるため、nth(1)で後者を取得
+    const docInfo = modal.locator('h3:has-text("書類情報")').nth(1);
+    await expect(docInfo).toBeVisible({ timeout: 3000 });
+
+    // 顧客名ラベルが表示されること
+    const customerLabel = modal.locator('text=顧客名').first();
+    await expect(customerLabel).toBeVisible();
+  });
+
+  test('右サイドバーがスクロール可能', async ({ page }) => {
+    await page.waitForSelector('table tbody tr', { timeout: 10000 });
+    const firstDoc = page.locator('table tbody tr').first();
+    await firstDoc.click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await page.waitForTimeout(500);
+
+    // サイドバー内のoverflow-y-autoコンテナを確認
+    // デスクトップではサイドバーコンテナとその内部コンテンツの両方に md:overflow-y-auto が設定
+    const overflowContainers = modal.locator('[class*="overflow-y-auto"]');
+    const count = await overflowContainers.count();
+
+    console.log(`overflow-y-auto コンテナ数: ${count}`);
+    expect(count).toBeGreaterThan(0);
+
+    // サイドバー側のコンテナのcomputed styleを確認
+    const lastContainer = overflowContainers.last();
+    const overflowY = await lastContainer.evaluate((el) => {
+      return window.getComputedStyle(el).overflowY;
+    });
+
+    console.log(`サイドバー overflow-y: ${overflowY}`);
+    expect(['auto', 'scroll']).toContain(overflowY);
+  });
+
+  test('スマホ横向き(md:以上)でもサイドバーがスクロール可能', async ({ page }) => {
+    // スマホ横向き（812x375 = iPhone X横向き相当、幅が768px以上でmd:適用）
+    await page.setViewportSize({ width: 812, height: 375 });
+
+    await page.waitForSelector('table tbody tr', { timeout: 10000 });
+    const firstDoc = page.locator('table tbody tr').first();
+    await firstDoc.click();
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await page.waitForTimeout(500);
+
+    // サイドバー内のoverflow-y-autoコンテナ確認
+    const scrollContainers = modal.locator('[class*="overflow-y-auto"]');
+    const count = await scrollContainers.count();
+
+    console.log(`overflow-y-auto コンテナ数: ${count}`);
+    expect(count).toBeGreaterThan(0);
+
+    // コンテナのcomputed styleを確認
+    const sidebarScroll = scrollContainers.last();
+    const overflowY = await sidebarScroll.evaluate((el) => {
+      return window.getComputedStyle(el).overflowY;
+    });
+    console.log(`サイドバー overflow-y: ${overflowY}`);
+    expect(['auto', 'scroll']).toContain(overflowY);
+  });
+});

--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -868,8 +868,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
               <div
                 className={`w-full border-t bg-white transition-all duration-200 md:flex md:h-auto md:w-72 md:flex-col md:flex-shrink-0 md:border-l md:border-t-0 md:p-4 ${
                   isMetadataCollapsed
-                    ? 'h-12 flex-shrink-0 overflow-hidden px-3 py-2'
-                    : 'min-h-0 max-h-[45vh] flex-shrink-0 overflow-y-auto overscroll-contain p-3 [-webkit-overflow-scrolling:touch] md:max-h-none'
+                    ? 'h-12 flex-shrink-0 overflow-hidden px-3 py-2 md:h-auto md:overflow-y-auto'
+                    : 'min-h-0 max-h-[45vh] flex-shrink-0 overflow-y-auto overscroll-contain p-3 [-webkit-overflow-scrolling:touch] md:max-h-none md:overflow-y-auto'
                 }`}
               >
                 <div className={`flex items-center justify-between ${isMetadataCollapsed ? '' : 'mb-4'}`}>
@@ -964,7 +964,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                 </div>
 
                 {/* 折りたたみコンテンツ（モバイルで折りたたみ可能、デスクトップは常時表示） */}
-                <div className={`relative md:flex md:flex-col md:flex-1 md:min-h-0 ${isMetadataCollapsed ? 'hidden md:flex' : 'block'}`}>
+                <div className={`relative md:flex md:flex-col md:flex-1 md:min-h-0 md:overflow-y-auto ${isMetadataCollapsed ? 'hidden md:flex' : 'block'}`}>
                 {editError && (
                   <div className="mb-4 rounded bg-red-50 p-2 text-xs text-red-600">
                     {editError}


### PR DESCRIPTION
## Summary
- タブレット/スマホ横向き（md:以上）で書類詳細モーダルの右サイドバーがスクロールできず、下部の情報が見られない問題を修正
- デスクトップレイアウトのサイドバーコンテナに `md:overflow-y-auto` と `md:h-auto` を追加
- E2Eテスト3件追加（iPad横向き1024x600、iPhone横向き812x375）

## 変更ファイル
- `frontend/src/components/DocumentDetailModal.tsx` - サイドバーのoverflow修正
- `frontend/e2e/tablet-landscape-sidebar.spec.ts` - 新規E2Eテスト

## Test plan
- [x] 既存E2Eテスト42件パス（chromium）
- [x] 新規タブレット横向きテスト3件パス
- [x] ビルド成功
- [x] TypeScript型チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved scroll behavior for the sidebar in the document details view on tablet and medium-sized screens. The metadata panel now properly supports vertical scrolling on these viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->