### PR TITLE
feat(textCap): aggregate cap warn に pageNumber 付与 (#288 item 2)

### DIFF
--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -161,8 +161,13 @@ export function capPageResultsAggregate<T extends SummaryField>(
       // - 同じ長さで返る idempotent 再 cap (text.length 不変) は重複アラート抑制
       // ocrProcessor 側の aggregate サマリ safeLogError (#283 Option B) と二段で観測性を確保。
       if (capped.text.length < page.text.length) {
+        // #288 item 2: pageNumber を message に含めて「どのページで発動したか」を特定可能に。
+        // T が pageNumber を持つ保証はない (SummaryField 自体に pageNumber なし) ため optional 読取り。
+        // 欠落時は `unknown` を出力し、grep/alert の shape を pageNumber 有無で割らない。
+        const pageNumber = (page as { pageNumber?: number }).pageNumber;
+        const pageLabel = typeof pageNumber === 'number' ? pageNumber : 'unknown';
         console.warn(
-          `[textCap] aggregate cap truncated page: ${page.text.length} → ${capped.text.length} chars (runningTotal=${runningTotal})`,
+          `[textCap] aggregate cap truncated page=${pageLabel}: ${page.text.length} → ${capped.text.length} chars (runningTotal=${runningTotal})`,
         );
       }
 

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -283,11 +283,40 @@ describe('textCap', () => {
         expect(firstMessage).to.match(/page=7\b/);
       });
 
-      // #288 item 2: pageNumber を持たない型 T (plain SummaryField 等) が渡された場合は page=unknown を出力。
-      // `(page as { pageNumber?: number }).pageNumber` で optional 読取り、undefined なら unknown fallback。
+      // #288 item 2: pageNumber を持たない型 T (plain SummaryField 等) では page=unknown fallback。
       it('pageNumber を持たない入力では warn message に page=unknown が含まれる', () => {
         const pages: SummaryField[] = [
           { text: 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 10), truncated: false },
+        ];
+        const { calls } = withWarnSpy(() => capPageResultsAggregate(pages));
+        expect(calls.length).to.be.at.least(1);
+        const firstMessage = String(calls[0]?.[0] ?? '');
+        expect(firstMessage).to.match(/page=unknown\b/);
+      });
+
+      // #288 item 2 境界値: pageNumber=0 (falsy だが number) で page=0 が出る契約。
+      // `typeof === 'number'` gate を `pageNumber > 0` に mutate する regression を捕捉する。
+      it('pageNumber=0 でも page=0 が出る (falsy 扱い禁止)', () => {
+        const pages = [
+          { text: 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 10), truncated: false as const, pageNumber: 0 },
+        ];
+        const { calls } = withWarnSpy(() => capPageResultsAggregate(pages));
+        expect(calls.length).to.be.at.least(1);
+        const firstMessage = String(calls[0]?.[0] ?? '');
+        expect(firstMessage).to.match(/page=0\b/);
+      });
+
+      // #288 item 2 異常系: non-number pageNumber (string 等の silent 型逸脱) で unknown fallback。
+      // `typeof === 'number'` gate を `pageNumber != null` に mutate する regression を捕捉する。
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      it('non-number pageNumber (string 等) では page=unknown に fallback', () => {
+        const pages = [
+          {
+            text: 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 10),
+            truncated: false as const,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            pageNumber: '7' as any,
+          },
         ];
         const { calls } = withWarnSpy(() => capPageResultsAggregate(pages));
         expect(calls.length).to.be.at.least(1);

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -271,6 +271,30 @@ describe('textCap', () => {
         expect(calls.length).to.equal(0);
       });
 
+      // #288 item 2: どのページが truncated されたか特定できるよう pageNumber を warn に含める契約。
+      // pageNumber を持つ型 T (例: RawPageOcrResult) が渡された場合は page=<N> を出力する。
+      it('pageNumber を持つ入力では warn message に page=<N> が含まれる', () => {
+        const pages = [
+          { text: 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 10), truncated: false as const, pageNumber: 7 },
+        ];
+        const { calls } = withWarnSpy(() => capPageResultsAggregate(pages));
+        expect(calls.length).to.be.at.least(1);
+        const firstMessage = String(calls[0]?.[0] ?? '');
+        expect(firstMessage).to.match(/page=7\b/);
+      });
+
+      // #288 item 2: pageNumber を持たない型 T (plain SummaryField 等) が渡された場合は page=unknown を出力。
+      // `(page as { pageNumber?: number }).pageNumber` で optional 読取り、undefined なら unknown fallback。
+      it('pageNumber を持たない入力では warn message に page=unknown が含まれる', () => {
+        const pages: SummaryField[] = [
+          { text: 'a'.repeat(MAX_PAGE_TEXT_LENGTH + 10), truncated: false },
+        ];
+        const { calls } = withWarnSpy(() => capPageResultsAggregate(pages));
+        expect(calls.length).to.be.at.least(1);
+        const firstMessage = String(calls[0]?.[0] ?? '');
+        expect(firstMessage).to.match(/page=unknown\b/);
+      });
+
       // #283 Codex / silent-failure-hunter 指摘対応: truncated=true + budget でさらに短縮される
       // 追加データロスケースを warn で検知する契約。旧実装 `!page.truncated` gate では silent に通過していた。
       it('既 truncated=true でも aggregate budget でさらに短縮される場合は warn が呼ばれる', () => {


### PR DESCRIPTION
## Summary

- aggregate cap 発動時の `console.warn` に `page=<N>` を付与し、どのページで truncation が発生したか特定可能に
- pageNumber を持たない型が渡された場合は `page=unknown` で出力（grep/alert shape を保護）
- #288 item 2 (Codex review Low suggestion) 単独対応

## Motivation

#283 で導入された aggregate cap 発動時の warn は `[textCap] aggregate cap truncated page: 50000 → 0 chars (runningTotal=200000)` のみで、どのページが truncated されたか運用側で特定できなかった。`processDocument` の caller は `RawPageOcrResult`（pageNumber 保持）を渡すため、低コストで observability を上げられる。

## Change

```diff
- `[textCap] aggregate cap truncated page: ${page.text.length} → ...`
+ `[textCap] aggregate cap truncated page=${pageLabel}: ${page.text.length} → ...`
```

`pageLabel` は `(page as { pageNumber?: number }).pageNumber` で optional 読取り、`typeof === 'number'` 時は数値、それ以外は `'unknown'`。

## Test plan

- [x] RED: pageNumber=7 入力で `/page=7\b/` 期待 → AssertionError を確認
- [x] GREEN: 実装後 `/page=7\b/` PASS
- [x] pageNumber 欠落入力で `/page=unknown\b/` PASS
- [x] 全 511 tests PASS
- [x] `npx tsc --noEmit` PASS
- [x] 既存 `runningTotal=\d+` 契約維持確認

## Impact

- 変更: `functions/src/utils/textCap.ts`（1箇所、+5/-1行）+ `functions/test/textCap.test.ts`（+24行）
- FE/BE境界・API契約・status管理 いずれも影響なし
- grep で拾える shape 変更: `aggregate cap truncated page:` → `aggregate cap truncated page=` （log 参照する外部 alert 等あれば要追従、現時点では該当なし）

## Refs

- #288 (parent follow-up bundle)
- #283 (original observability work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate cap truncation warnings now include page information in log messages, displaying either the page number or "unknown" when unavailable.

* **Tests**
  * Added test cases to validate logging behavior for truncation warnings with and without page identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->