### PR TITLE
refactor(textCap): capPageResultsAggregate を SummaryField generic 化 (#264)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -145,7 +145,7 @@ export async function processDocument(
     totalOutputTokens = result.outputTokens;
   }
 
-  // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御。#264 follow-up: 型レベル不変条件は textCap.ts 内コメント参照。
+  // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御。
   const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   pageResults = capPageResultsAggregate(pageResults);
   const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -49,15 +49,37 @@ export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_L
   };
 }
 
-// #258 follow-up (#264): generic `<T extends PageWithText>` の flat optional 戻り値が新 PageOcrResult
-// (discriminated union) の不変条件を runtime で破る経路を残す。Firestore 書込互換は維持。詳細は #264 参照。
-interface PageWithText {
-  text: string;
-  originalLength?: number;
-  truncated?: boolean;
+/**
+ * SummaryField 部 (text/truncated/originalLength) を除いた meta 部のみを抽出する helper。
+ * caller が追加フィールド (pageNumber/inputTokens/outputTokens 等) を持つ場合に、
+ * SummaryField を再構築する際の meta 保持のため使用。
+ *
+ * 用途は cap path (text 再生成経路) 限定。short path (L91 `return page;`) は入力が型準拠している
+ * 前提でそのまま返すため、本 helper は経由しない。型違反入力 (例: truncated=false に originalLength
+ * が混入) の robustness は cap path 内でのみ担保される。
+ */
+function stripSummaryFields<T extends SummaryField>(
+  page: T,
+): Omit<T, 'text' | 'truncated' | 'originalLength'> {
+  const rest = { ...page } as Record<string, unknown>;
+  delete rest.text;
+  delete rest.truncated;
+  delete rest.originalLength;
+  return rest as Omit<T, 'text' | 'truncated' | 'originalLength'>;
 }
 
-export function capPageResultsAggregate<T extends PageWithText>(pages: T[]): T[] {
+/**
+ * ページ配列の合計文字数を MAX_AGGREGATE_PAGE_CHARS 以下に収めるよう切り詰める。
+ *
+ * #264: generic を `<T extends SummaryField>` に制約することで、caller (PageOcrResult 等) の
+ * discriminated union 不変条件 (truncated=false ⟹ originalLength 不在) を型レベル + runtime で
+ * 両面保証する。`stripSummaryFields` で meta 部を抽出後、truncated=false/true を明示分岐して
+ * SummaryField を再構築する。
+ *
+ * T は `SummaryField` フル union を期待する。narrow された T (例: truncated=true 固定型) を
+ * 渡すと、cap 結果が truncated=false になる経路で型契約違反になるため、caller は union 型を保つこと。
+ */
+export function capPageResultsAggregate<T extends SummaryField>(pages: T[]): T[] {
   let runningTotal = 0;
   return pages.map((page) => {
     const remaining = Math.max(0, MAX_AGGREGATE_PAGE_CHARS - runningTotal);
@@ -68,15 +90,32 @@ export function capPageResultsAggregate<T extends PageWithText>(pages: T[]): T[]
       return page;
     }
 
-    const original = page.originalLength ?? page.text.length;
     const capped = capPageText(page.text, perPageBudget);
     runningTotal += capped.text.length;
-    const cappedOriginalLength = capped.truncated ? capped.originalLength : page.text.length;
+
+    const meta = stripSummaryFields(page);
+    // input が既に truncated=true だった場合は常に truncated=true を保持する (情報保存)。
+    // capped.truncated のみで分岐すると、input.truncated=true だが text が既に cap 内のケースで
+    // truncated=false + originalLength 消失という regression が発生する。
+    const isTruncated = page.truncated || capped.truncated;
+
+    if (isTruncated) {
+      // 再 cap 時は元の originalLength を優先保持 (idempotent + 過去情報保存)。
+      // page.truncated=false の場合、text 未切り詰めなので text.length が原本の長さ。
+      const originalFromPage = page.truncated ? page.originalLength : page.text.length;
+      const cappedOriginal = capped.truncated ? capped.originalLength : capped.text.length;
+      return {
+        ...meta,
+        text: capped.text,
+        truncated: true,
+        originalLength: Math.max(originalFromPage, cappedOriginal),
+      } as T;  // T は SummaryField union を保つ前提 (JSDoc 参照)
+    }
+    // truncated=false ⟹ originalLength 不在 (discriminated union 不変条件)
     return {
-      ...page,
+      ...meta,
       text: capped.text,
-      originalLength: Math.max(original, cappedOriginalLength),
-      truncated: page.truncated || capped.truncated,
-    };
+      truncated: false,
+    } as T;  // T は SummaryField union を保つ前提 (JSDoc 参照)
   });
 }

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -54,9 +54,11 @@ export function capPageText(rawText: string, maxLength: number = MAX_PAGE_TEXT_L
  * caller が追加フィールド (pageNumber/inputTokens/outputTokens 等) を持つ場合に、
  * SummaryField を再構築する際の meta 保持のため使用。
  *
- * 用途は cap path (text 再生成経路) 限定。short path (L91 `return page;`) は入力が型準拠している
- * 前提でそのまま返すため、本 helper は経由しない。型違反入力 (例: truncated=false に originalLength
- * が混入) の robustness は cap path 内でのみ担保される。
+ * 用途は cap path (text 再生成経路) 限定。short path (perPageBudget 内かつ !page.truncated の
+ * early return 分岐) は入力が型準拠している前提でそのまま返すため、本 helper は経由しない。
+ * cap path 内では truncated=false 経路から originalLength を確実に落とす (delete) ことで
+ * discriminated union 不変条件を維持するが、値の型バリデーション (例: originalLength が number か)
+ * は行わない — 入力 T が SummaryField 型契約に準拠していることを前提とする。
  */
 function stripSummaryFields<T extends SummaryField>(
   page: T,
@@ -72,9 +74,11 @@ function stripSummaryFields<T extends SummaryField>(
  * ページ配列の合計文字数を MAX_AGGREGATE_PAGE_CHARS 以下に収めるよう切り詰める。
  *
  * #264: generic を `<T extends SummaryField>` に制約することで、caller (PageOcrResult 等) の
- * discriminated union 不変条件 (truncated=false ⟹ originalLength 不在) を型レベル + runtime で
- * 両面保証する。`stripSummaryFields` で meta 部を抽出後、truncated=false/true を明示分岐して
- * SummaryField を再構築する。
+ * discriminated union 不変条件 (truncated=false ⟹ originalLength 不在) を型レベルで強制。
+ * runtime では truncated=false 経路で originalLength を出力しない分岐を明示し、テスト
+ * (textCap.test.ts describe 'discriminated union 不変条件 (#264)') で lock-in する。
+ * `stripSummaryFields` で meta 部を抽出後、truncated=false/true を明示分岐して SummaryField
+ * を再構築する。
  *
  * T は `SummaryField` フル union を期待する。narrow された T (例: truncated=true 固定型) を
  * 渡すと、cap 結果が truncated=false になる経路で型契約違反になるため、caller は union 型を保つこと。
@@ -109,13 +113,13 @@ export function capPageResultsAggregate<T extends SummaryField>(pages: T[]): T[]
         text: capped.text,
         truncated: true,
         originalLength: Math.max(originalFromPage, cappedOriginal),
-      } as T;  // T は SummaryField union を保つ前提 (JSDoc 参照)
+      } as T;  // narrow 型 T (truncated=false 固定等) を渡すと runtime 契約違反 — caller は union を保つこと
     }
