### PR TITLE
fix: ondocumentwritesearchindex メモリ 256→512MiB (#217)

### DIFF
--- a/functions/src/search/searchIndexer.ts
+++ b/functions/src/search/searchIndexer.ts
@@ -34,7 +34,9 @@ export const onDocumentWriteSearchIndex = onDocumentWritten(
   {
     document: 'documents/{docId}',
     region: 'asia-northeast1',
-    memory: '256MiB',
+    // Issue #217: 256MiB では db.getAll(...indexRefs) 時に境界を越えOOM頻発 (kanameone 04-14 12回+, 04-15 5回)。
+    // 応急で 512MiB に増強。本質対応 (getAll chunk化) は再発時に別Issueで検討。
+    memory: '512MiB',
     timeoutSeconds: 60,
   },
   async (event) => {


### PR DESCRIPTION
## Summary

- `onDocumentWriteSearchIndex` の memory を **256MiB → 512MiB** に増強
- kanameone で 04-14 12件+ / 04-15 5件 の OOM (`Memory limit of 256 MiB exceeded`) 発生に対する応急対処
- OOM時は検索インデックス更新スキップ = 該当書類が検索ヒットしなくなる silent failure

## 根本原因

`searchIndexer.ts` の `db.getAll(...indexRefs)` で全 tokenId を一括取得しており、大量トークン書類で 256MiB を境界越え。使用量実測は 256〜267 MiB で上限ギリギリ。

## 対応

応急として `memory: '512MiB'` に変更 (functions第2世代、コスト影響ほぼなし)。
本質対応 (`db.getAll` chunk 化) は再発時に別 Issue 化。

## Test plan

- [x] `cd functions && npm run build` — tsc pass
- [x] `cd functions && npm test` — 345 passing
- [ ] merge 後: kanameone/cocoro 両環境デプロイ
- [ ] 24h OOM 発生 0 件確認 (Cloud Logging)

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)