### PR TITLE
fix: Vertex AI暴走時のOCRページ巨大応答に対するFirestore書き込み防御 (#205)

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,10 +1,92 @@
 # ハンドオフメモ
 
-**更新日**: 2026-04-11（Gmail重複取得根本対策・Firestoreネイティブバックアップ・運用スクリプト統合）
-**ブランチ**: main
-**フェーズ**: Phase 8完了 + マルチクライアント安全運用機構 + displayFileName自動生成 + 重複対策・バックアップ完成
+**更新日**: 2026-04-15（Vertex AI暴走時のOCRページ巨大応答防御・運用スクリプト単一doc-id化）
+**ブランチ**: main + open PR #208
+**フェーズ**: Phase 8完了 + マルチクライアント安全運用機構 + displayFileName自動生成 + 重複対策・バックアップ完成 + OCR防御層
 
-## 直近の変更（04-11 最新）
+## 🚨 次セッション最優先タスク（kanameone本番障害復旧）
+
+| 順 | タスク | コマンド | 確認 |
+|---|---|---|---|
+| 1 | **PR #208 状況確認** | `gh pr view 208` / `gh pr checks 208` | CI all PASS |
+| 2 | **PR #208 マージ** | `gh pr merge 208 --squash --delete-branch` | mainに反映 |
+| 3 | dev 自動デプロイ確認 | `gh run list --workflow=deploy-functions.yml -L 3` | `processocr` revision UP |
+| 4 | kanameone デプロイ | `/deploy kanameone --functions` | `processocr` revision UP |
+| 5 | **本番障害書類の復旧** | GitHub Actions: `Run Operations Script` → `fix-stuck-documents --doc-id` → `doc_id: uUm2JJi5o9CgyQ9r4bIJ` | 1件pendingリセット |
+| 6 | OCR再処理確認 | `gcloud logging read` で `uUm2JJi5o9CgyQ9r4bIJ` を追跡 | `status: processed` |
+| 7 | cocoro 予防デプロイ | `/deploy cocoro --functions` | `processocr` revision UP |
+| 8 | LATEST.md 復旧記録 + Issue #205 close | `gh issue close 205 --comment "..."` | Issue closed |
+
+**復旧対象書類**: kanameone `uUm2JJi5o9CgyQ9r4bIJ` (`岩倉病院通所ﾘﾊﾋﾞﾘﾃｰｼｮﾝ-L1-20260414155319.pdf`、3ページPDF)
+
+## 直近の変更（04-15 最新セッション）
+
+| PR/Issue | 内容 |
+|----|------|
+| **PR #204** ✅マージ済み | **chore: .envrcでGH_TOKENを自動exportしClaude Code Bashから利用可能に** Claude Code Bash sessionで gh CLI/git 操作を確実に動作させる |
+| **PR #207** ✅マージ済み | **feat: fix-stuck-documents.jsに--doc-id単一指定オプション追加 (#206)** 単一書類リセット用、本番運用安全性向上。GitHub Actions UI に doc_id 入力欄追加、command injection 対策（env var化、英数字+_-のみ許可） |
+| **PR #208** 🔄 提出済み・マージ待ち | **fix: Vertex AI暴走時のOCRページ巨大応答に対するFirestore書き込み防御 (#205)** kanameone 本番障害（INVALID_ARGUMENT）に対する三段防御 |
+| #205 | OCR防御層 (PR #208 で対応中) |
+| #206 ✅クローズ | ops script `--doc-id` (PR #207 でクローズ) |
+
+### kanameone本番障害（2026-04-14 07:03 UTC）
+
+| 項目 | 値 |
+|---|---|
+| Document ID | `uUm2JJi5o9CgyQ9r4bIJ` |
+| ファイル | `岩倉病院通所ﾘﾊﾋﾞﾘﾃｰｼｮﾝ-L1-20260414155319.pdf` (3ページPDF) |
+| エラー | `3 INVALID_ARGUMENT: Property array contains an invalid nested entity` |
+| 真因 | Vertex AI Gemini が **Page 3 で 1,102,788文字** のOCR応答を返した（通常 711〜2,855 chars の400倍超）。`pageResults` 配列内の1要素が Firestore per-field 1 MiB 制限に違反 |
+| マスター破損 | **無関係** (kanameone master 1,467件 全クリーン) |
+| 影響範囲 | 1件のみ。サービス健全（4214件処理済み中） |
+
+### 三段防御の設計（PR #208）
+
+| 層 | 実装 | 値 |
+|---|---|---|
+| 1. per-page cap | `capPageText()` in `pageTextCap.ts` | `MAX_PAGE_TEXT_LENGTH = 50_000` chars |
+| 2. aggregate cap | `capPageResultsAggregate()` in `pageTextCap.ts` | `MAX_AGGREGATE_PAGE_CHARS = 200_000` chars (UTF-8 Japanese で約600KB) |
+| 3. Vertex AI出力上限 | `generationConfig.maxOutputTokens` in `ocrProcessor.ts:ocrWithGemini` | `GEMINI_MAX_OUTPUT_TOKENS = 8192` (≈25K chars Japanese) |
+| メタデータ | `PageOcrResult.originalLength`, `PageOcrResult.truncated` 追加 | shared/types.ts と functions側 PageOcrResult 両方 |
+
+### Codex セカンドオピニオン反映（High指摘）
+
+| ID | 指摘 | 対応 |
+|----|---|---|
+| H1 | per-page cap だけでは多ページで合計1MiB超 | aggregate cap 追加 ✅ |
+| H2 | テストが弱い、payload直接検証必要 | Firestore 1MiB制限内 serialized size 検証テスト追加 ✅ |
+| H3 | `--include-errors` は対象が広すぎる | `--doc-id` 単一指定追加 (PR #207) ✅ |
+| M1 | `maxOutputTokens` を別Issueでなく同PRで | 同PR内で対応 ✅ |
+| M2 | 切り詰めメタデータ保存 | `originalLength`, `truncated` 追加 ✅ |
+| M3 | 切り詰めはGemini直後で | 切り詰め位置: ocrProcessor.ts page loop直後 ✅ |
+| L1 | raw全文Storage退避方針 | 別Issue化候補（次セッション以降） |
+
+### 影響範囲とリスク
+
+| 観点 | 内容 |
+|---|---|
+| 既存4214件 | マイグレーションしない限り影響なし |
+| 新規ドキュメント | per-page/aggregate cap適用、`maxOutputTokens` で Gemini 暴走抑止 |
+| 既存split書類の再処理 | parentOcrExtraction経由は影響軽微（ocrExtractionに candidates なし） |
+| FE pageResults表示 | `pageResults[i].text` は cap 後の値、`originalLength`/`truncated` でメタ取得可能 |
+| PdfSplitModal | 切り詰めページのプレビュー不完全（ハルシネーション時のみ）→ 期待動作 |
+
+### 積み残しIssue（次セッション以降の優先順）
+
+| # | タイトル | ラベル | 優先 |
+|---|---|---|---|
+| #205 | Vertex AI 暴走時のOCR防御 | bug, P1 | ⏳ PR #208 でデプロイ・復旧待ち |
+| #196 | rescueStuckProcessingDocsにMAX_RETRY_COUNTチェックとretryAfter追加 | bug, P2 | 高 |
+| #190 | check-master-data.js --fix バッチ500件上限考慮 | bug, P2 | 中 |
+| #189 | ocrProcessorのdateMarkerサニタイズ境界外 | bug, P2 | 中 |
+| #183 | displayFileNameのファイル名サニタイズ | bug, P2 | 中 |
+| #182 | pdfOperationsのfileDateFormattedフォールバック | bug, P2 | 中 |
+| #200 | checkGmailAttachments/splitPdf統合テスト | enhancement, P2 | 低 |
+| #188 | マスターデータ読み込み共通関数化 | enhancement | 低 |
+| #181 | generateDisplayFileName を shared 統合 | enhancement, P2 | 低 |
+| #152 | dev 環境 Firestore 初期設定 | enhancement, P2 | 低 |
+
+## 直近の変更（04-11）
 
 | PR | コミット | 内容 |
 |----|------|------|

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -21,6 +21,7 @@ import {
 } from '../utils/extractors';
 import { generateDisplayFileName } from '../utils/displayFileNameGenerator';
 import { sanitizeCustomerMasters, sanitizeOfficeMasters, sanitizeDocumentMasters } from '../utils/sanitizeMasterData';
+import { capPageText, capPageResultsAggregate, MAX_PAGE_TEXT_LENGTH } from '../utils/pageTextCap';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -32,6 +33,8 @@ const MODEL_ID = GEMINI_CONFIG.modelId;
 
 // 定数
 const OCR_RESULT_MAX_LENGTH = 100000;
+// Vertex AI暴走時の出力トークン上限（Issue #205）。8192tokens ≈ 25K chars Japanese、通常OCRには十分
+const GEMINI_MAX_OUTPUT_TOKENS = 8192;
 
 /** ページ単位OCR結果 */
 export interface PageOcrResult {
@@ -39,6 +42,10 @@ export interface PageOcrResult {
   text: string;
   inputTokens: number;
   outputTokens: number;
+  /** OCR応答が MAX_PAGE_TEXT_LENGTH または aggregate cap で切り詰められた場合の元の文字数 (Issue #205) */
+  originalLength?: number;
+  /** 切り詰めが発生したか (Issue #205) */
+  truncated?: boolean;
 }
 
 /** OCR処理結果 */
@@ -115,8 +122,26 @@ export async function processDocument(
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
 
+  const buildPageResult = (
+    result: { text: string; inputTokens: number; outputTokens: number },
+    pageNumber: number,
+    label: string
+  ): PageOcrResult => {
+    const capped = capPageText(result.text);
+    if (capped.truncated) {
+      console.warn(`[OCR] ${label} text truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_PAGE_TEXT_LENGTH})`);
+    }
+    return {
+      pageNumber,
+      text: capped.text,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      originalLength: capped.originalLength,
+      truncated: capped.truncated,
+    };
+  };
+
   if (mimeType === 'application/pdf') {
-    // PDFの場合は各ページをOCR
     const pdfDoc = await PDFDocument.load(buffer);
     totalPages = pdfDoc.getPageCount();
 
@@ -129,27 +154,24 @@ export async function processDocument(
       const pageBuffer = await extractPdfPage(buffer, i);
       const result = await ocrWithGemini(pageBuffer, 'application/pdf', pageNumber);
 
-      pageResults.push({
-        pageNumber,
-        text: result.text,
-        inputTokens: result.inputTokens,
-        outputTokens: result.outputTokens,
-      });
+      pageResults.push(buildPageResult(result, pageNumber, `Page ${pageNumber}/${totalPages}`));
 
       totalInputTokens += result.inputTokens;
       totalOutputTokens += result.outputTokens;
     }
   } else {
-    // 画像の場合は直接OCR
     const result = await ocrWithGemini(buffer, mimeType);
-    pageResults.push({
-      pageNumber: 1,
-      text: result.text,
-      inputTokens: result.inputTokens,
-      outputTokens: result.outputTokens,
-    });
+    pageResults.push(buildPageResult(result, 1, 'Image'));
     totalInputTokens = result.inputTokens;
     totalOutputTokens = result.outputTokens;
+  }
+
+  // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御
+  const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
+  pageResults = capPageResultsAggregate(pageResults);
+  const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
+  if (afterAggregateChars < beforeAggregateChars) {
+    console.warn(`[OCR] Aggregate pageResults truncated: ${beforeAggregateChars} → ${afterAggregateChars} chars`);
   }
 
   // OCR結果を結合
@@ -479,6 +501,10 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
             ],
           },
         ],
+        // Issue #205: ハルシネーション/暴走による1.1M chars応答を防止する根本対策
+        generationConfig: {
+          maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
+        },
       });
     },
     RETRY_CONFIGS.gemini