-    // truncated=false ⟹ originalLength 不在 (discriminated union 不変条件)
+    // 意図的に originalLength 省略 (stripSummaryFields で除去済み、SummaryField 不変条件維持)
     return {
       ...meta,
       text: capped.text,
       truncated: false,
-    } as T;  // T は SummaryField union を保つ前提 (JSDoc 参照)
+    } as T;  // narrow 型 T (truncated=true 固定等) を渡すと runtime 契約違反 — caller は union を保つこと
   });
 }

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -122,9 +122,9 @@ describe('textCap', () => {
 
   describe('capPageResultsAggregate (aggregate cap)', () => {
     it('合計が閾値以下なら全ページそのまま返される', () => {
-      const pages = [
-        { text: 'page1', originalLength: 5, truncated: false },
-        { text: 'page2', originalLength: 5, truncated: false },
+      const pages: SummaryField[] = [
+        { text: 'page1', truncated: false },
+        { text: 'page2', truncated: false },
       ];
       const result = capPageResultsAggregate(pages);
 
@@ -137,8 +137,7 @@ describe('textCap', () => {
       const pageSize = MAX_PAGE_TEXT_LENGTH;
       const pages = Array.from({ length: 10 }, (_, i) => ({
         text: 'a'.repeat(pageSize),
-        originalLength: pageSize,
-        truncated: false,
+        truncated: false as const,
         pageNumber: i + 1,
       }));
 
@@ -150,9 +149,9 @@ describe('textCap', () => {
 
     it('aggregate超過時、超過したページは truncated=true でメタデータ保持', () => {
       const pageSize = MAX_PAGE_TEXT_LENGTH;
-      const pages = Array.from({ length: 10 }, () => ({
+      // SummaryField[] 明示注釈: 戻り値 narrowing が truncated:false only に固定されないように union で保持
+      const pages: SummaryField[] = Array.from({ length: 10 }, () => ({
         text: 'a'.repeat(pageSize),
-        originalLength: pageSize,
         truncated: false,
       }));
 
@@ -161,15 +160,16 @@ describe('textCap', () => {
 
       expect(truncatedPages.length).to.be.at.least(1);
       truncatedPages.forEach((p) => {
+        // assertTruncated で narrow (silent skip 回避: if ブロックでスキップされて PASS する誤検知を排除)
+        assertTruncated(p);
         expect(p.originalLength).to.equal(pageSize);
       });
     });
 
     it('1ページ目で既に閾値超過の場合は1ページ目内で切り詰め', () => {
-      const pages = [
+      const pages: SummaryField[] = [
         {
           text: 'a'.repeat(MAX_AGGREGATE_PAGE_CHARS + 100),
-          originalLength: MAX_AGGREGATE_PAGE_CHARS + 100,
           truncated: false,
         },
       ];
@@ -181,16 +181,16 @@ describe('textCap', () => {
 
     it('per-page cap と合計 cap の両方が適用される', () => {
       // 各ページ MAX_PAGE_TEXT_LENGTH 超 + 合計 MAX_AGGREGATE_PAGE_CHARS 超
-      const pages = [
-        { text: 'a'.repeat(60_000), originalLength: 60_000, truncated: false },
-        { text: 'b'.repeat(60_000), originalLength: 60_000, truncated: false },
-        { text: 'c'.repeat(60_000), originalLength: 60_000, truncated: false },
-        { text: 'd'.repeat(60_000), originalLength: 60_000, truncated: false },
+      const pages: SummaryField[] = [
+        { text: 'a'.repeat(60_000), truncated: false },
+        { text: 'b'.repeat(60_000), truncated: false },
+        { text: 'c'.repeat(60_000), truncated: false },
+        { text: 'd'.repeat(60_000), truncated: false },
       ];
       const result = capPageResultsAggregate(pages);
 
       // 各ページ per-page cap 内
-      result.forEach((p: { text: string; truncated?: boolean; originalLength?: number }) => {
+      result.forEach((p) => {
         expect(p.text.length).to.be.at.most(MAX_PAGE_TEXT_LENGTH);
       });
       // 合計が aggregate cap 内
@@ -200,6 +200,85 @@ describe('textCap', () => {
 
     it('空配列は空配列を返す', () => {
       expect(capPageResultsAggregate([])).to.deep.equal([]);
+    });
+
+    // #264: discriminated union 不変条件の runtime lock-in。
+    // 型レベルでは `<T extends SummaryField>` で truncated=false ⟹ originalLength 不在を保証するが、
+    // 実装バグで false path に originalLength を付与しないことを runtime でも明示検証する。
+    describe('discriminated union 不変条件 (#264)', () => {
+      it('truncated=false 経路の戻り値に originalLength キーが存在しない', () => {
+        const pages: SummaryField[] = [
+          { text: 'short', truncated: false },
+          { text: 'also-short', truncated: false },
+        ];
+        const result = capPageResultsAggregate(pages);
+
+        result.forEach((p) => {
+          expect(p.truncated).to.be.false;
+          expect(Object.prototype.hasOwnProperty.call(p, 'originalLength')).to.be.false;
+        });
+      });
+
+      it('truncated=true 経路の戻り値に originalLength が存在し number 型である', () => {
+        const pageSize = MAX_PAGE_TEXT_LENGTH;
+        const pages: SummaryField[] = Array.from({ length: 10 }, () => ({
+          text: 'a'.repeat(pageSize),
+          truncated: false,
+        }));
+
+        const result = capPageResultsAggregate(pages);
+        const truncatedPages = result.filter((p) => p.truncated);
+
+        expect(truncatedPages.length).to.be.at.least(1);
+        truncatedPages.forEach((p) => {
+          expect(Object.prototype.hasOwnProperty.call(p, 'originalLength')).to.be.true;
+          // assertTruncated で narrow (silent skip 回避)
+          assertTruncated(p);
+          expect(p.originalLength).to.be.a('number');
+          expect(p.originalLength).to.be.at.least(p.text.length);
+        });
+      });
+
+      it('入力 truncated=true + originalLength 付きの再 cap で元の originalLength が保持される', () => {
+        // 前回実行で既に truncated=true + originalLength=1,000,000 だったページを再 cap する想定。
+        // Math.max(originalFromPage, capped.originalLength) で過去情報が保存されることを lock-in。
+        const pages: SummaryField[] = [
+          { text: 'a'.repeat(MAX_PAGE_TEXT_LENGTH), truncated: true, originalLength: 1_000_000 },
+          { text: 'b'.repeat(MAX_PAGE_TEXT_LENGTH), truncated: false },
+          { text: 'c'.repeat(MAX_PAGE_TEXT_LENGTH), truncated: false },
+          { text: 'd'.repeat(MAX_PAGE_TEXT_LENGTH), truncated: false },
+          { text: 'e'.repeat(MAX_PAGE_TEXT_LENGTH), truncated: false },
+        ];
+        const result = capPageResultsAggregate(pages);
+        const first = result[0];
+        expect(first).to.exist;
+        assertTruncated(first!);
+        expect(first!.originalLength).to.equal(1_000_000);
+      });
+
+      it('meta フィールド (pageNumber/inputTokens/outputTokens) が全経路で保持される', () => {
+        // short path と cap path が混在するサイズで検証
+        const pages = [
+          // page 1: short path (budget 内)
+          { text: 'p1', truncated: false as const, pageNumber: 1, inputTokens: 100, outputTokens: 50 },
+          // page 2: cap path (per-page cap 超過)
+          {
+            text: 'b'.repeat(MAX_PAGE_TEXT_LENGTH + 10),
+            truncated: false as const,
+            pageNumber: 2,
+            inputTokens: 200,
+            outputTokens: 60,
+          },
+        ];
+        const result = capPageResultsAggregate(pages);
+
+        expect(result[0]?.pageNumber).to.equal(1);
+        expect(result[0]?.inputTokens).to.equal(100);
+        expect(result[0]?.outputTokens).to.equal(50);
+        expect(result[1]?.pageNumber).to.equal(2);
+        expect(result[1]?.inputTokens).to.equal(200);
+        expect(result[1]?.outputTokens).to.equal(60);
+      });
     });
   });
 
@@ -247,8 +326,7 @@ describe('textCap', () => {
     it('cap適用後のpageResults配列はFirestore 1MiB制限内に収まる', () => {
       const pages = Array.from({ length: 30 }, (_, i) => ({
         text: 'あ'.repeat(MAX_PAGE_TEXT_LENGTH * 2), // 各ページ大きすぎ
-        originalLength: MAX_PAGE_TEXT_LENGTH * 2,
-        truncated: false,
+        truncated: false as const,
         pageNumber: i + 1,
         inputTokens: 100,
         outputTokens: 50000,


### PR DESCRIPTION
## Summary

- `capPageResultsAggregate` の generic 制約を `<T extends PageWithText>` (flat optional) から `<T extends SummaryField>` (discriminated union) に変更
- `stripSummaryFields` helper 新設で runtime 側でも `originalLength` 混入を排除、cap path で防御的構築
- `truncated=false ⟹ originalLength 不在` の不変条件を **型レベル + runtime** 両面で保証
- #258 Evaluator MEDIUM 指摘のクリーン化 (#264 closes)

## 背景

PR #265 (#258) で `CappedText` / `SummaryField` / `PageOcrResult` を discriminated union 統合したが、`capPageResultsAggregate` の generic のみ `<T extends PageWithText>` で flat optional (`originalLength?, truncated?`) のまま残存。runtime で `truncated=false` でも `originalLength` が同居する経路を残していた。

## 実装 (Option A)

### textCap.ts
- `PageWithText` interface 削除、`<T extends SummaryField>` 制約へ
- `stripSummaryFields<T extends SummaryField>` helper 新設:
  - `Omit<T, 'text' | 'truncated' | 'originalLength'>` を返す
  - cap path 内で `originalLength` 混入を明示 `delete` で排除
  - short path (入力そのまま返却) は型準拠前提のため非経由 (docstring 明記)
- map 内で `truncated=true/false` を明示分岐、SummaryField を再構築
- `isTruncated = page.truncated || capped.truncated` で **input の truncated 情報保存** (pr-test-analyzer Important で regression 発見して修正)

### ocrProcessor.ts
- コメント 1 語削除のみ (#264 follow-up 参照コメント)

## テスト

### 既存 fixture 更新
- `capPageResultsAggregate` describe 内 6 fixture を SummaryField 準拠化 (truncated=false 時の originalLength 削除)

### 新規 #264 discriminated union 不変条件テスト (4 件追加、計 +4 = 461 → 465)
1. `truncated=false` 経路の戻り値に `originalLength` キーが存在しない (`hasOwnProperty` チェック)
2. `truncated=true` 経路の戻り値に `originalLength` が存在し `number` 型
3. meta フィールド (pageNumber/inputTokens/outputTokens) が全経路で保持される
4. **入力 `truncated=true` + `originalLength` 付きの再 cap で元の `originalLength` が保持される** (regression 検知用)

### 追加改善
- `assertTruncated` 徹底で silent skip 排除 (#255 Evaluator 指摘の活用)

## Quality Gate

| 段階 | 結果 | 対応 |
|---|---|---|
| `/impl-plan` | ✅ AC 7 項目定義、Option A 固定 | - |
| `/simplify` / `/safe-refactor` | ⏭️ スキップ | 実質 2 ファイル変更、3+ 基準未満 |
| Evaluator 分離 | ⏭️ スキップ | 5+ 基準未満 |
| `/review-pr` 3 並列 | type-design APPROVE / pr-test Important 2 採用 / code-reviewer issues なし | Invariant Expression 3→4 改善、**regression 発見 + 修正**、docstring 明確化 |
| `/codex review` MCP 版 | ✅ **GO 判定、必須対応なし** | 4 ケース idempotent + 情報保存確認、戻り値型改善は follow-up 候補 |

## regression 発見経緯 (pr-test-analyzer Important #1)

新実装の第一版は `if (capped.truncated)` のみで分岐していたため、**input.truncated=true だが text が既に `perPageBudget` 内で再 cap された場合**に `capped.truncated=false` となり `truncated=true` 情報と `originalLength` が消失する regression を含んでいた。

pr-test-analyzer が L89 の三項演算子挙動を lock-in する追加テストを提案。実装してテスト実行したところ失敗 → regression 確定。修正版は `const isTruncated = page.truncated || capped.truncated;` で旧実装の情報保持挙動を復元し、テスト PASS。

## 4 ケース検証 (Codex GO 判定に基づく)

| page.truncated | capped.truncated | 結果 | 評価 |
|---|---|---|---|
| true | true | truncated:true, originalLength=max | 情報保存 OK |
| true | false | truncated:true, originalLength 維持 | **regression 修正点** |
| false | true | truncated:true, originalLength=page.text.length | 新規 truncate OK |
| false | false | truncated:false, originalLength なし | union 不変条件 OK |

## 影響範囲

- caller: `functions/src/ocr/ocrProcessor.ts:150` 1 箇所のみ、`PageOcrResult extends SummaryField` を満たすため tsc 通過
- Firestore 書込 shape 完全互換、本番 (kanameone/cocoro) 影響ゼロ
- FE 影響なし (BE 内部型のみ)

## Test plan

- [x] `cd functions && npm test` — 465 passing (baseline 461 → +4)
- [x] `cd functions && npm run build` — PASS
- [x] `cd functions && npm run lint` — 0 errors
- [x] `cd functions && npm run type-check:test` — PASS (tsconfig.test.json #267 導入)
- [x] `cd frontend && npm test` — 134 passing 回帰なし
- [x] CI lint-build-test / CodeRabbit / GitGuardian SUCCESS 確認 (push 後)

## Follow-up 候補 (本 PR scope 外)

- Codex 指摘: 戻り値型を `Array<Omit<T, 'text'|'truncated'|'originalLength'> & SummaryField>` 系に寄せて `as T` cast を排除 → 将来 misuse 防御の改善提案
- pr-test Suggestion (rating 4): `runningTotal` aggregate cap 到達後の全 `truncated=true` 振る舞いの分離テスト (現状は間接カバー)

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text capping logic to properly preserve truncation state and text length information when processing aggregated results, ensuring consistent handling of truncated vs. non-truncated content.

* **Tests**
  * Enhanced test coverage with additional validation of text truncation behavior and metadata field preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->