### PR TITLE
feat: プロジェクトごとのSAでGitHub Actions全環境デプロイ対応

### DIFF
--- a/.github/workflows/backfill-display-filename.yml
+++ b/.github/workflows/backfill-display-filename.yml
@@ -1,7 +1,6 @@
 name: Backfill displayFileName
 
-# NOTE: GCP_SA_KEY は docsplit-cocoro の SA (docsplit-cloud-build@docsplit-cocoro.iam.gserviceaccount.com)。
-# 2026-03-16: kanameone, dev にも roles/datastore.user 付与済み → 全3環境で実行可能
+# 環境別SA: GCP_SA_KEY_KANAMEONE / GCP_SA_KEY_DEV / GCP_SA_KEY(cocoro、将来GCP_SA_KEY_COCOROに移行)
 # 汎用版: .github/workflows/run-ops-script.yml（このワークフローの機能を含む）
 
 on:
@@ -47,7 +46,10 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: |-
+            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
+                github.event.inputs.environment == 'dev' && secrets.GCP_SA_KEY_DEV ||
+                secrets.GCP_SA_KEY }}
 
       - name: Resolve project ID from .firebaserc
         id: resolve

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: |-
+            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
+                github.event.inputs.environment == 'dev' && secrets.GCP_SA_KEY_DEV ||
+                secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -4,8 +4,7 @@ name: Run Operations Script
 # check-master-data, fix-stuck-documents 等のFirestoreアクセスが必要なスクリプトを
 # GitHub Actions経由で実行する。ローカルADC不要。
 #
-# GCP_SA_KEY: docsplit-cocoro の SA (docsplit-cloud-build@docsplit-cocoro.iam.gserviceaccount.com)
-# 2026-03-16: kanameone, dev にも roles/datastore.user を付与済み → 全3環境で実行可能
+# 環境別SA: GCP_SA_KEY_KANAMEONE / GCP_SA_KEY_DEV / GCP_SA_KEY(cocoro、将来GCP_SA_KEY_COCOROに移行)
 
 on:
   workflow_dispatch:
@@ -54,7 +53,10 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: |-
+            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
+                github.event.inputs.environment == 'dev' && secrets.GCP_SA_KEY_DEV ||
+                secrets.GCP_SA_KEY }}
 
       - name: Resolve project ID from .firebaserc
         id: resolve

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ npm run build                    # 全体ビルド
 ### 運用スクリプト
 
 **推奨: GitHub Actions経由で実行**（ADC不要）。Actions → "Run Operations Script" → 環境とスクリプトを選択して実行。
-SA: `docsplit-cloud-build@docsplit-cocoro.iam.gserviceaccount.com`（全3環境に`roles/datastore.user`付与済み）
+SA: 環境別（`docsplit-cloud-build@{project-id}`）。GitHub Secrets: `GCP_SA_KEY_KANAMEONE` / `GCP_SA_KEY_DEV` / `GCP_SA_KEY`(cocoro)
 
 ```bash
 # GitHub Actions (推奨): https://github.com/yasushi-honda/doc-split/actions/workflows/run-ops-script.yml


### PR DESCRIPTION
## Summary
- kanameone/dev環境用に専用SA(`docsplit-cloud-build@{project-id}`)を作成し、環境別GitHub Secretsに登録
- 3つのワークフロー(`deploy-functions`, `run-ops-script`, `backfill-display-filename`)で環境に応じたSecretを選択するように変更
- cocoro環境は既存`GCP_SA_KEY`を継続使用（cocoro管理者のIAM権限が必要なため、`GCP_SA_KEY_COCORO`への移行は後日）

## 背景
cocoro用SAに全環境の権限を集約していたため、kanameone/devでFunctions deployが`iam.serviceAccounts.actAs`権限不足で失敗していた。

## SA構成

| Secret | SA | 環境 |
|--------|-----|------|
| `GCP_SA_KEY_KANAMEONE` | `docsplit-cloud-build@docsplit-kanameone` | kanameone |
| `GCP_SA_KEY_DEV` | `docsplit-cloud-build@doc-split-dev` | dev |
| `GCP_SA_KEY` | `docsplit-cloud-build@docsplit-cocoro` | cocoro (既存) |

## 残作業
- [ ] cocoro SAに`roles/cloudscheduler.admin`追加（cocoro管理者で実行）
- [ ] 全3環境で`Deploy Cloud Functions`実行 → 成功確認
- [ ] kanameoneで`fix-stuck-documents --include-errors --dry-run` → 成功確認
- [ ] 成功後、cocoro SAからkanameone/devの`roles/datastore.user`を剥奪
- [ ] 将来: `GCP_SA_KEY_COCORO`作成 → `GCP_SA_KEY`削除

## Test plan
- [ ] dev環境で`Deploy Cloud Functions`ワークフロー実行 → 成功
- [ ] kanameone環境で`Deploy Cloud Functions`ワークフロー実行 → 成功
- [ ] cocoro環境で`Deploy Cloud Functions`ワークフロー実行 → 成功（既存動作維持）
- [ ] kanameone環境で`Run Operations Script` → 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment infrastructure with environment-specific credential management for cloud deployments, enabling better separation of authentication across different deployment environments (production, staging, development).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->