### PR TITLE
fix: Vertex AI 429レートリミットエラーの根本対策

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ npm run build                    # 全体ビルド
 
 ### デプロイ
 
+**MUST**: デプロイ順序は必ず **dev → クライアント環境（kanameone/cocoro等）**。dev環境で動作確認が完了するまでクライアント本番環境へのデプロイは禁止。
+
 **IMPORTANT**: マルチ環境デプロイ時は必ずスクリプトを使用。手動`firebase deploy`は`.env.local`の設定で誤った環境にデプロイされる危険がある。
 
 ```bash

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -339,7 +339,7 @@ export async function processDocument(
 }
 
 /** リトライ上限 */
-const MAX_RETRY_COUNT = 3;
+const MAX_RETRY_COUNT = 5;
 
 /**
  * エラー時の処理

--- a/functions/src/ocr/processOCR.ts
+++ b/functions/src/ocr/processOCR.ts
@@ -51,6 +51,7 @@ export const processOCR = onSchedule(
     region: 'asia-northeast1',
     timeoutSeconds: 540,
     memory: '1GiB',
+    maxInstances: 1,
   },
   async () => {
     console.log('Starting OCR processing (polling)...');

--- a/functions/src/utils/retry.ts
+++ b/functions/src/utils/retry.ts
@@ -23,7 +23,7 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
 /** 処理別のリトライ設定 */
 export const RETRY_CONFIGS = {
   gmail: { ...DEFAULT_RETRY_CONFIG, initialDelayMs: 1000 },
-  gemini: { ...DEFAULT_RETRY_CONFIG, maxRetries: 2, initialDelayMs: 2000 },
+  gemini: { ...DEFAULT_RETRY_CONFIG, maxRetries: 3, initialDelayMs: 5000 },
   storage: { ...DEFAULT_RETRY_CONFIG, initialDelayMs: 500 },
   firestore: { ...DEFAULT_RETRY_CONFIG, initialDelayMs: 500 },
 } as const;


### PR DESCRIPTION
## Summary
- processOCRに`maxInstances: 1`を設定し、複数インスタンス同時起動によるレート制限無効化を防止
- Geminiリトライ設定を強化（初期遅延2s→5s、回数2→3）で429回復待ち時間を確保
- ドキュメントリトライ上限を3→5に引き上げ、transientエラーでのerror固定を軽減
- CLAUDE.mdにdev→クライアント環境のデプロイ順序ルールを追加

## Root Cause
kanameone健全性レポート(2026-03-10)でVertex AI 429エラー2件。`maxInstances`未設定により複数インスタンスが同時起動→インスタンス単位のトークンバケット(ADR-0010)が実質無効化。

## Test plan
- [x] Functions単体テスト 253件パス
- [x] 型チェック・lintエラーなし
- [ ] dev環境にFunctionsデプロイ後、OCR処理が正常動作すること
- [ ] kanameoneエラー2件をpendingリセットし再処理成功を確認

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added mandatory deployment sequencing guidelines for multi-environment deployments.

* **Chores**
  * Enhanced reliability of document processing with increased retry attempts for transient errors.
  * Optimized scheduler configuration to prevent concurrent processing conflicts.
  * Improved retry timing and attempt limits for better error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->