### PR TITLE
refactor(ocr): handleProcessingError の fallback を safeLogError に統合 (#271)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -8,7 +8,7 @@ import * as admin from 'firebase-admin';
 import { VertexAI } from '@google-cloud/vertexai';
 import { PDFDocument } from 'pdf-lib';
 import { withRetry, RETRY_CONFIGS, isTransientError, is429Error } from '../utils/retry';
-import { logError, safeLogError } from '../utils/errorLogger';
+import { safeLogError } from '../utils/errorLogger';
 import { getRateLimiter } from '../utils/rateLimiter';
 import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
 import {
@@ -455,16 +455,12 @@ export async function handleProcessingError(
     }
   }
 
-  try {
-    await logError({
-      error,
-      source: 'ocr',
-      functionName,
-      documentId: docId,
-    });
-  } catch (logErr) {
-    console.error(`Failed to log error for document ${docId}:`, logErr);
-  }
+  await safeLogError({
+    error,
+    source: 'ocr',
+    functionName,
+    documentId: docId,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- #266 で導入した `safeLogError` helper を `handleProcessingError` の logError 箇所にも適用し、catch 句 fallback の SSoT 化を完成させる
- `try{await logError}catch{console.error}` の 10 行パターンを `await safeLogError(...)` の 6 行に置換
- 直接 `logError` import を削除（handleProcessingError 以外で未使用を確認済）

## 背景

PR #270 (#266) で `safeLogError(params): Promise<void>` を `errorLogger.ts` に新設し、Vertex AI catch 3 箇所を集約済。`handleProcessingError` の同パターン fallback は #270 scope 外として touch せず、follow-up として #271 起票。本 PR で解消。

## 動作上の変更

- 挙動: 等価（safeLogError は logError 成功時に何もせず、失敗時に console.error で fallback ログ出力）
- fallback ログ情報量: 改善方向（従来 `Failed to log error for document ${docId}` → 新 `Failed to record error for ocr/${functionName} (${docId})` + 元エラーメッセージ）

## Quality Gate

- `/impl-plan`: ✅ Phase 1A WBS 策定済 (session14)
- `/simplify`: ⏭️ スキップ（1 ファイル・-4 行の scope、session13 #253 と同判断）
- `/safe-refactor`: ⏭️ 3 ファイル未満で基準外
- Evaluator: ⏭️ 5 ファイル未満で発動条件外

## Test plan

- [x] `npm run build` (functions) PASS
- [x] `npm test` (functions) 450 passing 維持（baseline 450 → 450）
- [x] 契約テスト `summaryCatchLogErrorContract` PASS 維持（handleProcessingError はテスト scope 外だが回帰ゼロ）
- [ ] CI (lint-build-test / CodeRabbit / GitGuardian) SUCCESS
- [ ] マージ後、次セッションで fallback ログが期待通り console に出力されることを手動確認（任意）

## 関連

- Closes #271
- 起点: PR #270 (#266) code-reviewer Important 指摘

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling robustness in the OCR processor by simplifying the error logging mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->