### PR TITLE
fix: generateSummaryにmaxOutputTokens追加とsummary cap適用 (#209)

### DIFF
--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -72,6 +72,8 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     ocrResult: data.ocrResult as string,
     ocrResultUrl: data.ocrResultUrl as string | undefined,
     summary: data.summary as string | undefined,
+    summaryTruncated: data.summaryTruncated as boolean | undefined,
+    summaryOriginalLength: data.summaryOriginalLength as number | undefined,
     documentType: data.documentType as string,
     customerName: data.customerName as string,
     officeName: data.officeName as string,
@@ -177,6 +179,8 @@ export function getReprocessClearFields() {
     ocrResult: df,
     ocrResultUrl: df,
     summary: df,
+    summaryTruncated: df,
+    summaryOriginalLength: df,
     ocrExtraction: df,
     pageResults: df,
     // 表示用ファイル名（#178 displayFileName自動生成）

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -72,6 +72,7 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     ocrResult: data.ocrResult as string,
     ocrResultUrl: data.ocrResultUrl as string | undefined,
     summary: data.summary as string | undefined,
+    // Issue #209: Vertex AI暴走時の切り詰め検出メタ
     summaryTruncated: data.summaryTruncated as boolean | undefined,
     summaryOriginalLength: data.summaryOriginalLength as number | undefined,
     documentType: data.documentType as string,

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -533,6 +533,10 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
 /**
  * OCR結果からAI要約を生成
  */
+/**
+ * OCR結果からAI要約を生成 (Issue #209)
+ * @returns CappedText - text(切り詰め後summary), originalLength(元文字数), truncated(切り詰めフラグ)
+ */
 async function generateSummary(
   ocrResult: string,
   documentType: string

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -21,7 +21,13 @@ import {
 } from '../utils/extractors';
 import { generateDisplayFileName } from '../utils/displayFileNameGenerator';
 import { sanitizeCustomerMasters, sanitizeOfficeMasters, sanitizeDocumentMasters } from '../utils/sanitizeMasterData';
-import { capPageText, capPageResultsAggregate, MAX_PAGE_TEXT_LENGTH } from '../utils/pageTextCap';
+import {
+  capPageText,
+  capPageResultsAggregate,
+  MAX_PAGE_TEXT_LENGTH,
+  MAX_SUMMARY_LENGTH,
+  type CappedText,
+} from '../utils/pageTextCap';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -34,7 +40,7 @@ const MODEL_ID = GEMINI_CONFIG.modelId;
 // 定数
 const OCR_RESULT_MAX_LENGTH = 100000;
 // Vertex AI暴走時の出力トークン上限（Issue #205）。8192tokens ≈ 25K chars Japanese、通常OCRには十分
-const GEMINI_MAX_OUTPUT_TOKENS = 8192;
+const GEMINI_MAX_OUTPUT_TOKENS = GEMINI_CONFIG.maxOutputTokens;
 
 /** ページ単位OCR結果 */
 export interface PageOcrResult {
@@ -182,7 +188,7 @@ export async function processDocument(
   // マスターデータ取得（要約生成と並列実行）
   const summaryPromise = generateSummary(ocrResult, '').catch((err) => {
     console.error('Summary generation failed:', err);
-    return '';
+    return { text: '', originalLength: 0, truncated: false };
   });
 
   // マスターデータ取得
@@ -281,7 +287,9 @@ export async function processDocument(
     ...(displayFileName ? { displayFileName } : {}),
     ocrResult: savedOcrResult,
     ocrResultUrl: ocrResultUrl ?? null,
-    summary: summary || '',
+    summary: summary.text,
+    summaryTruncated: summary.truncated,
+    summaryOriginalLength: summary.originalLength,
     pageResults,
     documentType: documentTypeResult.documentType || '未判定',
     customerName: customerResult.bestMatch?.name || '不明顧客',
@@ -528,9 +536,9 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
 async function generateSummary(
   ocrResult: string,
   documentType: string
-): Promise<string> {
+): Promise<CappedText> {
   if (!ocrResult || ocrResult.length < 100) {
-    return '';
+    return { text: '', originalLength: 0, truncated: false };
   }
 
   const rateLimiter = getRateLimiter();
@@ -569,13 +577,17 @@ ${truncatedText}
               parts: [{ text: prompt }],
             },
           ],
+          // Issue #209: Vertex AI 暴走対策。summary 経路でも maxOutputTokens を必ず設定。
+          generationConfig: {
+            maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
+          },
         });
       },
       RETRY_CONFIGS.gemini
     );
 
     const result = response.response;
-    const summary = result.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    const rawSummary = (result.candidates?.[0]?.content?.parts?.[0]?.text || '').trim();
 
     const usageMetadata = result.usageMetadata;
     trackGeminiUsage(
@@ -583,11 +595,19 @@ ${truncatedText}
       usageMetadata?.candidatesTokenCount || 0
     );
 
-    console.log(`Summary generated: ${summary.length} chars`);
-    return summary.trim();
+    // Issue #209: 二重防御。maxOutputTokens を抜けた異常応答も Firestore 1 MiB 超過前に切り詰め。
+    const capped = capPageText(rawSummary, MAX_SUMMARY_LENGTH);
+    if (capped.truncated) {
+      console.warn(
+        `[Summary] truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_SUMMARY_LENGTH})`
+      );
+    } else {
+      console.log(`Summary generated: ${capped.text.length} chars`);
+    }
+    return capped;
   } catch (error) {
     console.error('Failed to generate summary:', error);
-    return '';
+    return { text: '', originalLength: 0, truncated: false };
   }
 }
 

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -10,10 +10,12 @@ import { VertexAI } from '@google-cloud/vertexai';
 import { getRateLimiter, trackGeminiUsage } from '../utils/rateLimiter';
 import { withRetry, RETRY_CONFIGS } from '../utils/retry';
 import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
