### PR TITLE
fix(monitoring): search_index_silent_failure の alignmentPeriod を 25h 制約内に

### DIFF
--- a/docs/context/monitoring-setup.md
+++ b/docs/context/monitoring-setup.md
@@ -22,19 +22,22 @@ Issue #220 + ADR-0015 Follow-up で構築した log-based metric + Cloud Monitor
 | `ocr_page_truncated` | `[OCR] ... text truncated` (WARN) | 24h 以内に 3 件以上 | 過去30日実績 0.067件/日の約45倍 |
 | `ocr_aggregate_truncated` | `[OCR] Aggregate pageResults truncated` (WARN) | 24h 以内に 1 件以上 | per-page 二段目発動は異常 |
 | `summary_truncated` | `[Summary] truncated` (WARN) | 24h 以内に 1 件以上 | Issue #209 再発指標 |
-| `search_index_silent_failure` | `Failed to remove tokens` (severity=ERROR) | 7 日以内に 1 件以上 | ADR-0015 再評価トリガー条件1 (`#220 metric で severity=ERROR ログが 7日間に 1件以上発生`) と一致 |
+| `search_index_silent_failure` | `Failed to remove tokens` (severity=ERROR) | 24 時間窓で 1 件以上 (incident は 7 日間可視化) | ADR-0015 再評価トリガー条件1 (`#220 metric で severity=ERROR ログが 7日間に 1件以上発生`) を反映。GCP API 制約 (alignmentPeriod 最大 25h) のため厳密な 7 日 rolling ではなく、`autoClose: 7d` で incident 可視性を 7 日担保 |
 
 ### アラートポリシー共通パラメータ
 
 - `duration`: 0s (閾値超過で即発火)
-- `autoClose`: 24h 無発火で自動クローズ
-- `notificationRateLimit`: **未設定**。Cloud Monitoring API の仕様により metric-based alert policy では指定不可（log-based policy 限定）。metric alert は incident オープン時 1 通のみ送信、`autoClose` (24h) まで再通知されないため通知暴走リスクは元々低い
+- `autoClose`:
+  - 標準 (`searchindex_oom` / `ocr_*_truncated` / `summary_truncated`): 86400s (24h 無発火で自動クローズ)
+  - `search_index_silent_failure` のみ: 604800s (7 日間) — ADR-0015 の 7 日間監視要件を担保
+- `notificationRateLimit`: **未設定**。Cloud Monitoring API の仕様により metric-based alert policy では指定不可（log-based policy 限定）。metric alert は incident オープン時 1 通のみ送信、`autoClose` まで再通知されないため通知暴走リスクは元々低い
 - **検出遅延**:
   - `searchindex_oom` (alignment 1h): 約 3-5 分
   - `ocr_*_truncated` / `summary_truncated` (alignment 24h): 数分〜最大数時間 (Cloud Monitoring の rolling 評価依存)
-  - `search_index_silent_failure` (alignment 7日): 同上、即時検知には向かない
+  - `search_index_silent_failure` (alignment 24h): 同上、即時検知には向かない
 
-ADR-0015 要件「5 分以内」は `searchindex_oom` のみ厳密に満たす。他は「日次〜週次で必ず検出」を目標とする。
+ADR-0015 要件「5 分以内」は `searchindex_oom` のみ厳密に満たす。他は「日次で必ず検出」を目標とする。
+ADR-0015 要件「7 日間に 1 件以上」は metric alignment では厳密には表現できないため、`autoClose: 7d` による incident 継続可視化で実運用上の監査表現を代替する。より厳密な weekly 集計が必要な場合は scheduled query / health-report 等で別途担保する。
 
 ## 運用手順
 

--- a/scripts/monitoring-templates/README.md
+++ b/scripts/monitoring-templates/README.md
@@ -11,7 +11,7 @@ Cloud Monitoring アラートポリシーの YAML テンプレート。
 | `alert-ocr-page-truncated.yaml` | `ocr_page_truncated` | 3 件 / 1日 | 過去30日実績 2 件 (0.067件/日) の約45倍余裕 |
 | `alert-ocr-aggregate-truncated.yaml` | `ocr_aggregate_truncated` | 1 件 / 1日 | 過去30日実績 0 件。per-page 二段目発動は異常 |
 | `alert-summary-truncated.yaml` | `summary_truncated` | 1 件 / 1日 | Issue #209 再発指標 |
-| `alert-search-index-silent-failure.yaml` | `search_index_silent_failure` | 1 件 / 7日 | ADR-0015 再評価トリガーと一致 |
+| `alert-search-index-silent-failure.yaml` | `search_index_silent_failure` | 1 件 / 24h 窓 (incident は 7d 可視化) | ADR-0015「7日1件以上」を autoClose=7d で代替。GCP API alignmentPeriod 上限 25h のため厳密な 7d rolling ではない |
 
 ## 共通パラメータ
 

--- a/scripts/monitoring-templates/alert-search-index-silent-failure.yaml
+++ b/scripts/monitoring-templates/alert-search-index-silent-failure.yaml
@@ -1,24 +1,27 @@
-displayName: "[__ENV__] search_index_silent_failure: removeTokensFromIndex ERROR 7日以内"
+displayName: "[__ENV__] search_index_silent_failure: removeTokensFromIndex ERROR (24h detect, 7d persist)"
 documentation:
   content: |
     `removeTokensFromIndex` で permanent error (PERMISSION_DENIED 等) が発生しました。
