### PR TITLE
fix: 再処理時にdisplayFileNameをクリア (#178)

### DIFF
--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -174,6 +174,8 @@ export function getReprocessClearFields() {
     summary: df,
     ocrExtraction: df,
     pageResults: df,
+    // 表示用ファイル名（#178 displayFileName自動生成）
+    displayFileName: df,
     // メタ情報
     customerName: df,
     customerId: df,


### PR DESCRIPTION
## Summary
- `getReprocessClearFields()` に `displayFileName: deleteField()` を追加
- 再処理（pendingリセット）時に古い displayFileName が残存し、新OCR結果と不整合になる問題を防止

## 背景
PR #180 のレビューで検出された漏れ。再処理フローでメタ情報はクリアされるが displayFileName がクリアされていなかった。

## Test plan
- [x] Frontend 型チェック: クリーン
- [x] Frontend テスト: 94件全パス
- [x] firestore.rules で displayFileName は更新許可済み（PR #180で対応済み）

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document reprocessing by ensuring display name field is properly included in field handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->