### PR TITLE
fix: removeTokensFromIndex の silent failure 防止 (#219)

### DIFF
--- a/functions/src/search/errors.ts
+++ b/functions/src/search/errors.ts
@@ -1,17 +1,12 @@
 /**
- * 検索インデックス関連のエラー判定ユーティリティ
+ * Firestoreの NOT_FOUND エラーかを判定
  *
- * Issue #219: silent failure 防止のためのエラー分類
- */
-
-/**
- * Firestoreの NOT_FOUND エラーかを判定 (gRPC code 5)
- *
- * removeTokensFromIndex でドキュメント不在は正常系として無視するが、
- * それ以外のエラーは握潰さず明示的にログを残す必要がある。
+ * 削除トリガーで対象インデックスエントリが不在のケースを冪等な削除として許容する用途。
+ * Firebase admin SDK は SDK経由で `'not-found'` (kebab-case)、
+ * gRPC 直接呼び出しは数値 `5` または `'NOT_FOUND'` (UPPER) を返すため3形式を許容する。
  */
 export function isFirestoreNotFoundError(error: unknown): boolean {
   if (error === null || typeof error !== 'object') return false;
   const code = (error as { code?: unknown }).code;
-  return code === 5 || code === 'NOT_FOUND';
+  return code === 5 || code === 'NOT_FOUND' || code === 'not-found';
 }

--- a/functions/src/search/errors.ts
+++ b/functions/src/search/errors.ts
@@ -1,0 +1,17 @@
+/**
+ * 検索インデックス関連のエラー判定ユーティリティ
+ *
+ * Issue #219: silent failure 防止のためのエラー分類
+ */
+
+/**
+ * Firestoreの NOT_FOUND エラーかを判定 (gRPC code 5)
+ *
+ * removeTokensFromIndex でドキュメント不在は正常系として無視するが、
+ * それ以外のエラーは握潰さず明示的にログを残す必要がある。
+ */
+export function isFirestoreNotFoundError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  return code === 5 || code === 'NOT_FOUND';
+}

--- a/functions/src/search/searchIndexer.ts
+++ b/functions/src/search/searchIndexer.ts
@@ -195,11 +195,11 @@ async function removeTokensFromIndex(docId: string, tokens: string[]): Promise<v
     await batch.commit();
   } catch (error) {
     if (isFirestoreNotFoundError(error)) {
-      // インデックスエントリが既に削除済み (正常系)
-      console.warn(`Search index entry not found while removing tokens for ${docId} (already deleted)`);
+      // インデックスエントリ不在は冪等な削除として正常扱い (既削除/未作成いずれも該当)
+      console.warn(`Search index entry not found while removing tokens for ${docId} (idempotent skip)`);
       return;
     }
-    // Issue #219: NOT_FOUND以外は握潰さずERROR として残し監視可能にする
+    // Firestore権限/ネットワーク/クォータ等の障害は ERROR として残し監視/アラート対象化する
     console.error(`Failed to remove tokens from search index for ${docId}:`, error);
   }
 }

--- a/functions/src/search/searchIndexer.ts
+++ b/functions/src/search/searchIndexer.ts
@@ -15,6 +15,7 @@ import {
   type TokenField,
   type TokenInfo,
 } from '../utils/tokenizer';
+import { isFirestoreNotFoundError } from './errors';
 
 const db = getFirestore();
 
@@ -193,8 +194,13 @@ async function removeTokensFromIndex(docId: string, tokens: string[]): Promise<v
   try {
     await batch.commit();
   } catch (error) {
-    // ドキュメントが存在しない場合は無視
-    console.warn(`Failed to remove tokens from index for ${docId}:`, error);
+    if (isFirestoreNotFoundError(error)) {
+      // インデックスエントリが既に削除済み (正常系)
+      console.warn(`Search index entry not found while removing tokens for ${docId} (already deleted)`);
+      return;
+    }
+    // Issue #219: NOT_FOUND以外は握潰さずERROR として残し監視可能にする
+    console.error(`Failed to remove tokens from search index for ${docId}:`, error);
   }
 }
 

