### PR TITLE
fix: firestoreToDocumentにdisplayFileNameマッピング追加 (#178)

### DIFF
--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -67,6 +67,7 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     processedAt: data.processedAt as Timestamp,
     fileId: data.fileId as string,
     fileName: data.fileName as string,
+    displayFileName: data.displayFileName as string | undefined,
     mimeType: data.mimeType as string,
     ocrResult: data.ocrResult as string,
     ocrResultUrl: data.ocrResultUrl as string | undefined,


### PR DESCRIPTION
## Summary
- `firestoreToDocument`関数に`displayFileName`フィールドのマッピングが漏れていたため追加
- Firestoreに保存された`displayFileName`がフロントエンドのDocument型に反映されず、`getDisplayFileName()`が常にfallbackの`fileName`を返していた

## 原因
- #178 Stage 0-3で書き込みパス（OCR/分割/メタ編集）、クリアパス（再処理）は網羅したが、**読み取りパス（firestoreToDocument）**が漏れていた

## Test plan
- [x] 型チェック正常
- [x] 全94テスト合格
- [ ] dev環境でメタ編集後にdisplayFileNameがモーダルタイトルに反映されることを確認

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents now support optional custom display names, enabling improved document identification and presentation throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->