### PR TITLE
fix: 編集モード中は削除ボタンを無効化

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -852,13 +852,14 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                       <span className="hidden sm:inline">新しいタブで開く</span>
                     </Button>
                   )}
-                  {/* 削除ボタン（管理者のみ） */}
+                  {/* 削除ボタン（管理者のみ、編集中は無効） */}
                   {isAdmin && (
                     <Button
                       variant="outline"
                       size="sm"
                       onClick={() => setShowDeleteDialog(true)}
-                      className="text-red-600 border-red-300 hover:bg-red-50"
+                      disabled={isEditing}
+                      className="text-red-600 border-red-300 hover:bg-red-50 disabled:opacity-40"
                     >
                       <Trash2 className="h-4 w-4 sm:mr-1" />
                       <span className="hidden sm:inline">削除</span>


### PR DESCRIPTION
## Summary
- 詳細モーダルで編集モード中に削除ボタンを `disabled` にする
- 編集中の変更が確認なく失われることを防止

## 変更内容
- `disabled={isEditing}` を追加（1行）
- `disabled:opacity-40` で視覚的に無効状態を表示

## Test plan
- [ ] 編集モード中に削除ボタンがグレーアウトされる
- [ ] 編集モード終了後に削除ボタンが有効に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)