### PR TITLE
chore: 運用スクリプトにcleanup-duplicates追加

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -32,6 +32,8 @@ on:
           - backfill-display-filename --dry-run
           - backfill-display-filename
           - backfill-display-filename --force
+          - cleanup-duplicates
+          - cleanup-duplicates --execute
 
 jobs:
   run-script:


### PR DESCRIPTION
## Summary
- `cleanup-duplicates` (dry-run) と `cleanup-duplicates --execute` をGitHub Actions運用スクリプトに追加
- kanameone等での重複確認・削除をGitHub Actions経由で実行可能にする

## 背景
cocoro環境で重複問題を解決済み（PR #199）。kanameone環境でも同様の重複が発生しているか確認が必要。

## Test plan
- [ ] マージ後: kanameone環境で `cleanup-duplicates` (dry-run) を実行して重複有無を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)