### PR TITLE
fix(monitoring): metric-based alert policy から notificationRateLimit を削除

### DIFF
--- a/docs/context/monitoring-setup.md
+++ b/docs/context/monitoring-setup.md
@@ -28,7 +28,7 @@ Issue #220 + ADR-0015 Follow-up で構築した log-based metric + Cloud Monitor
 
 - `duration`: 0s (閾値超過で即発火)
 - `autoClose`: 24h 無発火で自動クローズ
-- `notificationRateLimit`: 1h (通知暴走抑制)
+- `notificationRateLimit`: **未設定**。Cloud Monitoring API の仕様により metric-based alert policy では指定不可（log-based policy 限定）。Cloud Monitoring のデフォルト再通知挙動に依存。まれな事象 (OOM / truncated) のため実害なし
 - **検出遅延**:
   - `searchindex_oom` (alignment 1h): 約 3-5 分
   - `ocr_*_truncated` / `summary_truncated` (alignment 24h): 数分〜最大数時間 (Cloud Monitoring の rolling 評価依存)

--- a/docs/context/monitoring-setup.md
+++ b/docs/context/monitoring-setup.md
@@ -28,7 +28,7 @@ Issue #220 + ADR-0015 Follow-up で構築した log-based metric + Cloud Monitor
 
 - `duration`: 0s (閾値超過で即発火)
 - `autoClose`: 24h 無発火で自動クローズ
-- `notificationRateLimit`: **未設定**。Cloud Monitoring API の仕様により metric-based alert policy では指定不可（log-based policy 限定）。Cloud Monitoring のデフォルト再通知挙動に依存。まれな事象 (OOM / truncated) のため実害なし
+- `notificationRateLimit`: **未設定**。Cloud Monitoring API の仕様により metric-based alert policy では指定不可（log-based policy 限定）。metric alert は incident オープン時 1 通のみ送信、`autoClose` (24h) まで再通知されないため通知暴走リスクは元々低い
 - **検出遅延**:
   - `searchindex_oom` (alignment 1h): 約 3-5 分
   - `ocr_*_truncated` / `summary_truncated` (alignment 24h): 数分〜最大数時間 (Cloud Monitoring の rolling 評価依存)

--- a/scripts/monitoring-templates/README.md
+++ b/scripts/monitoring-templates/README.md
@@ -17,7 +17,7 @@ Cloud Monitoring アラートポリシーの YAML テンプレート。
 
 - `duration`: `0s` (閾値超過で即発火)
 - `autoClose`: `86400s` (24h 無発火で自動クローズ)
-- `notificationRateLimit.period`: `3600s` (通知の暴走抑制)
+- `notificationRateLimit`: **未設定**。GCP API 仕様により metric-based alert policy では指定不可（log-based policy 限定）。metric alert は incident オープン時 1 通、`autoClose` まで再通知されない
 - 検出遅延: alignment 1h 以内なら約 3-5 分 (ADR-0015 「5分以内」要件を満たす)
 
 ## テンプレートの変数

--- a/scripts/monitoring-templates/alert-ocr-aggregate-truncated.yaml
+++ b/scripts/monitoring-templates/alert-ocr-aggregate-truncated.yaml
@@ -18,8 +18,6 @@ conditions:
       duration: 0s
 alertStrategy:
   autoClose: 86400s
-  notificationRateLimit:
-    period: 3600s
 userLabels:
   source: docsplit-monitoring-setup
 notificationChannels:

--- a/scripts/monitoring-templates/alert-ocr-page-truncated.yaml
+++ b/scripts/monitoring-templates/alert-ocr-page-truncated.yaml
@@ -18,8 +18,6 @@ conditions:
       duration: 0s
 alertStrategy:
   autoClose: 86400s
-  notificationRateLimit:
-    period: 3600s
 userLabels:
   source: docsplit-monitoring-setup
 notificationChannels:

--- a/scripts/monitoring-templates/alert-search-index-silent-failure.yaml
+++ b/scripts/monitoring-templates/alert-search-index-silent-failure.yaml
@@ -19,8 +19,6 @@ conditions:
       duration: 0s
 alertStrategy:
   autoClose: 86400s
-  notificationRateLimit:
-    period: 3600s
 userLabels:
   source: docsplit-monitoring-setup
 notificationChannels:

--- a/scripts/monitoring-templates/alert-searchindex-oom.yaml
+++ b/scripts/monitoring-templates/alert-searchindex-oom.yaml
@@ -18,8 +18,6 @@ conditions:
       duration: 0s
 alertStrategy:
   autoClose: 86400s
-  notificationRateLimit:
-    period: 3600s
 userLabels:
   source: docsplit-monitoring-setup
 notificationChannels:

--- a/scripts/monitoring-templates/alert-summary-truncated.yaml
+++ b/scripts/monitoring-templates/alert-summary-truncated.yaml
@@ -18,8 +18,6 @@ conditions:
       duration: 0s
 alertStrategy:
   autoClose: 86400s
-  notificationRateLimit:
-    period: 3600s
 userLabels:
   source: docsplit-monitoring-setup
 notificationChannels:


### PR DESCRIPTION
## Summary
- GCP Cloud Monitoring API の仕様により metric-based alert policy で `notificationRateLimit` 指定不可
- 全 5 テンプレート (`scripts/monitoring-templates/alert-*.yaml`) から該当ブロックを削除
- `docs/context/monitoring-setup.md` の alert policy 共通パラメータ記述を修正
- Sprint 1 Follow-up B: dev 環境 setup dispatch 再実行のブロッカー解消

## 背景

2026-04-17 session6 で dev 環境 setup dispatch (Run ID `24539026328`) を実行した際、alert policy 1 件目の作成で以下のエラー:

```
ERROR: (gcloud.alpha.monitoring.policies.create) INVALID_ARGUMENT:
Field alertStrategy.notificationRateLimit had an invalid value of "period seconds: 3600":
only log-based alert policies may specify a notification rate limit
```

**根本原因**: Cloud Monitoring API では `alertStrategy.notificationRateLimit` は log-based alert policy (`conditionMatchedLog`) 限定のフィールド。本 PR の対象は log-based **metric** (`conditionThreshold`) をベースとする metric-based alert のため、この API 制約に抵触していた。

## 変更内容

1. **YAML テンプレート 5 本** (`scripts/monitoring-templates/alert-*.yaml`):
   - `alertStrategy.notificationRateLimit` ブロック削除
   - `autoClose: 86400s` は metric alert でも有効のため残置
2. **docs** (`docs/context/monitoring-setup.md`): 共通パラメータ記述を API 制約反映に更新

## トレードオフ

- 通知再送頻度は Cloud Monitoring のデフォルト (30 分) に依存
- 検出対象 (OOM / truncated / silent failure) はまれな事象のため通知暴走リスクは低く、実害なし
- `autoClose=24h` により同一インシデントは 24 時間で自動クローズ

## Test plan
- [x] 全 5 YAML の構文検証 + `notificationRateLimit` 不在を Python `yaml.safe_load` で確認
- [ ] マージ後、dev 環境で setup dispatch 再実行し全 5 metric + 5 alert policy + 1 channel が作成されることを確認
- [ ] `gcloud alpha monitoring policies list --filter='userLabels.source="docsplit-monitoring-setup"'` で 5 件確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)