### PR TITLE
docs(CLAUDE.md): 環境別 gcloud 操作の必須プロトコルを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,18 @@ Gmailの添付ファイルを自動取得し、AI OCRでメタ情報を抽出、
 ./scripts/switch-client.sh --list         # 利用可能なクライアント一覧
 ```
 
+### 環境別 gcloud 操作の必須プロトコル（YOU MUST）
+
+環境別の gcloud 操作（SA 作成、IAM roles 付与、Secret 発行、setup/teardown スクリプト実行等）は、**必ず以下の順序で実施**:
+
+1. **`./scripts/switch-client.sh <env>` で named config を切替** — 各環境には事前整備された Owner/管理者認証の named config が存在する（`kanameone` = `systemkaname@kanameone.com`, `doc-split-cocoro` = `docsplit-deployer@...` SA）
+2. `gcloud config configurations list` で切替結果を確認してから gcloud コマンド実行
+3. 操作完了後は `./scripts/switch-client.sh dev` で開発環境に戻す
+
+**YOU MUST NOT**: `gcloud auth list` の結果 1 件だけを見て「権限不足」「ブロッカー」と即断しない。`scripts/clients/*.env` の `GCLOUD_CONFIG` / `EXPECTED_ACCOUNT` / `AUTH_TYPE` を先に確認すること。
+
+**失敗パターン（#220 Follow-up B 2026-04-17 session6）**: `Policy update access denied` 直後に `hy.unimail.11@gmail.com` のみで判断し「本番 Owner 認証ブロッカー」と誤診して A2/A3 を次セッション持越しにした。実際は `kanameone` named config が Owner 認証済で即実行可能だった。
+
 ### ビルド・テスト
 ```bash
 cd frontend && npm run dev      # フロントエンド開発サーバー


### PR DESCRIPTION
## Summary
- 2026-04-17 session6 の **本番展開セルフブロッカー** 失敗を恒久再発防止
- CLAUDE.md の「マルチクライアント環境切替」節直後に「環境別 gcloud 操作の必須プロトコル」セクションを新設
- `switch-client.sh` + named config 先読みを MUST 化、`gcloud auth list` 単独判断を MUST NOT 化
- 失敗パターン（session6 の具体例）を明記して同じ罠を踏むのを防ぐ

## 背景

session6 で Sprint 1 Follow-up B の dev 監視展開は完遂したが、本番 (kanameone/cocoro) 展開で以下が発生:

1. `gcloud projects add-iam-policy-binding docsplit-kanameone` で `Policy update access denied`
2. `hy.unimail.11@gmail.com` のみで判断し「本番 Owner 認証ブロッカー」と即断
3. A2/A3 を次セッション持越しに決定、ハンドオフに「Owner 認証必要」と記述

**実態**: `gcloud config configurations list` で `kanameone` named config が `systemkaname@kanameone.com` (Owner) で事前整備済であることが判明。`./scripts/switch-client.sh kanameone` で即切替可能、本来は同セッションで完遂できた。

CLAUDE.md 冒頭で switch-client.sh の存在は認識していたが、**障害遭遇時に既存資産を再参照するループが組まれていなかった**ことが根本原因。

## 追加内容

「環境別 gcloud 操作の必須プロトコル（YOU MUST）」セクション:
1. switch-client.sh で named config 切替が第一歩
2. `gcloud config configurations list` で切替結果確認
3. 操作後は dev に戻す
4. `gcloud auth list` 単独判断を明示的に禁止
5. 失敗パターン（session6 の具体例）を記載

## 関連変更（グローバル側）

- `~/.claude/CLAUDE.md` Debug Protocol に対応 MUST ルール追加（環境別 gcloud/認証エラー → wrapper/named config 先読み）
- `~/.claude/memory/feedback_project_wrappers_first.md` 新設
- `~/.claude/memory/MEMORY.md` に index 追加

## Test plan
- [x] CLAUDE.md の構造が壊れていない（セクション順序、見出しレベル）
- [ ] 次セッション開始時に `/catchup` でこの追加プロトコルが CLAUDE.md として読み込まれることを確認
- [ ] 次セッションで kanameone/cocoro 展開時、switch-client.sh が第一手として実行される

Refs: #220 (Sprint 1 Follow-up B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for environment-specific cloud configuration setup, including proper switching procedures and verification steps.
  * Included troubleshooting best practices for diagnosing credential and authorization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->