### PR TITLE
fix(ocr): Vertex AI catch 句で safeLogError 追加 silent failure 防止 (#266)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -187,8 +187,8 @@ export async function processDocument(
     .join('\n\n');
 
   // マスターデータ取得（要約生成と並列実行）
-  // Issue #266: generateSummary 内部 catch で empty 返却するため本 catch は通常 dead code だが、
-  // 将来の signature 変更で throw 経路が生じた場合の edge case safety net として残置。
+  // Issue #266: 通常は generateSummary 内部 catch で吸収されるため本 catch には到達しない。
+  // inner catch の regression や Promise 化されていない throw 経路に対する二重防御として残置。
   // safeLogError 経由で silent failure を防ぎ、errors collection から検知可能にする。
   const summaryPromise = generateSummary(ocrResult, '', { docId, functionName }).catch(
     async (err) => {

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -8,7 +8,7 @@ import * as admin from 'firebase-admin';
 import { VertexAI } from '@google-cloud/vertexai';
 import { PDFDocument } from 'pdf-lib';
 import { withRetry, RETRY_CONFIGS, isTransientError, is429Error } from '../utils/retry';
-import { logError } from '../utils/errorLogger';
+import { logError, safeLogError } from '../utils/errorLogger';
 import { getRateLimiter } from '../utils/rateLimiter';
 import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
 import {
@@ -187,10 +187,21 @@ export async function processDocument(
     .join('\n\n');
 
   // マスターデータ取得（要約生成と並列実行）
-  const summaryPromise = generateSummary(ocrResult, '').catch((err): SummaryField => {
-    console.error('Summary generation failed:', err);
-    return { text: '', truncated: false };
-  });
+  // Issue #266: generateSummary 内部 catch で empty 返却するため本 catch は通常 dead code だが、
+  // 将来の signature 変更で throw 経路が生じた場合の edge case safety net として残置。
+  // safeLogError 経由で silent failure を防ぎ、errors collection から検知可能にする。
+  const summaryPromise = generateSummary(ocrResult, '', { docId, functionName }).catch(
+    async (err) => {
+      console.error('Summary generation failed:', err);
+      await safeLogError({
+        error: err instanceof Error ? err : new Error(String(err)),
+        source: 'ocr',
+        functionName: `${functionName}:summaryPromise`,
+        documentId: docId,
+      });
+      return { text: '', truncated: false } satisfies SummaryField;
+    }
+  );
 
   // マスターデータ取得
   const [documentMasters, customerMasters, officeMasters] = await Promise.all([
@@ -535,16 +546,18 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
 }
 
 /**
- * OCR結果からAI要約を生成 (Issue #209, Issue #214, #258)
+ * OCR結果からAI要約を生成 (Issue #209, Issue #214, #258, #266)
  *
  * Precondition: core の `generateSummaryCore` は `length < MIN_OCR_LENGTH_FOR_SUMMARY` を許容しない。
  * 本 helper はその precondition を先に消化し、短文時は empty SummaryField を返して後続処理を継続する。
  * Vertex AI エラーは catch → empty 返却で best-effort (呼出元 `summaryPromise` の `.catch(empty)` と二重防御)。
+ * Issue #266: catch 句で logError 呼出を追加し、silent failure を防ぐ。
  * @returns SummaryField - text(切り詰め後summary), truncated(切り詰めフラグ), originalLength(truncated=true 時のみ)
  */
 async function generateSummary(
   ocrResult: string,
-  documentType: string
+  documentType: string,
+  logContext: { docId: string; functionName: string }
 ): Promise<SummaryField> {
   if (!ocrResult || ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {
     return { text: '', truncated: false };
@@ -553,6 +566,12 @@ async function generateSummary(
     return await generateSummaryCore(ocrResult, documentType);
   } catch (error) {
     console.error('Failed to generate summary:', error);
+    await safeLogError({
+      error: error instanceof Error ? error : new Error(String(error)),
+      source: 'ocr',
+      functionName: `${logContext.functionName}:generateSummary`,
+      documentId: logContext.docId,
+    });
     return { text: '', truncated: false };
   }
 }

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -69,6 +69,9 @@ export const regenerateSummary = functions.https.onCall(
 
     // 要約生成 (Issue #214: 共通コアに委譲。本経路は error を rethrow して onCall の internal error 化)
     // Issue #266: rethrow 前に safeLogError で errors collection + 通知による検知を確保。
+    // 順序根拠 (rules/error-handling.md § 1): 本経路は "状態復旧なし + 即 rethrow" のため、
+    // ログ記録 → rethrow の順を採る。safeLogError は内部で try/catch 済、caller に波及しない。
+    // onCall 呼出の client 側タイムアウトは Firebase 標準 70s、logError Firestore 書込 ~500ms で影響軽微。
     let summary: SummaryField;
     try {
       summary = await generateSummaryCore(ocrResult, documentType);

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -8,6 +8,7 @@
 import * as functions from 'firebase-functions/v2';
 import * as admin from 'firebase-admin';
 import { GCP_CONFIG } from '../utils/config';
+import { safeLogError } from '../utils/errorLogger';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
@@ -67,11 +68,18 @@ export const regenerateSummary = functions.https.onCall(
     }
 
     // 要約生成 (Issue #214: 共通コアに委譲。本経路は error を rethrow して onCall の internal error 化)
+    // Issue #266: rethrow 前に safeLogError で errors collection + 通知による検知を確保。
     let summary: SummaryField;
     try {
       summary = await generateSummaryCore(ocrResult, documentType);
     } catch (error) {
       console.error('Failed to generate summary:', error);
+      await safeLogError({
+        error: error instanceof Error ? error : new Error(String(error)),
+        source: 'ocr',
+        functionName: 'regenerateSummary',
+        documentId: docId,
+      });
       throw error;
     }
 

--- a/functions/src/utils/errorLogger.ts
+++ b/functions/src/utils/errorLogger.ts
@@ -130,6 +130,29 @@ export interface LogErrorParams {
 }
 
 /**
+ * logError を安全に呼び出すラッパ (Issue #266)
+ *
+ * logError 自体が Firestore 書込で throw した場合に console.error で fallback し、
+ * caller の主処理を中断させない。catch 句 / best-effort error path で使用する。
+ *
+ * 既存 `handleProcessingError` の fallback パターンは当 helper 移行対象だが、
+ * 本 PR scope 外 (follow-up で統合予定)。
+ */
+export async function safeLogError(params: LogErrorParams): Promise<void> {
+  try {
+    await logError(params);
+  } catch (logErr) {
+    // fallback に source/functionName を含めることで、logError 失敗時も発生箇所を特定可能にする。
+    const docRef = params.documentId ?? params.fileId ?? 'unknown';
+    console.error(
+      `Failed to record error for ${params.source}/${params.functionName} (${docRef}):`,
+      logErr,
+      { originalError: params.error.message }
+    );
+  }
+}
+
+/**
  * エラーをFirestoreに記録
  *
  * @returns 作成されたエラーログID

--- a/functions/src/utils/errorLogger.ts
+++ b/functions/src/utils/errorLogger.ts
@@ -135,8 +135,7 @@ export interface LogErrorParams {
  * logError 自体が Firestore 書込で throw した場合に console.error で fallback し、
  * caller の主処理を中断させない。catch 句 / best-effort error path で使用する。
  *
- * 既存 `handleProcessingError` の fallback パターンは当 helper 移行対象だが、
- * 本 PR scope 外 (follow-up で統合予定)。
+ * 既存 `handleProcessingError` の fallback パターンは当 helper 移行対象 (follow-up: #271)。
  */
 export async function safeLogError(params: LogErrorParams): Promise<void> {
   try {

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -1,0 +1,229 @@
+/**
+ * summary 経路 catch 句 logError 呼出契約テスト (Issue #266)
+ *
+ * 目的: ocrProcessor / regenerateSummary の summary 生成失敗 catch 句で、
+ * console.error だけでなく logError (errors collection + 通知) が呼ばれ続けることを保証する。
+ *
+ * 背景 (#178/#209 教訓):
+ * Vertex AI のクォータ枯渇・認証失効・暴走系エラーが silently swallow されると、
+ * documents は status:processed で完了し「summary が空」としか見えない。
+ * 6 ヶ月後のデバッグで原因不明となる silent failure を構造的に防ぐ。
+ *
+ * 方式: grep-based (静的検証)。`summaryWritePayloadContract.test.ts` (#259) と同方針。
+ * console.error メッセージをアンカーに、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を検知する。
+ * メッセージ変更時は test 失敗するが、意図的変更なのでメンテナンス負荷は許容範囲。
+ */
+
+import { expect } from 'chai';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * summary 生成失敗 catch 句のアンカー定義。
+ * anchor メッセージは console.error(...) 内の固定文字列で、catch 句内に残す前提。
+ * console.error を削除して logError のみに移行する場合は本契約の設計見直しが必要。
+ */
+const SUMMARY_CATCH_ANCHORS = [
+  {
+    file: 'src/ocr/ocrProcessor.ts',
+    anchor: 'Summary generation failed',
+    context: 'summaryPromise.catch (best-effort, edge case safety net)',
+  },
+  {
+    file: 'src/ocr/ocrProcessor.ts',
+    anchor: 'Failed to generate summary',
+    context: 'generateSummary inner catch (main path)',
+  },
+  {
+    file: 'src/ocr/regenerateSummary.ts',
+    anchor: 'Failed to generate summary',
+    context: 'regenerateSummary rethrow-preceding catch',
+  },
+] as const;
+
+// catch 句のスコープとして許容する近接ウィンドウ。catch ブロックは通常 3-5 行だが、
+// コメント行や空行・多段 await を吸収するため 8 行とする。
+const ANCHOR_WINDOW_LINES = 8;
+
+// logError / safeLogError 呼出の検知パターン。`await logError(` / `await safeLogError(` 等を許容。
+// Issue #266 simplify 指摘対応: catch 句の重複削減で safeLogError ラッパ経由の呼出を許容。
+const LOG_ERROR_CALL = /\b(?:safeLogError|logError)\s*\(/;
+
+/**
+ * アンカーメッセージの各 occurrence について、ANCHOR_WINDOW_LINES 行以内に
+ * logError 呼出が存在するかを全件検証する。
+ *
+ * 防御: occurrence が 0 件なら「アンカー不在 = catch 句リネーム/削除」として明示失敗させる。
+ * 単純な `some` 検証だと occurrence 0 件でも vacuous true で PASS する silent failure を防ぐ。
+ */
+function everyAnchorHasLogErrorNearby(source: string, anchor: string): {
+  ok: boolean;
+  occurrenceCount: number;
+  missingLines: number[];
+} {
+  const lines = source.split('\n');
+  const anchorIndices = lines
+    .map((line, idx) => ({ line, idx }))
+    .filter(({ line }) => line.includes(anchor))
+    .map(({ idx }) => idx);
+
+  const missingLines: number[] = [];
+  for (const idx of anchorIndices) {
+    const start = Math.max(0, idx - ANCHOR_WINDOW_LINES);
+    const end = Math.min(lines.length, idx + ANCHOR_WINDOW_LINES + 1);
+    const window = lines.slice(start, end).join('\n');
+    if (!LOG_ERROR_CALL.test(window)) {
+      missingLines.push(idx + 1); // 1-based for error messages
+    }
+  }
+
+  return {
+    ok: anchorIndices.length > 0 && missingLines.length === 0,
+    occurrenceCount: anchorIndices.length,
+    missingLines,
+  };
+}
+
+describe('summary catch logError contract (#266)', () => {
+  // パス実在を describe 評価時に明示確認 (#259 同パターン)。
+  // readFileSync の ENOENT で suite 起動失敗が「caller 削除/リネーム」のシグナルとして
+  // 埋もれるのを防ぐ。
+  before(() => {
+    for (const { file } of SUMMARY_CATCH_ANCHORS) {
+      const absPath = resolve(process.cwd(), file);
+      if (!existsSync(absPath)) {
+        throw new Error(
+          `SUMMARY_CATCH_ANCHORS に登録された ${file} が存在しない。` +
+            `caller がリネーム/削除された場合は本契約の見直しが必要。`
+        );
+      }
+    }
+  });
+
+  for (const { file, anchor, context } of SUMMARY_CATCH_ANCHORS) {
+    describe(`${file} (${context})`, () => {
+      const absPath = resolve(process.cwd(), file);
+      const source = readFileSync(absPath, 'utf-8');
+
+      it(`アンカー '${anchor}' が console.error 内に存在する`, () => {
+        expect(source).to.include(anchor);
+      });
+
+      it(`アンカー '${anchor}' の各 occurrence 近傍 (±${ANCHOR_WINDOW_LINES} 行) に logError 呼出がある`, () => {
+        const result = everyAnchorHasLogErrorNearby(source, anchor);
+
+        expect(result.occurrenceCount).to.be.greaterThan(
+          0,
+          `アンカー '${anchor}' が ${file} に見つからない (0 occurrence)。` +
+            `catch 句の console.error メッセージが変更された可能性あり。`
+        );
+
+        expect(result.ok).to.equal(
+          true,
+          `アンカー '${anchor}' の近傍に logError 呼出が見つからない。` +
+            `行番号 (1-based): ${result.missingLines.join(', ')}。` +
+            `catch 句で silent failure を起こしている可能性あり (#178/#209 違反)。`
+        );
+      });
+    });
+  }
+
+  describe('everyAnchorHasLogErrorNearby detection logic', () => {
+    it('positive: catch 句直後に logError 呼出がある場合は PASS', () => {
+      const fixture = `
+try {
+  await doThing();
+} catch (err) {
+  console.error('Operation failed:', err);
+  logError({ error: err, source: 'ocr', functionName: 'doThing' });
+}
+      `;
+      const result = everyAnchorHasLogErrorNearby(fixture, 'Operation failed');
+      expect(result.ok).to.equal(true);
+      expect(result.occurrenceCount).to.equal(1);
+    });
+
+    it('negative: catch 句内に logError がなければ FAIL (silent failure 検知)', () => {
+      const fixture = `
+try {
+  await doThing();
+} catch (err) {
+  console.error('Operation failed:', err);
+  return defaultValue;
+}
+      `;
+      const result = everyAnchorHasLogErrorNearby(fixture, 'Operation failed');
+      expect(result.ok).to.equal(false);
+      expect(result.occurrenceCount).to.equal(1);
+      expect(result.missingLines).to.have.lengthOf(1);
+    });
+
+    it('negative: アンカー不在は 0 occurrence として FAIL (vacuous true 防御)', () => {
+      const fixture = `const x = 1;`;
+      const result = everyAnchorHasLogErrorNearby(fixture, 'NonExistentAnchor');
+      expect(result.ok).to.equal(false);
+      expect(result.occurrenceCount).to.equal(0);
+    });
+
+    it('positive: ANCHOR_WINDOW_LINES 境界内 (8 行先) の logError は検知する', () => {
+      const fixture = [
+        `console.error('Msg:', err);`,
+        `  line1`,
+        `  line2`,
+        `  line3`,
+        `  line4`,
+        `  line5`,
+        `  line6`,
+        `  line7`,
+        `  logError({ error: err });`, // 8 行先 (idx=8)、ANCHOR_WINDOW_LINES=8 で window=[0..8+1) 境界内
+      ].join('\n');
+      const result = everyAnchorHasLogErrorNearby(fixture, 'Msg:');
+      expect(result.ok).to.equal(true);
+    });
+
+    it('negative: ANCHOR_WINDOW_LINES 境界超過 (10 行先) の logError は検知しない', () => {
+      const fixture = [
+        `console.error('Msg:', err);`,
+        `  line1`,
+        `  line2`,
+        `  line3`,
+        `  line4`,
+        `  line5`,
+        `  line6`,
+        `  line7`,
+        `  line8`,
+        `  line9`,
+        `  logError({ error: err });`, // 10 行先、ANCHOR_WINDOW_LINES=8 境界超過
+      ].join('\n');
+      const result = everyAnchorHasLogErrorNearby(fixture, 'Msg:');
+      expect(result.ok).to.equal(false);
+    });
+
+    it('negative: 複数 occurrence のうち 1 件でも logError 不在なら FAIL', () => {
+      // 1 回目 (line 0): 近傍に logError あり → OK
+      // 2 回目 (line 13): 近傍 8 行以内に logError なし → FAIL 寄与
+      // ANCHOR_WINDOW_LINES=8 を超える距離を確保するため filler 11 行挿入
+      const fixture = [
+        `console.error('Msg:', err);`, // line 0
+        `logError({ error: err });`, // line 1 (1 回目近傍)
+        `filler 1`,
+        `filler 2`,
+        `filler 3`,
+        `filler 4`,
+        `filler 5`,
+        `filler 6`,
+        `filler 7`,
+        `filler 8`,
+        `filler 9`,
+        `filler 10`,
+        `filler 11`,
+        `console.error('Msg:', err);`, // line 13 (2 回目、logError 不在)
+        `return defaultValue;`,
+      ].join('\n');
+      const result = everyAnchorHasLogErrorNearby(fixture, 'Msg:');
+      expect(result.ok).to.equal(false);
+      expect(result.occurrenceCount).to.equal(2);
+      expect(result.missingLines).to.deep.equal([14]); // 1-based line number of 2 回目
+    });
+  });
+});

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -128,6 +128,90 @@ describe('summary catch logError contract (#266)', () => {
     });
   }
 
+  // #266 review-pr (pr-test-analyzer I2) 対応: logError/safeLogError 呼出の params shape を
+  // 静的検証。grep-based のため値の実行時検証はできないが、source: 'ocr' と
+  // 適切な functionName suffix が記述されていることで「呼出コードが正しい shape で書かれている」
+  // ことを契約化する。動的 mock 検証は #251 (summaryGenerator unit test) で補完予定。
+  describe('logError/safeLogError params shape contract (#266)', () => {
+    const ocrProcessorSource = readFileSync(
+      resolve(process.cwd(), 'src/ocr/ocrProcessor.ts'),
+      'utf-8'
+    );
+    const regenerateSummarySource = readFileSync(
+      resolve(process.cwd(), 'src/ocr/regenerateSummary.ts'),
+      'utf-8'
+    );
+
+    it('ocrProcessor.ts の safeLogError 呼出に source: \'ocr\' が含まれる', () => {
+      // safeLogError( ... source: 'ocr' ... ) の近接パターン検証
+      // ANCHOR_WINDOW_LINES=8 内で両要素が共存することを確認
+      const SAFE_LOG_ERROR_CALL = /safeLogError\s*\(/;
+      const SOURCE_OCR = /source:\s*['"]ocr['"]/;
+      const lines = ocrProcessorSource.split('\n');
+      const safeLogLines = lines
+        .map((line, idx) => ({ line, idx }))
+        .filter(({ line }) => SAFE_LOG_ERROR_CALL.test(line))
+        .map(({ idx }) => idx);
+
+      expect(safeLogLines.length).to.be.greaterThanOrEqual(
+        2,
+        'ocrProcessor.ts で safeLogError 呼出が 2 箇所以上あることを想定 (summaryPromise + generateSummary inner)'
+      );
+
+      for (const idx of safeLogLines) {
+        const end = Math.min(lines.length, idx + ANCHOR_WINDOW_LINES + 1);
+        const window = lines.slice(idx, end).join('\n');
+        expect(SOURCE_OCR.test(window)).to.equal(
+          true,
+          `safeLogError 呼出 (line ${idx + 1}) の近傍に source: 'ocr' が見つからない`
+        );
+      }
+    });
+
+    it('regenerateSummary.ts の safeLogError 呼出に functionName: \'regenerateSummary\' が含まれる', () => {
+      const SAFE_LOG_ERROR_CALL = /safeLogError\s*\(/;
+      const FUNCTION_NAME_REGENERATE = /functionName:\s*['"]regenerateSummary['"]/;
+      const lines = regenerateSummarySource.split('\n');
+      const safeLogLines = lines
+        .map((line, idx) => ({ line, idx }))
+        .filter(({ line }) => SAFE_LOG_ERROR_CALL.test(line))
+        .map(({ idx }) => idx);
+
+      expect(safeLogLines.length).to.be.greaterThanOrEqual(
+        1,
+        'regenerateSummary.ts で safeLogError 呼出が 1 箇所以上あることを想定'
+      );
+
+      for (const idx of safeLogLines) {
+        const end = Math.min(lines.length, idx + ANCHOR_WINDOW_LINES + 1);
+        const window = lines.slice(idx, end).join('\n');
+        expect(FUNCTION_NAME_REGENERATE.test(window)).to.equal(
+          true,
+          `safeLogError 呼出 (line ${idx + 1}) の近傍に functionName: 'regenerateSummary' が見つからない`
+        );
+      }
+    });
+
+    it('ocrProcessor.ts の safeLogError 呼出で documentId が渡されている', () => {
+      const SAFE_LOG_ERROR_CALL = /safeLogError\s*\(/;
+      const DOCUMENT_ID_PARAM = /documentId:/;
+      const lines = ocrProcessorSource.split('\n');
+      const safeLogLines = lines
+        .map((line, idx) => ({ line, idx }))
+        .filter(({ line }) => SAFE_LOG_ERROR_CALL.test(line))
+        .map(({ idx }) => idx);
+
+      for (const idx of safeLogLines) {
+        const end = Math.min(lines.length, idx + ANCHOR_WINDOW_LINES + 1);
+        const window = lines.slice(idx, end).join('\n');
+        expect(DOCUMENT_ID_PARAM.test(window)).to.equal(
+          true,
+          `safeLogError 呼出 (line ${idx + 1}) の近傍に documentId: が見つからない`
+        );
+      }
+    });
+  });
+
   describe('everyAnchorHasLogErrorNearby detection logic', () => {
     it('positive: catch 句直後に logError 呼出がある場合は PASS', () => {
       const fixture = `


### PR DESCRIPTION
## Summary
- **#265 (#258)** silent-failure-hunter C1 指摘対応。summary 生成失敗時に `console.error` のみで `logError` 未呼出だった catch 句 3 箇所に `safeLogError` 追加
- `safeLogError(params)` helper を `errorLogger.ts` に新設し、3 箇所のコピペ (try/catch fallback) を集約
- 新規 grep-based 契約テストで catch 句の `logError`/`safeLogError` 呼出維持を静的検証

## 背景

PR #265 (#258) の `silent-failure-hunter` C1 指摘: Vertex AI のクォータ枯渇・認証失効・暴走系エラーが silently swallow され、`processDocument` は `status:processed` で完了する。**ユーザーには「summary が空」としか見えない** 状態が 6 ヶ月後のデバッグで原因不明になる silent failure を構造的に排除する。

## 変更内容

| ファイル | 変更 |
|---|---|
| `functions/src/ocr/ocrProcessor.ts` | `summaryPromise.catch` (L190) と `generateSummary` inner catch (L570) に `safeLogError` 呼出。`generateSummary` シグネチャを `logContext: { docId, functionName }` 必須で拡張 |
| `functions/src/ocr/regenerateSummary.ts` | rethrow 前に `safeLogError` 呼出 (onCall handler の internal error 化前に errors collection に記録) |
| `functions/src/utils/errorLogger.ts` | `safeLogError(params): Promise<void>` helper 新設。`logError` の try/catch ラッパで caller の主処理を中断させず、fallback console.error に `source/functionName` を含める |
| `functions/test/summaryCatchLogErrorContract.test.ts` | 新規 grep-based 契約テスト。`console.error` アンカーメッセージ近傍 (±8 行) に `logError`/`safeLogError` 呼出が残ることを静的検証、12 cases |

## Acceptance Criteria

- [x] ocrProcessor.ts の summary 関連 catch 2箇所で safeLogError 呼出追加
- [x] regenerateSummary.ts の catch で safeLogError 呼出追加 (rethrow 維持)
- [x] OCR 経路全体で `console.error` → `logError` 移行漏れ監査済
  - 監査結果: 残存 15 件すべて rules/error-handling.md § 1 準拠の fallback または handleProcessingError 併記パターン
  - `processOCR.ts:176 rescueStuckProcessingDocs` のみ併記なしだが冪等リトライで補完、本 PR scope 外 (follow-up 候補)
- [x] テスト追加 (契約テスト 12 cases、detection logic 自己テスト含む)
- [x] 全 BE test PASS: 435 → 447 passing (+12)
- [x] build/lint PASS: 0 errors, 18 warnings (既存のみ)

## Quality Gate 実施記録

| 段階 | 結果 | 指摘・対応 |
|---|---|---|
| `/impl-plan` | ✅ AC 5 項目定義、3 Phase + Quality Gate | scope 確定 (severity override / errorIds 追加は別 Issue 化) |
| TDD: 契約テスト RED → 実装 GREEN | ✅ 3 RED → 12 passing | anchor 近傍 logError 呼出の静的検証 |
| `/simplify` 3 並列 | catch 句コピペ指摘 (中) | `safeLogError` helper 化で 3 箇所の `try { logError } catch` 重複解消、`: Promise<SummaryField>` 型注釈削除 |
| `/safe-refactor` | MEDIUM 2 / LOW 2 | MEDIUM 却下 (既存コード、scope 外)、LOW 1 採用 (safeLogError fallback に source/functionName 追加)、LOW 1 却下 (既存 contract test パターン踏襲) |

## 残存 follow-up 候補

本 PR で対応せず、別 Issue 化推奨:
- `handleProcessingError` (ocrProcessor.ts L447-471) の既存 try/catch fallback を `safeLogError` に移行
- `categorizeError` の型アサーション重複 (errorLogger.ts L75, L161)
- `generateSummary(ocrResult, '')` の documentType 固定空文字列 (#214 設計起因、#251 unit test 時に整理)
- `rescueStuckProcessingDocs` (processOCR.ts:176) の status update 失敗時に logError 併記
- contract test ヘルパー (hasPatternsAdjacent / everyAnchorHasLogErrorNearby) の共通化 (#262 統合)

## 本番環境への影響

error logging 経路の追加のみ、status 遷移・Firestore 書込スキーマ・summary 生成ロジック変更なし。kanameone/cocoro 本番環境への影響ゼロ。

## Test plan

- [x] `cd functions && npm test` — 447 passing
- [x] `cd functions && npm run build` — PASS
- [x] `cd functions && npm run lint` — 0 errors
- [x] 新規契約テスト 12 cases PASS (anchor 近傍検知 + detection logic 自己テスト)
- [x] 変更コードパス: 契約テストで logError 呼出を静的検証 (動的 mock 検証は #251 で追補予定)

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling for document processing failures with improved logging reliability, including graceful fallback mechanisms if the logging system encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->