### PR TITLE
feat(monitoring): workflow credentials を専用 SA 用 Secret に切り替え + dev セットアップ完了

### DIFF
--- a/.github/workflows/setup-monitoring.yml
+++ b/.github/workflows/setup-monitoring.yml
@@ -38,12 +38,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
+        # 監視基盤専用 SA (docsplit-monitoring-admin@*) を使用。
+        # 必要 roles: logging.configWriter / monitoring.alertPolicyEditor / monitoring.notificationChannelEditor
+        # Secret 未登録環境では setup/teardown dispatch は auth step で失敗する (Issue #220 Follow-up)。
         uses: google-github-actions/auth@v2
         with:
           credentials_json: |-
-            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
-                github.event.inputs.environment == 'dev' && secrets.GCP_SA_KEY_DEV ||
-                secrets.GCP_SA_KEY }}
+            ${{ github.event.inputs.environment == 'kanameone' && secrets.MONITORING_SA_KEY_KANAMEONE ||
+                github.event.inputs.environment == 'dev' && secrets.MONITORING_SA_KEY_DEV ||
+                secrets.MONITORING_SA_KEY_COCORO }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/docs/context/monitoring-setup.md
+++ b/docs/context/monitoring-setup.md
@@ -125,13 +125,46 @@ for role in \
 done
 ```
 
-**オプション 2: 専用 SA 新規作成** (最小権限原則、Codex 推奨、要 Secret 登録):
-- SA 名: `docsplit-monitoring-admin@<project>`
-- 上記 3 roles のみ付与
-- キー発行 → GitHub Secrets に `MONITORING_SA_KEY_<ENV>` として登録
-- workflow の `credentials_json` を SA 別に差し替え
+**オプション 2: 専用 SA 新規作成** (最小権限原則、採用方針):
+- SA 名: `docsplit-monitoring-admin@<project>.iam.gserviceaccount.com`
+- 上記 3 roles のみ付与 (`roles/logging.configWriter`, `roles/monitoring.alertPolicyEditor`, `roles/monitoring.notificationChannelEditor`)
+- キー発行 → GitHub Secrets に登録
+- `setup-monitoring.yml` の `credentials_json` は以下の Secret を参照する:
+  - `MONITORING_SA_KEY_DEV` (dev)
+  - `MONITORING_SA_KEY_KANAMEONE` (kanameone)
+  - `MONITORING_SA_KEY_COCORO` (cocoro)
 
-本 PR では script と workflow の枠組みのみを提供し、**権限付与はフォローアップタスクとして別 PR で実施**する。
+### セットアップ手順 (環境ごとに 1 回)
+
+```bash
+# 1. SA 作成
+gcloud iam service-accounts create docsplit-monitoring-admin \
+  --display-name="DocSplit Monitoring Admin (log-based metrics + alerts)" \
+  --project=<project-id>
+
+# 2. 3 roles 付与
+SA="docsplit-monitoring-admin@<project-id>.iam.gserviceaccount.com"
+for role in \
+  roles/logging.configWriter \
+  roles/monitoring.alertPolicyEditor \
+  roles/monitoring.notificationChannelEditor; do
+  gcloud projects add-iam-policy-binding <project-id> \
+    --member="serviceAccount:$SA" --role="$role" --condition=None --quiet
+done
+
+# 3. キー発行 → Secret 登録 → 鍵ファイル削除
+gcloud iam service-accounts keys create /tmp/monitoring-sa.json \
+  --iam-account=$SA --project=<project-id>
+gh secret set MONITORING_SA_KEY_<ENV> --repo yasushi-honda/doc-split \
+  < /tmp/monitoring-sa.json
+rm /tmp/monitoring-sa.json
+```
+
+### 展開状況
+
+- ✅ dev: SA + Secret 登録済み (2026-04-17)
+- ⏳ kanameone: 未セットアップ
+- ⏳ cocoro: 未セットアップ
 
 ## 通知先の調整
 


### PR DESCRIPTION
## Summary
- Issue #220 Follow-up: 監視基盤 (log-based metric + alert policy) を dev 環境で実運用開始可能にする
- `setup-monitoring.yml` の `credentials_json` 分岐を deploy 用 `GCP_SA_KEY_*` から監視専用 `MONITORING_SA_KEY_{DEV,KANAMEONE,COCORO}` に差し替え (Codex 推奨 Option 2: 最小権限原則)
- dev 環境の SA `docsplit-monitoring-admin@doc-split-dev` を作成し 3 roles 付与 + Secret `MONITORING_SA_KEY_DEV` 登録済み
- `docs/context/monitoring-setup.md` にセットアップコマンドと展開状況を追記

## 作業内容
- `gcloud iam service-accounts create docsplit-monitoring-admin` (dev)
- `roles/logging.configWriter`, `roles/monitoring.alertPolicyEditor`, `roles/monitoring.notificationChannelEditor` を付与
- キー発行 → `gh secret set MONITORING_SA_KEY_DEV` (stdin リダイレクトで鍵内容は conversation context 未露出)
- 鍵ファイル `/tmp/monitoring-sa-dev.json` を削除済み

## 次セッション以降
- dev で `setup-monitoring.yml` を `action=setup` / `notification_email=<email>` で dispatch し、AC3b/AC4 (監視メトリクス + alert 作成) を通過確認
- kanameone / cocoro 順次同じ手順で展開 (未登録環境は auth step で失敗する旨は workflow コメント記載済み)

## Test plan
- [x] workflow yaml 構文確認 (GitHub Actions パーサー互換)
- [x] docs/context/monitoring-setup.md の手順が実作業と一致することを確認
- [x] dev SA が 3 roles 保持していることを `gcloud projects get-iam-policy` で確認済み
- [x] GitHub Secret `MONITORING_SA_KEY_DEV` が `gh secret list` に存在することを確認済み
- [ ] 本 PR マージ後、Setup Monitoring workflow を dev に dispatch し正常完了を確認 (次セッション Follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)