### PR TITLE
docs: 2026-04-19 session17 (Phase 3+4 完遂) を記録

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,8 +1,59 @@
 # ハンドオフメモ
 
-**更新日**: 2026-04-19 session16 (Phase 1 #276 + Phase 2 #283 完遂、セカンドオピニオン ROI 実証、follow-up Issue 起票)
-**ブランチ**: main (PR #286 + #287 マージ済、clean)
-**フェーズ**: Phase 8 + 運用監視基盤全環境展開完了 + Summary リファクタ集約 3/3 + Phase 3 #258 + follow-up 消化 Phase A (2/2) + session14 follow-up Phase 1A/1B (3/3) + session15 follow-up Phase 2 (1/1) + session16 follow-up Phase 1+2 (2/2) 完遂
+**更新日**: 2026-04-19 session17 (Phase 3 #278+#284 + Phase 4 #279 完遂、session16 WBS 4 Phase 全完了)
+**ブランチ**: main (PR #290 + #291 マージ済、clean)
+**フェーズ**: Phase 8 + 運用監視基盤全環境展開完了 + Summary リファクタ集約 3/3 + Phase 3 #258 + follow-up 消化 Phase A (2/2) + session14 follow-up Phase 1A/1B (3/3) + session15 follow-up Phase 2 (1/1) + session16+17 follow-up Phase 1-4 (4/4) 完遂
+
+<a id="session17"></a>
+## ✅ session17 完了サマリー (Phase 3 #278+#284 + Phase 4 #279 完遂)
+
+session16 で策定した WBS 4 Phase のうち残 2 Phase (#278+#284 統合、#279) を完遂し、**1 日 WBS の 4/4 全消化**。Phase 3 は 6 ファイル変更で Evaluator 分離プロトコル発動対象、Phase 4 は軽量 test-only PR で contrast 構成。
+
+| 順 | フェーズ | 結果 |
+|---|---|---|
+| 1 | **Phase 3 (#278+#284): PageOcrResult 3 重定義解消 + `as T` cast 排除** | ✅ PR #290 MERGED (`0878173`) |
+| 2 | **Phase 3 Evaluator 修正** | ✅ contract test ENV_GATE 緩和、aggregate 固有関数名検出、short-path dev-assert 追加 |
+| 3 | **Phase 4 (#279): buildPageResult console.warn 副作用検証** | ✅ PR #291 MERGED (`23b9c62`) |
+
+### Phase 3 設計ポイント (PR #290)
+- `buildPageResult.PageOcrResult` → `RawPageOcrResult` にリネーム、`pdfOperations.ts` ローカル → `SplitPageInput` に分離 → `PageOcrResult` 定義は `shared/types.ts:430` の 1 箇所に限定
+- `capPageResultsAggregate` 戻り値型を `Array<CappedAggregatePage<T>>` (= `Omit<T,'text'|'truncated'|'originalLength'> & SummaryField`) 化し `as T` cast を 0 箇所に削減 → narrow 型 T の silent 契約違反を tsc で検知可能に
+- `assertAggregatePageInvariant` dev-assert (prod no-op) 追加、`capPageText` の dev-assert とペアで型契約を runtime で lock-in
+- contract test (`textCapAsCastContract.test.ts`) で cast 不在 + 命名 + dev-assert 存在を grep lock-in
+
+### Evaluator 指摘への対応 (MEDIUM+LOW 3 件)
+1. **ENV_GATE false-pass リスク** → pattern を `[!=]==` 緩和 + count >= 2 + aggregate 固有関数名 `assertAggregatePageInvariant` を独立検出
+2. **short-path invariant 未検証** → `rebuilt = page` path でも dev-assert を適用、Firestore 旧データ (`originalLength` 残存) を早期検知
+3. **dev-assert 呼び出し重複** → map 末尾 1 回に DRY 化、分岐追加時の漏れ防止
+
+### Phase 4 設計ポイント (PR #291)
+- `buildPageResult` の `console.warn` 副作用 (label/originalLength/cap 値) を 3 test で lock-in
+- `sinon` 依存追加せず、`textCap.test.ts` (#283) の `withWarnSpy` polyfill を踏襲 (try/finally で console.warn 確実復元)
+
+### 達成効果
+- **テスト数**: 496 → 509 passing (+13、Phase 3 で +10、Phase 4 で +3)
+- **tsc exit 0** / **lint errors 0** (warnings は既存ファイルのみ)
+- **型契約の silent divergence リスク根絶**: PageOcrResult 3 重定義解消 + `as T` cast 排除 + dev-assert の二段防御
+
+### follow-up Issue (#288 にコメント追記)
+PR #290 の silent-failure-hunter + pr-test-analyzer レビューで判明した 3 項目を #288 (observability follow-up bundle) に記録:
+1. **prod 環境 invariant violation の observability 格上げ** (critical): 現状 prod は assert no-op。`safeLogError` 化が必要
+2. **capPageResultsAggregate caller の try/catch 方針整理** (medium): dev throw が processDocument 全体を abort させる
+3. **integration/mixed-input テスト** (rating 5-6): ocrProcessor 経由の end-to-end と mixed input 分岐
+
+### マージ済 PR
+- PR #290 (`0878173`): refactor(textCap): PageOcrResult 3重定義解消 + as T cast 排除 (#278 + #284)
+- PR #291 (`23b9c62`): test(ocr): buildPageResult の console.warn 副作用検証追加 (#279)
+
+### 次セッション着手候補 (優先度順)
+1. **#288**: aggregate cap observability follow-up bundle (上記 3 項目。prod observability 格上げは critical)
+2. **#262**: summaryWritePayloadContract diagnostics 強化
+3. **#251**: summaryGenerator unit test + buildSummaryPrompt 分離
+4. **#237**: search tokenizer FE/BE/script 共通化 (横断変更、`/batch` 候補)
+5. **#239 / #238**: force-reindex 機能拡張
+6. **#220**: OOM/truncated log-based metric + alert
+
+---
 
 <a id="session16"></a>
 ## ✅ session16 完了サマリー (Phase 1 #276 + Phase 2 #283 完遂、セカンドオピニオン ROI 実証)
@@ -258,86 +309,6 @@ session13 で完遂した Phase A (#266 + #253) の follow-up 消化スプリン
 
 ---
 
-<a id="session13"></a>
-## ✅ session13 完了サマリー (Phase A 完遂: #266 + #253、follow-up 2 Issue 起票)
-
-session12 で完遂した Phase 3 (#258) + Phase 1 (#259) の follow-up 消化スプリントとして計画。
-PM/PL 視点で WBS 策定 → Phase A (即効性 2 タスク) を 1 セッションで直列完遂。
-CLAUDE.md グローバル ルール (impl-plan / simplify / safe-refactor / review-pr) + プロジェクト
-CLAUDE.md (#178 教訓チェックリスト) を多層適用、各 PR で Critical/Important 全解消 → follow-up Issue 化で scope 明確化。
-
-| 順 | フェーズ | 結果 |
-|---|---|---|
-| 1 | **スプリント計画 (session12 follow-up 消化)** | ✅ WBS Phase A/B/C 策定、Codex 要否判定 (B-2 のみ) |
-| 2 | **Phase A-1 (#266): Vertex AI silent failure 対策** | ✅ PR #270 MERGED (`46a3f2d`) |
-| 3 | **Phase A-2 (#253): firestoreToDocument 集約** | ✅ PR #272 MERGED (`d9187b8`) |
-| 4 | **Follow-up 起票** | ✅ #271 (handleProcessingError safeLogError 統合) + #273 (useProcessingHistory.test.ts 新設) |
-
-### 達成効果 (Phase A 完遂)
-
-| 効果 | 内容 |
-|---|---|
-| 🛡️ silent failure 撃退 | Vertex AI catch 句 3 箇所で `console.error` のみ → `safeLogError` 経由で errors collection + 通知に記録。Firestore 書込失敗時も caller 主処理を中断しない try/catch ラッパ化 |
-| 📦 SSoT 化 | FE の firestoreToDocument を useDocuments に完全集約。useProcessingHistory の劣化コピー 36 行削除。派生フィールド追加時の同期漏れリスク (#178 教訓) を構造的解消 |
-| 🧪 契約テスト | summaryCatchLogErrorContract.test.ts 新設 (grep-based、15 cases)。アンカー近傍 logError/safeLogError 呼出 + params shape 静的検証。#259 同方針で SSoT 確保 |
-| ⚙️ helper 導入 | `safeLogError(params)` を errorLogger.ts に新設。4 箇所 (本 PR 3 + 既存 handleProcessingError 1) の重複パターンを SSoT 化、既存 handleProcessingError は follow-up #271 |
-
-### Phase A-1 (#266) Quality Gate 実施記録
-
-| 段階 | 結果 | 指摘・対応 |
-|---|---|---|
-| `/impl-plan` | ✅ AC 5 項目、3 Phase | scope 確定 (severity override / errorIds 追加は別 Issue) |
-| TDD (契約テスト RED→GREEN) | ✅ 3 本命 RED → 12 passing | anchor 近傍 logError 呼出の静的検証 |
-| `/simplify` 3 並列 | catch コピペ指摘 (中) | `safeLogError` helper 化で重複解消、`: Promise<SummaryField>` 型注釈削除 |
-| `/safe-refactor` | MEDIUM 2 / LOW 2 | MEDIUM 却下 (既存コード、scope 外)、LOW 1 採用 (safeLogError fallback 情報量改善) |
-| `/review-pr` 4 並列 | Critical 0 / Important 5 採用 / 3 却下 | コメント改善 3 (dead code/signature 変更/順序根拠)、契約テスト params shape 拡充、Issue #271 起票 |
-
-### Phase A-2 (#253) Quality Gate 実施記録
-
-| 段階 | 結果 | 指摘・対応 |
-|---|---|---|
-| 事前調査 | ✅ 差分明確化 | useProcessingHistory 固有 `needsManualCustomerSelection` のみ / useDocuments 固有 20+ フィールド |
-| 実装 (Option A 拡張版) | ✅ 2 ファイル +4/-41 | useDocuments に `needsManualCustomerSelection` 追加 + useProcessingHistory 内部関数削除 |
-| `/simplify` / `/safe-refactor` | ⏭️ スキップ | 2 ファイル変更、3+ファイル基準未満 |
-| `/review-pr` 3 並列 | Critical 1 (採用) / Important 3 (1 採用 + 2 follow-up) / Suggestion 1 (採用) | `needsManualCustomerSelection` テスト 3 追加、コメント rot 改善、tombstone 削除、Issue #273 起票 |
-| **#178 教訓チェックリスト準拠** | ✅ 4 点全 OK | mapping / 書込 / reprocess clear / 型定義 全確認済 |
-
-### CI / マージ結果
-
-- BE: `npm test` 435 → 450 passing (+15 = 12 初期 grep 契約テスト + 3 `/review-pr` 指摘対応で追加した params shape 検証)
-- FE: `npm test` 113 → 116 passing (+3 needsManualCustomerSelection 検証)
-- PR #270 CI: lint-build-test SUCCESS / CodeRabbit SUCCESS / GitGuardian SUCCESS → MERGED `46a3f2d`
-- PR #272 CI: lint-build-test SUCCESS / CodeRabbit SUCCESS / GitGuardian SUCCESS → MERGED `d9187b8`
-- 本 PR 群は error logging 追加 + FE refactor (情報量増加方向)、status 遷移・Firestore 書込スキーマ変更なし → kanameone / cocoro 本番環境への影響ゼロ
-
-### 教訓 (PM/PL 視点)
-
-| 教訓 | 内容 |
-|---|---|
-| **follow-up 消化スプリントの価値** | session10/12 起票の follow-up が累積していたのを Phase A で 2 件解消。scope 小の即効タスクを優先することで session 内 2 PR マージが可能 |
-| **グローバル + プロジェクト ルール多層適用** | CLAUDE.md CRITICAL (3 ステップ+→impl-plan / 3 ファイル+→simplify+safe-refactor) と プロジェクト CLAUDE.md (#178 教訓チェックリスト) を併用。#253 で #178 4 点を事前確認したことで回帰リスクゼロ化 |
-| **PR description での指摘判定明記** | `/review-pr` 指摘を採用/却下/follow-up で明示分類。却下理由も記録で監査可能、follow-up Issue への継承が clean |
-| **Codex セカンドオピニオン判定は scope 次第** | 本セッションは scope 小 (bug fix + FE refactor) で Codex 不要と判定、時間節約。B-2 (#264 generic 再設計) は scope 拡大で Codex 対象と予定 |
-| **契約テストの grep パターン継承** | #259 summaryWritePayloadContract パターンを #266 summaryCatchLogErrorContract で再利用。`hasPatternsAdjacent` ヘルパー共通化は #262 に集約予定 |
-
-### 次セッション着手予定 (session14)
-
-**最優先タスク** (Phase B、handoff 継続):
-- **Phase B-1 (#267)**: PageOcrResult 型不変条件 + buildPageResult 振る舞いテスト追加 (~1h、test のみ、#258 follow-up)
-- **Phase B-2 (#264)**: capPageResultsAggregate generic を新 PageOcrResult 対応に書き直し (~1h、3-5 ファイル想定、**Codex セカンドオピニオン予定**)
-- **Phase C-1 (#262)**: summaryWritePayloadContract grep-based 既知制限 + diagnostics 強化 (~1h、contract test ヘルパー共通化と統合余地)
-
-**follow-up Issue (session13 起票)**:
-- **#271**: handleProcessingError の fallback を `safeLogError` に統合 (scope 小、~30min)
-- **#273**: useProcessingHistory.test.ts 新設 + isCustomerConfirmed デュアルリード統合テスト (~1.5h)
-
-**残り WBS** (session10 から継続):
-- **Sprint 3 (#253)**: ✅ 本セッション完遂
-- **Sprint 4 (#237)**: search tokenizer FE/BE/script 3 箇所重複共通化 (大規模)
-- **Sprint 5**: 運用監視拡充 (#220 / #239 / #238)
-- **Sprint 6**: テスト補強 (#200) + bug 消化 (#196)
-
----
 
 ## ✅ session12 完了サマリー (Phase 3 完遂: #258 型統合 + bridge code 削除 + dev-assert)
 

--- a/docs/handoff/archive/2026-04-history.md
+++ b/docs/handoff/archive/2026-04-history.md
@@ -991,3 +991,84 @@ session9 終了時の handoff 誤記録（PR #256 が PR #254 より先にマー
 - **新規 follow-up**: #258 (型設計統合) / #259 (contract test 強化) — 条件付き待機
 
 ---
+
+<a id="session13"></a>
+## ✅ session13 完了サマリー (Phase A 完遂: #266 + #253、follow-up 2 Issue 起票)
+
+session12 で完遂した Phase 3 (#258) + Phase 1 (#259) の follow-up 消化スプリントとして計画。
+PM/PL 視点で WBS 策定 → Phase A (即効性 2 タスク) を 1 セッションで直列完遂。
+CLAUDE.md グローバル ルール (impl-plan / simplify / safe-refactor / review-pr) + プロジェクト
+CLAUDE.md (#178 教訓チェックリスト) を多層適用、各 PR で Critical/Important 全解消 → follow-up Issue 化で scope 明確化。
+
+| 順 | フェーズ | 結果 |
+|---|---|---|
+| 1 | **スプリント計画 (session12 follow-up 消化)** | ✅ WBS Phase A/B/C 策定、Codex 要否判定 (B-2 のみ) |
+| 2 | **Phase A-1 (#266): Vertex AI silent failure 対策** | ✅ PR #270 MERGED (`46a3f2d`) |
+| 3 | **Phase A-2 (#253): firestoreToDocument 集約** | ✅ PR #272 MERGED (`d9187b8`) |
+| 4 | **Follow-up 起票** | ✅ #271 (handleProcessingError safeLogError 統合) + #273 (useProcessingHistory.test.ts 新設) |
+
+### 達成効果 (Phase A 完遂)
+
+| 効果 | 内容 |
+|---|---|
+| 🛡️ silent failure 撃退 | Vertex AI catch 句 3 箇所で `console.error` のみ → `safeLogError` 経由で errors collection + 通知に記録。Firestore 書込失敗時も caller 主処理を中断しない try/catch ラッパ化 |
+| 📦 SSoT 化 | FE の firestoreToDocument を useDocuments に完全集約。useProcessingHistory の劣化コピー 36 行削除。派生フィールド追加時の同期漏れリスク (#178 教訓) を構造的解消 |
+| 🧪 契約テスト | summaryCatchLogErrorContract.test.ts 新設 (grep-based、15 cases)。アンカー近傍 logError/safeLogError 呼出 + params shape 静的検証。#259 同方針で SSoT 確保 |
+| ⚙️ helper 導入 | `safeLogError(params)` を errorLogger.ts に新設。4 箇所 (本 PR 3 + 既存 handleProcessingError 1) の重複パターンを SSoT 化、既存 handleProcessingError は follow-up #271 |
+
+### Phase A-1 (#266) Quality Gate 実施記録
+
+| 段階 | 結果 | 指摘・対応 |
+|---|---|---|
+| `/impl-plan` | ✅ AC 5 項目、3 Phase | scope 確定 (severity override / errorIds 追加は別 Issue) |
+| TDD (契約テスト RED→GREEN) | ✅ 3 本命 RED → 12 passing | anchor 近傍 logError 呼出の静的検証 |
+| `/simplify` 3 並列 | catch コピペ指摘 (中) | `safeLogError` helper 化で重複解消、`: Promise<SummaryField>` 型注釈削除 |
+| `/safe-refactor` | MEDIUM 2 / LOW 2 | MEDIUM 却下 (既存コード、scope 外)、LOW 1 採用 (safeLogError fallback 情報量改善) |
+| `/review-pr` 4 並列 | Critical 0 / Important 5 採用 / 3 却下 | コメント改善 3 (dead code/signature 変更/順序根拠)、契約テスト params shape 拡充、Issue #271 起票 |
+
+### Phase A-2 (#253) Quality Gate 実施記録
+
+| 段階 | 結果 | 指摘・対応 |
+|---|---|---|
+| 事前調査 | ✅ 差分明確化 | useProcessingHistory 固有 `needsManualCustomerSelection` のみ / useDocuments 固有 20+ フィールド |
+| 実装 (Option A 拡張版) | ✅ 2 ファイル +4/-41 | useDocuments に `needsManualCustomerSelection` 追加 + useProcessingHistory 内部関数削除 |
+| `/simplify` / `/safe-refactor` | ⏭️ スキップ | 2 ファイル変更、3+ファイル基準未満 |
+| `/review-pr` 3 並列 | Critical 1 (採用) / Important 3 (1 採用 + 2 follow-up) / Suggestion 1 (採用) | `needsManualCustomerSelection` テスト 3 追加、コメント rot 改善、tombstone 削除、Issue #273 起票 |
+| **#178 教訓チェックリスト準拠** | ✅ 4 点全 OK | mapping / 書込 / reprocess clear / 型定義 全確認済 |
+
+### CI / マージ結果
+
+- BE: `npm test` 435 → 450 passing (+15 = 12 初期 grep 契約テスト + 3 `/review-pr` 指摘対応で追加した params shape 検証)
+- FE: `npm test` 113 → 116 passing (+3 needsManualCustomerSelection 検証)
+- PR #270 CI: lint-build-test SUCCESS / CodeRabbit SUCCESS / GitGuardian SUCCESS → MERGED `46a3f2d`
+- PR #272 CI: lint-build-test SUCCESS / CodeRabbit SUCCESS / GitGuardian SUCCESS → MERGED `d9187b8`
+- 本 PR 群は error logging 追加 + FE refactor (情報量増加方向)、status 遷移・Firestore 書込スキーマ変更なし → kanameone / cocoro 本番環境への影響ゼロ
+
+### 教訓 (PM/PL 視点)
+
+| 教訓 | 内容 |
+|---|---|
+| **follow-up 消化スプリントの価値** | session10/12 起票の follow-up が累積していたのを Phase A で 2 件解消。scope 小の即効タスクを優先することで session 内 2 PR マージが可能 |
+| **グローバル + プロジェクト ルール多層適用** | CLAUDE.md CRITICAL (3 ステップ+→impl-plan / 3 ファイル+→simplify+safe-refactor) と プロジェクト CLAUDE.md (#178 教訓チェックリスト) を併用。#253 で #178 4 点を事前確認したことで回帰リスクゼロ化 |
+| **PR description での指摘判定明記** | `/review-pr` 指摘を採用/却下/follow-up で明示分類。却下理由も記録で監査可能、follow-up Issue への継承が clean |
+| **Codex セカンドオピニオン判定は scope 次第** | 本セッションは scope 小 (bug fix + FE refactor) で Codex 不要と判定、時間節約。B-2 (#264 generic 再設計) は scope 拡大で Codex 対象と予定 |
+| **契約テストの grep パターン継承** | #259 summaryWritePayloadContract パターンを #266 summaryCatchLogErrorContract で再利用。`hasPatternsAdjacent` ヘルパー共通化は #262 に集約予定 |
+
+### 次セッション着手予定 (session14)
+
+**最優先タスク** (Phase B、handoff 継続):
+- **Phase B-1 (#267)**: PageOcrResult 型不変条件 + buildPageResult 振る舞いテスト追加 (~1h、test のみ、#258 follow-up)
+- **Phase B-2 (#264)**: capPageResultsAggregate generic を新 PageOcrResult 対応に書き直し (~1h、3-5 ファイル想定、**Codex セカンドオピニオン予定**)
+- **Phase C-1 (#262)**: summaryWritePayloadContract grep-based 既知制限 + diagnostics 強化 (~1h、contract test ヘルパー共通化と統合余地)
+
+**follow-up Issue (session13 起票)**:
+- **#271**: handleProcessingError の fallback を `safeLogError` に統合 (scope 小、~30min)
+- **#273**: useProcessingHistory.test.ts 新設 + isCustomerConfirmed デュアルリード統合テスト (~1.5h)
+
+**残り WBS** (session10 から継続):
+- **Sprint 3 (#253)**: ✅ 本セッション完遂
+- **Sprint 4 (#237)**: search tokenizer FE/BE/script 3 箇所重複共通化 (大規模)
+- **Sprint 5**: 運用監視拡充 (#220 / #239 / #238)
+- **Sprint 6**: テスト補強 (#200) + bug 消化 (#196)
+
+---


### PR DESCRIPTION
## Summary

session17 の成果 (Phase 3 #278+#284 + Phase 4 #279 完遂) を handoff に記録。session16 で策定した WBS 4 Phase を全消化。

## 変更

- `docs/handoff/LATEST.md`: session17 セクション追加、session13 を archive に移設 (538 → 458 行、500 以下達成)
- `docs/handoff/archive/2026-04-history.md`: session13 を追記 (+80 行)

## Test plan

- [x] LATEST.md 500 行以下 (458 行)
- [x] session13 の内容が archive に保存されていること
- [x] 次セッション着手候補 6 件が優先度順に記載されていること
- [x] PR #290/#291 のコミットハッシュが正確

## 関連

- PR #290 (`0878173`): Phase 3 #278+#284 → Closes #278, #284
- PR #291 (`23b9c62`): Phase 4 #279 → Closes #279
- 次セッション最優先: #288 (aggregate cap observability follow-up bundle、prod observability 格上げ critical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)