### PR TITLE
feat: Firestoreネイティブバックアップ自動設定

### DIFF
--- a/.github/workflows/setup-firestore-backup.yml
+++ b/.github/workflows/setup-firestore-backup.yml
@@ -1,0 +1,44 @@
+name: Setup Firestore Backup
+
+# Firestoreネイティブバックアップの初回設定。
+# 日次(7日保持) + 週次(8週保持)。一度実行すれば自動スケジュール。
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - kanameone
+          - cocoro
+
+jobs:
+  setup-backup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: |-
+            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
+                secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve project ID
+        id: resolve
+        run: |
+          PROJECT_ID=$(node scripts/helpers/firebaserc-helper.js get-project "${{ github.event.inputs.environment }}")
+          echo "project_id=$PROJECT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Firestore backup schedules
+        env:
+          PROJECT_ID: ${{ steps.resolve.outputs.project_id }}
+        run: bash scripts/setup-firestore-backup.sh "$PROJECT_ID"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,14 @@ FIREBASE_PROJECT_ID=<project-id> node scripts/backfill-display-filename.js      
 FIREBASE_PROJECT_ID=<project-id> node scripts/backfill-display-filename.js --force     # 既存値も上書き
 ```
 
+### Firestoreバックアップ（ネイティブ）
+```bash
+# GitHub Actions (推奨): Actions → "Setup Firestore Backup" → 環境選択 → 実行（初回のみ）
+# ローカル: ./scripts/setup-firestore-backup.sh <project-id>
+# 確認: gcloud firestore backups schedules list --database='(default)' --project=<project-id>
+# 日次(7日保持) + 週次(8週保持)。月数円未満。
+```
+
 ### マスターデータ
 ```bash
 FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --all scripts/samples/

--- a/scripts/setup-firestore-backup.sh
+++ b/scripts/setup-firestore-backup.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Firestore ネイティブバックアップ設定スクリプト
+#
+# 日次バックアップ（7日保持）+ 週次バックアップ（8週保持）を設定する。
+# 一度実行すれば自動的にスケジュール実行される。
+#
+# 使用方法:
+#   ./scripts/setup-firestore-backup.sh <project-id>
+#   ./scripts/setup-firestore-backup.sh docsplit-cocoro
+#   ./scripts/setup-firestore-backup.sh docsplit-kanameone
+#
+# 確認:
+#   gcloud firestore backups schedules list --database='(default)' --project=<project-id>
+#
+# コスト目安: データ量数MB以下の場合、月数円未満（$0.18/GB/月）
+
+set -euo pipefail
+
+PROJECT_ID="${1:-}"
+
+if [ -z "$PROJECT_ID" ]; then
+  echo "Usage: $0 <project-id>"
+  echo "Example: $0 docsplit-cocoro"
+  exit 1
+fi
+
+echo "=== Firestore バックアップ設定 ==="
+echo "プロジェクト: $PROJECT_ID"
+echo ""
+
+# 既存スケジュール確認
+echo "--- 既存スケジュール確認 ---"
+EXISTING=$(gcloud firestore backups schedules list \
+  --database='(default)' \
+  --project="$PROJECT_ID" \
+  --format='value(name)' 2>/dev/null || true)
+
+if [ -n "$EXISTING" ]; then
+  echo "既にスケジュールが設定されています:"
+  gcloud firestore backups schedules list \
+    --database='(default)' \
+    --project="$PROJECT_ID"
+  echo ""
+  echo "追加設定は不要です。上書きする場合は先に削除してください。"
+  exit 0
+fi
+
+# 日次バックアップ（7日保持）
+echo "--- 日次バックアップ設定（7日保持）---"
+gcloud firestore backups schedules create \
+  --database='(default)' \
+  --recurrence=daily \
+  --retention=7d \
+  --project="$PROJECT_ID"
+echo "✅ 日次バックアップ設定完了"
+
+# 週次バックアップ（8週保持）
+echo ""
+echo "--- 週次バックアップ設定（8週保持、日曜）---"
+gcloud firestore backups schedules create \
+  --database='(default)' \
+  --recurrence=weekly \
+  --retention=8w \
+  --day-of-week=SUN \
+  --project="$PROJECT_ID"
+echo "✅ 週次バックアップ設定完了"
+
+# 設定確認
+echo ""
+echo "=== 設定済みスケジュール ==="
+gcloud firestore backups schedules list \
+  --database='(default)' \
+  --project="$PROJECT_ID"
+
+echo ""
+echo "完了。以降は自動でバックアップが取得されます。"
+echo ""
+echo "バックアップ一覧確認:"
+echo "  gcloud firestore backups list --project=$PROJECT_ID"
+echo ""
+echo "復元（新しいDBに復元）:"
+echo "  gcloud firestore databases restore --source-backup=BACKUP_NAME --destination-database=NEW_DB_ID --project=$PROJECT_ID"


### PR DESCRIPTION
## Summary
- cocoro/kanameone環境向けのFirestoreネイティブバックアップを自動化
- 日次（7日保持）+ 週次（8週保持）のスケジュール設定
- GitHub Actionsワークフローで初回セットアップを実行可能

## 背景
PR #199 の重複データ復旧で物理削除を実施。万一のデータ損失に備え、低コストの自動バックアップを導入。

## コスト
データ量数MB以下（cocoro: 344件、kanameone: 数百件）のため **月数円未満**（$0.18/GB/月）

## 使用方法
GitHub Actions → "Setup Firestore Backup" → 環境選択 → Run workflow（**初回のみ**）

## Test plan
- [ ] マージ後: cocoro環境でGitHub Actions実行
- [ ] マージ後: kanameone環境でGitHub Actions実行
- [ ] `gcloud firestore backups schedules list` で設定確認
- [ ] 翌日: `gcloud firestore backups list` でバックアップ生成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated Firestore backup configuration with daily (7-day retention) and weekly (8-week retention) scheduling options

* **Documentation**
  * Added comprehensive guide for setting up and managing Firestore backups, including verification commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->