### PR TITLE
feat: fix-stuck-documents.jsに--doc-id単一指定オプション追加 (#206)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -29,11 +29,18 @@ on:
           - fix-stuck-documents
           - fix-stuck-documents --include-errors --dry-run
           - fix-stuck-documents --include-errors
+          - fix-stuck-documents --doc-id --dry-run
+          - fix-stuck-documents --doc-id
           - backfill-display-filename --dry-run
           - backfill-display-filename
           - backfill-display-filename --force
           - cleanup-duplicates
           - cleanup-duplicates --execute
+      doc_id:
+        description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   run-script:
@@ -69,27 +76,49 @@ jobs:
 
       - name: Parse script and args
         id: parse
+        env:
+          INPUT: ${{ github.event.inputs.script }}
+          DOC_ID: ${{ github.event.inputs.doc_id }}
         run: |
-          INPUT="${{ github.event.inputs.script }}"
           SCRIPT_NAME=$(echo "$INPUT" | awk '{print $1}')
           SCRIPT_ARGS=$(echo "$INPUT" | sed 's/^[^ ]* *//')
           if [ "$SCRIPT_ARGS" = "$SCRIPT_NAME" ]; then
             SCRIPT_ARGS=""
           fi
+
+          # --doc-id 指定スクリプトには doc_id 入力を必須化
+          if echo "$SCRIPT_ARGS" | grep -q -- '--doc-id'; then
+            if [ -z "$DOC_ID" ]; then
+              echo "ERROR: doc_id input is required when script contains --doc-id" >&2
+              exit 1
+            fi
+            # ドキュメントIDは英数字のみ許可（コマンドインジェクション対策）
+            if ! echo "$DOC_ID" | grep -qE '^[A-Za-z0-9_-]+$'; then
+              echo "ERROR: doc_id must contain only alphanumeric, underscore, hyphen characters" >&2
+              exit 1
+            fi
+            SCRIPT_ARGS=$(echo "$SCRIPT_ARGS" | sed "s/--doc-id/--doc-id $DOC_ID/")
+          fi
+
           echo "script_name=$SCRIPT_NAME" >> "$GITHUB_OUTPUT"
           echo "script_args=$SCRIPT_ARGS" >> "$GITHUB_OUTPUT"
           echo "Script: $SCRIPT_NAME"
           echo "Args: $SCRIPT_ARGS"
 
       - name: Run script
+        env:
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
+          PROJECT_ID: ${{ steps.resolve.outputs.project_id }}
+          SCRIPT_NAME: ${{ steps.parse.outputs.script_name }}
+          SCRIPT_ARGS: ${{ steps.parse.outputs.script_args }}
         run: |
           echo "=== Operations Script ==="
-          echo "Environment: ${{ github.event.inputs.environment }}"
-          echo "Project ID: ${{ steps.resolve.outputs.project_id }}"
-          echo "Script: ${{ steps.parse.outputs.script_name }}"
-          echo "Args: ${{ steps.parse.outputs.script_args }}"
+          echo "Environment: $ENVIRONMENT"
+          echo "Project ID: $PROJECT_ID"
+          echo "Script: $SCRIPT_NAME"
+          echo "Args: $SCRIPT_ARGS"
           echo "========================="
 
           NODE_PATH=./functions/node_modules \
-            FIREBASE_PROJECT_ID=${{ steps.resolve.outputs.project_id }} \
-            node scripts/${{ steps.parse.outputs.script_name }}.js ${{ steps.parse.outputs.script_args }}
+            FIREBASE_PROJECT_ID="$PROJECT_ID" \
+            node "scripts/${SCRIPT_NAME}.js" $SCRIPT_ARGS

--- a/scripts/fix-stuck-documents.js
+++ b/scripts/fix-stuck-documents.js
@@ -7,6 +7,8 @@
  *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/fix-stuck-documents.js --dry-run
  *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/fix-stuck-documents.js --include-errors
  *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/fix-stuck-documents.js --include-errors --dry-run
+ *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/fix-stuck-documents.js --doc-id <id>
+ *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/fix-stuck-documents.js --doc-id <id> --dry-run
  */
 
 const admin = require('firebase-admin');
@@ -19,11 +21,59 @@ if (!projectId) {
 
 const dryRun = process.argv.includes('--dry-run');
 const includeErrors = process.argv.includes('--include-errors');
+const docIdIndex = process.argv.indexOf('--doc-id');
+const targetDocId = docIdIndex >= 0 ? process.argv[docIdIndex + 1] : null;
+
+if (docIdIndex >= 0 && !targetDocId) {
+  console.error('--doc-id にはドキュメントIDを指定してください');
+  process.exit(1);
+}
 
 admin.initializeApp({ projectId });
 const db = admin.firestore();
 
+async function resetDoc(docRef, data) {
+  console.log(`  - ${docRef.id}: ${data.fileName || '(no name)'} [${data.status}]`);
+  if (dryRun) return;
+  await docRef.update({
+    status: 'pending',
+    retryCount: 0,
+    lastErrorMessage: null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  console.log(`    → pendingに変更（retryCount: 0）`);
+}
+
+async function runSingle() {
+  console.log(`プロジェクト: ${projectId}`);
+  console.log(`モード: ${dryRun ? 'DRY RUN（変更なし）' : '実行'}`);
+  console.log(`対象: 単一指定 (${targetDocId})`);
+  console.log('---');
+
+  const docRef = db.collection('documents').doc(targetDocId);
+  const docSnap = await docRef.get();
+
+  if (!docSnap.exists) {
+    console.warn(`⚠️ 書類が見つかりません: ${targetDocId}`);
+    process.exit(1);
+  }
+
+  await resetDoc(docRef, docSnap.data());
+
+  if (dryRun) {
+    console.log('\n--dry-run モードのため変更なし。実行するには --dry-run を外してください。');
+  } else {
+    console.log('\n対象書類をpendingに変更しました。OCRポーリングが自動で再処理します。');
+  }
+  process.exit(0);
+}
+
 async function main() {
+  if (targetDocId) {
+    await runSingle();
+    return;
+  }
+
   console.log(`プロジェクト: ${projectId}`);
   console.log(`モード: ${dryRun ? 'DRY RUN（変更なし）' : '実行'}`);
   console.log(`対象: processing${includeErrors ? ' + error' : ''}`);
@@ -52,18 +102,7 @@ async function main() {
   console.log(`${docs.length}件のドキュメントを検出:`);
 
   for (const doc of docs) {
-    const data = doc.data();
-    console.log(`  - ${doc.id}: ${data.fileName || '(no name)'} [${data.status}]`);
-
-    if (!dryRun) {
-      await db.doc(`documents/${doc.id}`).update({
-        status: 'pending',
-        retryCount: 0,
-        lastErrorMessage: null,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      });
-      console.log(`    → pendingに変更（retryCount: 0）`);
-    }
+    await resetDoc(doc.ref, doc.data());
   }
 
   if (dryRun) {


### PR DESCRIPTION
## Summary
- `scripts/fix-stuck-documents.js` に `--doc-id <id>` オプション追加（単一書類のみリセット）
- GitHub Actions ワークフローに対応する選択肢と `doc_id` 入力フィールド追加
- `run-ops-script.yml` を env var ベースに改修（command injection対策）

## 背景
`--include-errors` は error 全件をリセットするため、本番で単一書類のみ復旧したいケースで巻き込みリスクがある。Codex セカンドオピニオンの High 指摘事項対応。

## 関連
- Closes #206
- ブロック解除対象: #205（kanameone INVALID_ARGUMENT 復旧で本オプションを使用）

## 仕様
\`\`\`bash
# 既存（変更なし）
node scripts/fix-stuck-documents.js                          # processing のみ
node scripts/fix-stuck-documents.js --include-errors          # processing + error
node scripts/fix-stuck-documents.js --dry-run                 # 確認モード

# 追加
node scripts/fix-stuck-documents.js --doc-id <id>             # 単一指定
node scripts/fix-stuck-documents.js --doc-id <id> --dry-run   # 単一指定 + 確認
\`\`\`

GitHub Actions: \`Run Operations Script\` ワークフローで \`fix-stuck-documents --doc-id\` を選択 → \`doc_id\` 入力欄に書類IDを記入。

## セキュリティ対策
- workflow run ステップを env var 経由に統一（直接 \`\${{ ... }}\` 補間を排除）
- \`doc_id\` 入力を英数字+\`_\`+\`-\` のみに制限（コマンドインジェクション防止）

## Test plan
- [x] node --check 構文チェックPASS
- [x] FIREBASE_PROJECT_ID 未設定時の早期 exit 動作
- [ ] dev環境で `--doc-id <存在しないID>` → warning + exit 1
- [ ] dev環境で `--doc-id <実在ID> --dry-run` → 対象表示のみ
- [ ] GitHub Actions UI から実行時に doc_id 入力欄が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)