--- a/functions/src/utils/pageTextCap.ts
+++ b/functions/src/utils/pageTextCap.ts
@@ -1,0 +1,66 @@
+/**
+ * OCRページテキスト長さ制限ユーティリティ (Issue #205)
+ *
+ * 背景: Vertex AI Geminiのハルシネーション/暴走による異常に長い応答（実害事例: 1.1M chars）が
+ * Firestoreの per-field 1 MiB 制限を超え INVALID_ARGUMENT を引き起こす問題への防御。
+ *
+ * 二段防御:
+ * 1. per-page cap (capPageText): 各ページ単独で MAX_PAGE_TEXT_LENGTH に切り詰め
+ * 2. aggregate cap (capPageResultsAggregate): 全ページ合計で MAX_AGGREGATE_PAGE_CHARS に切り詰め
+ */
+
+export const MAX_PAGE_TEXT_LENGTH = 50_000;
+
+// 200K chars × 3 bytes/char (UTF-8 Japanese) ≈ 600KB。Firestore 1 MiB制限内に余裕を残す。
+export const MAX_AGGREGATE_PAGE_CHARS = 200_000;
+
+const TRUNCATION_MARKER = '\n[TRUNCATED]';
+
+export interface CappedText {
+  text: string;
+  originalLength: number;
+  truncated: boolean;
+}
+
+export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_LENGTH): CappedText {
+  const originalLength = rawText.length;
+  if (originalLength <= maxLength) {
+    return { text: rawText, originalLength, truncated: false };
+  }
+  const sliceLen = Math.max(0, maxLength - TRUNCATION_MARKER.length);
+  const truncatedText = sliceLen === 0 ? '' : rawText.slice(0, sliceLen) + TRUNCATION_MARKER;
+  return {
+    text: truncatedText.slice(0, maxLength),
+    originalLength,
+    truncated: true,
+  };
+}
+
+interface PageWithText {
+  text: string;
+  originalLength?: number;
+  truncated?: boolean;
+}
+
+export function capPageResultsAggregate<T extends PageWithText>(pages: T[]): T[] {
+  let runningTotal = 0;
+  return pages.map((page) => {
+    const remaining = Math.max(0, MAX_AGGREGATE_PAGE_CHARS - runningTotal);
+    const perPageBudget = Math.min(MAX_PAGE_TEXT_LENGTH, remaining);
+
+    if (page.text.length <= perPageBudget && !page.truncated) {
+      runningTotal += page.text.length;
+      return page;
+    }
+
+    const original = page.originalLength ?? page.text.length;
+    const capped = capPageText(page.text, perPageBudget);
+    runningTotal += capped.text.length;
+    return {
+      ...page,
+      text: capped.text,
+      originalLength: Math.max(original, capped.originalLength),
+      truncated: page.truncated || capped.truncated,
+    };
+  });
+}

