### PR TITLE
fix: PDF分割時にcareManagerフィールドが正しく保存されない

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -19,6 +19,7 @@ import {
   MasterData,
 } from '../utils/pdfAnalyzer';
 import { CustomerMaster, DocumentMaster, OfficeMaster } from '../utils/extractors';
+import { buildSplitDocumentData } from './splitDocumentBuilder';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -316,8 +317,7 @@ export const splitPdf = onCall(
         officeCandidates,
         // needsManualCustomerSelection, needsManualOfficeSelectionは
         // 分割UIで選択済みのため常にfalseになる
-        isDuplicateCustomer,
-        careManagerName,
+        // isDuplicateCustomer, careManagerName は buildSplitDocumentData(segment) で処理
       } = segment;
 
       // 新しいPDFを作成
@@ -390,6 +390,7 @@ export const splitPdf = onCall(
       // 新しいドキュメントをFirestoreに作成
       // ユーザーが分割UIで選択した値は常にconfirmed=true
       const newDocRef = db.collection('documents').doc();
+      const splitDocFields = buildSplitDocumentData(segment);
       await newDocRef.set({
         id: newDocRef.id,
         processedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -401,23 +402,11 @@ export const splitPdf = onCall(
           startPage,
           endPage
         ),
-        // 書類種別
-        documentType,
-        // 顧客関連
-        customerName,
-        customerId: customerId || null,
-        customerCandidates: customerCandidates || [],
-        customerConfirmed: true, // 分割UIで選択したため確定済み
-        needsManualCustomerSelection: false, // 分割UIで確定したため手動選択不要
-        isDuplicateCustomer: isDuplicateCustomer || false,
-        careManagerName: careManagerName || null,
+        // セグメントから構築したフィールド（careManager/careManagerKey含む）
+        ...splitDocFields,
         confirmedBy: request.auth?.uid || null,
         confirmedAt: admin.firestore.FieldValue.serverTimestamp(),
-        // 事業所関連
-        officeName,
-        officeId: officeId || null,
-        officeCandidates: officeCandidates || [],
-        officeConfirmed: true, // 分割UIで選択したため確定済み
+        // 事業所確定
         officeConfirmedBy: request.auth?.uid || null,
         officeConfirmedAt: admin.firestore.FieldValue.serverTimestamp(),
         // OCR抽出スナップショット

--- a/functions/src/pdf/splitDocumentBuilder.ts
+++ b/functions/src/pdf/splitDocumentBuilder.ts
@@ -1,0 +1,56 @@
+/**
+ * PDF分割時のFirestoreドキュメントデータ構築
+ *
+ * pdfOperations.tsから純粋なデータ構築ロジックを抽出し、テスト可能にする。
+ * Firestore依存（serverTimestamp等）を含まない部分のみ。
+ */
+
+export interface SplitSegmentInput {
+  startPage: number;
+  endPage: number;
+  documentType: string;
+  customerName: string;
+  customerId?: string | null;
+  officeName: string;
+  officeId?: string | null;
+  customerCandidates?: Array<{
+    id: string;
+    name: string;
+    score: number;
+    isDuplicate: boolean;
+    careManagerName?: string;
+  }>;
+  officeCandidates?: Array<{
+    id: string;
+    name: string;
+    score: number;
+    isDuplicate: boolean;
+  }>;
+  isDuplicateCustomer?: boolean;
+  careManagerName?: string | null;
+}
+
+/**
+ * 分割セグメントからFirestoreドキュメントの静的フィールドを構築する。
+ *
+ * careManagerNameフィールドをcareManager + careManagerKeyに正しくマッピングする。
+ */
+export function buildSplitDocumentData(segment: SplitSegmentInput): Record<string, unknown> {
+  const careManager = segment.careManagerName || null;
+
+  return {
+    documentType: segment.documentType,
+    customerName: segment.customerName,
+    customerId: segment.customerId || null,
+    customerCandidates: segment.customerCandidates || [],
+    customerConfirmed: true,
+    needsManualCustomerSelection: false,
+    isDuplicateCustomer: segment.isDuplicateCustomer || false,
+    careManager: careManager,
+    careManagerKey: careManager || '',
+    officeName: segment.officeName,
+    officeId: segment.officeId || null,
+    officeCandidates: segment.officeCandidates || [],
+    officeConfirmed: true,
+  };
+}

--- a/functions/test/pdfSplitCareManager.test.ts
+++ b/functions/test/pdfSplitCareManager.test.ts
@@ -1,0 +1,87 @@
+/**
+ * PDF分割時のcareManagerフィールド伝播テスト
+ *
+ * TDD: #172 PDF分割時にcareManagerNameが正しく伝播されない
+ *
+ * 根本原因: pdfOperations.tsでFirestoreに書き込む際、
+ * フィールド名が「careManagerName」になっているが、
+ * Documentスキーマでは「careManager」+「careManagerKey」が正しい。
+ */
+
+import { expect } from 'chai';
+
+/**
+ * pdfOperations.tsのFirestore書き込みデータを構築するロジックを
+ * 純粋関数として抽出し、テスト可能にする。
+ *
+ * 実際のFirestore書き込みはCloud Function内で行われるため、
+ * ここではデータ構築ロジックの正しさを検証する。
+ */
+import { buildSplitDocumentData } from '../src/pdf/splitDocumentBuilder';
+
+describe('PDF分割 - careManagerフィールド伝播 (#172)', () => {
+  const baseSegment = {
+    startPage: 1,
+    endPage: 3,
+    documentType: '請求書',
+    customerName: '田村 勝義',
+    customerId: 'cust-001',
+    officeName: 'テスト事業所',
+    officeId: 'office-001',
+    customerCandidates: [],
+    officeCandidates: [],
+    isDuplicateCustomer: false,
+    careManagerName: '長谷川 由紀',
+  };
+
+  describe('careManagerフィールドの正しいマッピング', () => {
+    it('careManagerNameがcareManagerフィールドとして保存される', () => {
+      const data = buildSplitDocumentData(baseSegment);
+      expect(data.careManager).to.equal('長谷川 由紀');
+    });
+
+    it('careManagerKeyがcareManagerから派生して設定される', () => {
+      const data = buildSplitDocumentData(baseSegment);
+      expect(data.careManagerKey).to.equal('長谷川 由紀');
+    });
+
+    it('careManagerNameフィールドはFirestoreに保存されない', () => {
+      const data = buildSplitDocumentData(baseSegment);
+      expect(data).to.not.have.property('careManagerName');
+    });
+  });
+
+  describe('careManagerNameが未設定の場合', () => {
+    it('careManagerNameがnullの場合、careManagerはnullになる', () => {
+      const segment = { ...baseSegment, careManagerName: null };
+      const data = buildSplitDocumentData(segment);
+      expect(data.careManager).to.be.null;
+      expect(data.careManagerKey).to.equal('');
+    });
+
+    it('careManagerNameがundefinedの場合、careManagerはnullになる', () => {
+      const segment = { ...baseSegment, careManagerName: undefined };
+      const data = buildSplitDocumentData(segment);
+      expect(data.careManager).to.be.null;
+      expect(data.careManagerKey).to.equal('');
+    });
+
+    it('careManagerNameが空文字の場合、careManagerはnullになる', () => {
+      const segment = { ...baseSegment, careManagerName: '' };
+      const data = buildSplitDocumentData(segment);
+      expect(data.careManager).to.be.null;
+      expect(data.careManagerKey).to.equal('');
+    });
+  });
+
+  describe('他のフィールドとの整合性', () => {
+    it('customerName, documentType等は正しく含まれる', () => {
+      const data = buildSplitDocumentData(baseSegment);
+      expect(data.customerName).to.equal('田村 勝義');
+      expect(data.documentType).to.equal('請求書');
+      expect(data.customerId).to.equal('cust-001');
+      expect(data.officeName).to.equal('テスト事業所');
+      expect(data.customerConfirmed).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- PDF分割時に`careManagerName`フィールド名でFirestoreに書き込んでいたバグを修正
- 正しいフィールド名`careManager` + `careManagerKey`で保存するように変更
- データ構築ロジックを`splitDocumentBuilder.ts`に抽出しテスト7件追加

## 根本原因
`pdfOperations.ts:413`で`careManagerName: careManagerName || null`と書き込んでいたが、Documentスキーマのフィールド名は`careManager`（型定義 shared/types.ts:37）。OCR処理では正しく`careManager`で書き込んでいたため、PDF分割で作成されたドキュメントだけCMフィルターに表示されなかった。

## Test plan
- [x] functions テスト 260件全パス（うちcareManager関連7件）
- [x] functions ビルド成功
- [x] frontend テスト 83件全パス
- [x] lint エラー0件

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored PDF document splitting logic to improve data construction consistency and maintainability.

* **Tests**
  * Added tests to verify proper handling of care manager information when splitting PDF documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->