### PR TITLE
fix(monitoring): setup-gcloud に alpha component を明示的にインストール

### DIFF
--- a/.github/workflows/setup-monitoring.yml
+++ b/.github/workflows/setup-monitoring.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: 'alpha'
 
       - name: Resolve project ID
         id: resolve


### PR DESCRIPTION
## Summary
- `gcloud alpha monitoring` コマンドの alpha component 依存を `setup-gcloud@v2` の `install_components` で事前解決
- 非対話環境 (GitHub Actions) で初回インストール時の Y/n プロンプトに応答できず `exit 1` で失敗していた問題を修正
- Sprint 1 Follow-up B: dev 環境 setup dispatch のブロッカー解消

## 背景

2026-04-17 session6 で dev 環境 setup dispatch (Run ID `24538738707`) を実行した際、以下のエラーで失敗:

```
ERROR: (gcloud) This prompt could not be answered because you are not in an interactive session.
You can re-run the command with the --quiet flag to accept default answers for all prompts.
```

`gcloud alpha monitoring channels create` 呼び出し時に alpha component 未インストールが検出され、
「Do you want to continue (Y/n)?」プロンプトが出たが非対話環境のため exit 1 終了。

通知チャネルのみ作成済みの部分状態になったが、スクリプトは冪等性を備えているため修正後の再実行で復旧可能。

## 変更内容

`.github/workflows/setup-monitoring.yml` の `Set up Cloud SDK` ステップに `install_components: 'alpha'` を追加。

## Test plan
- [x] YAML 構文検証 (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] マージ後、dev 環境で setup dispatch 再実行し成功することを確認
- [ ] 冪等性: 既存の通知チャネルは skip されることを確認
- [ ] `gcloud logging metrics list` および `gcloud alpha monitoring policies list` で 5 件ずつ作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring setup workflow to ensure Cloud SDK alpha components are properly installed during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->