--- a/functions/test/pageTextCap.test.ts
+++ b/functions/test/pageTextCap.test.ts
@@ -1,0 +1,198 @@
+/**
+ * OCRページテキスト長さ制限ユーティリティのテスト (Issue #205)
+ *
+ * 背景: Vertex AI Geminiのハルシネーション/暴走により異常に長い応答が
+ * Firestoreの per-field 1 MiB 制限を超え INVALID_ARGUMENT を引き起こす問題への防御。
+ */
+
+import { expect } from 'chai';
+import {
+  capPageText,
+  capPageResultsAggregate,
+  MAX_PAGE_TEXT_LENGTH,
+  MAX_AGGREGATE_PAGE_CHARS,
+} from '../src/utils/pageTextCap';
+
+describe('pageTextCap', () => {
+  describe('capPageText (per-page cap)', () => {
+    it('短いテキストはそのまま返される', () => {
+      const input = 'これはテストです。';
+      const result = capPageText(input);
+
+      expect(result.text).to.equal(input);
+      expect(result.originalLength).to.equal(input.length);
+      expect(result.truncated).to.be.false;
+    });
+
+    it('境界値: text.length === MAX_PAGE_TEXT_LENGTH は切り詰めない', () => {
+      const input = 'a'.repeat(MAX_PAGE_TEXT_LENGTH);
+      const result = capPageText(input);
+
+      expect(result.text.length).to.equal(MAX_PAGE_TEXT_LENGTH);
+      expect(result.truncated).to.be.false;
+      expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH);
+    });
+
+    it('境界値: text.length === MAX_PAGE_TEXT_LENGTH + 1 は切り詰める', () => {
+      const input = 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 1);
+      const result = capPageText(input);
+
+      expect(result.truncated).to.be.true;
+      expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH + 1);
+      expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
+    });
+
+    it('巨大テキスト (1.1M chars) でも text.length が cap を超えない', () => {
+      const input = 'x'.repeat(1_102_788);
+      const result = capPageText(input);
+
+      expect(result.truncated).to.be.true;
+      expect(result.originalLength).to.equal(1_102_788);
+      expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
+    });
+
+    it('切り詰めマーカー [TRUNCATED] が末尾に付与される', () => {
+      const input = 'a'.repeat(MAX_PAGE_TEXT_LENGTH * 2);
+      const result = capPageText(input);
+
+      expect(result.text).to.match(/\[TRUNCATED\]$/);
+    });
+
+    it('カスタム maxLength が反映される', () => {
+      const input = 'a'.repeat(100);
+      const result = capPageText(input, 50);
+
+      expect(result.truncated).to.be.true;
+      expect(result.text.length).to.be.at.most(50);
+      expect(result.originalLength).to.equal(100);
+    });
+
+    it('日本語マルチバイト文字でも文字数ベースで動作する', () => {
+      const input = 'あ'.repeat(MAX_PAGE_TEXT_LENGTH + 100);
+      const result = capPageText(input);
+
+      expect(result.truncated).to.be.true;
+      expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH + 100);
+      expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
+    });
+
+    it('空文字列は切り詰められない', () => {
+      const result = capPageText('');
+
+      expect(result.text).to.equal('');
+      expect(result.originalLength).to.equal(0);
+      expect(result.truncated).to.be.false;
+    });
+
+    it('maxLength=0 でも安全に動作する（text空、truncated=true）', () => {
+      const result = capPageText('hello', 0);
+
+      expect(result.truncated).to.be.true;
+      expect(result.text.length).to.be.at.most(0);
+      expect(result.originalLength).to.equal(5);
+    });
+  });
+
+  describe('capPageResultsAggregate (aggregate cap)', () => {
+    it('合計が閾値以下なら全ページそのまま返される', () => {
+      const pages = [
+        { text: 'page1', originalLength: 5, truncated: false },
+        { text: 'page2', originalLength: 5, truncated: false },
+      ];
+      const result = capPageResultsAggregate(pages);
+
+      expect(result).to.have.length(2);
+      expect(result[0]?.text).to.equal('page1');
+      expect(result[1]?.text).to.equal('page2');
+    });
+
+    it('合計が閾値を超える場合は後続ページが切り詰められる', () => {
+      const pageSize = MAX_PAGE_TEXT_LENGTH;
+      const pages = Array.from({ length: 10 }, (_, i) => ({
+        text: 'a'.repeat(pageSize),
+        originalLength: pageSize,
+        truncated: false,
+        pageNumber: i + 1,
+      }));
+
+      const result = capPageResultsAggregate(pages);
+      const totalChars = result.reduce((sum: number, p) => sum + p.text.length, 0);
+
+      expect(totalChars).to.be.at.most(MAX_AGGREGATE_PAGE_CHARS);
+    });
+
+    it('aggregate超過時、超過したページは truncated=true でメタデータ保持', () => {
+      const pageSize = MAX_PAGE_TEXT_LENGTH;
+      const pages = Array.from({ length: 10 }, () => ({
+        text: 'a'.repeat(pageSize),
+        originalLength: pageSize,
+        truncated: false,
+      }));
+
+      const result = capPageResultsAggregate(pages);
+      const truncatedPages = result.filter((p) => p.truncated);
+
+      expect(truncatedPages.length).to.be.at.least(1);
+      truncatedPages.forEach((p) => {
+        expect(p.originalLength).to.equal(pageSize);
+      });
+    });
+
+    it('1ページ目で既に閾値超過の場合は1ページ目内で切り詰め', () => {
+      const pages = [
+        {
+          text: 'a'.repeat(MAX_AGGREGATE_PAGE_CHARS + 100),
+          originalLength: MAX_AGGREGATE_PAGE_CHARS + 100,
+          truncated: false,
+        },
+      ];
+      const result = capPageResultsAggregate(pages);
+
+      expect(result[0]?.text.length).to.be.at.most(MAX_AGGREGATE_PAGE_CHARS);
+      expect(result[0]?.truncated).to.be.true;
+    });
+
+    it('per-page cap と合計 cap の両方が適用される', () => {
+      // 各ページ MAX_PAGE_TEXT_LENGTH 超 + 合計 MAX_AGGREGATE_PAGE_CHARS 超
+      const pages = [
+        { text: 'a'.repeat(60_000), originalLength: 60_000, truncated: false },
+        { text: 'b'.repeat(60_000), originalLength: 60_000, truncated: false },
+        { text: 'c'.repeat(60_000), originalLength: 60_000, truncated: false },
+        { text: 'd'.repeat(60_000), originalLength: 60_000, truncated: false },
+      ];
+      const result = capPageResultsAggregate(pages);
+
+      // 各ページ per-page cap 内
+      result.forEach((p: { text: string; truncated?: boolean; originalLength?: number }) => {
+        expect(p.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
+      });
+      // 合計が aggregate cap 内
+      const totalChars = result.reduce((sum: number, p) => sum + p.text.length, 0);
+      expect(totalChars).to.be.at.most(MAX_AGGREGATE_PAGE_CHARS);
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(capPageResultsAggregate([])).to.deep.equal([]);
+    });
+  });
+
+  describe('Firestore書き込みサイズの実害確認', () => {
+    it('cap適用後のpageResults配列はFirestore 1MiB制限内に収まる', () => {
+      const pages = Array.from({ length: 30 }, (_, i) => ({
+        text: 'あ'.repeat(MAX_PAGE_TEXT_LENGTH * 2), // 各ページ大きすぎ
+        originalLength: MAX_PAGE_TEXT_LENGTH * 2,
+        truncated: false,
+        pageNumber: i + 1,
+        inputTokens: 100,
+        outputTokens: 50000,
+      }));
+
+      const capped = capPageResultsAggregate(pages);
+      const serialized = JSON.stringify(capped);
+      const bytesSize = Buffer.byteLength(serialized, 'utf8');
+
+      // 1 MiB = 1,048,576 bytes
+      expect(bytesSize).to.be.at.most(1_048_576);
+    });
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -403,6 +403,10 @@ export interface PageOcrResult {
   detectedDate: Date | null;
   matchScore: number; // マッチ精度スコア（0-100）
   matchType: 'exact' | 'partial' | 'none';
+  /** OCR応答長制限により切り詰められた場合の元文字数 (Issue #205) */
+  originalLength?: number;
+  /** 切り詰めが発生したか (Issue #205) */
+  truncated?: boolean;
 }
 
 export interface SplitSuggestion {


### PR DESCRIPTION
## Summary
kanameone本番で `INVALID_ARGUMENT: Property array contains an invalid nested entity` を引き起こした Vertex AI Gemini の OCR 応答暴走（Page 3 で 1,102,788 文字、通常の400倍）に対する三段防御を実装。

## 真因
| Page | 文字数 |
|---|---|
| 1 | 711 |
| 2 | 2,855 |
| **3** | **1,102,788** ⚠️ |

`pageResults` 配列内の1要素（page 3 の text フィールド）が Firestore の per-field 1 MiB 制限に違反。マスターデータは無関係（kanameone 1,467件全クリーン）。

## 三段防御

### 1. per-page cap (`pageTextCap.ts`)
- 純粋関数 `capPageText(text, maxLength=50_000)` で各ページ単独切り詰め
- `truncated` / `originalLength` を切り詰めメタデータ保存

### 2. aggregate cap (`pageTextCap.ts`)
- `capPageResultsAggregate(pages)` で `pages` 全体を1パス走査
- `MAX_AGGREGATE_PAGE_CHARS = 200_000` (UTF-8 Japanese で約600KB、Firestore 1 MiB余裕)
- 残予算ベースで後続ページを追加切り詰め

### 3. Vertex AI 出力上限 (`ocrProcessor.ts`)
- `generationConfig.maxOutputTokens: 8192` を `generateContent` に追加
- 8192 tokens ≈ 25K chars Japanese、通常OCRには十分かつ暴走を抑止

## 型整合性 (#178教訓準拠)
- `shared/types.ts` PageOcrResult: `originalLength?`, `truncated?` 追加
- `functions/src/ocr/ocrProcessor.ts` PageOcrResult: 同様に追加
- `frontend/src/hooks/useDocuments.ts` は型キャストでマッピング自動継承
- `getReprocessClearFields` に `pageResults: deleteField()` 既存

## テスト
- `functions/test/pageTextCap.test.ts`: 16 unit tests
  - 境界値 (`length === MAX`, `MAX + 1`)
  - 1,102,788 chars 再現
  - マルチバイト文字 (日本語)
  - aggregate cap 単独・per-page との組合せ
  - **Firestore 1 MiB制限内 serialized size 検証**
- 全 **340 tests PASS** (新規16含む) / tsc / lint 0 errors

## レビュー反映
**Codex セカンドオピニオン (High指摘):**
- H1: per-page のみで多ページ累計1MiB超 → aggregate cap 追加 ✅
- H2: payload直接検証 → Firestore 1MiB制限内 serialized size テスト追加 ✅
- H3: ops script `--doc-id` オプション → **PR #207 で先行マージ済み** ✅
- M1: `maxOutputTokens` 同時導入 ✅
- M2: truncation metadata 保存 ✅
- M3: Gemini呼び出し直後で切り詰め ✅

**simplify (3並列):**
- DRY違反修正: `buildPageResult` ヘルパー化で PDF/Image path 共通化 ✅
- 状態冗長性 (`truncated` 導出可能): 意図的スキップ（Firestore永続化フィールドの明示性優先）

## 復旧手順 (本PRマージ後・別作業)
1. dev 自動デプロイ確認 (`processocr` revision UP)
2. `/deploy kanameone --functions`
3. GitHub Actions: `Run Operations Script` → `fix-stuck-documents --doc-id` → `doc_id: uUm2JJi5o9CgyQ9r4bIJ` で再処理
4. Cloud Logging で `processed` 状態と truncation 警告無しを確認
5. `/deploy cocoro --functions` (予防デプロイ)

## 関連
- Closes #205
- 依存PR: #207 (`fix-stuck-documents --doc-id` オプション、本PR復旧で使用)

## Test plan
- [x] 全340テストPASS (新規16含む)
- [x] tsc / ESLint 0 errors
- [x] 1,102,788 chars 再現テストで Firestore 1MiB制限内に収まることを確認
- [ ] dev環境で実OCR処理（任意のPDF）でtruncation発生せず正常完了
- [ ] kanameone デプロイ後、`uUm2JJi5o9CgyQ9r4bIJ` を `--doc-id` 指定で再処理 → status:processed
- [ ] kanameone Cloud Logging で `INVALID_ARGUMENT` エラー再発なし（24時間監視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)