### PR TITLE
feat: 顧客マスターcareManagerName変更時に既存ドキュメントを自動同期

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -51,6 +51,9 @@ export {
 // Phase 8: ドキュメントグループ集計トリガー
 export { onDocumentWrite } from './triggers/updateDocumentGroups';
 
+// 顧客マスターcareManagerName変更同期トリガー (#173)
+export { onCustomerMasterWrite } from './triggers/syncCareManager';
+
 // 検索機能
 export { searchDocuments } from './search/searchDocuments';
 export { onDocumentWriteSearchIndex } from './search/searchIndexer';

--- a/functions/src/triggers/syncCareManager.ts
+++ b/functions/src/triggers/syncCareManager.ts
@@ -1,0 +1,72 @@
+/**
+ * 顧客マスターcareManagerName変更時の同期トリガー
+ *
+ * #173: masters/customers/items のcareManagerNameが変更されたら、
+ * 該当顧客の全ドキュメントの careManager + careManagerKey を更新する。
+ */
+
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import * as admin from 'firebase-admin';
+import { detectCareManagerChange, buildCareManagerUpdate } from './syncCareManagerLogic';
+
+const db = admin.firestore();
+
+export const onCustomerMasterWrite = onDocumentWritten(
+  {
+    document: 'masters/customers/items/{customerId}',
+    region: 'asia-northeast1',
+  },
+  async (event) => {
+    const beforeData = event.data?.before?.data() as { name?: string; careManagerName?: string } | undefined;
+    const afterData = event.data?.after?.data() as { name?: string; careManagerName?: string } | undefined;
+
+    const before = beforeData?.name ? { name: beforeData.name, careManagerName: beforeData.careManagerName } : null;
+    const after = afterData?.name ? { name: afterData.name, careManagerName: afterData.careManagerName } : null;
+
+    if (!detectCareManagerChange(before, after)) {
+      return;
+    }
+
+    // afterがnullの場合はdetectCareManagerChangeでfalseになるので、ここではafter非null
+    const customerName = after!.name;
+    const customerId = event.params.customerId;
+    const update = buildCareManagerUpdate(after!.careManagerName);
+
+    // customerIdで特定（正確）、なければcustomerNameで検索
+    const byIdSnapshot = await db.collection('documents')
+      .where('customerId', '==', customerId)
+      .get();
+
+    const byNameSnapshot = byIdSnapshot.empty
+      ? await db.collection('documents')
+          .where('customerName', '==', customerName)
+          .get()
+      : null;
+
+    const targetDocs = byNameSnapshot ?? byIdSnapshot;
+
+    if (targetDocs.empty) {
+      console.log(`No documents found for customer: ${customerName} (id: ${customerId})`);
+      return;
+    }
+
+    // バッチ更新（Firestoreバッチは500件まで）
+    const batches: admin.firestore.WriteBatch[] = [];
+    let currentBatch = db.batch();
+    let count = 0;
+
+    for (const doc of targetDocs.docs) {
+      currentBatch.update(doc.ref, update);
+      count++;
+      if (count % 500 === 0) {
+        batches.push(currentBatch);
+        currentBatch = db.batch();
+      }
+    }
+    batches.push(currentBatch);
+
+    await Promise.all(batches.map(b => b.commit()));
+
+    console.log(`Updated careManager for ${count} documents (customer: ${customerName}, careManager: ${update.careManager})`);
+  },
+);

--- a/functions/src/triggers/syncCareManagerLogic.ts
+++ b/functions/src/triggers/syncCareManagerLogic.ts
@@ -1,0 +1,39 @@
+/**
+ * 顧客マスターcareManagerName変更時の同期ロジック（純粋関数）
+ *
+ * #173: 顧客マスターのcareManagerName変更が既存ドキュメントに反映されない
+ */
+
+interface CustomerMasterData {
+  name: string;
+  careManagerName?: string;
+}
+
+/**
+ * before/afterのcareManagerNameを比較し、変更があるかを判定する。
+ *
+ * - 新規作成（before=null）でcareManagerNameありの場合はtrue
+ * - 削除（after=null）の場合はfalse（ドキュメント更新不要）
+ */
+export function detectCareManagerChange(
+  before: CustomerMasterData | null,
+  after: CustomerMasterData | null,
+): boolean {
+  if (!after) return false;
+  const beforeCm = before?.careManagerName ?? undefined;
+  const afterCm = after.careManagerName ?? undefined;
+  return beforeCm !== afterCm;
+}
+
+/**
+ * careManagerNameからFirestoreドキュメント更新データを構築する。
+ */
+export function buildCareManagerUpdate(
+  careManagerName: string | undefined,
+): { careManager: string | null; careManagerKey: string } {
+  const careManager = careManagerName || null;
+  return {
+    careManager,
+    careManagerKey: careManager || '',
+  };
+}

--- a/functions/test/syncCareManager.test.ts
+++ b/functions/test/syncCareManager.test.ts
@@ -1,0 +1,82 @@
+/**
+ * 顧客マスターcareManagerName変更時の同期ロジック テスト
+ *
+ * TDD: #173 顧客マスターのcareManagerName変更が既存ドキュメントに反映されない
+ *
+ * ロジック:
+ * - マスターのcareManagerNameが変更されたら、該当顧客のドキュメントを更新
+ * - 変更検知: before/afterのcareManagerNameを比較
+ * - 更新対象: customerName一致のドキュメント（customerIdがあればそちらを優先）
+ */
+
+import { expect } from 'chai';
+import { detectCareManagerChange, buildCareManagerUpdate } from '../src/triggers/syncCareManagerLogic';
+
+describe('顧客マスターcareManagerName同期 (#173)', () => {
+  describe('detectCareManagerChange - 変更検知', () => {
+    it('careManagerNameが変更された場合trueを返す', () => {
+      const before = { name: '田村 勝義', careManagerName: '板垣 亜紀子' };
+      const after = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      expect(detectCareManagerChange(before, after)).to.be.true;
+    });
+
+    it('careManagerNameが追加された場合trueを返す', () => {
+      const before = { name: '田村 勝義' };
+      const after = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      expect(detectCareManagerChange(before, after)).to.be.true;
+    });
+
+    it('careManagerNameが削除された場合trueを返す', () => {
+      const before = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      const after = { name: '田村 勝義' };
+      expect(detectCareManagerChange(before, after)).to.be.true;
+    });
+
+    it('careManagerNameが変わっていない場合falseを返す', () => {
+      const before = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      const after = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      expect(detectCareManagerChange(before, after)).to.be.false;
+    });
+
+    it('両方ともcareManagerNameがない場合falseを返す', () => {
+      const before = { name: '田村 勝義' };
+      const after = { name: '田村 勝義' };
+      expect(detectCareManagerChange(before, after)).to.be.false;
+    });
+
+    it('新規作成（beforeがnull）でcareManagerNameありはtrueを返す', () => {
+      const after = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      expect(detectCareManagerChange(null, after)).to.be.true;
+    });
+
+    it('新規作成（beforeがnull）でcareManagerNameなしはfalseを返す', () => {
+      const after = { name: '田村 勝義' };
+      expect(detectCareManagerChange(null, after)).to.be.false;
+    });
+
+    it('削除（afterがnull）はfalseを返す（ドキュメント更新不要）', () => {
+      const before = { name: '田村 勝義', careManagerName: '長谷川 由紀' };
+      expect(detectCareManagerChange(before, null)).to.be.false;
+    });
+  });
+
+  describe('buildCareManagerUpdate - 更新データ構築', () => {
+    it('careManagerとcareManagerKeyを正しく構築する', () => {
+      const update = buildCareManagerUpdate('長谷川 由紀');
+      expect(update.careManager).to.equal('長谷川 由紀');
+      expect(update.careManagerKey).to.equal('長谷川 由紀');
+    });
+
+    it('careManagerNameがundefinedの場合はnullと空文字', () => {
+      const update = buildCareManagerUpdate(undefined);
+      expect(update.careManager).to.be.null;
+      expect(update.careManagerKey).to.equal('');
+    });
+
+    it('careManagerNameが空文字の場合はnullと空文字', () => {
+      const update = buildCareManagerUpdate('');
+      expect(update.careManager).to.be.null;
+      expect(update.careManagerKey).to.equal('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `masters/customers/items` のcareManagerName変更を検知するFirestoreトリガーを追加
- 該当顧客の全ドキュメントの `careManager` + `careManagerKey` を自動更新
- customerIdで特定（正確）、なければcustomerNameで検索（フォールバック）
- 変更検知・データ構築ロジックを純粋関数に抽出しテスト11件追加

## 技術詳細
- `onDocumentWritten('masters/customers/items/{customerId}')` トリガー
- バッチ更新（500件制限対応）
- ドキュメント更新により `updateDocumentGroups` トリガーが二次発火し、CMグループ集計も自動更新

## Test plan
- [x] functions テスト 271件全パス（うちcareManager同期11件）
- [x] functions ビルド成功
- [x] lint エラー0件

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added automated care manager synchronization triggered when customer master records change in the Asia region. Updates are propagated to matched documents with fallback lookups by customer ID or name.

## Tests
* Added comprehensive test coverage for change detection and update generation logic, including edge cases and null value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->