### PR TITLE
refactor(hooks): useProcessingHistory.firestoreToDocument を useDocuments 側に集約 (#253)

### DIFF
--- a/frontend/src/hooks/__tests__/useDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useDocuments.test.ts
@@ -81,6 +81,39 @@ describe('firestoreToDocument', () => {
     })
   })
 
+  // Issue #253: 派生フィールド追加時の同期漏れ (#178 教訓) を防ぐ lock-in。
+  // useProcessingHistory の劣化コピーを削除して useDocuments 版に集約した際に、
+  // 旧 useProcessingHistory 固有だった needsManualCustomerSelection を取りこぼさないことを保証。
+  describe('後方互換フィールド (#253)', () => {
+    it('needsManualCustomerSelection: true を正しく変換する', () => {
+      const data = {
+        ...baseFirestoreData,
+        needsManualCustomerSelection: true,
+      }
+
+      const result = firestoreToDocument('doc-001', data)
+
+      expect(result.needsManualCustomerSelection).toBe(true)
+    })
+
+    it('needsManualCustomerSelection: false を正しく変換する', () => {
+      const data = {
+        ...baseFirestoreData,
+        needsManualCustomerSelection: false,
+      }
+
+      const result = firestoreToDocument('doc-001', data)
+
+      expect(result.needsManualCustomerSelection).toBe(false)
+    })
+
+    it('needsManualCustomerSelection が undefined (Phase 6 以前) の場合も正しく処理する', () => {
+      const result = firestoreToDocument('doc-001', baseFirestoreData)
+
+      expect(result.needsManualCustomerSelection).toBeUndefined()
+    })
+  })
+
   describe('事業所確定フィールド（Phase 8 同名対応）★重要', () => {
     it('officeConfirmed: true を正しく変換する', () => {
       const data = {

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -195,6 +195,8 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     verified: data.verified as boolean | undefined,
     verifiedBy: data.verifiedBy as string | null | undefined,
     verifiedAt: data.verifiedAt as Timestamp | null | undefined,
+    // Phase 6 以前の後方互換 (isCustomerConfirmed のデュアルリード経路で使用)
+    needsManualCustomerSelection: data.needsManualCustomerSelection as boolean | undefined,
   }
 }
 

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -195,7 +195,7 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     verified: data.verified as boolean | undefined,
     verifiedBy: data.verifiedBy as string | null | undefined,
     verifiedAt: data.verifiedAt as Timestamp | null | undefined,
-    // Phase 6 以前の後方互換 (isCustomerConfirmed のデュアルリード経路で使用)
+    // 後方互換: 顧客確定状態のレガシー表現。customerConfirmed と併読される。
     needsManualCustomerSelection: data.needsManualCustomerSelection as boolean | undefined,
   }
 }

--- a/frontend/src/hooks/useProcessingHistory.ts
+++ b/frontend/src/hooks/useProcessingHistory.ts
@@ -23,7 +23,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import type { Document, DocumentStatus, CustomerCandidateInfo } from '@shared/types';
-import { normalizeSummary } from './useDocuments';
+import { firestoreToDocument } from './useDocuments';
 
 // ============================================
 // 定数
@@ -106,46 +106,7 @@ export function normalizeCandidate(raw: Record<string, unknown>): CustomerCandid
   };
 }
 
-/**
- * Firestore → Document 変換
- */
-function firestoreToDocument(id: string, data: Record<string, unknown>): Document {
-  return {
-    id,
-    processedAt: data.processedAt as Timestamp,
-    fileId: data.fileId as string,
-    fileName: data.fileName as string,
-    mimeType: data.mimeType as string,
-    ocrResult: data.ocrResult as string,
-    ocrResultUrl: data.ocrResultUrl as string | undefined,
-    // Issue #209/#215: 切り詰めメタ込みの discriminated union (旧フラット形式も互換読込)
-    summary: normalizeSummary(data),
-    documentType: data.documentType as string,
-    customerName: data.customerName as string,
-    officeName: data.officeName as string,
-    fileUrl: data.fileUrl as string,
-    fileDate: data.fileDate as Timestamp,
-    isDuplicateCustomer: data.isDuplicateCustomer as boolean,
-    allCustomerCandidates: data.allCustomerCandidates as string | undefined,
-    totalPages: data.totalPages as number,
-    targetPageNumber: data.targetPageNumber as number,
-    status: data.status as DocumentStatus,
-    careManager: data.careManager as string | undefined,
-    category: data.category as string | undefined,
-    pageResults: data.pageResults as Document['pageResults'],
-    splitSuggestions: data.splitSuggestions as Document['splitSuggestions'],
-    pageRotations: data.pageRotations as Document['pageRotations'],
-    parentDocumentId: data.parentDocumentId as string | undefined,
-    splitFromPages: data.splitFromPages as Document['splitFromPages'],
-    // Phase 7 fields
-    customerId: data.customerId as string | null | undefined,
-    customerCandidates: data.customerCandidates as CustomerCandidateInfo[] | undefined,
-    customerConfirmed: data.customerConfirmed as boolean | undefined,
-    confirmedBy: data.confirmedBy as string | null | undefined,
-    confirmedAt: data.confirmedAt as Timestamp | null | undefined,
-    needsManualCustomerSelection: data.needsManualCustomerSelection as boolean | undefined,
-  };
-}
+// Issue #253: firestoreToDocument は useDocuments から import (#178 教訓の構造的解消)
 
 /**
  * 期間フィルターから日付を計算

--- a/frontend/src/hooks/useProcessingHistory.ts
+++ b/frontend/src/hooks/useProcessingHistory.ts
@@ -106,8 +106,6 @@ export function normalizeCandidate(raw: Record<string, unknown>): CustomerCandid
   };
 }
 
-// Issue #253: firestoreToDocument は useDocuments から import (#178 教訓の構造的解消)
-
 /**
  * 期間フィルターから日付を計算
  */


