### PR TITLE
test(contract): summary 直接書込パターンの caller 検知を追加 (#259)

### DIFF
--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -28,6 +28,13 @@ const SUMMARY_TRUNCATED_DELETE =
 const SUMMARY_ORIGINAL_LENGTH_DELETE =
   /summaryOriginalLength:\s*(?:admin\.firestore\.)?FieldValue\.delete\s*\(\s*\)/;
 
+// #259: 直接書込パターン検知 (buildSummaryFields 経由しない anti-pattern)。
+// `summary: { text, truncated, originalLength }` のような object literal 直書きを検出する。
+// ADJACENCY_WINDOW_LINES 内に `.update(` があるときのみ検知し、型定義などの誤検知を抑制。
+// `\b` で word boundary を強制し `commentSummary: {` / `errorSummary: {` の suffix 一致誤検知を排除。
+const SUMMARY_DIRECT_WRITE_LITERAL = /\bsummary\s*:\s*\{/;
+const UPDATE_CALL = /\.update\s*\(/;
+
 // #178 教訓: 派生フィールド 3 要素は同一 update() ブロック内で書き込む必要がある。
 // 本契約に含める caller ファイル。新規 caller 追加時は手動追記すること。
 const WRITE_PAYLOAD_CALLERS = [
@@ -40,23 +47,35 @@ const WRITE_PAYLOAD_CALLERS = [
 const ADJACENCY_WINDOW_LINES = 30;
 
 /**
- * 3 要素 (buildSummaryFields / summaryTruncated.delete / summaryOriginalLength.delete) が
- * 同一 update() ブロック内 (ADJACENCY_WINDOW_LINES 行以内) に共存するかを検証。
- * ファイル全体で 3 要素が散在する false positive (review-pr Critical 指摘) を防ぐ。
+ * 全 patterns が同一 ADJACENCY_WINDOW_LINES 行以内に共存するかをスライディングウィンドウで判定。
+ * 同パターンの契約検知 (3 要素 / 直接書込 / 将来拡張) を 1 関数に集約し、コピペドリフトを防ぐ。
  */
-function hasThreeElementsAdjacent(source: string): boolean {
+function hasPatternsAdjacent(source: string, ...patterns: RegExp[]): boolean {
   const lines = source.split('\n');
-  for (let i = 0; i <= lines.length - 1; i++) {
+  for (let i = 0; i < lines.length; i++) {
     const window = lines.slice(i, i + ADJACENCY_WINDOW_LINES).join('\n');
-    if (
-      BUILD_SUMMARY_FIELDS_CALL.test(window) &&
-      SUMMARY_TRUNCATED_DELETE.test(window) &&
-      SUMMARY_ORIGINAL_LENGTH_DELETE.test(window)
-    ) {
-      return true;
-    }
+    if (patterns.every((p) => p.test(window))) return true;
   }
   return false;
+}
+
+// 3 要素 (buildSummaryFields / summaryTruncated.delete / summaryOriginalLength.delete) が
+// 同一 update() ブロック内 (ADJACENCY_WINDOW_LINES 行以内) に共存するかを検証。
+// ファイル全体で 3 要素が散在する false positive (review-pr Critical 指摘) を防ぐ。
+function hasThreeElementsAdjacent(source: string): boolean {
+  return hasPatternsAdjacent(
+    source,
+    BUILD_SUMMARY_FIELDS_CALL,
+    SUMMARY_TRUNCATED_DELETE,
+    SUMMARY_ORIGINAL_LENGTH_DELETE
+  );
+}
+
+// #259: 直接書込パターン (`summary: { ... }` object literal) を `.update(` 近傍で検知。
+// 型定義 `interface Foo { summary: { text: string } }` などは update 呼び出しを伴わないため
+// 誤検知しない。同一 ADJACENCY_WINDOW_LINES 内に両方が存在することを必須とする。
+function hasDirectSummaryWriteInUpdate(source: string): boolean {
+  return hasPatternsAdjacent(source, UPDATE_CALL, SUMMARY_DIRECT_WRITE_LITERAL);
 }
 
 describe('summary write-payload contract (#255)', () => {
@@ -105,8 +124,10 @@ describe('summary write-payload contract (#255)', () => {
 
   describe('caller 追加検知 (noUnused contract)', () => {
     // 新しく `documents/{id}.summary` を update する箇所ができた場合の検知手段として、
-    // summary 書込 3 要素パターンを持つファイルが WRITE_PAYLOAD_CALLERS 以外にないか確認。
+    // summary 書込パターン (buildSummaryFields 経由 OR 直接 object literal 書込) を
+    // 持つファイルが WRITE_PAYLOAD_CALLERS 以外にないか確認。
     // 既知の caller が increase すれば本テストの expected が更新必要 = 意図的な変更検知。
+    // #259: `buildSummaryFields` を経由しない直接書込 anti-pattern も OR 集合で検知する。
     it('summary 書込 caller 数が期待値と一致する', () => {
       const walk = (dir: string): string[] =>
         readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -119,12 +140,68 @@ describe('summary write-payload contract (#255)', () => {
       const tsFiles = walk(srcRoot);
       const callers = tsFiles.filter((f) => {
         const s = readFileSync(f, 'utf-8');
-        return BUILD_SUMMARY_FIELDS_CALL.test(s);
+        return BUILD_SUMMARY_FIELDS_CALL.test(s) || hasDirectSummaryWriteInUpdate(s);
       });
       expect(callers).to.have.lengthOf(
         WRITE_PAYLOAD_CALLERS.length,
         `summary 書込 caller が想定外。現在の caller: ${callers.join(', ')}`
       );
+    });
+  });
+
+  // #259 follow-up: 検知ロジック自体の単体テスト。fixture 文字列で正常系/異常系を網羅。
+  // 本ロジックは contract 全体の信頼性の核なので、grep-based テストの限界
+  // (false negative 発生時に sinon spy へ昇格) を意識して挙動を固定化する。
+  describe('hasDirectSummaryWriteInUpdate detection logic (#259)', () => {
+    it('positive: `.update({ summary: { ... } })` 直接書込を検知する', () => {
+      const fixture = `
+        await ref.update({
+          summary: { text: 'foo', truncated: false },
+          updatedAt: now,
+        });
+      `;
+      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(true);
+    });
+
+    it('positive: Transaction 形式 `tx.update(docRef, { summary: { ... } })` も検知する', () => {
+      const fixture = `
+        tx.update(docRef, {
+          summary: { text: 'bar', truncated: true, originalLength: 100 },
+        });
+      `;
+      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(true);
+    });
+
+    it('negative: summary 書込のない update は false', () => {
+      const fixture = `
+        await ref.update({
+          status: 'completed',
+          updatedAt: now,
+        });
+      `;
+      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(false);
+    });
+
+    it('negative: 型定義 `interface Foo { summary: { text } }` は update 外で false', () => {
+      const fixture = `
+        interface Foo {
+          summary: { text: string; truncated: boolean };
+        }
+      `;
+      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(false);
+    });
+
+    // word boundary `\b` で suffix 一致誤検知を排除する不変条件を lock-in。
+    // この境界が外れると `commentSummary: {` / `errorSummary: {` 等を持つ無関係ファイルが
+    // 誤って caller として計上され、契約テストが沈黙誤検知する。
+    it('negative: `commentSummary: { ... }` は word boundary により update 内でも false', () => {
+      const fixture = `
+        await ref.update({
+          commentSummary: { text: 'foo' },
+          errorSummary: { code: 1 },
+        });
+      `;
+      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(false);
     });
   });
 });

--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -1,11 +1,15 @@
 /**
- * summary 書込経路 caller-side 契約テスト (Issue #255)
+ * summary 書込経路 caller-side 契約テスト (Issue #255 + #259)
  *
- * 目的: ocrProcessor / regenerateSummary の Firestore update() 呼出で、
+ * 目的: ocrProcessor / regenerateSummary の Firestore 書込呼出で、
  * 以下 3 要素が同時に含まれ続けることを保証する:
  *   1. `summary: buildSummaryFields(...)` — 新 discriminated union ネスト書込 (#215)
  *   2. `summaryTruncated: FieldValue.delete()` — 旧フラットフィールドの削除
  *   3. `summaryOriginalLength: FieldValue.delete()` — 旧フラットフィールドの削除
+ *
+ * #259: 加えて `buildSummaryFields` を経由しない直接書込 (`summary: { ... }` object literal)
+ * を anti-pattern として検知。`.update()` だけでなく `.set()` / `.create()` 経路も対象とし、
+ * `merge: true` 等のバイパスで派生フィールド整合が崩れる経路を塞ぐ。
  *
  * 背景 (#178 教訓):
  * 派生フィールドの一括書込が壊れると FE 表示が崩れる。#215 で新形式への移行
@@ -13,7 +17,8 @@
  * Firestore に旧フィールドが残留し、後方互換読込に無限依存するリスクがある。
  *
  * 方式: grep-based (静的検証)。`summaryBuilderCallerContract.test.ts` (#214)
- * と同じ方針。false negative 発生時に sinon spy へ昇格。
+ * と同じ方針。false negative 発生時に sinon spy へ昇格。既知の grep limitation
+ * (コメント/文字列リテラル内の偽陽性、quoted key、CJK prefix) は follow-up Issue で扱う。
  */
 
 import { expect } from 'chai';
@@ -29,11 +34,12 @@ const SUMMARY_ORIGINAL_LENGTH_DELETE =
   /summaryOriginalLength:\s*(?:admin\.firestore\.)?FieldValue\.delete\s*\(\s*\)/;
 
 // #259: 直接書込パターン検知 (buildSummaryFields 経由しない anti-pattern)。
-// `summary: { text, truncated, originalLength }` のような object literal 直書きを検出する。
-// ADJACENCY_WINDOW_LINES 内に `.update(` があるときのみ検知し、型定義などの誤検知を抑制。
 // `\b` で word boundary を強制し `commentSummary: {` / `errorSummary: {` の suffix 一致誤検知を排除。
 const SUMMARY_DIRECT_WRITE_LITERAL = /\bsummary\s*:\s*\{/;
-const UPDATE_CALL = /\.update\s*\(/;
+
+// #259: `.update()` だけでなく `.set()` / `.create()` も Firestore 書込として扱う。
+// `set({...}, { merge: true })` で派生フィールド整合をバイパスする経路を検知対象に含める。
+const FIRESTORE_WRITE_CALL = /\.(?:update|set|create)\s*\(/;
 
 // #178 教訓: 派生フィールド 3 要素は同一 update() ブロック内で書き込む必要がある。
 // 本契約に含める caller ファイル。新規 caller 追加時は手動追記すること。
@@ -47,10 +53,18 @@ const WRITE_PAYLOAD_CALLERS = [
 const ADJACENCY_WINDOW_LINES = 30;
 
 /**
- * 全 patterns が同一 ADJACENCY_WINDOW_LINES 行以内に共存するかをスライディングウィンドウで判定。
- * 同パターンの契約検知 (3 要素 / 直接書込 / 将来拡張) を 1 関数に集約し、コピペドリフトを防ぐ。
+ * 全 patterns が同一 ADJACENCY_WINDOW_LINES 行以内に共存するかをスライディングウィンドウで判定する汎用ヘルパ。
+ * `hasThreeElementsAdjacent` と `hasDirectSummaryWrite` の共通ロジックを抽出し、コピペドリフトを防ぐ。
+ *
+ * 防御: patterns が空配列なら `Array.prototype.every` の vacuous truth で常に true となり、
+ * 全 source を caller として誤分類する silent failure になる。明示的に throw して阻止。
  */
 function hasPatternsAdjacent(source: string, ...patterns: RegExp[]): boolean {
+  if (patterns.length === 0) {
+    throw new Error(
+      'hasPatternsAdjacent requires at least one pattern (vacuous true would silently match all sources).'
+    );
+  }
   const lines = source.split('\n');
   for (let i = 0; i < lines.length; i++) {
     const window = lines.slice(i, i + ADJACENCY_WINDOW_LINES).join('\n');
@@ -71,11 +85,12 @@ function hasThreeElementsAdjacent(source: string): boolean {
   );
 }
 
-// #259: 直接書込パターン (`summary: { ... }` object literal) を `.update(` 近傍で検知。
-// 型定義 `interface Foo { summary: { text: string } }` などは update 呼び出しを伴わないため
-// 誤検知しない。同一 ADJACENCY_WINDOW_LINES 内に両方が存在することを必須とする。
-function hasDirectSummaryWriteInUpdate(source: string): boolean {
-  return hasPatternsAdjacent(source, UPDATE_CALL, SUMMARY_DIRECT_WRITE_LITERAL);
+// #259: 直接書込パターン (`summary: { ... }` object literal) を Firestore 書込呼出 (`.update`/`.set`/`.create`)
+// の近傍で検知。型定義 `interface Foo { summary: { text: string } }` などは書込呼出を伴わないため誤検知しない。
+// パターン側 `SUMMARY_DIRECT_WRITE_LITERAL` の `\b` 境界は `commentSummary:` / `errorSummary:` の
+// suffix 一致誤検知を防ぐため必須 (regex 簡素化名目で外すと caller 数契約が膨張する)。
+function hasDirectSummaryWrite(source: string): boolean {
+  return hasPatternsAdjacent(source, FIRESTORE_WRITE_CALL, SUMMARY_DIRECT_WRITE_LITERAL);
 }
 
 describe('summary write-payload contract (#255)', () => {
@@ -113,7 +128,7 @@ describe('summary write-payload contract (#255)', () => {
 
       // review-pr Critical 指摘対応: 3 要素がファイル内に分散していないこと
       // (同一 update() ブロックでの隣接性) を保証。
-      it('3 要素が同一 update() ブロック近接 (≤30 行) に共存する', () => {
+      it(`3 要素が同一 update() ブロック近接 (≤${ADJACENCY_WINDOW_LINES} 行) に共存する`, () => {
         expect(hasThreeElementsAdjacent(source)).to.equal(
           true,
           '3 要素が散在している。同一 update() で書き込まれていない可能性あり (#178 違反)'
@@ -123,12 +138,12 @@ describe('summary write-payload contract (#255)', () => {
   }
 
   describe('caller 追加検知 (noUnused contract)', () => {
-    // 新しく `documents/{id}.summary` を update する箇所ができた場合の検知手段として、
-    // summary 書込パターン (buildSummaryFields 経由 OR 直接 object literal 書込) を
-    // 持つファイルが WRITE_PAYLOAD_CALLERS 以外にないか確認。
-    // 既知の caller が increase すれば本テストの expected が更新必要 = 意図的な変更検知。
-    // #259: `buildSummaryFields` を経由しない直接書込 anti-pattern も OR 集合で検知する。
-    it('summary 書込 caller 数が期待値と一致する', () => {
+    // summary 書込パターンを持つファイルが WRITE_PAYLOAD_CALLERS と完全一致するか identity で検証。
+    // count のみだと「rename + 新規追加」で count 維持されたまま identity が乖離する silent drift を見逃す。
+    // #259: `buildSummaryFields` 経由 OR 直接 object literal 書込の OR 集合で検知し、
+    // anti-pattern による「テストは緑、本番は静かに壊れる」を防ぐ。診断メッセージは
+    // viaBuilder / viaDirect を区別し失敗時の原因究明を即時化する。
+    it('summary 書込 caller の identity が WRITE_PAYLOAD_CALLERS と一致する', () => {
       const walk = (dir: string): string[] =>
         readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
           const full = join(dir, entry.name);
@@ -138,21 +153,37 @@ describe('summary write-payload contract (#255)', () => {
         });
       const srcRoot = resolve(process.cwd(), 'src');
       const tsFiles = walk(srcRoot);
-      const callers = tsFiles.filter((f) => {
-        const s = readFileSync(f, 'utf-8');
-        return BUILD_SUMMARY_FIELDS_CALL.test(s) || hasDirectSummaryWriteInUpdate(s);
-      });
-      expect(callers).to.have.lengthOf(
-        WRITE_PAYLOAD_CALLERS.length,
-        `summary 書込 caller が想定外。現在の caller: ${callers.join(', ')}`
+      const detected = tsFiles
+        .map((f) => {
+          const s = readFileSync(f, 'utf-8');
+          return {
+            file: f,
+            viaBuilder: BUILD_SUMMARY_FIELDS_CALL.test(s),
+            viaDirect: hasDirectSummaryWrite(s),
+          };
+        })
+        .filter((c) => c.viaBuilder || c.viaDirect);
+
+      const actualSorted = detected.map((c) => c.file).sort();
+      const expectedSorted = WRITE_PAYLOAD_CALLERS.map((p) => resolve(process.cwd(), p)).sort();
+
+      const diagnosticDetail = detected
+        .map((c) => `  ${c.file} (viaBuilder=${c.viaBuilder}, viaDirect=${c.viaDirect})`)
+        .join('\n');
+      expect(actualSorted).to.deep.equal(
+        expectedSorted,
+        `summary 書込 caller の identity が WRITE_PAYLOAD_CALLERS と乖離。\n` +
+          `expected:\n${expectedSorted.map((f) => `  ${f}`).join('\n')}\n` +
+          `actual:\n${diagnosticDetail || '  (none)'}`
       );
     });
   });
 
   // #259 follow-up: 検知ロジック自体の単体テスト。fixture 文字列で正常系/異常系を網羅。
-  // 本ロジックは contract 全体の信頼性の核なので、grep-based テストの限界
-  // (false negative 発生時に sinon spy へ昇格) を意識して挙動を固定化する。
-  describe('hasDirectSummaryWriteInUpdate detection logic (#259)', () => {
+  // 本検知が緩むと caller 追加検知テスト (#255) が黙って素通りするため、
+  // regex 改変・window 縮小・OR 合成変更時の安全網として正常系・型定義除外・word boundary・
+  // ADJACENCY_WINDOW_LINES 境界を lock-in する。
+  describe('hasDirectSummaryWrite detection logic (#259)', () => {
     it('positive: `.update({ summary: { ... } })` 直接書込を検知する', () => {
       const fixture = `
         await ref.update({
@@ -160,7 +191,7 @@ describe('summary write-payload contract (#255)', () => {
           updatedAt: now,
         });
       `;
-      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(true);
+      expect(hasDirectSummaryWrite(fixture)).to.equal(true);
     });
 
     it('positive: Transaction 形式 `tx.update(docRef, { summary: { ... } })` も検知する', () => {
@@ -169,39 +200,122 @@ describe('summary write-payload contract (#255)', () => {
           summary: { text: 'bar', truncated: true, originalLength: 100 },
         });
       `;
-      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(true);
+      expect(hasDirectSummaryWrite(fixture)).to.equal(true);
     });
 
-    it('negative: summary 書込のない update は false', () => {
+    // C1 (review-pr Critical): `.set({...}, { merge: true })` で派生フィールド整合をバイパスする
+    // 経路を検知できないと #178 教訓の根幹 (FE↔BE 整合崩壊) が silent fail する。
+    it('positive: `.set({ summary }, { merge: true })` バイパスを検知する', () => {
+      const fixture = `await ref.set({ summary: { text: 'foo' } }, { merge: true });`;
+      expect(hasDirectSummaryWrite(fixture)).to.equal(true);
+    });
+
+    it('positive: `.create({ summary })` バイパスを検知する', () => {
+      const fixture = `await ref.create({ summary: { text: 'foo' } });`;
+      expect(hasDirectSummaryWrite(fixture)).to.equal(true);
+    });
+
+    it('positive: `batch.update(docRef, { summary })` バイパスを検知する', () => {
+      const fixture = `batch.update(docRef, { summary: { text: 'foo' } });`;
+      expect(hasDirectSummaryWrite(fixture)).to.equal(true);
+    });
+
+    it('negative: summary 書込のない write call は検知しない', () => {
       const fixture = `
         await ref.update({
           status: 'completed',
           updatedAt: now,
         });
       `;
-      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(false);
+      expect(hasDirectSummaryWrite(fixture)).to.equal(false);
     });
 
-    it('negative: 型定義 `interface Foo { summary: { text } }` は update 外で false', () => {
+    it('negative: TypeScript 型定義中の summary フィールドは検知しない', () => {
       const fixture = `
         interface Foo {
           summary: { text: string; truncated: boolean };
         }
       `;
-      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(false);
+      expect(hasDirectSummaryWrite(fixture)).to.equal(false);
     });
 
     // word boundary `\b` で suffix 一致誤検知を排除する不変条件を lock-in。
     // この境界が外れると `commentSummary: {` / `errorSummary: {` 等を持つ無関係ファイルが
     // 誤って caller として計上され、契約テストが沈黙誤検知する。
-    it('negative: `commentSummary: { ... }` は word boundary により update 内でも false', () => {
+    it('negative: `commentSummary: { ... }` は word boundary により write call 内でも検知しない', () => {
       const fixture = `
         await ref.update({
           commentSummary: { text: 'foo' },
           errorSummary: { code: 1 },
         });
       `;
-      expect(hasDirectSummaryWriteInUpdate(fixture)).to.equal(false);
+      expect(hasDirectSummaryWrite(fixture)).to.equal(false);
+    });
+  });
+
+  // I1 (silent-failure-hunter IMP-3): ADJACENCY_WINDOW_LINES の値が変更されたり
+  // slice の off-by-one が混入した時に静かに通り抜ける silent failure を防ぐ境界 lock-in。
+  describe('hasPatternsAdjacent ウィンドウ境界 (#259)', () => {
+    it(`正の境界: ${ADJACENCY_WINDOW_LINES - 1} 行間隔は同一ウィンドウとみなす`, () => {
+      const padding = '  // pad\n'.repeat(ADJACENCY_WINDOW_LINES - 2);
+      const fixture = `await ref.update({\n${padding}  summary: { text: 'x' }\n});`;
+      expect(hasDirectSummaryWrite(fixture)).to.equal(true);
+    });
+
+    it(`負の境界: ${ADJACENCY_WINDOW_LINES + 5} 行以上の間隔は別ウィンドウとして扱う`, () => {
+      const gap = '\n'.repeat(ADJACENCY_WINDOW_LINES + 5);
+      const fixture = `await ref.update({});${gap}const x = { summary: { text: 'y' } };`;
+      expect(hasDirectSummaryWrite(fixture)).to.equal(false);
+    });
+
+    it('単一行に両 pattern が同居しても検知する', () => {
+      expect(hasDirectSummaryWrite(`ref.update({summary:{text:'x'}});`)).to.equal(true);
+    });
+  });
+
+  // I2 (pr-test-analyzer Important): hasThreeElementsAdjacent を hasPatternsAdjacent 経由化した
+  // リファクタの回帰保護。実 caller のみに依存すると共通関数バグが両方向に波及した時に検知できない。
+  describe('hasThreeElementsAdjacent regression (#259 共通化保護)', () => {
+    it('positive: 3 要素隣接 fixture を検知する', () => {
+      const fixture = `
+        await ref.update({
+          summary: buildSummaryFields(s),
+          summaryTruncated: admin.firestore.FieldValue.delete(),
+          summaryOriginalLength: admin.firestore.FieldValue.delete(),
+        });
+      `;
+      expect(hasThreeElementsAdjacent(fixture)).to.equal(true);
+    });
+
+    it(`negative: 3 要素が ${ADJACENCY_WINDOW_LINES + 5} 行超に散在する場合は検知しない`, () => {
+      const gap = '\n'.repeat(ADJACENCY_WINDOW_LINES + 5);
+      const fixture =
+        `summary: buildSummaryFields(s),${gap}` +
+        `summaryTruncated: admin.firestore.FieldValue.delete(),${gap}` +
+        `summaryOriginalLength: admin.firestore.FieldValue.delete(),`;
+      expect(hasThreeElementsAdjacent(fixture)).to.equal(false);
+    });
+
+    it('negative: 2 要素のみ隣接 (3 要素 AND 合成の確認) で検知しない', () => {
+      const fixture = `
+        await ref.update({
+          summary: buildSummaryFields(s),
+          summaryTruncated: admin.firestore.FieldValue.delete(),
+        });
+      `;
+      expect(hasThreeElementsAdjacent(fixture)).to.equal(false);
+    });
+  });
+
+  // CRIT-1 (silent-failure-hunter): hasPatternsAdjacent の vacuous-truth 防御を契約として固定化。
+  describe('hasPatternsAdjacent 防御 (#259)', () => {
+    it('patterns が空配列なら throw して silent universal-true を阻止する', () => {
+      expect(() => hasPatternsAdjacent('any source')).to.throw(/at least one pattern/);
+    });
+
+    it('1 pattern のみでも正常動作する', () => {
+      expect(hasPatternsAdjacent('foo bar baz', /foo/)).to.equal(true);
+      expect(hasPatternsAdjacent('foo bar baz', /qux/)).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Issue #259 — `summaryWritePayloadContract` の検知範囲を拡張し、`buildSummaryFields` を経由しない直接書込 anti-pattern (`.update({ summary: { ... } })`) も regression として検知できるよう契約を強化。

## 背景

PR #257 (#255) で導入した契約テストは `summary: buildSummaryFields(...)` 経由の caller のみカウント。新規 caller が `buildSummaryFields` を経由せず直接 object literal を update に書いた場合、検知不能で #178 教訓 (派生フィールド整合崩壊) の回避経路として実害シナリオが残っていた。

pr-test-analyzer Important 指摘 (rating 8/10):
> 新規 caller が `buildSummaryFields` を経由せず直接 `summary: { text, truncated, originalLength }` を update に書いた場合、検知不可能。

## 変更点

1. **共通ヘルパー `hasPatternsAdjacent(source, ...patterns)`**: `hasThreeElementsAdjacent` と本 PR の `hasDirectSummaryWriteInUpdate` の window-based scan ロジックを 1 関数に集約 (コピペドリフト防止、Reuse HIGH 対応)
2. **直接書込検知 `SUMMARY_DIRECT_WRITE_LITERAL = /\bsummary\s*:\s*\{/`**: `\b` で word boundary を強制し `commentSummary: {` / `errorSummary: {` の suffix 誤検知を排除 (Quality HIGH 対応)
3. **caller filter を OR 集合化**: `BUILD_SUMMARY_FIELDS_CALL || hasDirectSummaryWriteInUpdate`
4. **検知ロジック単体テスト 5 件追加** (positive 2 / negative 3、word boundary lock-in 含む)

## Quality Gate

- ✅ \`/simplify\` 3 並列 (reuse / quality / efficiency) → HIGH 2 件対応済み (上記 1, 2)
- ⏭️ \`/safe-refactor\` (1 ファイル変更、3+ 基準未満)
- ⏭️ Evaluator 分離プロトコル (1 ファイル、5+ 基準未満)
- ✅ 423 passing / lint 0 errors / tsc PASS / build PASS

## 未対応 (将来 follow-up)

- **案 B (sinon spy 化)**: ocrProcessor の Cloud Function 依存複雑のため見送り。本 contract の grep-based false negative が顕在化した場合に昇格する (PR #257 description にも明記済み)。

## Test plan

- [x] 全テスト PASS (423 件、新規 +5 件)
- [x] lint 0 errors
- [x] tsc 型チェック PASS
- [x] build PASS
- [x] 既存 caller (ocrProcessor / regenerateSummary) が引き続き 2 件として検知
- [x] word boundary lock-in fixture (`commentSummary: {`) で false 確認
- [x] 直接書込 hypothetical fixture (`.update({ summary: {...} })`) で true 確認

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for payload write operation detection, including direct object-literal writes and expanded Firestore write call patterns (`.update()`, `.set()`, `.create()`).
  * Improved adjacency validation logic with new test suites covering edge cases and boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->