-    ADR-0015 の再評価トリガー「ERROR ログ 7日間に 1件以上」に該当します。
+    24 時間窓で 1 件以上検知し、incident は 7 日間クローズせず可視化します
+    (最後のエラーから 7 日間警戒表示)。ADR-0015 の「7 日間に 1 件以上」評価は
+    Cloud Monitoring API 制約 (alignmentPeriod 最大 25h) のため厳密な 7d rolling
+    ではないが、autoClose=7d で実運用上の可視性を担保。
     search_index drift が残存する可能性があるため、Issue #229 の復旧 SOP を確認してください。
     PR #222 / ADR-0015 / #220 / #229 参照。
   mimeType: "text/markdown"
 combiner: OR
 conditions:
-  - displayName: "search_index_silent_failure > 0 in 7d"
+  - displayName: "search_index_silent_failure > 0 in 24h"
     conditionThreshold:
       filter: 'metric.type="logging.googleapis.com/user/search_index_silent_failure" AND resource.type="cloud_function"'
       aggregations:
-        - alignmentPeriod: 604800s
+        - alignmentPeriod: 86400s
           perSeriesAligner: ALIGN_SUM
       comparison: COMPARISON_GT
       thresholdValue: 0
       duration: 0s
 alertStrategy:
-  autoClose: 86400s
+  autoClose: 604800s
 userLabels:
   source: docsplit-monitoring-setup
 notificationChannels:


### PR DESCRIPTION
## Summary
- GCP Cloud Monitoring API の `alignmentPeriod` 上限 25h 制約に対応（`604800s` → `86400s`）
- ADR-0015 「7 日間 1 件以上」semantic は `autoClose: 7d` で incident 継続可視化として代替
- Sprint 1 Follow-up B: dev 環境 setup dispatch の最終ブロッカー解消
- Codex (MCP) でセカンドオピニオン取得済、他 4 テンプレートに追加制約違反がないことも確認

## 背景

2026-04-17 session6 の dev 環境 setup dispatch (Run `24539548612`) で 3 件目の alert policy 作成時に:

```
ERROR: (gcloud.alpha.monitoring.policies.create) INVALID_ARGUMENT:
Field alert_policy.conditions[0].condition_threshold.aggregations[0].alignment_period had
an invalid value of "Alignment periods longer than 25h are not supported."
```

GCP Cloud Monitoring API では `alignmentPeriod` は最大 `90000s` (25h)。`604800s` (7 日) は拒否対象。

## 変更内容

### `alert-search-index-silent-failure.yaml`
- `alignmentPeriod`: `604800s` → `86400s`（24h, API 制約内）
- `autoClose`: `86400s` → `604800s`（7 日, incident 継続可視化）
- `displayName`: `... > 0 in 7d` → `... (24h detect, 7d persist)`
- `documentation.content`: 新 semantic と GCP API 制約の理由を記載

### `docs/context/monitoring-setup.md`
- メトリクス表の閾値カラム更新（「24 時間窓で 1 件以上 (incident は 7 日間可視化)」）
- `autoClose` の共通パラメータを「標準 24h + silent_failure のみ 7d」に分岐記述
- ADR-0015「7 日 1 件以上」の厳密性は別途 scheduled query / health-report で担保する方針を明記

### `scripts/monitoring-templates/README.md`
- 該当行を上記と同じ記述に同期

## semantic トレードオフ

| 観点 | 変更前（API拒否） | 変更後（本PR） |
|---|---|---|
| 厳密な「7日 rolling sum」 | API 制約で不可能 | 代替: 24h 窓検知 + autoClose 7d |
| ERROR 発生時の検知 | — | 24h 窓で 1 件以上 → 即 incident オープン |
| incident 可視性 | — | 最後の ERROR から 7 日間 incident 継続 |
| オンコール体験 | — | UI 上「最後の ERROR から N 日」を視覚化可能 |

## Codex セカンドオピニオン概要

- 提案修正で API 制約は解消、semantic は「24h 検知 + 7 日可視化」として代替可能（厳密等価ではない、doc 明記必要）
- 他 4 テンプレートに追加の GCP API 制約違反なし（`alignmentPeriod`: 3600s/86400s, `duration`: 0s, `ALIGN_SUM`, filter 書式いずれも妥当）
- `notificationRateLimit` は既に PR #244 で削除済、正しい対応

Thread ID: `019d98a8-2971-7620-a882-99c6729b33a8`

## Test plan
- [x] 全 5 テンプレの `alignmentPeriod <= 25h` を Python で機械検証
- [x] 全 5 テンプレに `notificationRateLimit` 不在を機械検証
- [ ] マージ後、dev 環境で setup dispatch を再実行し全 5 metric + 5 alert policy + 1 channel が作成されることを確認
- [ ] `gcloud alpha monitoring policies list --filter='userLabels.source="docsplit-monitoring-setup"'` で 5 件（うち silent_failure の autoClose が 604800s）確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)