### PR TITLE
docs: CLAUDE.mdに認証体系（3層構造）を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,33 @@ npm run build                    # 全体ビルド
 firebase deploy --only functions -P <alias>      # Functionsのみ（直接実行OK）
 ```
 
+### 認証体系（3層構造）
+
+Firebase/GCP操作には3つの独立した認証があり、混同しないこと。
+
+| 認証 | 用途 | 切替方法 | Claude Codeで実行 |
+|------|------|---------|-------------------|
+| **Firebase CLI** | `firebase deploy` | `firebase login:use <email>` | ❌ `login:add`はブラウザ必要（別ターミナル） |
+| **gcloud構成** | `gcloud`コマンド | `switch-client.sh` / `.envrc.client` | ✅ |
+| **ADC** | firebase-admin SDK（運用スクリプト） | `gcloud auth application-default login` | ❌ ブラウザ必要（別ターミナル） |
+
+**IMPORTANT**: クライアント環境のFirestoreを操作する運用スクリプト（`fix-stuck-documents.js`等）はADCを使う。対象環境のADCに切替えてから実行すること。ADCはグローバル設定のため、**作業後に元の環境に戻す必要はない**（次回使用時に切替える運用）。
+
+#### 各環境のFirebase CLIアカウント
+
+| 環境 | Firebase CLIアカウント | 備考 |
+|------|----------------------|------|
+| dev | `hy.unimail.11@gmail.com` | Owner |
+| kanameone | `systemkaname@kanameone.com` | Workspace Owner |
+| cocoro | GitHub Actions（`GCP_SA_KEY`） | ローカルデプロイ不要 |
+
+**Functionsデプロイ手順**（クライアント環境）:
+```bash
+firebase login:use <対象アカウント>       # Firebase CLI切替
+firebase deploy --only functions -P <alias>  # デプロイ
+firebase login:use hy.unimail.11@gmail.com   # dev用に戻す
+```
+
 | 変更内容 | コマンド |
 |---------|---------|
 | フロントエンドのみ | `deploy-to-project.sh <alias>` |


### PR DESCRIPTION
## Summary
- Firebase CLI / gcloud構成 / ADCの3層認証体系を表で明示
- 各環境のFirebase CLIアカウント対応表を追加
- クライアント環境へのFunctionsデプロイ手順を文書化

## 背景
Issue #161対応時に、認証の混同で時間を浪費した経験を文書化。

## Test plan
- [ ] CLAUDE.mdの内容が正確であることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance for Firebase and GCP operations with detailed information including a comparative analysis of authentication methods, recommendations for authentication strategies in client applications, environment-specific account information and configurations, as well as comprehensive deployment procedures and best practices for managing authentication across multiple environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->