### PR TITLE
refactor(types): CappedText / SummaryField / PageOcrResult を discriminated union で統合 (#258)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -139,8 +139,7 @@ export async function processDocument(
     if (capped.truncated) {
       console.warn(`[OCR] ${label} text truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_PAGE_TEXT_LENGTH})`);
     }
-    // #258: PageOcrResult を SummaryField & {meta} に統合した結果、bridge code (truncated/originalLength の手動再構築) が消滅。
-    // capped を spread すれば truncated/originalLength の不変条件 (型レベル) が caller 側に伝播する。
+    // #258: `...capped` で discriminated union の不変条件 (truncated tag + originalLength) が caller に伝播。
     return {
       ...capped,
       pageNumber,
@@ -174,10 +173,7 @@ export async function processDocument(
     totalOutputTokens = result.outputTokens;
   }
 
-  // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御
-  // #258 既知: capPageResultsAggregate は generic `<T extends PageWithText>` で flat optional 戻り値を生成するため、
-  // PageOcrResult (discriminated union) を再代入しても runtime には truncated/originalLength が同居する可能性あり。
-  // Firestore 書込互換は維持（旧形式と同 JSON）。型レベル不変条件強化は #264 で対応予定。
+  // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御。#264 follow-up: 型レベル不変条件は textCap.ts 内コメント参照。
   const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   pageResults = capPageResultsAggregate(pageResults);
   const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -27,8 +27,8 @@ import {
   capPageText,
   capPageResultsAggregate,
   MAX_PAGE_TEXT_LENGTH,
-  type CappedText,
 } from '../utils/textCap';
+import type { SummaryField } from '../../../shared/types';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -43,17 +43,18 @@ const OCR_RESULT_MAX_LENGTH = 100000;
 // Vertex AI暴走時の出力トークン上限（Issue #205）。8192tokens ≈ 25K chars Japanese、通常OCRには十分
 const GEMINI_MAX_OUTPUT_TOKENS = GEMINI_CONFIG.maxOutputTokens;
 
-/** ページ単位OCR結果 */
-export interface PageOcrResult {
+/**
+ * ページ単位OCR結果 (Issue #258 で discriminated union 化)
+ *
+ * SummaryField (text/truncated/originalLength) + OCR メタ (pageNumber/inputTokens/outputTokens) の合成。
+ * 不変条件: truncated=true ⟹ originalLength 必須（型レベル保証）。
+ * truncated=false の場合 page.originalLength は型に存在しない（access で tsc エラー）。
+ */
+export type PageOcrResult = SummaryField & {
   pageNumber: number;
-  text: string;
   inputTokens: number;
   outputTokens: number;
-  /** OCR応答が MAX_PAGE_TEXT_LENGTH または aggregate cap で切り詰められた場合の元の文字数 (Issue #205) */
-  originalLength?: number;
-  /** 切り詰めが発生したか (Issue #205) */
-  truncated?: boolean;
-}
+};
 
 /** OCR処理結果 */
 export interface OcrProcessingResult {
@@ -138,15 +139,13 @@ export async function processDocument(
     if (capped.truncated) {
       console.warn(`[OCR] ${label} text truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_PAGE_TEXT_LENGTH})`);
     }
+    // #258: PageOcrResult を SummaryField & {meta} に統合した結果、bridge code (truncated/originalLength の手動再構築) が消滅。
+    // capped を spread すれば truncated/originalLength の不変条件 (型レベル) が caller 側に伝播する。
     return {
+      ...capped,
       pageNumber,
-      text: capped.text,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,
-      // #255: discriminated union 化により truncated=false 時は capped.originalLength 不在。
-      // 切り詰めなしの場合は原文長 = result.text.length なのでフォールバック。
-      originalLength: capped.truncated ? capped.originalLength : result.text.length,
-      truncated: capped.truncated,
     };
   };
 
@@ -176,6 +175,9 @@ export async function processDocument(
   }
 
   // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御
+  // #258 既知: capPageResultsAggregate は generic `<T extends PageWithText>` で flat optional 戻り値を生成するため、
+  // PageOcrResult (discriminated union) を再代入しても runtime には truncated/originalLength が同居する可能性あり。
+  // Firestore 書込互換は維持（旧形式と同 JSON）。型レベル不変条件強化は #264 で対応予定。
   const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   pageResults = capPageResultsAggregate(pageResults);
   const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
@@ -189,7 +191,7 @@ export async function processDocument(
     .join('\n\n');
 
   // マスターデータ取得（要約生成と並列実行）
-  const summaryPromise = generateSummary(ocrResult, '').catch((err): CappedText => {
+  const summaryPromise = generateSummary(ocrResult, '').catch((err): SummaryField => {
     console.error('Summary generation failed:', err);
     return { text: '', truncated: false };
   });
@@ -537,17 +539,17 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
 }
 
 /**
- * OCR結果からAI要約を生成 (Issue #209, Issue #214)
+ * OCR結果からAI要約を生成 (Issue #209, Issue #214, #258)
  *
  * Precondition: core の `generateSummaryCore` は `length < MIN_OCR_LENGTH_FOR_SUMMARY` を許容しない。
- * 本 helper はその precondition を先に消化し、短文時は empty CappedText を返して後続処理を継続する。
+ * 本 helper はその precondition を先に消化し、短文時は empty SummaryField を返して後続処理を継続する。
  * Vertex AI エラーは catch → empty 返却で best-effort (呼出元 `summaryPromise` の `.catch(empty)` と二重防御)。
- * @returns CappedText - text(切り詰め後summary), originalLength(元文字数), truncated(切り詰めフラグ)
+ * @returns SummaryField - text(切り詰め後summary), truncated(切り詰めフラグ), originalLength(truncated=true 時のみ)
  */
 async function generateSummary(
   ocrResult: string,
   documentType: string
-): Promise<CappedText> {
+): Promise<SummaryField> {
   if (!ocrResult || ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {
     return { text: '', truncated: false };
   }

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -8,7 +8,7 @@
 import * as functions from 'firebase-functions/v2';
 import * as admin from 'firebase-admin';
 import { GCP_CONFIG } from '../utils/config';
-import type { CappedText } from '../utils/textCap';
+import type { SummaryField } from '../../../shared/types';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
 
@@ -67,7 +67,7 @@ export const regenerateSummary = functions.https.onCall(
     }
 
     // 要約生成 (Issue #214: 共通コアに委譲。本経路は error を rethrow して onCall の internal error 化)
-    let summary: CappedText;
+    let summary: SummaryField;
     try {
       summary = await generateSummaryCore(ocrResult, documentType);
     } catch (error) {

--- a/functions/src/ocr/summaryGenerator.ts
+++ b/functions/src/ocr/summaryGenerator.ts
@@ -17,7 +17,8 @@ import { VertexAI } from '@google-cloud/vertexai';
 import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
 import { getRateLimiter, trackGeminiUsage } from '../utils/rateLimiter';
 import { withRetry, RETRY_CONFIGS } from '../utils/retry';
-import { capPageText, MAX_SUMMARY_LENGTH, type CappedText } from '../utils/textCap';
+import { capPageText, MAX_SUMMARY_LENGTH } from '../utils/textCap';
+import type { SummaryField } from '../../../shared/types';
 import { buildSummaryGenerationRequest } from './summaryRequestBuilder';
 
 const PROJECT_ID = GCP_CONFIG.projectId;
@@ -62,13 +63,13 @@ ${truncatedText}
  *
  * - 呼び出し前提: `ocrResult` は非空文字列。短文ガード (例: `length < 100`) は caller 責任。
  * - エラー時: throw する (catch は caller 責任)。
- *   - ocrProcessor: empty CappedText を返して後続処理を継続
+ *   - ocrProcessor: empty SummaryField を返して後続処理を継続
  *   - regenerateSummary: console.error 後 rethrow し onCall handler が internal error 化
  */
 export async function generateSummaryCore(
   ocrResult: string,
   documentType: string
-): Promise<CappedText> {
+): Promise<SummaryField> {
   // 新 caller が短文ガードを忘れた場合の safety net (type-design-analyzer 指摘)。
   // 既存 caller (ocrProcessor / regenerateSummary) は手前で同じ閾値チェック済のため到達しない。
   if (ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {

--- a/functions/src/ocr/summaryRequestBuilder.ts
+++ b/functions/src/ocr/summaryRequestBuilder.ts
@@ -12,7 +12,6 @@
 
 import type { GenerateContentRequest } from '@google-cloud/vertexai';
 import { GEMINI_CONFIG } from '../utils/config';
-import type { CappedText } from '../utils/textCap';
 import type { SummaryField } from '../../../shared/types';
 
 export interface SummaryGenerationRequest {
@@ -40,8 +39,12 @@ export function buildSummaryGenerationRequest(prompt: string): SummaryGeneration
  * 廃止し、不変条件 (truncated=true ⟹ originalLength 必須) を型レベル保証する
  * SummaryField ネスト型に統一。#178 教訓の「派生フィールドの書き込み漏れで
  * FE 表示が壊れる」問題は union の tag (truncated) で構造的に排除される。
+ *
+ * #258: CappedText と SummaryField を統合した結果、本関数は identity 化したが、
+ * 「summary 書込前に必ず通る単一通過点」としての契約テスト保護目的で存続。
+ * caller が直接書込にバイパスすると summaryWritePayloadContract.test.ts が検知。
  */
-export function buildSummaryFields(summary: CappedText): SummaryField {
+export function buildSummaryFields(summary: SummaryField): SummaryField {
   if (summary.truncated) {
     return {
       text: summary.text,

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -1,5 +1,5 @@
 /**
- * テキスト長さ制限ユーティリティ (Issue #205, #209, #215)
+ * テキスト長さ制限ユーティリティ (Issue #205, #209, #215, #258)
  *
  * 背景: Vertex AI Geminiのハルシネーション/暴走による異常に長い応答（実害事例: 1.1M chars）が
  * Firestoreの per-field 1 MiB 制限を超え INVALID_ARGUMENT を引き起こす問題への防御。
@@ -8,7 +8,12 @@
  * 1. per-page cap (capPageText + MAX_PAGE_TEXT_LENGTH): OCRページ単独の切り詰め
  * 2. aggregate cap (capPageResultsAggregate + MAX_AGGREGATE_PAGE_CHARS): 全ページ合計の切り詰め
  * 3. summary cap (capPageText + MAX_SUMMARY_LENGTH): AI要約の切り詰め (#215 で統合)
+ *
+ * Issue #258: 旧 `CappedText` 型は shared `SummaryField` と構造的同型だったため統合。
+ * single source of truth = shared/types.ts の SummaryField。
  */
+
+import type { SummaryField } from '../../../shared/types';
 
 export const MAX_PAGE_TEXT_LENGTH = 50_000;
 
@@ -21,26 +26,35 @@ export const MAX_SUMMARY_LENGTH = 30_000;
 
 const TRUNCATION_MARKER = '\n[TRUNCATED]';
 
-// Discriminated union (#255): truncated=true の時のみ originalLength が型レベルで必須。
-// truncated=false で originalLength にアクセスすると tsc エラー → silent failure 再発防止 (#178/#209)。
-export type CappedText =
-  | { text: string; truncated: false }
-  | { text: string; truncated: true; originalLength: number };
-
-export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_LENGTH): CappedText {
+export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_LENGTH): SummaryField {
   const originalLength = rawText.length;
   if (originalLength <= maxLength) {
     return { text: rawText, truncated: false };
   }
   const sliceLen = Math.max(0, maxLength - TRUNCATION_MARKER.length);
   const truncatedText = sliceLen === 0 ? '' : rawText.slice(0, sliceLen) + TRUNCATION_MARKER;
+  const cappedText = truncatedText.slice(0, maxLength);
+
+  // Issue #258 dev-assert: production では no-op、dev で originalLength > cappedText.length の不変条件を verify。
+  if (process.env.NODE_ENV !== 'production' && originalLength <= cappedText.length) {
+    throw new Error(
+      `capPageText invariant violation: originalLength (${originalLength}) <= cappedText.length (${cappedText.length})`,
+    );
+  }
+
   return {
-    text: truncatedText.slice(0, maxLength),
+    text: cappedText,
     truncated: true,
     originalLength,
   };
 }
 
+// #258 follow-up (Issue #264): capPageResultsAggregate の generic 内部は flat optional `PageWithText`
+// 制約のままで、戻り値も flat fields を生成している。新 PageOcrResult (discriminated union) を input にしても
+// structural compatibility で tsc は通るが、runtime には truncated=false でも originalLength が同居する可能性がある。
+// 機能的には Firestore 書込時に問題なし (旧型と同形式)。型レベル厳格化は #264 で対応:
+// - Option A (推奨): capPageResultsAggregate を `<T extends SummaryField>` 化 + 戻り値で originalLength を明示 strip
+// - Option B: ocrProcessor 専用 helper として specialize し、generic を捨てる
 interface PageWithText {
   text: string;
   originalLength?: number;

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -49,12 +49,8 @@ export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_L
   };
 }
 
-// #258 follow-up (Issue #264): capPageResultsAggregate の generic 内部は flat optional `PageWithText`
-// 制約のままで、戻り値も flat fields を生成している。新 PageOcrResult (discriminated union) を input にしても
-// structural compatibility で tsc は通るが、runtime には truncated=false でも originalLength が同居する可能性がある。
-// 機能的には Firestore 書込時に問題なし (旧型と同形式)。型レベル厳格化は #264 で対応:
-// - Option A (推奨): capPageResultsAggregate を `<T extends SummaryField>` 化 + 戻り値で originalLength を明示 strip
-// - Option B: ocrProcessor 専用 helper として specialize し、generic を捨てる
+// #258 follow-up (#264): generic `<T extends PageWithText>` の flat optional 戻り値が新 PageOcrResult
+// (discriminated union) の不変条件を runtime で破る経路を残す。Firestore 書込互換は維持。詳細は #264 参照。
 interface PageWithText {
   text: string;
   originalLength?: number;

--- a/functions/test/summaryRequestBuilder.test.ts
+++ b/functions/test/summaryRequestBuilder.test.ts
@@ -12,7 +12,7 @@ import {
   buildSummaryFields,
 } from '../src/ocr/summaryRequestBuilder';
 import { GEMINI_CONFIG } from '../src/utils/config';
-import type { CappedText } from '../src/utils/textCap';
+import type { SummaryField } from '../../shared/types';
 
 describe('summaryRequestBuilder: buildSummaryGenerationRequest', () => {
   it('generationConfig.maxOutputTokens に GEMINI_CONFIG.maxOutputTokens を必ず設定する', () => {
@@ -51,7 +51,7 @@ describe('summaryRequestBuilder: buildSummaryGenerationRequest', () => {
 
 describe('summaryRequestBuilder: buildSummaryFields (Issue #215 discriminated union)', () => {
   it('truncated=false で { text, truncated:false } のみ返す (originalLength は型レベルで不在)', () => {
-    const summary: CappedText = {
+    const summary: SummaryField = {
       text: '通常の要約テキスト',
       truncated: false,
     };
@@ -62,7 +62,7 @@ describe('summaryRequestBuilder: buildSummaryFields (Issue #215 discriminated un
   });
 
   it('truncated=true で { text, truncated:true, originalLength } を返す', () => {
-    const summary: CappedText = {
+    const summary: SummaryField = {
       text: '切り詰め後\n[TRUNCATED]',
       originalLength: 1_100_000,
       truncated: true,
@@ -75,7 +75,7 @@ describe('summaryRequestBuilder: buildSummaryFields (Issue #215 discriminated un
   });
 
   it('空テキスト (truncated=false) でも { text:"", truncated:false } が返る', () => {
-    const summary: CappedText = { text: '', truncated: false };
+    const summary: SummaryField = { text: '', truncated: false };
     const fields = buildSummaryFields(summary);
     expect(fields).to.deep.equal({ text: '', truncated: false });
     // 不変条件の保証: truncated=false の分岐で originalLength キーが含まれない
@@ -83,7 +83,7 @@ describe('summaryRequestBuilder: buildSummaryFields (Issue #215 discriminated un
   });
 
   it('discriminated union: truncated=true の場合に必ず originalLength を含む (#215 型不変条件)', () => {
-    const summary: CappedText = {
+    const summary: SummaryField = {
       text: 'a'.repeat(30_000),
       originalLength: 50_000,
       truncated: true,

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -111,54 +111,11 @@ describe('textCap', () => {
       expect(Object.prototype.hasOwnProperty.call(result, 'originalLength')).to.be.false;
     });
 
-    // #258 dev-assert: NODE_ENV !== 'production' で originalLength <= cappedText.length の不変条件を verify。
-    // 内部不整合 (例: 既切り詰めテキストの再cap) を即座に検知。production では no-op (パフォーマンス担保)。
-    //
-    // 設計上の制約 (Evaluator LOW 指摘): capPageText の通常呼出経路では invariant violation を外部から
-    // 誘発できない (originalLength = rawText.length は常に成立)。そのため 2件目・3件目は contract test
-    // (assert 条件式の論理を直接 throw) として実装し、condition の論理一貫性のみ保証する。
-    // capPageText 実装本体の dev-assert 動作は 1件目で実呼出 PASS (throw しない) を担保する。
-    describe('dev-assert (#258 originalLength > cappedText.length 不変条件)', () => {
-      const originalEnv = process.env.NODE_ENV;
-      afterEach(() => {
-        process.env.NODE_ENV = originalEnv;
-      });
-
-      it('dev: 通常の切り詰めでは fire しない (originalLength > text.length が成立)', () => {
-        process.env.NODE_ENV = 'development';
+    // #258 dev-assert: capPageText 通常呼出からは違反不可能な invariant (originalLength > cappedText.length)。
+    // 将来の内部実装変更 (再cap 経路追加等) で違反したら即時検知。production では no-op (パフォーマンス担保)。
+    describe('dev-assert (#258)', () => {
+      it('通常の切り詰めでは fire しない (originalLength > cappedText.length が常時成立)', () => {
         expect(() => capPageText('a'.repeat(MAX_PAGE_TEXT_LENGTH + 1))).to.not.throw();
-      });
-
-      it('dev: maxLength を巨大化して capped.length が originalLength に近づくと assert fire', () => {
-        process.env.NODE_ENV = 'development';
-        // text.length === maxLength の境界では truncated=false 経路 (assert 通過しない)。
-        // text.length === maxLength + 1 で originalLength=maxLength+1, cappedText.length<=maxLength
-        // → originalLength > cappedText.length 成立 → assert fire しない。
-        // 不変条件違反を起こすには capPageText を不正に呼ぶ経路が必要。
-        // 直接の violation は capPageText 内部ロジックを通っては発生しない設計。
-        // 本テストは「violation 条件 = originalLength <= cappedText.length」を直接 throw でカバーする contract test。
-        const wouldViolate = () => {
-          const originalLength = 10;
-          const cappedText = 'a'.repeat(10); // 同じ長さ → violation
-          if (process.env.NODE_ENV !== 'production' && originalLength <= cappedText.length) {
-            throw new Error(
-              `capPageText invariant violation: originalLength (${originalLength}) <= cappedText.length (${cappedText.length})`,
-            );
-          }
-        };
-        expect(wouldViolate).to.throw(/invariant violation/);
-      });
-
-      it('production: NODE_ENV=production では assert は no-op (throw しない)', () => {
-        process.env.NODE_ENV = 'production';
-        const wouldBeViolation = () => {
-          const originalLength = 10;
-          const cappedText = 'a'.repeat(10);
-          if (process.env.NODE_ENV !== 'production' && originalLength <= cappedText.length) {
-            throw new Error('should not be thrown in production');
-          }
-        };
-        expect(wouldBeViolation).to.not.throw();
       });
     });
   });

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -12,14 +12,15 @@ import {
   MAX_PAGE_TEXT_LENGTH,
   MAX_AGGREGATE_PAGE_CHARS,
   MAX_SUMMARY_LENGTH,
-  type CappedText,
 } from '../src/utils/textCap';
+import type { SummaryField } from '../../shared/types';
 
 // #255 Evaluator 指摘対応: discriminated union narrowing を `if (result.truncated)` で
 // 行うと、実装バグで truncated=false が返った場合にアサート群がスキップされ、テスト全体が
 // PASS する誤検知リスクがある。`asserts` 型述語で明示的に narrow し、不変条件を強制する。
+// #258: CappedText を SummaryField に統合（structurally identical）。
 function assertTruncated(
-  result: CappedText
+  result: SummaryField
 ): asserts result is { text: string; truncated: true; originalLength: number } {
   expect(result.truncated).to.be.true;
   if (!result.truncated) throw new Error('unreachable: expected truncated=true');
@@ -108,6 +109,57 @@ describe('textCap', () => {
 
       expect(result.truncated).to.be.false;
       expect(Object.prototype.hasOwnProperty.call(result, 'originalLength')).to.be.false;
+    });
+
+    // #258 dev-assert: NODE_ENV !== 'production' で originalLength <= cappedText.length の不変条件を verify。
+    // 内部不整合 (例: 既切り詰めテキストの再cap) を即座に検知。production では no-op (パフォーマンス担保)。
+    //
+    // 設計上の制約 (Evaluator LOW 指摘): capPageText の通常呼出経路では invariant violation を外部から
+    // 誘発できない (originalLength = rawText.length は常に成立)。そのため 2件目・3件目は contract test
+    // (assert 条件式の論理を直接 throw) として実装し、condition の論理一貫性のみ保証する。
+    // capPageText 実装本体の dev-assert 動作は 1件目で実呼出 PASS (throw しない) を担保する。
+    describe('dev-assert (#258 originalLength > cappedText.length 不変条件)', () => {
+      const originalEnv = process.env.NODE_ENV;
+      afterEach(() => {
+        process.env.NODE_ENV = originalEnv;
+      });
+
+      it('dev: 通常の切り詰めでは fire しない (originalLength > text.length が成立)', () => {
+        process.env.NODE_ENV = 'development';
+        expect(() => capPageText('a'.repeat(MAX_PAGE_TEXT_LENGTH + 1))).to.not.throw();
+      });
+
+      it('dev: maxLength を巨大化して capped.length が originalLength に近づくと assert fire', () => {
+        process.env.NODE_ENV = 'development';
+        // text.length === maxLength の境界では truncated=false 経路 (assert 通過しない)。
+        // text.length === maxLength + 1 で originalLength=maxLength+1, cappedText.length<=maxLength
+        // → originalLength > cappedText.length 成立 → assert fire しない。
+        // 不変条件違反を起こすには capPageText を不正に呼ぶ経路が必要。
+        // 直接の violation は capPageText 内部ロジックを通っては発生しない設計。
+        // 本テストは「violation 条件 = originalLength <= cappedText.length」を直接 throw でカバーする contract test。
+        const wouldViolate = () => {
+          const originalLength = 10;
+          const cappedText = 'a'.repeat(10); // 同じ長さ → violation
+          if (process.env.NODE_ENV !== 'production' && originalLength <= cappedText.length) {
+            throw new Error(
+              `capPageText invariant violation: originalLength (${originalLength}) <= cappedText.length (${cappedText.length})`,
+            );
+          }
+        };
+        expect(wouldViolate).to.throw(/invariant violation/);
+      });
+
+      it('production: NODE_ENV=production では assert は no-op (throw しない)', () => {
+        process.env.NODE_ENV = 'production';
+        const wouldBeViolation = () => {
+          const originalLength = 10;
+          const cappedText = 'a'.repeat(10);
+          if (process.env.NODE_ENV !== 'production' && originalLength <= cappedText.length) {
+            throw new Error('should not be thrown in production');
+          }
+        };
+        expect(wouldBeViolation).to.not.throw();
+      });
     });
   });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -411,20 +411,23 @@ export const CONSTANTS = {
 // ページ単位OCR結果（PDF分割用）
 // ============================================
 
-export interface PageOcrResult {
+/**
+ * ページ単位OCR結果のメタ情報（分割判定用）。
+ * #258: SummaryField (text/truncated/originalLength) を合成して discriminated union 化することで、
+ * truncated=true ⟹ originalLength 必須を型レベル保証。
+ * meta 部のみを参照したい caller (split 判定など) のために export。
+ */
+export type PageOcrMeta = {
   pageNumber: number;
-  text: string;
   detectedDocumentType: string | null;
   detectedCustomerName: string | null;
   detectedOfficeName: string | null;
   detectedDate: Date | null;
   matchScore: number; // マッチ精度スコア（0-100）
   matchType: 'exact' | 'partial' | 'none';
-  /** OCR応答長制限により切り詰められた場合の元文字数 (Issue #205) */
-  originalLength?: number;
-  /** 切り詰めが発生したか (Issue #205) */
-  truncated?: boolean;
-}
+};
+
+export type PageOcrResult = PageOcrMeta & SummaryField;
 
 export interface SplitSuggestion {
   afterPageNumber: number; // このページの後で分割


### PR DESCRIPTION
## Summary
- `CappedText` 型を削除し、shared `SummaryField` を Single Source of Truth として統合
- `PageOcrResult` を `SummaryField & {meta}` の discriminated union 化（functions + shared 両方）
- `ocrProcessor.ts` の bridge code (L146-149) を削除
- `capPageText` 内に dev-assert (NODE_ENV !== 'production') 追加で originalLength 不変条件を verify

## Background
PR #257 (#255) の type-design-analyzer 5軸評価で指摘された改善余地:
- Encapsulation 2/5: plain structural type で外部から構築可能
- Enforcement 3/5: 数値範囲不変条件 (originalLength > 0) は型外

これらを解消し、長期保守性を改善する型統合 PR。

## Changes (8 files / +132 -108)
- `functions/src/utils/textCap.ts`: CappedText 削除、capPageText 戻り値を SummaryField に変更、dev-assert 追加
- `functions/src/ocr/ocrProcessor.ts`: PageOcrResult discriminated union 化、bridge code 削除
- `functions/src/ocr/{summaryGenerator,summaryRequestBuilder,regenerateSummary}.ts`: import を SummaryField に統一
- `shared/types.ts`: PageOcrResult を `PageOcrMeta & SummaryField` 化、PageOcrMeta を export
- `functions/test/textCap.test.ts`: dev-assert 1 テスト追加（実呼出 PASS のみ、contract test は false negative リスクあり省略）
- `functions/test/summaryRequestBuilder.test.ts`: 型 import 更新

## Acceptance Criteria
- [x] `CappedText` 型定義が functions/src または shared に存在しない
- [x] PageOcrResult の `truncated=false` 構築時に `originalLength` access が tsc エラー
- [x] ocrProcessor.ts の bridge code 削除
- [x] dev-assert 動作確認 (1 テスト追加 PASS、本体実呼出経路で fire しないことを担保)
- [x] 動作不変: functions 434 → 435 passing / frontend 113 passing
- [x] 書込互換: summaryWritePayloadContract.test.ts PASS
- [x] FE 動作不変: useDocuments.test.ts firestoreToDocument 全 PASS

## Quality Gates (7 セッション完了)
- ✅ Evaluator (rules/quality-gate.md, 5ファイル超で発動): **APPROVE**
- ✅ /simplify (reuse / quality / efficiency 3並列): 提案全て scope 外/既対処で却下
- ✅ /safe-refactor (code-reviewer, 型安全性focus): HIGH 1件 → #264 で対応、LOW 対処済
- ✅ /review-pr (4エージェント並列):
  - type-design-analyzer: APPROVE (Encapsulation 2→4, Enforcement 3→4 改善)
  - pr-test-analyzer: dev-assert contract test 削除済、その他 → #267
  - silent-failure-hunter: Vertex AI catch swallow → #266, capPageResultsAggregate → #264
  - comment-analyzer: コメント圧縮対応済
- ✅ /codex review (セカンドオピニオン): **GO**、マージ前必須対応なし

## Test plan
- [x] `cd functions && npm test` → 435 passing (baseline 434 + dev-assert 1)
- [x] `cd frontend && npm test` → 113 passing (回帰なし)
- [x] `cd functions && npx tsc --noEmit` → 0 errors
- [x] `cd frontend && npx tsc --noEmit` → 0 errors
- [x] `cd functions && npm run lint` → 0 errors (19 既存 warnings)
- [x] `cd frontend && npm run lint` → 0 errors
- [x] `cd functions && npm run build` → success
- [x] `cd frontend && npm run build` → success

## Out of Scope (別 Issue 化済)
本 PR は型表現の統合に scope を絞り、以下は別 Issue で対応:

- **#264**: `capPageResultsAggregate` の generic を新 PageOcrResult 対応に書き直し
  - 現状 structural compatibility で tsc は通るが、runtime には truncated=false でも originalLength が同居する可能性あり
  - Firestore 書込互換は維持（旧形式と同 JSON）、機能影響なし
- **#266**: Vertex AI catch 句で logError 追加 (silent-failure-hunter Critical)
  - 既存の console.error swallow を logError 経由に統一
- **#267**: PageOcrResult 型不変条件 + buildPageResult 振る舞いテスト追加
  - @ts-expect-error テストによる継続検証セーフティネット

**注**: PageOcrResult は shared/types.ts と functions/src/ocr/ocrProcessor.ts に同名別構造で 2 定義存在（OCR 処理中間表現 vs Firestore 保存用）。本 PR は型表現の統一のみで、**Firestore 実データの完全統一は #264/#267 後**。FE の `firestoreToDocument` は raw cast 経由のため shape 差の吸収は normalizeSummary 同様の正規化レイヤー追加が将来必要。

## Related
- Closes #258
- Follow-up: #264, #266, #267
- Related: #178 (派生フィールド教訓), #215 (SummaryField discriminated union 化), #255 / #257 (前 Phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)