### PR TITLE
test(ocr): PageOcrResult 型不変条件 + buildPageResult 振る舞いテスト (#267)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,8 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "lint": "eslint src test",
-    "test": "mocha --require ts-node/register --timeout 10000 'test/**/*.test.ts' --ignore 'test/firestore.rules.test.ts' --ignore 'test/ocrRetryIntegration.test.ts'",
+    "type-check:test": "tsc --noEmit -p tsconfig.test.json",
+    "test": "npm run type-check:test && mocha --require ts-node/register --timeout 10000 'test/**/*.test.ts' --ignore 'test/firestore.rules.test.ts' --ignore 'test/ocrRetryIntegration.test.ts'",
     "test:rules": "mocha --require ts-node/register --timeout 10000 'test/firestore.rules.test.ts'",
     "test:integration": "mocha --require ts-node/register --timeout 10000 'test/ocrRetryIntegration.test.ts'"
   },

--- a/functions/src/ocr/buildPageResult.ts
+++ b/functions/src/ocr/buildPageResult.ts
@@ -1,0 +1,51 @@
+/**
+ * OCR 1 ページ分の結果 (text + token counts) を PageOcrResult に変換する。(#267)
+ *
+ * 本モジュールは firebase-admin / Vertex AI などの副作用を持つ依存を持たず、
+ * capPageText だけを利用する pure function に限定している。これにより
+ * unit test から import しても admin 初期化エラーが発生しない。
+ *
+ * 不変条件 (#258):
+ * - truncated=true ⟹ originalLength 必須（SummaryField の discriminated union で型保証）
+ * - truncated=false の場合、戻り値オブジェクトに originalLength キーは存在しない
+ */
+
+import type { SummaryField } from '../../../shared/types';
+import { capPageText, MAX_PAGE_TEXT_LENGTH } from '../utils/textCap';
+
+/**
+ * ページ単位OCR結果 (Issue #258 で discriminated union 化)
+ *
+ * SummaryField (text/truncated/originalLength) + OCR メタ (pageNumber/inputTokens/outputTokens) の合成。
+ * 不変条件: truncated=true ⟹ originalLength 必須（型レベル保証）。
+ * truncated=false の場合 page.originalLength は型に存在しない（access で tsc エラー）。
+ */
+export type PageOcrResult = SummaryField & {
+  pageNumber: number;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+/**
+ * OCR 結果 (text + token counts) を PageOcrResult に変換する。
+ *
+ * capPageText で per-page cap を適用し、truncated=true の場合は originalLength を伝播する
+ * discriminated union shape で返す。label は truncate 時の warn ログに使用。
+ */
+export function buildPageResult(
+  result: { text: string; inputTokens: number; outputTokens: number },
+  pageNumber: number,
+  label: string
+): PageOcrResult {
+  const capped = capPageText(result.text);
+  if (capped.truncated) {
+    console.warn(`[OCR] ${label} text truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_PAGE_TEXT_LENGTH})`);
+  }
+  // #258: `...capped` で discriminated union の不変条件 (truncated tag + originalLength) が caller に伝播。
+  return {
+    ...capped,
+    pageNumber,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+  };
+}

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -24,11 +24,14 @@ import { sanitizeCustomerMasters, sanitizeOfficeMasters, sanitizeDocumentMasters
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
 import {
-  capPageText,
   capPageResultsAggregate,
-  MAX_PAGE_TEXT_LENGTH,
 } from '../utils/textCap';
 import type { SummaryField } from '../../../shared/types';
+import { buildPageResult, type PageOcrResult } from './buildPageResult';
+
+// #267: buildPageResult / PageOcrResult 型は ./buildPageResult モジュールに移設。
+// ここでは re-export のみ行い、既存の import パス互換性を維持する。
+export { buildPageResult, type PageOcrResult };
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -42,19 +45,6 @@ const MODEL_ID = GEMINI_CONFIG.modelId;
 const OCR_RESULT_MAX_LENGTH = 100000;
 // Vertex AI暴走時の出力トークン上限（Issue #205）。8192tokens ≈ 25K chars Japanese、通常OCRには十分
 const GEMINI_MAX_OUTPUT_TOKENS = GEMINI_CONFIG.maxOutputTokens;
-
-/**
- * ページ単位OCR結果 (Issue #258 で discriminated union 化)
- *
- * SummaryField (text/truncated/originalLength) + OCR メタ (pageNumber/inputTokens/outputTokens) の合成。
- * 不変条件: truncated=true ⟹ originalLength 必須（型レベル保証）。
- * truncated=false の場合 page.originalLength は型に存在しない（access で tsc エラー）。
- */
-export type PageOcrResult = SummaryField & {
-  pageNumber: number;
-  inputTokens: number;
-  outputTokens: number;
-};
 
 /** OCR処理結果 */
 export interface OcrProcessingResult {
@@ -129,24 +119,6 @@ export async function processDocument(
   let totalPages = 1;
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
-
-  const buildPageResult = (
-    result: { text: string; inputTokens: number; outputTokens: number },
-    pageNumber: number,
-    label: string
-  ): PageOcrResult => {
-    const capped = capPageText(result.text);
-    if (capped.truncated) {
-      console.warn(`[OCR] ${label} text truncated: ${capped.originalLength} → ${capped.text.length} chars (cap=${MAX_PAGE_TEXT_LENGTH})`);
-    }
-    // #258: `...capped` で discriminated union の不変条件 (truncated tag + originalLength) が caller に伝播。
-    return {
-      ...capped,
-      pageNumber,
-      inputTokens: result.inputTokens,
-      outputTokens: result.outputTokens,
-    };
-  };
 
   if (mimeType === 'application/pdf') {
     const pdfDoc = await PDFDocument.load(buffer);

--- a/functions/test/buildPageResult.test.ts
+++ b/functions/test/buildPageResult.test.ts
@@ -68,4 +68,31 @@ describe('buildPageResult (#267)', () => {
       expect(result.outputTokens).to.equal(200);
     });
   });
+
+  describe('境界値 (MAX_PAGE_TEXT_LENGTH 前後)', () => {
+    it('text.length === MAX_PAGE_TEXT_LENGTH で truncated=false を返す', () => {
+      const exactText = 'x'.repeat(MAX_PAGE_TEXT_LENGTH);
+      const result = buildPageResult(
+        { text: exactText, inputTokens: 1, outputTokens: 1 },
+        1,
+        'Boundary'
+      );
+      expect(result.truncated).to.equal(false);
+      expect(result.text.length).to.equal(MAX_PAGE_TEXT_LENGTH);
+      expect(Object.prototype.hasOwnProperty.call(result, 'originalLength')).to.equal(false);
+    });
+
+    it('text.length === MAX_PAGE_TEXT_LENGTH + 1 で truncated=true を返す', () => {
+      const overByOne = 'x'.repeat(MAX_PAGE_TEXT_LENGTH + 1);
+      const result = buildPageResult(
+        { text: overByOne, inputTokens: 1, outputTokens: 1 },
+        1,
+        'Boundary+1'
+      );
+      expect(result.truncated).to.equal(true);
+      if (result.truncated) {
+        expect(result.originalLength).to.equal(MAX_PAGE_TEXT_LENGTH + 1);
+      }
+    });
+  });
 });

--- a/functions/test/buildPageResult.test.ts
+++ b/functions/test/buildPageResult.test.ts
@@ -1,0 +1,71 @@
+/**
+ * buildPageResult 振る舞いテスト (Issue #267, #258 follow-up)
+ *
+ * 目的: #258 で ocrProcessor.ts L146-149 の bridge code (capped.truncated ? ... )
+ * を削除して `{ ...capped, pageNumber, ... }` に簡略化した際、Firestore 書込形式が
+ * 旧 bridge code 経由と完全一致することを保証する。processDocument 統合テストは
+ * OCR を mock しているため、buildPageResult 単体の振る舞いは未保証だった (pr-test-analyzer I3)。
+ *
+ * 方式: buildPageResult を module-level export (#267) し、truncated=true/false の
+ * 両ケースで戻り値の shape (hasOwnProperty 含む) を検証。
+ */
+
+import { expect } from 'chai';
+import { buildPageResult } from '../src/ocr/buildPageResult';
+import { MAX_PAGE_TEXT_LENGTH } from '../src/utils/textCap';
+
+describe('buildPageResult (#267)', () => {
+  describe('truncated=false (short text)', () => {
+    const result = buildPageResult(
+      { text: 'short page body', inputTokens: 10, outputTokens: 20 },
+      1,
+      'Page 1/1'
+    );
+
+    it('text / pageNumber / tokens を正しく伝播する', () => {
+      expect(result.text).to.equal('short page body');
+      expect(result.pageNumber).to.equal(1);
+      expect(result.inputTokens).to.equal(10);
+      expect(result.outputTokens).to.equal(20);
+    });
+
+    it('truncated: false を返す', () => {
+      expect(result.truncated).to.equal(false);
+    });
+
+    it('戻り値オブジェクトに originalLength キーが存在しない (hasOwnProperty で検証)', () => {
+      expect(Object.prototype.hasOwnProperty.call(result, 'originalLength')).to.equal(false);
+    });
+  });
+
+  describe('truncated=true (long text beyond MAX_PAGE_TEXT_LENGTH)', () => {
+    const longText = 'x'.repeat(MAX_PAGE_TEXT_LENGTH + 1000);
+    const result = buildPageResult(
+      { text: longText, inputTokens: 100, outputTokens: 200 },
+      3,
+      'Page 3/5'
+    );
+
+    it('text は MAX_PAGE_TEXT_LENGTH 以下に切り詰められる', () => {
+      expect(result.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
+    });
+
+    it('truncated: true を返す', () => {
+      expect(result.truncated).to.equal(true);
+    });
+
+    it('originalLength は元テキスト長と一致する', () => {
+      if (result.truncated) {
+        expect(result.originalLength).to.equal(longText.length);
+      } else {
+        throw new Error('truncated should be true for this test');
+      }
+    });
+
+    it('pageNumber / tokens を正しく伝播する', () => {
+      expect(result.pageNumber).to.equal(3);
+      expect(result.inputTokens).to.equal(100);
+      expect(result.outputTokens).to.equal(200);
+    });
+  });
+});

--- a/functions/test/types/pageOcrResult.types.test.ts
+++ b/functions/test/types/pageOcrResult.types.test.ts
@@ -1,0 +1,45 @@
+/**
+ * PageOcrResult 型不変条件テスト (Issue #267, #258 follow-up)
+ *
+ * 目的: PageOcrResult = SummaryField & { pageNumber, inputTokens, outputTokens } の
+ * discriminated union 不変条件を @ts-expect-error で lock-in する。
+ *
+ * 背景 (#258 pr-test-analyzer I2): PR #265 で「truncated=false では originalLength は型に存在しない」
+ * ことを AC で宣言したが、将来 PageOcrResult の型表現が崩れた場合 (例: truncated を optional 化、
+ * originalLength を両 variant で optional 化) に検知する静的契約が無かった。
+ *
+ * 方式: 型レベルテスト。tsc --noEmit で compile エラーを期待する行に @ts-expect-error を置き、
+ * 将来 discriminated union が崩れたら @ts-expect-error 自体が "unused directive" エラーになる。
+ */
+
+import { expect } from 'chai';
+import type { PageOcrResult } from '../../src/ocr/buildPageResult';
+
+describe('PageOcrResult 型不変条件 (#267)', () => {
+  it('truncated=false では originalLength が型に存在しない (@ts-expect-error で lock-in)', () => {
+    const page: PageOcrResult = {
+      pageNumber: 1,
+      text: 'short',
+      truncated: false,
+      inputTokens: 10,
+      outputTokens: 20,
+    };
+    // @ts-expect-error: truncated=false variant では originalLength は型に存在しない (#258 discriminated union 不変条件)
+    void page.originalLength;
+    expect(page.truncated).to.equal(false);
+  });
+
+  it('truncated=true では originalLength が必須', () => {
+    const page: PageOcrResult = {
+      pageNumber: 2,
+      text: 'truncated',
+      truncated: true,
+      originalLength: 100_000,
+      inputTokens: 10,
+      outputTokens: 20,
+    };
+    expect(page.truncated).to.equal(true);
+    // truncated=true variant では originalLength は型に存在する (access OK)
+    expect(page.originalLength).to.equal(100_000);
+  });
+});

--- a/functions/tsconfig.test.json
+++ b/functions/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false
+  },
+  "include": [
+    "src",
+    "../shared",
+    "test/types/**/*.ts"
+  ]
+}