+import { capPageText, MAX_SUMMARY_LENGTH, type CappedText } from '../utils/pageTextCap';
 
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
 const MODEL_ID = GEMINI_CONFIG.modelId;
+const GEMINI_MAX_OUTPUT_TOKENS = GEMINI_CONFIG.maxOutputTokens;
 
 const db = admin.firestore();
 
@@ -69,16 +71,20 @@ export const regenerateSummary = functions.https.onCall(
     // 要約生成
     const summary = await generateSummaryInternal(ocrResult, documentType);
 
-    if (!summary) {
+    if (!summary.text) {
       throw new functions.https.HttpsError('internal', '要約の生成に失敗しました');
     }
 
-    // ドキュメント更新
-    await docRef.update({ summary });
+    // ドキュメント更新（Issue #209: 切り詰めメタデータも保存し後追い検出を可能にする）
+    await docRef.update({
+      summary: summary.text,
+      summaryTruncated: summary.truncated,
+      summaryOriginalLength: summary.originalLength,
+    });
 
-    console.log(`Summary regenerated for ${docId}: ${summary.length} chars`);
+    console.log(`Summary regenerated for ${docId}: ${summary.text.length} chars`);
 
-    return { success: true, summary };
+    return { success: true, summary: summary.text };
   }
 );
 
@@ -88,7 +94,7 @@ export const regenerateSummary = functions.https.onCall(
 async function generateSummaryInternal(
   ocrResult: string,
   documentType: string
-): Promise<string> {
+): Promise<CappedText> {
   const rateLimiter = getRateLimiter();
   await rateLimiter.acquire();
 
@@ -127,13 +133,17 @@ ${truncatedText}
               parts: [{ text: prompt }],
             },
           ],
+          // Issue #209: Vertex AI 暴走対策。summary 経路でも maxOutputTokens を必ず設定。
+          generationConfig: {
+            maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
+          },
         });
       },
       RETRY_CONFIGS.gemini
     );
 
     const result = response.response;
-    const summary = result.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    const rawSummary = (result.candidates?.[0]?.content?.parts?.[0]?.text || '').trim();
 
     // トークン使用量を記録
     const usageMetadata = result.usageMetadata;
@@ -142,8 +152,16 @@ ${truncatedText}
       usageMetadata?.candidatesTokenCount || 0
     );
 