--- a/functions/test/searchIndexer.test.ts
+++ b/functions/test/searchIndexer.test.ts
@@ -1,0 +1,57 @@
+/**
+ * 検索インデックス: silent failure 防止テスト
+ *
+ * Issue #219: removeTokensFromIndex の catch で全エラー握潰し対策
+ * NOT_FOUND (gRPC code 5) のみ無視可、それ以外は明示的にログを残す。
+ */
+
+import { expect } from 'chai';
+import { isFirestoreNotFoundError } from '../src/search/errors';
+
+describe('searchIndexer: isFirestoreNotFoundError', () => {
+  it('gRPC code 5 (NOT_FOUND) を true と判定', () => {
+    const error = Object.assign(new Error('Document not found'), { code: 5 });
+    expect(isFirestoreNotFoundError(error)).to.be.true;
+  });
+
+  it('文字列 "NOT_FOUND" を含む code を true と判定', () => {
+    const error = Object.assign(new Error('Document not found'), { code: 'NOT_FOUND' });
+    expect(isFirestoreNotFoundError(error)).to.be.true;
+  });
+
+  it('PERMISSION_DENIED (code 7) を false と判定', () => {
+    const error = Object.assign(new Error('Permission denied'), { code: 7 });
+    expect(isFirestoreNotFoundError(error)).to.be.false;
+  });
+
+  it('UNAVAILABLE (code 14) を false と判定', () => {
+    const error = Object.assign(new Error('Service unavailable'), { code: 14 });
+    expect(isFirestoreNotFoundError(error)).to.be.false;
+  });
+
+  it('DEADLINE_EXCEEDED (code 4) を false と判定', () => {
+    const error = Object.assign(new Error('Deadline exceeded'), { code: 4 });
+    expect(isFirestoreNotFoundError(error)).to.be.false;
+  });
+
+  it('code が無いエラーを false と判定', () => {
+    const error = new Error('Unknown error');
+    expect(isFirestoreNotFoundError(error)).to.be.false;
+  });
+
+  it('null/undefined を false と判定', () => {
+    expect(isFirestoreNotFoundError(null)).to.be.false;
+    expect(isFirestoreNotFoundError(undefined)).to.be.false;
+  });
+
+  it('プリミティブ値を false と判定', () => {
+    expect(isFirestoreNotFoundError('string')).to.be.false;
+    expect(isFirestoreNotFoundError(42)).to.be.false;
+    expect(isFirestoreNotFoundError(true)).to.be.false;
+  });
+
+  it('code が空オブジェクトのエラーを false と判定', () => {
+    const error = Object.assign(new Error('Edge case'), { code: {} });
+    expect(isFirestoreNotFoundError(error)).to.be.false;
+  });
+});

--- a/functions/test/searchIndexer.test.ts
+++ b/functions/test/searchIndexer.test.ts
@@ -1,21 +1,26 @@
 /**
- * 検索インデックス: silent failure 防止テスト
+ * 検索インデックス: NOT_FOUND判定テスト
  *
- * Issue #219: removeTokensFromIndex の catch で全エラー握潰し対策
- * NOT_FOUND (gRPC code 5) のみ無視可、それ以外は明示的にログを残す。
+ * 削除トリガーでインデックスエントリ不在を冪等削除として許容するため、
+ * gRPC/REST/Firebase admin SDK の3形式の code を識別する必要がある。
  */
 
 import { expect } from 'chai';
 import { isFirestoreNotFoundError } from '../src/search/errors';
 
 describe('searchIndexer: isFirestoreNotFoundError', () => {
-  it('gRPC code 5 (NOT_FOUND) を true と判定', () => {
+  it('gRPC code 5 (数値) を true と判定', () => {
     const error = Object.assign(new Error('Document not found'), { code: 5 });
     expect(isFirestoreNotFoundError(error)).to.be.true;
   });
 
-  it('文字列 "NOT_FOUND" を含む code を true と判定', () => {
+  it('REST/gcloud形式 "NOT_FOUND" (UPPER) を true と判定', () => {
     const error = Object.assign(new Error('Document not found'), { code: 'NOT_FOUND' });
+    expect(isFirestoreNotFoundError(error)).to.be.true;
+  });
+
+  it('Firebase admin SDK形式 "not-found" (kebab-case) を true と判定', () => {
+    const error = Object.assign(new Error('Document not found'), { code: 'not-found' });
     expect(isFirestoreNotFoundError(error)).to.be.true;
   });
 


### PR DESCRIPTION
## Summary
- `isFirestoreNotFoundError` を新ファイル `errors.ts` に分離 (テスタブル化)
- `removeTokensFromIndex` の catch を **NOT_FOUND (正常系) vs その他 (ERROR)** に分岐
- ユニットテスト9件追加

## 背景
Issue #217 (PR #218) の `/review-pr` silent-failure-hunter HIGH 指摘。
コメント「ドキュメントが存在しない場合は無視」と異なり、実装は **全エラー一律 console.warn** で握潰しており、Firestore権限/ネットワーク/クォータ障害が **無自覚に検索インデックス不整合** を蓄積させる状態だった。

## 修正方針
| 旧 | 新 |
|----|-----|
| `console.warn(...)` 全エラー | NOT_FOUND → `console.warn` (正常系) / それ以外 → `console.error` (ALERT 対象) |

throw はしない (onDocumentWritten で連鎖障害を避ける)。代わりに ERROR severity でログを残し、将来の log-based metric (#220) で監視可能にする。

## Test plan
- [x] `npm test` → 354 passing (9 new + 345 existing)
- [x] `npm run lint` → 0 errors (既存warning 19件のみ)
- [x] `npm run build` → success
- [x] 既存 `removeTokensFromIndex` の正常系挙動が変わらないこと (NOT_FOUND時は WARN+return)
- [ ] マージ後 dev → kanameone → cocoro 順にデプロイ (Actions: Deploy Cloud Functions)
- [ ] デプロイ後24h以内に `ondocumentwritesearchindex` の severity=ERROR ログを監視

## 関連
- Closes #219
- 関連 #217 (PR #218) / #220 (log-based metric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)