### PR TITLE
fix: ヘッダーナビのレスポンシブ対応をタブレット向けに改善

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -31,14 +31,14 @@ export function Layout() {
         <header className="bg-brand-900 text-white shadow-lg">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="flex h-14 items-center justify-between">
-              <div className="flex items-center gap-6">
+              <div className="flex items-center gap-3 md:gap-6">
                 <Link to="/" className="flex items-center gap-2">
                   <img
                     src="/app-icon.png"
                     alt="DocSplit"
                     className="h-9 w-9 rounded-lg object-contain"
                   />
-                  <span className="hidden text-lg font-bold sm:inline">DocSplit</span>
+                  <span className="hidden text-lg font-bold md:inline">DocSplit</span>
                 </Link>
 
                 <nav className="flex gap-1">
@@ -53,20 +53,20 @@ export function Layout() {
                       }`}
                     >
                       <item.icon className="h-4 w-4" />
-                      <span className="hidden sm:inline">{item.name}</span>
+                      <span className="hidden md:inline">{item.name}</span>
                     </Link>
                   ))}
                 </nav>
               </div>
 
-              <div className="flex items-center gap-2 sm:gap-4">
-                <span className="hidden text-sm text-brand-200 sm:inline">{user?.email}</span>
+              <div className="flex items-center gap-2 md:gap-4">
+                <span className="hidden text-sm text-brand-200 lg:inline">{user?.email}</span>
                 <button
                   onClick={() => signOut()}
                   className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-brand-200 hover:bg-brand-800 hover:text-white"
                 >
                   <LogOut className="h-4 w-4" />
-                  <span className="hidden sm:inline">ログアウト</span>
+                  <span className="hidden md:inline">ログアウト</span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- タブレット（768px〜1024px）でヘッダーナビが見切れる問題を改善
- ブレークポイントを段階的に設定（sm→md/lgにシフト）
- 640px〜767pxではアイコンのみ表示、768px以上でテキスト表示、1024px以上でメールアドレス表示

## 変更内容
| 要素 | 変更前 | 変更後 |
|------|--------|--------|
| ナビタブテキスト | sm:inline (640px) | md:inline (768px) |
| DocSplitロゴ | sm:inline | md:inline |
| ログアウトテキスト | sm:inline | md:inline |
| メールアドレス | sm:inline | lg:inline (1024px) |
| 左側gap | gap-6 | gap-3 md:gap-6 |

## Test plan
- [x] E2Eテスト46件全パス（chromium）
- [x] TypeScript型チェックパス
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined responsive layout spacing and visibility breakpoints for improved display across screen sizes
  * Adjusted header and navigation spacing to reduce horizontal padding on smaller screens
  * Updated UI element visibility thresholds to progressively display information as screen sizes increase
  * Enhanced mobile and tablet user experience while maintaining full feature visibility on larger displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->