-    console.log(`Summary generated: ${summary.length} chars`);
-    return summary.trim();
+    // Issue #209: 二重防御。maxOutputTokens を抜けた異常応答も Firestore 1 MiB 超過前に切り詰め。
+    const capped = capPageText(rawSummary, MAX_SUMMARY_LENGTH);
+    if (capped.truncated) {
+      console.warn(
+        `[Summary] truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_SUMMARY_LENGTH})`
+      );
+    } else {
+      console.log(`Summary generated: ${capped.text.length} chars`);
+    }
+    return capped;
   } catch (error) {
     console.error('Failed to generate summary:', error);
     throw error;

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -15,6 +15,7 @@ import { capPageText, MAX_SUMMARY_LENGTH, type CappedText } from '../utils/pageT
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
 const MODEL_ID = GEMINI_CONFIG.modelId;
+// Vertex AI暴走時の出力トークン上限（Issue #205, #209）。8192tokens ≈ 25K chars Japanese
 const GEMINI_MAX_OUTPUT_TOKENS = GEMINI_CONFIG.maxOutputTokens;
 
 const db = admin.firestore();
@@ -89,7 +90,8 @@ export const regenerateSummary = functions.https.onCall(
 );
 
 /**
- * OCR結果からAI要約を生成（内部関数）
+ * OCR結果からAI要約を生成（内部関数, Issue #209）
+ * @returns CappedText - text(切り詰め後summary), originalLength(元文字数), truncated(切り詰めフラグ)
  */
 async function generateSummaryInternal(
   ocrResult: string,

--- a/functions/src/utils/config.ts
+++ b/functions/src/utils/config.ts
@@ -18,4 +18,10 @@ export const GEMINI_CONFIG = {
   modelId: 'gemini-2.5-flash',
   /** モデルのリージョン */
   location: GCP_CONFIG.location,
+  /**
+   * generateContent の maxOutputTokens 上限 (Issue #205, #209)
+   * Vertex AI のハルシネーション/暴走で1.1M chars を返す事故への根本対策。
+   * OCR 経路・summary 経路の両方で必須設定。
+   */
+  maxOutputTokens: 8192,
 } as const;

--- a/functions/src/utils/pageTextCap.ts
+++ b/functions/src/utils/pageTextCap.ts
@@ -14,6 +14,10 @@ export const MAX_PAGE_TEXT_LENGTH = 50_000;
 // 200K chars × 3 bytes/char (UTF-8 Japanese) ≈ 600KB。Firestore 1 MiB制限内に余裕を残す。
 export const MAX_AGGREGATE_PAGE_CHARS = 200_000;
 
+// summary は1書類あたり1フィールドのみ。30K chars × 3 bytes/char ≈ 90KB で1 MiB制限に十分余裕。
+// (Issue #209) Vertex AI 暴走で summary が1.1M chars 等を返した場合の Firestore INVALID_ARGUMENT 防御。
+export const MAX_SUMMARY_LENGTH = 30_000;
+
 const TRUNCATION_MARKER = '\n[TRUNCATED]';
 
 export interface CappedText {

--- a/functions/test/pageTextCap.test.ts
+++ b/functions/test/pageTextCap.test.ts
@@ -11,6 +11,7 @@ import {
   capPageResultsAggregate,
   MAX_PAGE_TEXT_LENGTH,
   MAX_AGGREGATE_PAGE_CHARS,
+  MAX_SUMMARY_LENGTH,
 } from '../src/utils/pageTextCap';
 
 describe('pageTextCap', () => {
@@ -173,6 +174,46 @@ describe('pageTextCap', () => {
 
     it('空配列は空配列を返す', () => {
       expect(capPageResultsAggregate([])).to.deep.equal([]);
+    });
+  });
+
+  describe('MAX_SUMMARY_LENGTH (Issue #209)', () => {
+    it('サマリー上限定数が想定値である', () => {
+      expect(MAX_SUMMARY_LENGTH).to.equal(30_000);
+    });
+
+    it('境界値: text.length === MAX_SUMMARY_LENGTH は切り詰めない', () => {
+      const input = 'a'.repeat(MAX_SUMMARY_LENGTH);
+      const result = capPageText(input, MAX_SUMMARY_LENGTH);
+
+      expect(result.text.length).to.equal(MAX_SUMMARY_LENGTH);
+      expect(result.truncated).to.be.false;
+    });
+
+    it('境界値: text.length === MAX_SUMMARY_LENGTH + 1 は切り詰める', () => {
+      const input = 'a'.repeat(MAX_SUMMARY_LENGTH + 1);
+      const result = capPageText(input, MAX_SUMMARY_LENGTH);
+
+      expect(result.truncated).to.be.true;
+      expect(result.originalLength).to.equal(MAX_SUMMARY_LENGTH + 1);
+      expect(result.text.length).to.be.at.most(MAX_SUMMARY_LENGTH);
+    });
+
+    it('巨大サマリー (1.1M chars 暴走相当) でも cap 内に収まる', () => {
+      const input = 'x'.repeat(1_100_000);
+      const result = capPageText(input, MAX_SUMMARY_LENGTH);
+
+      expect(result.truncated).to.be.true;
+      expect(result.originalLength).to.equal(1_100_000);
+      expect(result.text.length).to.be.at.most(MAX_SUMMARY_LENGTH);
+    });
+
+    it('cap適用後のsummary は Firestore 1 MiB 制限内に余裕で収まる', () => {
+      const input = 'あ'.repeat(MAX_SUMMARY_LENGTH * 2);
+      const result = capPageText(input, MAX_SUMMARY_LENGTH);
+      const bytesSize = Buffer.byteLength(result.text, 'utf8');
+
+      expect(bytesSize).to.be.at.most(1_048_576);
     });
   });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -24,6 +24,8 @@ export interface Document {
   ocrResult: string;
   ocrResultUrl?: string; // 長い場合はCloud Storage参照
   summary?: string; // AI生成の要約
+  summaryTruncated?: boolean; // Vertex AI暴走時に切り詰めが発生したか (Issue #209)
+  summaryOriginalLength?: number; // 切り詰め前の元文字数 (Issue #209)
   documentType: string;
   customerName: string;
   officeName: string;


### PR DESCRIPTION
## Summary

Vertex AI Geminiのハルシネーション/暴走でsummary経路が異常長応答を返した場合のFirestore per-field 1 MiB制限超過(INVALID_ARGUMENT)を防ぐ二段防御。PR #208でOCRページ経路を防御済み、本PRは要約経路の同等対策（Codex セカンドオピニオン M1 指摘事項対応）。

- maxOutputTokens=8192 を `generateSummary()` (ocrProcessor.ts) と `generateSummaryInternal()` (regenerateSummary.ts) に設定
- 二重防御として `capPageText(summary, MAX_SUMMARY_LENGTH=30_000)` を summary 結果に適用
- 切り詰め時のメタデータ (summaryTruncated, summaryOriginalLength) を Firestore に保存し後追い検出可能に

## Changes

| File | 変更内容 |
|------|---------|
| `functions/src/utils/pageTextCap.ts` | `MAX_SUMMARY_LENGTH = 30_000` 定数追加 |
| `functions/src/utils/config.ts` | `GEMINI_CONFIG.maxOutputTokens = 8192` 統一管理 |
| `functions/src/ocr/ocrProcessor.ts` | `generateSummary` に防御層追加、戻り値を `CappedText` に変更 |
| `functions/src/ocr/regenerateSummary.ts` | `generateSummaryInternal` に同等防御 |
| `frontend/src/hooks/useDocuments.ts` | `firestoreToDocument()` と `getReprocessClearFields()` に新フィールド追加（#178教訓） |
| `shared/types.ts` | `summaryTruncated`, `summaryOriginalLength` 型定義追加 |
| `functions/test/pageTextCap.test.ts` | `MAX_SUMMARY_LENGTH` 境界値テスト 5件追加 |

## Test plan

- [x] 単体テスト: `cd functions && npm test` → 345 passing（新規5件含む pageTextCap 21件）
- [x] frontend テスト: 94 passing
- [x] TypeScript build: `npm run build` ✅
- [x] lint: errors 0 (warnings は既存)
- [ ] kanameone デプロイ後、`regenerateSummary` を実書類で1回手動実行し summary が正常生成・Firestore書き込み成功を確認
- [ ] Cloud Logging で `[Summary] truncated:` 警告ログが新規発生していないこと確認（暴走未発生時は出ないのが正常）

## レビュー対応

`/simplify` 3エージェント並列レビュー結果:
- High（コピペ重複）→ `GEMINI_CONFIG.maxOutputTokens` への config 統一、`SummaryResult` interface を `pageTextCap.CappedText` に統合して対応
- Medium（pageTextCap → textCap リネーム）→ スコープ拡大のためフォローアップ Issue 候補（指摘記録）
- Efficiency: 修正不要

## Related

- Issue #209
- Codex セカンドオピニオン (2026-04-15) M1 指摘
- 関連: PR #208 (OCR ページ経路 cap), Issue #205 (背景の本番 INVALID_ARGUMENT 事故)

🤖 Generated with [Claude Code](https://claude.com/claude-code)