### PR TITLE
chore: .envrcでGH_TOKENを自動exportしClaude Code Bashから利用可能に

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,6 +7,16 @@
 # GitHub CLI認証（プロジェクト分離）
 export GH_CONFIG_DIR="$(pwd)/.gh"
 
+# GH_TOKEN（Claude Code Bash ツールは direnv フックが発火しないため明示export）
+# gh が keyring 認証でログイン済みであれば `gh auth token` で取得可能
+if command -v gh >/dev/null 2>&1; then
+    _tmp_gh_token="$(gh auth token 2>/dev/null)"
+    if [ -n "$_tmp_gh_token" ]; then
+        export GH_TOKEN="$_tmp_gh_token"
+    fi
+    unset _tmp_gh_token
+fi
+
 # クライアント設定（.envrc.client から読み込み）
 # switch-client.sh が .envrc.client を生成・更新する
 if [ -f .envrc.client ]; then


### PR DESCRIPTION
## Summary
- `.envrc` に `gh auth token` を用いた `GH_TOKEN` の自動export処理を追加
- Claude Code Bash ツールは direnv フックが発火しないが、session起動時の direnv load で事前exportされるため gh CLI および認証を要する git 操作が動作する
- `~/.claude/rules/env-isolation.md` の推奨パターンに準拠

## 背景
`/catchup` 実行時に `GH_TOKEN 未設定 ❌` と報告され、Claude Code セッションから gh / git 操作が認証失敗する可能性があった。

## 動作確認
```bash
$ direnv exec . bash -c 'echo "GH_TOKEN=${GH_TOKEN:+<SET>}"'
GH_TOKEN=<SET>
```

`gh` が未インストール・未認証の環境では副作用なし（if分岐で保護）。

## Test plan
- [x] `direnv exec .` で `GH_TOKEN` が設定されることを確認
- [x] `gh auth status` が既に認証済みの場合に動作
- [x] `.envrc` 既存のクライアント環境分離ロジックに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development environment now automatically retrieves and configures GitHub authentication when the GitHub CLI is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->