### PR TITLE
refactor(textCap): CappedText を discriminated union 化 + 書込契約テスト (#255)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -143,7 +143,9 @@ export async function processDocument(
       text: capped.text,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,
-      originalLength: capped.originalLength,
+      // #255: discriminated union 化により truncated=false 時は capped.originalLength 不在。
+      // 切り詰めなしの場合は原文長 = result.text.length なのでフォールバック。
+      originalLength: capped.truncated ? capped.originalLength : result.text.length,
       truncated: capped.truncated,
     };
   };
@@ -187,9 +189,9 @@ export async function processDocument(
     .join('\n\n');
 
   // マスターデータ取得（要約生成と並列実行）
-  const summaryPromise = generateSummary(ocrResult, '').catch((err) => {
+  const summaryPromise = generateSummary(ocrResult, '').catch((err): CappedText => {
     console.error('Summary generation failed:', err);
-    return { text: '', originalLength: 0, truncated: false };
+    return { text: '', truncated: false };
   });
 
   // マスターデータ取得
@@ -547,13 +549,13 @@ async function generateSummary(
   documentType: string
 ): Promise<CappedText> {
   if (!ocrResult || ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {
-    return { text: '', originalLength: 0, truncated: false };
+    return { text: '', truncated: false };
   }
   try {
     return await generateSummaryCore(ocrResult, documentType);
   } catch (error) {
     console.error('Failed to generate summary:', error);
-    return { text: '', originalLength: 0, truncated: false };
+    return { text: '', truncated: false };
   }
 }
 

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -21,23 +21,23 @@ export const MAX_SUMMARY_LENGTH = 30_000;
 
 const TRUNCATION_MARKER = '\n[TRUNCATED]';
 
-export interface CappedText {
-  text: string;
-  originalLength: number;
-  truncated: boolean;
-}
+// Discriminated union (#255): truncated=true の時のみ originalLength が型レベルで必須。
+// truncated=false で originalLength にアクセスすると tsc エラー → silent failure 再発防止 (#178/#209)。
+export type CappedText =
+  | { text: string; truncated: false }
+  | { text: string; truncated: true; originalLength: number };
 
 export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_LENGTH): CappedText {
   const originalLength = rawText.length;
   if (originalLength <= maxLength) {
-    return { text: rawText, originalLength, truncated: false };
+    return { text: rawText, truncated: false };
   }
   const sliceLen = Math.max(0, maxLength - TRUNCATION_MARKER.length);
   const truncatedText = sliceLen === 0 ? '' : rawText.slice(0, sliceLen) + TRUNCATION_MARKER;
   return {
     text: truncatedText.slice(0, maxLength),
-    originalLength,
     truncated: true,
+    originalLength,
   };
 }
 
@@ -61,10 +61,11 @@ export function capPageResultsAggregate<T extends PageWithText>(pages: T[]): T[]
     const original = page.originalLength ?? page.text.length;
     const capped = capPageText(page.text, perPageBudget);
     runningTotal += capped.text.length;
+    const cappedOriginalLength = capped.truncated ? capped.originalLength : page.text.length;
     return {
       ...page,
       text: capped.text,
-      originalLength: Math.max(original, capped.originalLength),
+      originalLength: Math.max(original, cappedOriginalLength),
       truncated: page.truncated || capped.truncated,
     };
   });

--- a/functions/test/summaryRequestBuilder.test.ts
+++ b/functions/test/summaryRequestBuilder.test.ts
@@ -53,7 +53,6 @@ describe('summaryRequestBuilder: buildSummaryFields (Issue #215 discriminated un
   it('truncated=false で { text, truncated:false } のみ返す (originalLength は型レベルで不在)', () => {
     const summary: CappedText = {
       text: '通常の要約テキスト',
-      originalLength: 100,
       truncated: false,
     };
     expect(buildSummaryFields(summary)).to.deep.equal({
@@ -76,7 +75,7 @@ describe('summaryRequestBuilder: buildSummaryFields (Issue #215 discriminated un
   });
 
   it('空テキスト (truncated=false) でも { text:"", truncated:false } が返る', () => {
-    const summary: CappedText = { text: '', originalLength: 0, truncated: false };
+    const summary: CappedText = { text: '', truncated: false };
     const fields = buildSummaryFields(summary);
     expect(fields).to.deep.equal({ text: '', truncated: false });
     // 不変条件の保証: truncated=false の分岐で originalLength キーが含まれない

--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { expect } from 'chai';
-import { readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 
 // summary 書込 3 要素を検出するパターン。
@@ -35,7 +35,46 @@ const WRITE_PAYLOAD_CALLERS = [
   'src/ocr/regenerateSummary.ts',
 ] as const;
 
+// 同一 update() ブロック近接性の検証ウィンドウ。ocrProcessor の update は spread 含む
+// 大ブロック (~20 行)、regenerateSummary は ~4 行。30 行で両 caller を吸収。
+const ADJACENCY_WINDOW_LINES = 30;
+
+/**
+ * 3 要素 (buildSummaryFields / summaryTruncated.delete / summaryOriginalLength.delete) が
+ * 同一 update() ブロック内 (ADJACENCY_WINDOW_LINES 行以内) に共存するかを検証。
+ * ファイル全体で 3 要素が散在する false positive (review-pr Critical 指摘) を防ぐ。
+ */
+function hasThreeElementsAdjacent(source: string): boolean {
+  const lines = source.split('\n');
+  for (let i = 0; i <= lines.length - 1; i++) {
+    const window = lines.slice(i, i + ADJACENCY_WINDOW_LINES).join('\n');
+    if (
+      BUILD_SUMMARY_FIELDS_CALL.test(window) &&
+      SUMMARY_TRUNCATED_DELETE.test(window) &&
+      SUMMARY_ORIGINAL_LENGTH_DELETE.test(window)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe('summary write-payload contract (#255)', () => {
+  // silent-failure-hunter 指摘対応: パス実在を describe 評価時に明示的に確認。
+  // 旧来は readFileSync の ENOENT で suite 起動失敗となり「テスト未実行」が
+  // 「ファイル不在 = caller 削除/リネーム」のシグナルとして埋もれていた。
+  before(() => {
+    for (const relPath of WRITE_PAYLOAD_CALLERS) {
+      const absPath = resolve(process.cwd(), relPath);
+      if (!existsSync(absPath)) {
+        throw new Error(
+          `WRITE_PAYLOAD_CALLERS に登録された ${relPath} が存在しない。` +
+            `caller がリネーム/削除された場合は本契約の見直しが必要。`
+        );
+      }
+    }
+  });
+
   for (const relPath of WRITE_PAYLOAD_CALLERS) {
     describe(relPath, () => {
       const absPath = resolve(process.cwd(), relPath);
@@ -51,6 +90,15 @@ describe('summary write-payload contract (#255)', () => {
 
       it('`summaryOriginalLength: FieldValue.delete()` で旧フィールドを削除する', () => {
         expect(source).to.match(SUMMARY_ORIGINAL_LENGTH_DELETE);
+      });
+
+      // review-pr Critical 指摘対応: 3 要素がファイル内に分散していないこと
+      // (同一 update() ブロックでの隣接性) を保証。
+      it('3 要素が同一 update() ブロック近接 (≤30 行) に共存する', () => {
+        expect(hasThreeElementsAdjacent(source)).to.equal(
+          true,
+          '3 要素が散在している。同一 update() で書き込まれていない可能性あり (#178 違反)'
+        );
       });
     });
   }

--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -1,0 +1,82 @@
+/**
+ * summary 書込経路 caller-side 契約テスト (Issue #255)
+ *
+ * 目的: ocrProcessor / regenerateSummary の Firestore update() 呼出で、
+ * 以下 3 要素が同時に含まれ続けることを保証する:
+ *   1. `summary: buildSummaryFields(...)` — 新 discriminated union ネスト書込 (#215)
+ *   2. `summaryTruncated: FieldValue.delete()` — 旧フラットフィールドの削除
+ *   3. `summaryOriginalLength: FieldValue.delete()` — 旧フラットフィールドの削除
+ *
+ * 背景 (#178 教訓):
+ * 派生フィールドの一括書込が壊れると FE 表示が崩れる。#215 で新形式への移行
+ * + 旧フィールド delete を徹底したが、将来のリファクタで delete 忘れが起きると
+ * Firestore に旧フィールドが残留し、後方互換読込に無限依存するリスクがある。
+ *
+ * 方式: grep-based (静的検証)。`summaryBuilderCallerContract.test.ts` (#214)
+ * と同じ方針。false negative 発生時に sinon spy へ昇格。
+ */
+
+import { expect } from 'chai';
+import { readdirSync, readFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+// summary 書込 3 要素を検出するパターン。
+// `admin.firestore.FieldValue.delete()` と `FieldValue.delete()` の両表記を許容。
+const BUILD_SUMMARY_FIELDS_CALL = /summary:\s*buildSummaryFields\s*\(/;
+const SUMMARY_TRUNCATED_DELETE =
+  /summaryTruncated:\s*(?:admin\.firestore\.)?FieldValue\.delete\s*\(\s*\)/;
+const SUMMARY_ORIGINAL_LENGTH_DELETE =
+  /summaryOriginalLength:\s*(?:admin\.firestore\.)?FieldValue\.delete\s*\(\s*\)/;
+
+// #178 教訓: 派生フィールド 3 要素は同一 update() ブロック内で書き込む必要がある。
+// 本契約に含める caller ファイル。新規 caller 追加時は手動追記すること。
+const WRITE_PAYLOAD_CALLERS = [
+  'src/ocr/ocrProcessor.ts',
+  'src/ocr/regenerateSummary.ts',
+] as const;
+
+describe('summary write-payload contract (#255)', () => {
+  for (const relPath of WRITE_PAYLOAD_CALLERS) {
+    describe(relPath, () => {
+      const absPath = resolve(process.cwd(), relPath);
+      const source = readFileSync(absPath, 'utf-8');
+
+      it('`summary: buildSummaryFields(...)` の新形式書込が存在する', () => {
+        expect(source).to.match(BUILD_SUMMARY_FIELDS_CALL);
+      });
+
+      it('`summaryTruncated: FieldValue.delete()` で旧フィールドを削除する', () => {
+        expect(source).to.match(SUMMARY_TRUNCATED_DELETE);
+      });
+
+      it('`summaryOriginalLength: FieldValue.delete()` で旧フィールドを削除する', () => {
+        expect(source).to.match(SUMMARY_ORIGINAL_LENGTH_DELETE);
+      });
+    });
+  }
+
+  describe('caller 追加検知 (noUnused contract)', () => {
+    // 新しく `documents/{id}.summary` を update する箇所ができた場合の検知手段として、
+    // summary 書込 3 要素パターンを持つファイルが WRITE_PAYLOAD_CALLERS 以外にないか確認。
+    // 既知の caller が increase すれば本テストの expected が更新必要 = 意図的な変更検知。
+    it('summary 書込 caller 数が期待値と一致する', () => {
+      const walk = (dir: string): string[] =>
+        readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+          const full = join(dir, entry.name);
+          if (entry.isDirectory()) return walk(full);
+          if (entry.isFile() && entry.name.endsWith('.ts')) return [full];
+          return [];
+        });
+      const srcRoot = resolve(process.cwd(), 'src');
+      const tsFiles = walk(srcRoot);
+      const callers = tsFiles.filter((f) => {
+        const s = readFileSync(f, 'utf-8');
+        return BUILD_SUMMARY_FIELDS_CALL.test(s);
+      });
+      expect(callers).to.have.lengthOf(
+        WRITE_PAYLOAD_CALLERS.length,
+        `summary 書込 caller が想定外。現在の caller: ${callers.join(', ')}`
+      );
+    });
+  });
+});

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -12,7 +12,18 @@ import {
   MAX_PAGE_TEXT_LENGTH,
   MAX_AGGREGATE_PAGE_CHARS,
   MAX_SUMMARY_LENGTH,
+  type CappedText,
 } from '../src/utils/textCap';
+
+// #255 Evaluator 指摘対応: discriminated union narrowing を `if (result.truncated)` で
+// 行うと、実装バグで truncated=false が返った場合にアサート群がスキップされ、テスト全体が
+// PASS する誤検知リスクがある。`asserts` 型述語で明示的に narrow し、不変条件を強制する。
+function assertTruncated(
+  result: CappedText
+): asserts result is { text: string; truncated: true; originalLength: number } {
+  expect(result.truncated).to.be.true;
+  if (!result.truncated) throw new Error('unreachable: expected truncated=true');
+}
 
 describe('textCap', () => {
   describe('capPageText (per-page cap)', () => {
@@ -21,7 +32,6 @@ describe('textCap', () => {
       const result = capPageText(input);
 
       expect(result.text).to.equal(input);
-      expect(result.originalLength).to.equal(input.length);
       expect(result.truncated).to.be.false;
     });
 
@@ -31,14 +41,13 @@ describe('textCap', () => {
 
       expect(result.text.length).to.equal(MAX_PAGE_TEXT_LENGTH);
       expect(result.truncated).to.be.false;
-      expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH);
     });
 
     it('境界値: text.length === MAX_PAGE_TEXT_LENGTH + 1 は切り詰める', () => {
       const input = 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 1);
       const result = capPageText(input);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH + 1);
       expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
     });
@@ -47,7 +56,7 @@ describe('textCap', () => {
       const input = 'x'.repeat(1_102_788);
       const result = capPageText(input);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.originalLength).to.equal(1_102_788);
       expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
     });
@@ -63,7 +72,7 @@ describe('textCap', () => {
       const input = 'a'.repeat(100);
       const result = capPageText(input, 50);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.text.length).to.be.at.most(50);
       expect(result.originalLength).to.equal(100);
     });
@@ -72,7 +81,7 @@ describe('textCap', () => {
       const input = 'あ'.repeat(MAX_PAGE_TEXT_LENGTH + 100);
       const result = capPageText(input);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH + 100);
       expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
     });
@@ -81,16 +90,24 @@ describe('textCap', () => {
       const result = capPageText('');
 
       expect(result.text).to.equal('');
-      expect(result.originalLength).to.equal(0);
       expect(result.truncated).to.be.false;
     });
 
     it('maxLength=0 でも安全に動作する（text空、truncated=true）', () => {
       const result = capPageText('hello', 0);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.text.length).to.be.at.most(0);
       expect(result.originalLength).to.equal(5);
+    });
+
+    // #255: discriminated union の型絞り込み。truncated=false 分岐で originalLength
+    // プロパティが型システム上存在しないことをランタイムでも確認 (silent failure 防止)。
+    it('discriminated union: truncated=false では originalLength プロパティが存在しない', () => {
+      const result = capPageText('short');
+
+      expect(result.truncated).to.be.false;
+      expect(Object.prototype.hasOwnProperty.call(result, 'originalLength')).to.be.false;
     });
   });
 
@@ -194,7 +211,7 @@ describe('textCap', () => {
       const input = 'a'.repeat(MAX_SUMMARY_LENGTH + 1);
       const result = capPageText(input, MAX_SUMMARY_LENGTH);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.originalLength).to.equal(MAX_SUMMARY_LENGTH + 1);
       expect(result.text.length).to.be.at.most(MAX_SUMMARY_LENGTH);
     });
@@ -203,7 +220,7 @@ describe('textCap', () => {
       const input = 'x'.repeat(1_100_000);
       const result = capPageText(input, MAX_SUMMARY_LENGTH);
 
-      expect(result.truncated).to.be.true;
+      assertTruncated(result);
       expect(result.originalLength).to.equal(1_100_000);
       expect(result.text.length).to.be.at.most(MAX_SUMMARY_LENGTH);
     });


### PR DESCRIPTION
## 背景

PR #254 (#215) で `SummaryField` を discriminated union 化したが、上流の `CappedText` (capPageText 戻り値) はフラットな `interface` のまま残存。`truncated=false` かつ `originalLength=0/NaN/負値` が型エラーにならず、`buildSummaryFields` で silent に誤った `SummaryField` を構築するリスクが残っていた。

## 変更内容

### 型レベル保証 (functions/src/utils/textCap.ts)
- `CappedText` を discriminated union 化:
  ```ts
  export type CappedText =
    | { text: string; truncated: false }
    | { text: string; truncated: true; originalLength: number };
  ```
- `truncated=false` 分岐で `originalLength` アクセスが tsc エラーになる

### 利用箇所追従 (functions/src/ocr/ocrProcessor.ts)
- `capped.originalLength` アクセスを `truncated` 分岐化（truncated=false 時は `result.text.length` にフォールバック）
- 3 箇所の `{ text:'', originalLength:0, truncated:false }` リテラルを新型に
- `summaryPromise` の `.catch` に `(): CappedText` 型注釈追加（union narrow）
- `capPageResultsAggregate` の `capped.originalLength` も同様の追従

### Regression Test (functions/test/summaryWritePayloadContract.test.ts)
- `summaryBuilderCallerContract.test.ts` (#214) のパターン踏襲、grep-based 契約テスト
- `ocrProcessor` / `regenerateSummary` の summary 書込 3 要素を検証:
  1. `summary: buildSummaryFields(...)`
  2. `summaryTruncated: FieldValue.delete()`
  3. `summaryOriginalLength: FieldValue.delete()`
- caller 増加検知テストで未知の write site も検出 (#178 教訓)

### テスト追従
- `textCap.test.ts`: `assertTruncated()` 型述語ヘルパー追加、`if (result.truncated) { ... }` の if-guard を排除（**Evaluator 指摘**: バグで truncated=false が返った場合にアサート群がスキップされ false negative になるリスクを構造的に排除）
- `summaryRequestBuilder.test.ts`: truncated=false 入力から `originalLength: 0` を削除（新型整合）

## Quality Gate 実施記録

| 段階 | 結果 |
|---|---|
| `/impl-plan` | AC 7 項目定義（5+ ファイル → evaluator 発動確定） |
| `/simplify` 3 並列 (reuse / quality / efficiency) | Reuse 1 件指摘 → false positive 判定で skip（利用箇所 1 箇所のみ、Premature abstraction） |
| `/safe-refactor` | LOW 1 件のみ（型 narrowing 都合の if-guard 反復、後段の evaluator で根本解決） |
| **Evaluator 分離** (5+ ファイル発動) | REQUEST_CHANGES → MEDIUM 1 件対応（`assertTruncated` 型述語ヘルパー化、if-guard 排除で false negative リスク解消）|

## CI / テスト結果
- BE: `npm run build` PASS / `npm test` 416 passing / `npm run lint` 0 errors（既存 19 warnings）
- 新規テスト 7 件: 契約テスト 6 件 + discriminated union ランタイム検証 1 件

## Test plan

- [x] `npm test` 416 passing 確認
- [x] `npm run lint` 0 errors 確認
- [x] `npm run build` PASS 確認
- [x] `npx tsc --noEmit` 0 errors 確認
- [x] discriminated union 検証テスト（hasOwnProperty で `originalLength` 不在確認）
- [x] write-payload contract test で 3 要素同時書込検証
- [ ] PR マージ後に dev で OCR / regenerate summary の動作確認（FE 表示は #254 で検証済み、本 PR は BE 型変更のみで wire format 不変）

## 関連
- Closes #255
- Builds on #215 (PR #254)
- 関連 Issue: #178 (派生フィールド追加時の教訓), #214 (契約テストパターン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved text truncation tracking by refining how original text length metadata is stored and retrieved. The system now more efficiently distinguishes between truncated and non-truncated content.

* **Tests**
  * Added contract tests to validate payload writing logic for summary fields.
  * Enhanced type safety verification for truncation-related data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->