### PR DESCRIPTION
## Summary
- **#215 follow-up** Sprint 2-2 Critical 指摘対応。FE 側の `firestoreToDocument` 重複実装 2 箇所を完全統合
- #178 教訓 (派生フィールド追加時の同期漏れ) の**構造的解消**
- useProcessingHistory 経路でも Phase 8 以降の 20+ フィールド (displayFileName / officeId / sourceType 等) が取得可能に

## 背景

useProcessingHistory.ts:112 の内部 `firestoreToDocument` は useDocuments.ts:137 の export 版と比較して **フィールドが大幅に不足** していた:
- **useProcessingHistory 固有**: `needsManualCustomerSelection` 1 件のみ (Phase 6 以前の後方互換、`isCustomerConfirmed` のデュアルリード経路で active 使用中)
- **useDocuments 固有**: 20+ 件 (`displayFileName`, `officeId` + Phase 8 office 系 5 件, `sourceType`, `messageId`, `isSplitSource`, `splitInto`, `customerKey`/`officeKey`/`documentTypeKey`/`careManagerKey`, `ocrExtraction`, `extractionScores`, `extractionDetails`, `verified` + 確認ステータス 2 件)

#215 で `normalizeSummary()` を両方に追加したことで重複同期の維持コストが顕在化。

## 変更内容

| ファイル | 変更 |
|---|---|
| `frontend/src/hooks/useDocuments.ts` | `firestoreToDocument` に `needsManualCustomerSelection` マッピング追加 (Phase 6 以前の後方互換、isCustomerConfirmed のデュアルリード経路で必要) |
| `frontend/src/hooks/useProcessingHistory.ts` | 内部 `firestoreToDocument` (36 行) 削除、useDocuments の export 関数を import。呼出 2 箇所 (L214 / L319) は関数シグネチャ互換のため変更不要 |

## Acceptance Criteria (#253)

- [x] useProcessingHistory.ts から firestoreToDocument 内部定義を削除
- [x] useDocuments.ts の firestoreToDocument を import して使用
- [x] useProcessingHistory の既存テストが全て PASS (113 passing 変動なし)
- [ ] 表示挙動に回帰がないことを dev で目視確認 (push 後 CI 自動 deploy 経由、マージ後に確認予定)

## #178 教訓チェックリスト準拠

- [x] **firestoreToDocument のマッピング** — useDocuments 側に needsManualCustomerSelection 追加 (SSoT 化)
- [x] **書き込みパス** — BE (ocrProcessor.ts, pdfOperations.ts) で既に needsManualCustomerSelection を書込中、変更なし
- [x] **getReprocessClearFields に deleteField() 追加** — useDocuments.ts:280 で既に含まれている
- [x] **型定義 (shared/types.ts) との整合性** — L476 で `needsManualCustomerSelection?: boolean` 定義済

## 効果

- 派生フィールド追加時の同期漏れリスク構造的解消 (1 箇所で管理)
- 情報量向上: useProcessingHistory 経路でも Phase 8 以降のフィールド取得可能
- コード行数削減: -41 行 (+4 行)

## Test plan

- [x] `cd frontend && npm test -- --run` — 113 passing
- [x] `cd frontend && npx tsc --noEmit` — PASS
- [x] `cd frontend && npm run build` — PASS
- [x] `cd frontend && npm run lint` — 0 errors
- [ ] dev 環境での表示挙動確認 (mainマージ後 CI 自動 deploy → 履歴ページ / メインページで回帰なきこと)

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)