### PR TITLE
feat: displayFileName フィールド追加と UI フォールバック表示 (#178 Stage 0)

### DIFF
--- a/docs/adr/0014-display-filename.md
+++ b/docs/adr/0014-display-filename.md
@@ -1,0 +1,73 @@
+# ADR-0014: メタ情報に基づく表示ファイル名の自動生成（displayFileName）
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+現在、ドキュメントの `fileName` はアップロード時の元ファイル名がそのまま使われている。OCRや手動編集でメタ情報（書類種別、顧客名、事業所名、日付）が確定してもファイル名には反映されず、ユーザーにとって識別しづらい。
+
+一方、`generateOptimalFileName()`（命名ルール: 書類名_事業所_日付_顧客名）は既に実装済みだが未活用。
+
+## 決定
+
+`fileName` は原本由来の安定値として維持し、新たに `displayFileName` をサーバー管理の派生値として追加する。
+
+### フィールド責務の分離
+
+| フィールド | 責務 | 更新者 | 変更頻度 |
+|-----------|------|--------|---------|
+| `fileName` | 原本由来の安定値。検索・OCR補助に継続使用 | アップロード時のみ | 不変 |
+| `displayFileName` | 表示・DL名。メタ情報から自動生成 | Cloud Functions のみ | メタ情報変更時 |
+| `storagePath` | Storageファイル参照（実質ID） | アップロード時のみ | 不変 |
+
+### 重要な制約
+
+- `fileName` は一切変更しない（検索・OCR補助への副作用を防止）
+- `displayFileName` はユーザー直接編集不可（Firestoreルールで制御）
+- 再生成はCloud Functions側に一本化（命名ルールの単一責任点）
+- 未設定時は `fileName` にフォールバック（既存データ互換）
+
+### 再生成の発火タイミング
+
+| タイミング | トリガー | 利用可能な情報 |
+|-----------|---------|---------------|
+| OCR完了時 | processOCR内 | documentType, customerName, officeName, fileDate 全て揃う |
+| PDF分割時 | splitPdf内 | セグメントのメタ情報から生成 |
+| メタ編集時 | onDocumentWriteトリガー | 変更後のメタ情報 |
+
+### 並行更新の優先順位
+
+手動編集 > OCR再処理（手動確定後にOCRで上書きしない）
+
+### 段階的導入
+
+| Stage | 内容 | リスク | ロールバック |
+|-------|------|--------|-------------|
+| 0 | 型定義追加 + UIフォールバック表示 | ゼロ | ヘルパー関数を戻すだけ |
+| 1 | OCR完了時に自動生成 | 低 | 設定行を削除 |
+| 2 | PDF分割時に自動生成 | 低 | 設定行を削除 |
+| 3 | メタ編集時の再生成 | 中 | 再生成ロジックを削除 |
+| 4 | 既存データのバックフィル | 中 | FieldValue.delete()で一括削除 |
+
+全Stage、fileNameは不変のため安全にロールバック可能。
+
+### トリガー連鎖への影響
+
+- `displayFileName` はグループキーではないため `onDocumentWrite`（集計）に影響なし
+- `displayFileName` は現在の検索インデックス対象外のため `onDocumentWriteSearchIndex` に影響なし
+- 再帰防止: displayFileName自体の変更は再生成をトリガーしない
+
+## 根拠
+
+- Storage側を一切変更しないため、参照整合性・並行処理のリスクがない
+- fileNameの既存責務（検索・OCR補助）を維持しつつ、表示品質を向上できる
+- 段階的導入により、各Stageで動作確認・ロールバックが可能
+
+## 影響
+
+- `shared/types.ts`: Document型に `displayFileName` 追加
+- `firestore.rules`: displayFileName はユーザー編集不可
+- Functions: processOCR, splitPdf, onDocumentWrite に生成ロジック追加
+- Frontend: 表示箇所を `displayFileName ?? fileName` に切り替え

--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -38,6 +38,7 @@ import { useAliasLearningHistory, useInvalidateAliasLearningHistory } from '@/ho
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
 import { useDocumentVerification } from '@/hooks/useDocumentVerification'
 import { resolveCareManager } from '@/utils/resolveCareManager'
+import { getDisplayFileName } from '@/utils/getDisplayFileName'
 import type { DocumentStatus } from '@shared/types'
 
 // 閉じる確認ダイアログ用のAlertDialog
@@ -575,7 +576,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       const url = URL.createObjectURL(blob)
       const link = window.document.createElement('a')
       link.href = url
-      link.download = document.fileName || 'document.pdf'
+      link.download = getDisplayFileName(document) || 'document.pdf'
       window.document.body.appendChild(link)
       link.click()
       window.document.body.removeChild(link)
@@ -801,7 +802,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                 <div className="flex items-center gap-2 sm:gap-3">
                   <FileText className="hidden h-6 w-6 text-gray-400 sm:block" />
                   <div className="min-w-0 flex-1">
-                    <DialogTitle className="truncate text-base sm:text-lg">{document.fileName}</DialogTitle>
+                    <DialogTitle className="truncate text-base sm:text-lg">{getDisplayFileName(document)}</DialogTitle>
                     <div className="flex items-center gap-2 mt-0.5">
                       <p className="text-xs text-gray-500 sm:text-sm">{document.documentType || '未判定'}</p>
                       {document.category && (
@@ -1605,7 +1606,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
               <span className="text-blue-600">書類を削除しています。しばらくお待ちください...</span>
             ) : (
               <>
-                「{document?.fileName}」を削除します。<br />
+                「{document ? getDisplayFileName(document) : ''}」を削除します。<br />
                 この操作は元に戻せません。関連するファイルとログも同時に削除されます。
               </>
             )}

--- a/frontend/src/components/PdfSplitModal.tsx
+++ b/frontend/src/components/PdfSplitModal.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/hooks/usePdfSplit'
 import { useDocumentMasters, useCustomerMasters, useOfficeMasters } from '@/hooks/useDocuments'
 import { PdfSplitPreview } from './PdfSplitPreview'
+import { getDisplayFileName } from '@/utils/getDisplayFileName'
 import type { Document, SplitSuggestion, SplitSegment } from '@shared/types'
 
 interface PdfSplitModalProps {
@@ -330,7 +331,7 @@ export function PdfSplitModal({
             PDF分割
           </DialogTitle>
           <DialogDescription>
-            {document.fileName} ({document.totalPages}ページ)
+            {getDisplayFileName(document)} ({document.totalPages}ページ)
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/components/views/GroupDocumentList.tsx
+++ b/frontend/src/components/views/GroupDocumentList.tsx
@@ -17,6 +17,7 @@ import {
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
 import { CustomerSubGroup } from './CustomerSubGroup';
 import { getStatusConfig, formatTimestamp } from '@/lib/documentUtils';
+import { getDisplayFileName } from '@/utils/getDisplayFileName';
 import type { Document } from '@shared/types';
 import type { DateRange } from '@/components/DateRangeFilter';
 
@@ -81,7 +82,7 @@ function DocumentRow({ document, groupType, onClick }: DocumentRowProps) {
       <FileText className="h-4 w-4 flex-shrink-0 text-gray-400" />
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-gray-900 truncate">
-          {document.fileName}
+          {getDisplayFileName(document)}
         </p>
         <p className="text-xs text-gray-500 truncate">{getSubInfo()}</p>
       </div>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -61,6 +61,7 @@ import { GroupList } from '@/components/views'
 import { SearchBar } from '@/components/SearchBar'
 import { LoadMoreIndicator } from '@/components/LoadMoreIndicator'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import { getDisplayFileName } from '@/utils/getDisplayFileName'
 import type { Document, DocumentStatus } from '@shared/types'
 import type { GroupType } from '@/hooks/useDocumentGroups'
 
@@ -259,7 +260,7 @@ function DocumentRow({
         <div className="flex items-center gap-2 sm:gap-3">
           <FileText className="h-4 w-4 flex-shrink-0 text-gray-400 sm:h-5 sm:w-5" />
           <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-gray-900 sm:text-base">{document.fileName}</p>
+            <p className="truncate text-sm font-medium text-gray-900 sm:text-base">{getDisplayFileName(document)}</p>
             <p className="truncate text-xs text-gray-500 sm:text-sm">{document.documentType || '未判定'}</p>
           </div>
         </div>

--- a/frontend/src/utils/__tests__/getDisplayFileName.test.ts
+++ b/frontend/src/utils/__tests__/getDisplayFileName.test.ts
@@ -1,0 +1,30 @@
+/**
+ * getDisplayFileName テスト
+ *
+ * #178: displayFileName フォールバックロジック
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getDisplayFileName } from '../getDisplayFileName';
+
+describe('getDisplayFileName (#178)', () => {
+  it('displayFileName が設定されている場合はそちらを返す', () => {
+    const doc = { fileName: 'original.pdf', displayFileName: '介護保険証_デイサービス_20260315_田中太郎.pdf' };
+    expect(getDisplayFileName(doc)).toBe('介護保険証_デイサービス_20260315_田中太郎.pdf');
+  });
+
+  it('displayFileName が未設定の場合は fileName にフォールバック', () => {
+    const doc = { fileName: 'original.pdf' };
+    expect(getDisplayFileName(doc)).toBe('original.pdf');
+  });
+
+  it('displayFileName が空文字の場合は fileName にフォールバック', () => {
+    const doc = { fileName: 'original.pdf', displayFileName: '' };
+    expect(getDisplayFileName(doc)).toBe('original.pdf');
+  });
+
+  it('displayFileName が undefined の場合は fileName にフォールバック', () => {
+    const doc = { fileName: 'original.pdf', displayFileName: undefined };
+    expect(getDisplayFileName(doc)).toBe('original.pdf');
+  });
+});

--- a/frontend/src/utils/getDisplayFileName.ts
+++ b/frontend/src/utils/getDisplayFileName.ts
@@ -1,0 +1,9 @@
+/**
+ * ドキュメントの表示用ファイル名を取得する
+ *
+ * #178: displayFileName が設定されていればそちらを返し、
+ * 未設定の場合は fileName にフォールバックする。
+ */
+export function getDisplayFileName(doc: { fileName: string; displayFileName?: string }): string {
+  return doc.displayFileName || doc.fileName;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,6 +19,7 @@ export interface Document {
   processedAt: Timestamp;
   fileId: string;
   fileName: string;
+  displayFileName?: string;
   mimeType: string;
   ocrResult: string;
   ocrResultUrl?: string; // 長い場合はCloud Storage参照


### PR DESCRIPTION
## Summary

- メタ情報から自動生成される表示用ファイル名（`displayFileName`）の基盤を構築（ADR-0014）
- Document 型に `displayFileName?: string` を追加
- UI 表示箇所を `getDisplayFileName(doc)` に切り替え（`displayFileName ?? fileName` フォールバック）
- 既存動作に変化なし（Stage 0: 破壊的変更ゼロ）

Closes #178 の Stage 0 部分のみ。Stage 1以降（OCR完了時・分割時の自動生成）は別PRで段階的に進める。

## Test plan

- [x] `getDisplayFileName` ユニットテスト 4件追加・全パス
- [x] フロントエンド全テスト 87件パス
- [x] Functions 全テスト 271件パス
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Documents now display with metadata-generated names, providing clearer identification across downloads, detail modals, and document lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->