### PR TITLE
fix: health-reportのerrorカウント表示バグ修正

### DIFF
--- a/scripts/health-report/lib/report-formatter.js
+++ b/scripts/health-report/lib/report-formatter.js
@@ -126,7 +126,7 @@ function renderScheduler(data) {
 }
 
 function renderDocumentStats(stats) {
-  if (stats.error) {
+  if (typeof stats.error === 'string') {
     return `<h3>Documents</h3><div class="env-error">${escapeHtml(stats.error)}</div>`;
   }
 


### PR DESCRIPTION
## Summary
- `renderDocumentStats`で`stats.error`のチェックが、エラーステータスの件数（number）と収集エラー（string）を区別できていなかった
- kanameoneでerror=1のドキュメントがあると、Documentsセクションが`env-error`表示になりカード表示がスキップされるバグ
- `typeof stats.error === 'string'`で正確に判別するよう修正

## Root Cause
- `collectDocumentStats`は成功時に `{ processed: N, ..., error: N, split: N }` を返す
- 失敗時に `{ error: 'Failed to collect' }` を返す
- `if (stats.error)` は `error: 1` でもtruthyとなり、エラーパスに入っていた

## Test plan
- [x] ローカルで3パターン検証（error=1, error=0, collection failed）
- [x] CI dry runで正常動作確認済み（Firestore含む全データ取得成功）
- [ ] マージ後にCI再実行でkanameoneのDocumentsカード表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the health report would fail to display document statistics under certain error conditions, ensuring more reliable reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->