--- a/functions/tsconfig.test.json
+++ b/functions/tsconfig.test.json
@@ -1,4 +1,10 @@
 {
+  // #267: 型レベルテスト (@ts-expect-error) 専用の tsc 検証設定。
+  // ts-node/register は tsconfig include 外のテストファイルを strict 型チェックしないため、
+  // @ts-expect-error directive の実効性確保には tsc を明示的に走らせる必要がある。
+  // include は test/types/ のみ。通常の *.test.ts はランタイムで ts-node/register が処理する。
+  // noUnusedLocals 緩和は型宣言保持のため不可避。副作用として src の本番コード検査が弱まる点は
+  // `npm run build` (tsconfig.json) 側で補完される想定。
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,


### PR DESCRIPTION
## Summary

- `@ts-expect-error` による `PageOcrResult` 型不変条件テストを新設（#258 discriminated union lock-in）
- `buildPageResult` を `src/ocr/buildPageResult.ts` に分離し振る舞いテストで Firestore 書込形式を回帰保護
- `tsconfig.test.json` + `type-check:test` スクリプト追加で CI enforcement を確立

## 背景

PR #265 (#258) pr-test-analyzer 指摘 (I2 / I3):
- **I2**: 「truncated=false では originalLength access が tsc エラー」の継続検証テストが無い
- **I3**: buildPageResult の Firestore 書込形式を担保する unit test が無い（processDocument 統合テストは OCR mock）

## 変更点

### 1. `src/ocr/buildPageResult.ts` 新設
`buildPageResult` と `PageOcrResult` 型を ocrProcessor.ts から移設。ocrProcessor.ts は top-level で \`admin.firestore()\` / \`admin.storage()\` を呼ぶため unit test で直接 import すると \`app/no-app\` エラーが発生する。pure function に分離することで副作用なしで import 可能に。ocrProcessor.ts から re-export して既存 import パス互換性を維持。

### 2. `test/types/pageOcrResult.types.test.ts` 新設 (I2 対応)
\`\`\`ts
// @ts-expect-error: truncated=false variant では originalLength は型に存在しない
void page.originalLength;
\`\`\`
将来 discriminated union が崩れた場合、@ts-expect-error 自体が unused directive となり tsc が失敗する。

### 3. `tsconfig.test.json` + `type-check:test` スクリプト追加
`ts-node/register` は tsconfig include 外のテストを strict 型チェックしないため @ts-expect-error directive が無効化される問題を構造的に解消。`npm test` で `tsc --noEmit -p tsconfig.test.json` が先行、型不変条件の CI enforcement を確立。

### 4. `test/buildPageResult.test.ts` 新設 (I3 対応)
- truncated=false: `Object.prototype.hasOwnProperty` で originalLength キー不在を検証
- truncated=true: originalLength が元テキスト長と一致

## Quality Gate

- `/impl-plan`: ✅ Phase 1A WBS 策定済
- `/simplify`: ⏭️ scope が test 追加 + 純粋関数抽出のみで既に minimal
- `/safe-refactor`: ⏭️ 3 ファイル未満の src 変更（test 追加は対象外）
- Evaluator: ⏭️ 5 ファイル未満
- 負検証: @ts-expect-error を一時削除 → tsc が TS2339 で失敗することを確認（enforcement 動作検証済）

## Test plan

- [x] `npm run build` (functions) PASS
- [x] `npm test` (functions) 450 → 459 passing (+9: type test 2 + behavior test 7)
- [x] `npm run lint` (functions) 0 errors (既存 18 warnings は変更なし)
- [x] negative check: @ts-expect-error 削除で tsc 失敗確認
- [ ] CI (lint-build-test / CodeRabbit / GitGuardian) SUCCESS

## 関連

- Closes #267
- 起点: PR #265 (#258) pr-test-analyzer I2 / I3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Type-checking now runs automatically as a prerequisite when executing the test suite.
  * Added test coverage for page result processing with type validation.

* **Chores**
  * Internal code restructuring to improve organization of page processing logic.
  * Added TypeScript configuration for test type-checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->