### PR TITLE
test: generateSummary maxOutputTokens regression test 追加 (#213)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -21,6 +21,7 @@ import {
 } from '../utils/extractors';
 import { generateDisplayFileName } from '../utils/displayFileNameGenerator';
 import { sanitizeCustomerMasters, sanitizeOfficeMasters, sanitizeDocumentMasters } from '../utils/sanitizeMasterData';
+import { buildSummaryGenerationRequest, buildSummaryFields } from './summaryRequestBuilder';
 import {
   capPageText,
   capPageResultsAggregate,
@@ -287,9 +288,7 @@ export async function processDocument(
     ...(displayFileName ? { displayFileName } : {}),
     ocrResult: savedOcrResult,
     ocrResultUrl: ocrResultUrl ?? null,
-    summary: summary.text,
-    summaryTruncated: summary.truncated,
-    summaryOriginalLength: summary.originalLength,
+    ...buildSummaryFields(summary),
     pageResults,
     documentType: documentTypeResult.documentType || '未判定',
     customerName: customerResult.bestMatch?.name || '不明顧客',
@@ -574,18 +573,7 @@ ${truncatedText}
   try {
     const response = await withRetry(
       async () => {
-        return await model.generateContent({
-          contents: [
-            {
-              role: 'user',
-              parts: [{ text: prompt }],
-            },
-          ],
-          // Issue #209: Vertex AI 暴走対策。summary 経路でも maxOutputTokens を必ず設定。
-          generationConfig: {
-            maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
-          },
-        });
+        return await model.generateContent(buildSummaryGenerationRequest(prompt));
       },
       RETRY_CONFIGS.gemini
     );

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -11,12 +11,11 @@ import { getRateLimiter, trackGeminiUsage } from '../utils/rateLimiter';
 import { withRetry, RETRY_CONFIGS } from '../utils/retry';
 import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
 import { capPageText, MAX_SUMMARY_LENGTH, type CappedText } from '../utils/pageTextCap';
+import { buildSummaryGenerationRequest, buildSummaryFields } from './summaryRequestBuilder';
 
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
 const MODEL_ID = GEMINI_CONFIG.modelId;
-// Vertex AI暴走時の出力トークン上限（Issue #205, #209）。8192tokens ≈ 25K chars Japanese
-const GEMINI_MAX_OUTPUT_TOKENS = GEMINI_CONFIG.maxOutputTokens;
 
 const db = admin.firestore();
 
@@ -77,11 +76,7 @@ export const regenerateSummary = functions.https.onCall(
     }
 
     // ドキュメント更新（Issue #209: 切り詰めメタデータも保存し後追い検出を可能にする）
-    await docRef.update({
-      summary: summary.text,
-      summaryTruncated: summary.truncated,
-      summaryOriginalLength: summary.originalLength,
-    });
+    await docRef.update(buildSummaryFields(summary));
 
     console.log(`Summary regenerated for ${docId}: ${summary.text.length} chars`);
 
@@ -128,18 +123,7 @@ ${truncatedText}
   try {
     const response = await withRetry(
       async () => {
-        return await model.generateContent({
-          contents: [
-            {
-              role: 'user',
-              parts: [{ text: prompt }],
-            },
-          ],
-          // Issue #209: Vertex AI 暴走対策。summary 経路でも maxOutputTokens を必ず設定。
-          generationConfig: {
-            maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
-          },
-        });
+        return await model.generateContent(buildSummaryGenerationRequest(prompt));
       },
       RETRY_CONFIGS.gemini
     );

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -76,7 +76,7 @@ export const regenerateSummary = functions.https.onCall(
     }
 
     // ドキュメント更新（Issue #209: 切り詰めメタデータも保存し後追い検出を可能にする）
-    await docRef.update(buildSummaryFields(summary));
+    await docRef.update({ ...buildSummaryFields(summary) });
 
     console.log(`Summary regenerated for ${docId}: ${summary.text.length} chars`);
 

--- a/functions/src/ocr/summaryRequestBuilder.ts
+++ b/functions/src/ocr/summaryRequestBuilder.ts
@@ -1,27 +1,41 @@
 /**
  * Vertex AI 要約生成リクエスト/Firestore 書き込みペイロードのビルダー
  *
- * Issue #213: ocrProcessor / regenerateSummary 双方の generateContent 呼び出しと
- * Firestore update payload を共通化し、リファクタやtypoで maxOutputTokens 防御
- * (Issue #209) や summaryTruncated/summaryOriginalLength の出力 (#178教訓) が
- * 失われる回帰を pure function テストで検出する。
+ * リファクタや typo で `maxOutputTokens` 防御や 3点セット書き込みが
+ * 失われる回帰を pure function テストで検出可能にする。
+ *
+ * 関連経緯:
+ * - Issue #205: GEMINI_CONFIG.maxOutputTokens=8192 を導入 (OCR経路の暴走対策)
+ * - Issue #209: summary 経路にも適用 + capPageText で二段防御
+ * - #178 教訓: 派生フィールド (truncated/originalLength) を一括で書き込まないとFE側マッピングが破壊される
  */
 
+import type { GenerateContentRequest } from '@google-cloud/vertexai';
 import { GEMINI_CONFIG } from '../utils/config';
 import type { CappedText } from '../utils/pageTextCap';
+
+export interface SummaryGenerationRequest {
+  contents: Array<{ role: 'user'; parts: Array<{ text: string }> }>;
+  generationConfig: { maxOutputTokens: number };
+}
+
+export interface SummaryUpdatePayload {
+  summary: string;
+  summaryTruncated: boolean;
+  summaryOriginalLength: number;
+}
 
 /**
  * Vertex AI Gemini に渡す GenerateContentRequest を構築。
  * `generationConfig.maxOutputTokens` の付与漏れを呼び出し元から構造的に排除する。
+ * `satisfies GenerateContentRequest` で SDK 型変更時にコンパイルエラーで検知。
  */
-export function buildSummaryGenerationRequest(prompt: string): {
-  contents: Array<{ role: 'user'; parts: Array<{ text: string }> }>;
-  generationConfig: { maxOutputTokens: number };
-} {
-  return {
-    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+export function buildSummaryGenerationRequest(prompt: string): SummaryGenerationRequest {
+  const request = {
+    contents: [{ role: 'user' as const, parts: [{ text: prompt }] }],
     generationConfig: { maxOutputTokens: GEMINI_CONFIG.maxOutputTokens },
-  };
+  } satisfies GenerateContentRequest;
+  return request;
 }
 
 /**
@@ -29,11 +43,7 @@ export function buildSummaryGenerationRequest(prompt: string): {
  * truncated / originalLength を併せて書き込まないと FE で切り詰めバナーが
  * 表示できないため (#178 教訓)、3フィールドをセットで構築する。
  */
-export function buildSummaryFields(summary: CappedText): {
-  summary: string;
-  summaryTruncated: boolean;
-  summaryOriginalLength: number;
-} {
+export function buildSummaryFields(summary: CappedText): SummaryUpdatePayload {
   return {
     summary: summary.text,
     summaryTruncated: summary.truncated,

--- a/functions/src/ocr/summaryRequestBuilder.ts
+++ b/functions/src/ocr/summaryRequestBuilder.ts
@@ -1,0 +1,42 @@
+/**
+ * Vertex AI 要約生成リクエスト/Firestore 書き込みペイロードのビルダー
+ *
+ * Issue #213: ocrProcessor / regenerateSummary 双方の generateContent 呼び出しと
+ * Firestore update payload を共通化し、リファクタやtypoで maxOutputTokens 防御
+ * (Issue #209) や summaryTruncated/summaryOriginalLength の出力 (#178教訓) が
+ * 失われる回帰を pure function テストで検出する。
+ */
+
+import { GEMINI_CONFIG } from '../utils/config';
+import type { CappedText } from '../utils/pageTextCap';
+
+/**
+ * Vertex AI Gemini に渡す GenerateContentRequest を構築。
+ * `generationConfig.maxOutputTokens` の付与漏れを呼び出し元から構造的に排除する。
+ */
+export function buildSummaryGenerationRequest(prompt: string): {
+  contents: Array<{ role: 'user'; parts: Array<{ text: string }> }>;
+  generationConfig: { maxOutputTokens: number };
+} {
+  return {
+    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    generationConfig: { maxOutputTokens: GEMINI_CONFIG.maxOutputTokens },
+  };
+}
+
+/**
+ * Firestore documents/{docId} の summary 関連フィールド更新ペイロード。
+ * truncated / originalLength を併せて書き込まないと FE で切り詰めバナーが
+ * 表示できないため (#178 教訓)、3フィールドをセットで構築する。
+ */
+export function buildSummaryFields(summary: CappedText): {
+  summary: string;
+  summaryTruncated: boolean;
+  summaryOriginalLength: number;
+} {
+  return {
+    summary: summary.text,
+    summaryTruncated: summary.truncated,
+    summaryOriginalLength: summary.originalLength,
+  };
+}

--- a/functions/test/summaryRequestBuilder.test.ts
+++ b/functions/test/summaryRequestBuilder.test.ts
@@ -1,0 +1,92 @@
+/**
+ * generateSummary regression テスト (Issue #213)
+ *
+ * 目的:
+ * - Vertex AI generateContent 呼び出しに maxOutputTokens=8192 が付与され続けることを保証 (Issue #209 再発防止)
+ * - Firestore の summary フィールド書き込みに truncated/originalLength が同梱され続けることを保証 (#178 教訓)
+ */
+
+import { expect } from 'chai';
+import {
+  buildSummaryGenerationRequest,
+  buildSummaryFields,
+} from '../src/ocr/summaryRequestBuilder';
+import { GEMINI_CONFIG } from '../src/utils/config';
+import type { CappedText } from '../src/utils/pageTextCap';
+
+describe('summaryRequestBuilder: buildSummaryGenerationRequest', () => {
+  it('generationConfig.maxOutputTokens に GEMINI_CONFIG.maxOutputTokens を必ず設定する', () => {
+    const req = buildSummaryGenerationRequest('test prompt');
+    expect(req.generationConfig.maxOutputTokens).to.equal(GEMINI_CONFIG.maxOutputTokens);
+  });
+
+  it('Issue #209 再発防止: maxOutputTokens は 8192 で固定 (config整合性)', () => {
+    const req = buildSummaryGenerationRequest('test prompt');
+    expect(req.generationConfig.maxOutputTokens).to.equal(8192);
+  });
+
+  it('contents[0].parts[0].text に prompt 全文を含む', () => {
+    const prompt = '【要約】以下のOCR結果を要約してください\n本文サンプル';
+    const req = buildSummaryGenerationRequest(prompt);
+    expect(req.contents).to.have.lengthOf(1);
+    expect(req.contents[0].role).to.equal('user');
+    expect(req.contents[0].parts).to.have.lengthOf(1);
+    expect(req.contents[0].parts[0].text).to.equal(prompt);
+  });
+
+  it('空 prompt でも generationConfig は維持される (防御の不変条件)', () => {
+    const req = buildSummaryGenerationRequest('');
+    expect(req.generationConfig).to.deep.equal({ maxOutputTokens: 8192 });
+  });
+
+  it('長大 prompt (50K chars) でも generationConfig は維持される', () => {
+    const longPrompt = 'a'.repeat(50_000);
+    const req = buildSummaryGenerationRequest(longPrompt);
+    expect(req.generationConfig.maxOutputTokens).to.equal(8192);
+    expect(req.contents[0].parts[0].text.length).to.equal(50_000);
+  });
+});
+
+describe('summaryRequestBuilder: buildSummaryFields', () => {
+  it('truncated=false の通常ケースで3フィールド全てを返す (#178 教訓)', () => {
+    const summary: CappedText = {
+      text: '通常の要約テキスト',
+      originalLength: 100,
+      truncated: false,
+    };
+    expect(buildSummaryFields(summary)).to.deep.equal({
+      summary: '通常の要約テキスト',
+      summaryTruncated: false,
+      summaryOriginalLength: 100,
+    });
+  });
+
+  it('truncated=true の切り詰めケースでも3フィールド全てを返す', () => {
+    const summary: CappedText = {
+      text: '切り詰め後\n[TRUNCATED]',
+      originalLength: 1_100_000,
+      truncated: true,
+    };
+    expect(buildSummaryFields(summary)).to.deep.equal({
+      summary: '切り詰め後\n[TRUNCATED]',
+      summaryTruncated: true,
+      summaryOriginalLength: 1_100_000,
+    });
+  });
+
+  it('空 summary でも 3 フィールドが必ず含まれる (FE側マッピングを破壊しない)', () => {
+    const summary: CappedText = { text: '', originalLength: 0, truncated: false };
+    const fields = buildSummaryFields(summary);
+    expect(Object.keys(fields).sort()).to.deep.equal([
+      'summary',
+      'summaryOriginalLength',
+      'summaryTruncated',
+    ]);
+  });
+});
+
+describe('GEMINI_CONFIG: maxOutputTokens 不変条件', () => {
+  it('Issue #205, #209 防御: maxOutputTokens は 8192 で固定', () => {
+    expect(GEMINI_CONFIG.maxOutputTokens).to.equal(8192);
+  });
+});

--- a/functions/test/summaryRequestBuilder.test.ts
+++ b/functions/test/summaryRequestBuilder.test.ts
@@ -20,7 +20,9 @@ describe('summaryRequestBuilder: buildSummaryGenerationRequest', () => {
     expect(req.generationConfig.maxOutputTokens).to.equal(GEMINI_CONFIG.maxOutputTokens);
   });
 
-  it('Issue #209 再発防止: maxOutputTokens は 8192 で固定 (config整合性)', () => {
+  // canary: GEMINI_CONFIG.maxOutputTokens を意図せず緩和した場合の安全網。
+  // 値変更が必要なら #205/#209 の防御目的を再評価し、本テストも明示的に更新すること。
+  it('canary: maxOutputTokens は 8192 で固定 (#205で導入、#209でsummary適用)', () => {
     const req = buildSummaryGenerationRequest('test prompt');
     expect(req.generationConfig.maxOutputTokens).to.equal(8192);
   });
@@ -85,8 +87,10 @@ describe('summaryRequestBuilder: buildSummaryFields', () => {
   });
 });
 
-describe('GEMINI_CONFIG: maxOutputTokens 不変条件', () => {
-  it('Issue #205, #209 防御: maxOutputTokens は 8192 で固定', () => {
+describe('GEMINI_CONFIG: maxOutputTokens 不変条件 (canary)', () => {
+  // builder 側 canary と二重で固定。値変更時は #205 (定数導入) と #209 (summary適用) の
+  // 防御目的を再評価し、両テストを明示的に更新すること。
+  it('GEMINI_CONFIG.maxOutputTokens は 8192 で固定', () => {
     expect(GEMINI_CONFIG.maxOutputTokens).to.equal(8192);
   });
 });


### PR DESCRIPTION
## Summary
- `summaryRequestBuilder.ts` 新設し generateContent と Firestore update を builder 化
- `ocrProcessor.ts` / `regenerateSummary.ts` の重複 (-34/+6 lines) を解消
- 9件の regression test 追加

## 背景
Issue #209 (PR #212) で maxOutputTokens=8192 を追加したが、generateContent 呼び出しに実際に値が渡るかの自動検証がなかった。将来のリファクタや typo で防御無効化のリスク。

## 採用方針
当初案「sinon stub + private 関数 export」ではなく、**pure builder 抽出方式** を採用。

| 観点 | sinon stub | pure builder (採用) |
|------|-----------|--------------------|
| 新規依存 | sinon 必要 | なし |
| private export | 必要 | 不要 |
| 重複解消 | しない | 両経路の duplication 同時解消 |
| 回帰検出 | call site 直接 | builder 経由が前提 (構造的に保証) |

## Test plan
- [x] `npm test` → 364 passing (9 new + 355 existing)
- [x] `npm run lint` → 0 errors
- [x] `npm run build` → success
- [x] `ocrProcessor.ts` 内の **OCR 経路** (line 513 の \`maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS\`) は #213 スコープ外のため変更していないこと
- [ ] マージ後 dev → kanameone → cocoro 順にデプロイ (Actions: Deploy Cloud Functions)
- [ ] kanameone で regenerateSummary を1件実行し summary が3フィールド全て更新されることを確認

## 関連
- Closes #213
- 関連 Issue #209 (PR #212), #178 教訓 (派生フィールド漏れ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated OCR summary generation and Firestore serialization logic into shared builder utilities for improved code maintainability and consistency across summary-related operations.

* **Tests**
  * Added comprehensive test suite verifying summary builder functionality, including edge cases and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->