### PR TITLE
test: careManager自動補完ロジックのテスト追加

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -37,6 +37,7 @@ import { useMasterAlias } from '@/hooks/useMasterAlias'
 import { useAliasLearningHistory, useInvalidateAliasLearningHistory } from '@/hooks/useAliasLearningHistory'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
 import { useDocumentVerification } from '@/hooks/useDocumentVerification'
+import { resolveCareManager } from '@/utils/resolveCareManager'
 import type { DocumentStatus } from '@shared/types'
 
 // 閉じる確認ダイアログ用のAlertDialog
@@ -1056,10 +1057,9 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                             suggestedItems={suggestedCustomerItems.length > 0 ? suggestedCustomerItems : undefined}
                             onChange={(v) => {
                               updateField('customerName', v)
-                              // 顧客選択時にcareManagerを自動補完
-                              const matched = (customers || []).filter(c => c.name === v)
-                              if (matched.length === 1 && matched[0]) {
-                                updateField('careManager', matched[0].careManagerName ?? '')
+                              const cm = resolveCareManager(v, customers || [])
+                              if (cm !== null) {
+                                updateField('careManager', cm)
                               }
                             }}
                           />

--- a/frontend/src/utils/__tests__/resolveCareManager.test.ts
+++ b/frontend/src/utils/__tests__/resolveCareManager.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { resolveCareManager } from '../resolveCareManager'
+
+describe('resolveCareManager', () => {
+  const customers = [
+    { name: '田村 勝義', careManagerName: '長谷川 由紀' },
+    { name: '杉山 洋子', careManagerName: '板垣 亜紀子' },
+    { name: '中村 太郎', careManagerName: undefined },
+    // 同名顧客（isDuplicate相当）
+    { name: '鈴木 花子', careManagerName: '長谷川 由紀' },
+    { name: '鈴木 花子', careManagerName: '板垣 亜紀子' },
+  ]
+
+  it('一意にマッチする顧客のcareManagerNameを返す', () => {
+    expect(resolveCareManager('田村 勝義', customers)).toBe('長谷川 由紀')
+    expect(resolveCareManager('杉山 洋子', customers)).toBe('板垣 亜紀子')
+  })
+
+  it('careManagerNameが未設定の顧客は空文字を返す', () => {
+    expect(resolveCareManager('中村 太郎', customers)).toBe('')
+  })
+
+  it('同名顧客が複数存在する場合はnullを返す（補完しない）', () => {
+    expect(resolveCareManager('鈴木 花子', customers)).toBeNull()
+  })
+
+  it('マッチする顧客がいない場合はnullを返す', () => {
+    expect(resolveCareManager('存在しない名前', customers)).toBeNull()
+  })
+
+  it('空の顧客リストではnullを返す', () => {
+    expect(resolveCareManager('田村 勝義', [])).toBeNull()
+  })
+})

--- a/frontend/src/utils/resolveCareManager.ts
+++ b/frontend/src/utils/resolveCareManager.ts
@@ -1,0 +1,17 @@
+/**
+ * 顧客選択時にcareManagerを解決する
+ *
+ * - 一意にマッチ → そのcareManagerName（未設定なら空文字）
+ * - 同名顧客が複数（isDuplicate） → null（補完しない）
+ * - マッチなし → null（補完しない）
+ */
+export function resolveCareManager(
+  customerName: string,
+  customers: readonly { name: string; careManagerName?: string }[]
+): string | null {
+  const matched = customers.filter(c => c.name === customerName)
+  if (matched.length === 1 && matched[0]) {
+    return matched[0].careManagerName ?? ''
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- PR #174 で不足していたcareManager解決ロジックのテストを追加
- インラインのonChangeコールバックからresolveCareManager関数を抽出しテスト可能に
- isDuplicate・未設定・マッチなし等の全分岐パスをカバー（5件）

## 変更
- `resolveCareManager.ts` — 顧客名からcareManagerを解決する純粋関数
- `resolveCareManager.test.ts` — ユニットテスト5件
- `DocumentDetailModal.tsx` — インラインロジックを関数呼び出しに置換

Closes #171

## Test plan
- [x] resolveCareManagerテスト 5件 PASS
- [x] 全テスト 83件 PASS
- [x] 型チェック エラーなし
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced care manager auto-fill functionality when selecting customers. The system now uses an improved matching mechanism that robustly handles duplicate customer names and missing care manager information, delivering more reliable auto-population of the care manager field in document details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->