### PR TITLE
docs(test): summaryBuilderCallerContract docstring 整理 (#228)

### DIFF
--- a/functions/test/summaryBuilderCallerContract.test.ts
+++ b/functions/test/summaryBuilderCallerContract.test.ts
@@ -1,11 +1,17 @@
 /**
  * generateSummary caller-side 契約テスト (Issue #225)
  *
- * summaryRequestBuilder.test.ts の canary は builder 側の契約を固定するが、
- * caller 側で builder を経由しなくなると canary は PASS のまま Issue #209 が再発する。
+ * builder 側 canary は builder の契約を固定するが、caller 側で builder を経由
+ * しなくなると canary は PASS のまま Issue #209 (Vertex AI summary 暴走) が再発する。
  * 本テストは caller 側の呼び出しパターンを構文検証して bypass を検出する。
  *
- * 方式: grep-based (静的検証)。flaky/擦り抜けが発生したら sinon spy 化を検討。
+ * 方式: grep-based (静的検証)。
+ *
+ * 既知の limitation:
+ * - 型 alias 経由 (const gen = model.generateContent; gen(...)) や分割代入の呼び出しは未検出
+ * - caller 追加時は CALLER_FILES への手動追記が必要 (grep 動的検出は未導入)
+ *
+ * 昇格条件: false negative が 1 件でも実発生した時点で sinon spy (案A) へ切替。
  */
 
 import { expect } from 'chai';
@@ -32,7 +38,7 @@ function countMatches(source: string): number {
   return source.match(BUILDER_CALL_PATTERN)?.length ?? 0;
 }
 
-describe('generateSummary caller contract (Issue #225)', () => {
+describe('generateSummary caller contract', () => {
   for (const relPath of CALLER_FILES) {
     it(`${relPath} は buildSummaryGenerationRequest 経由で model.generateContent を呼ぶ`, () => {
       const absPath = resolve(process.cwd(), relPath);


### PR DESCRIPTION
## Summary

- PR #227 の comment-analyzer 指摘に対応 (Issue #228)
- docstring の Issue 番号混在を整理し、既知の limitation と昇格条件を明記
- テストロジックは不変 (docstring/describe タイトルのみ変更)

## 変更内容

1. **Issue 番号の整理**
   - `(Issue #225)` を describe タイトルから削除 (file docstring と重複)
   - 残すのは `#225` (本テスト) + `#209` (根本原因) のみ、過去の `#213/#224` は既に抽象表記化済み

2. **既知の limitation を明記**
   - 型 alias 経由 (\`const gen = model.generateContent; gen(...)\`) / 分割代入は未検出
   - caller 追加時は \`CALLER_FILES\` への手動追記が必要 (grep 動的検出は未導入)

3. **昇格条件を明記**
   - false negative が 1 件でも実発生した時点で sinon spy (案A) へ切替

## Test plan

- [x] \`functions/test/summaryBuilderCallerContract.test.ts\` 実行 → 7 passing
- [x] tsc (\`functions/\` 全体) クリーン
- [x] eslint (対象ファイル) クリーン
- [x] diff レビュー: docstring/describe タイトルのみ変更、テストロジック不変

## 関連

- Closes #228
- 関連: PR #227 (#225)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test documentation to clarify known limitations and edge cases.

* **Documentation**
  * Refined test descriptions for improved clarity.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->