### PR TITLE
feat(textCap): prod invariant violation を safeLogError で観測可能に (#288 item 6)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -149,7 +149,8 @@ export async function processDocument(
 
   // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御。
   const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
-  pageResults = capPageResultsAggregate(pageResults);
+  // #288 item 6: invariant violation 発生時の errors collection triage のため docId を伝搬。
+  pageResults = capPageResultsAggregate(pageResults, { documentId: docId });
   const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   if (afterAggregateChars < beforeAggregateChars) {
     // #283: 集約サマリの observability を console.warn → safeLogError に格上げ。

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -78,27 +78,31 @@ export type CappedAggregatePage<T extends SummaryField> =
   Omit<T, 'text' | 'truncated' | 'originalLength'> & SummaryField;
 
 /**
- * invariant violation 検出時の dev/prod 分岐ハンドラ (#288 item 6)。
- *
- * - dev: throw で early fail (既存 #284 契約)
- * - prod: throw せず safeLogError fire-and-forget で errors collection に記録
- *
- * 背景 (#288 item 6 / PR #290 silent-failure-hunter S1 CRITICAL):
- * 旧実装は prod で silent early return だったため、Firestore 旧データ由来の discriminated
- * union 違反 (#209 型: truncated=false + originalLength 残存) が prod で silent に伝播する
- * 経路が残っていた。prod 観測性を safeLogError 経由で格上げし、運用側で検知可能にする。
- *
- * 設計: errorLogger は top-level で admin.firestore() を呼ぶため、prod path に限定した
- * dynamic require で unit test 環境 (admin 未初期化) への影響を回避 (buildPageResult.ts の
- * 「unit test から import しても admin 初期化エラーが発生しない」方針と整合)。safeLogError
- * 内部で try/catch 済み (errorLogger.ts:141-151) なので reject せず、map 処理継続。
+ * capPageResultsAggregate の observability context。
+ * documentId を caller から伝搬させ、errors collection の triage を可能にする
+ * (#288 item 6 + silent-failure-hunter/Codex S2 指摘対応)。
  */
-function handleAggregateInvariantViolation(detail: string): void {
+export interface AggregateInvariantContext {
+  documentId?: string;
+}
+
+/**
+ * invariant violation 検出時の dev/prod 分岐ハンドラ。
+ *
+ * - dev: throw で early fail (#284 契約)
+ * - prod: throw せず safeLogError fire-and-forget で errors collection に記録
+ *   (#288 item 6, PR #290 silent-failure-hunter S1 対応)
+ *
+ * errorLogger は top-level で admin.firestore() を呼ぶため prod path に限定した
+ * dynamic require で unit test (admin 未初期化) への影響を回避 (buildPageResult.ts 方針と整合)。
+ * safeLogError 内部で try/catch 済み (errorLogger.ts:141-151) なので reject せず処理継続。
+ */
+function handleAggregateInvariantViolation(
+  detail: string,
+  context?: AggregateInvariantContext,
+): void {
   const message = `capPageResultsAggregate invariant violation: ${detail}`;
   if (process.env.NODE_ENV === 'production') {
-    // errorLogger top-level の `const db = admin.firestore()` が admin 未初期化環境で throw
-    // するため、load 失敗を try/catch し console.error fallback。prod runtime (Cloud Functions)
-    // では admin 初期化済みのため通常到達せず、万一の失敗も主処理を abort させない。
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { safeLogError } = require('./errorLogger') as typeof import('./errorLogger');
@@ -106,6 +110,7 @@ function handleAggregateInvariantViolation(detail: string): void {
         error: new Error(message),
         source: 'ocr',
         functionName: 'capPageResultsAggregate',
+        documentId: context?.documentId,
       });
     } catch (loadErr) {
       console.error(
@@ -121,22 +126,17 @@ function handleAggregateInvariantViolation(detail: string): void {
 
 /**
  * dev-assert: capPageResultsAggregate の戻り値 1 要素が SummaryField discriminated union の
- * 不変条件を満たしているか runtime 検証する。
+ * 不変条件を満たしているか runtime 検証する (#284 Option B)。
  *
- * - truncated は boolean
- * - text は string
+ * - truncated は boolean / text は string
  * - truncated=true ⟹ originalLength は number
  * - truncated=false ⟹ originalLength キーが存在しない (undefined でなく絶対欠落)
  *
- * caller が narrow 型 T を渡し、コード変更で discriminated union 契約を破った場合の早期検知。
- * capPageText L39-43 の dev-assert と対 (#284 Option B)。引数を unknown にし runtime 型 guard で
- * narrowing することで、戻り値型が厳格になっても追加 cast 不要にしている。
- *
- * #288 item 6: prod でも `handleAggregateInvariantViolation` 経由で safeLogError emit に格上げ。
+ * prod では `handleAggregateInvariantViolation` 経由で safeLogError emit に格上げ (#288 item 6)。
  */
-function assertAggregatePageInvariant(page: unknown): void {
+function assertAggregatePageInvariant(page: unknown, context?: AggregateInvariantContext): void {
   if (typeof page !== 'object' || page === null) {
-    handleAggregateInvariantViolation('not an object');
+    handleAggregateInvariantViolation('not an object', context);
     return;
   }
   const record = page as Record<string, unknown>;
@@ -150,6 +150,7 @@ function assertAggregatePageInvariant(page: unknown): void {
   if (!textOk || !truncatedOk || !originalLengthOk) {
     handleAggregateInvariantViolation(
       `text=${typeof record.text} truncated=${String(truncated)} originalLengthKey=${'originalLength' in record}`,
+      context,
     );
   }
 }
@@ -169,6 +170,7 @@ function assertAggregatePageInvariant(page: unknown): void {
  */
 export function capPageResultsAggregate<T extends SummaryField>(
   pages: T[],
+  context?: AggregateInvariantContext,
 ): Array<CappedAggregatePage<T>> {
   let runningTotal = 0;
   return pages.map((page) => {
@@ -235,7 +237,7 @@ export function capPageResultsAggregate<T extends SummaryField>(
       }
     }
 
-    assertAggregatePageInvariant(rebuilt);
+    assertAggregatePageInvariant(rebuilt, context);
     return rebuilt;
   });
 }

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -78,8 +78,50 @@ export type CappedAggregatePage<T extends SummaryField> =
   Omit<T, 'text' | 'truncated' | 'originalLength'> & SummaryField;
 
 /**
+ * invariant violation 検出時の dev/prod 分岐ハンドラ (#288 item 6)。
+ *
+ * - dev: throw で early fail (既存 #284 契約)
+ * - prod: throw せず safeLogError fire-and-forget で errors collection に記録
+ *
+ * 背景 (#288 item 6 / PR #290 silent-failure-hunter S1 CRITICAL):
+ * 旧実装は prod で silent early return だったため、Firestore 旧データ由来の discriminated
+ * union 違反 (#209 型: truncated=false + originalLength 残存) が prod で silent に伝播する
+ * 経路が残っていた。prod 観測性を safeLogError 経由で格上げし、運用側で検知可能にする。
+ *
+ * 設計: errorLogger は top-level で admin.firestore() を呼ぶため、prod path に限定した
+ * dynamic require で unit test 環境 (admin 未初期化) への影響を回避 (buildPageResult.ts の
+ * 「unit test から import しても admin 初期化エラーが発生しない」方針と整合)。safeLogError
+ * 内部で try/catch 済み (errorLogger.ts:141-151) なので reject せず、map 処理継続。
+ */
+function handleAggregateInvariantViolation(detail: string): void {
+  const message = `capPageResultsAggregate invariant violation: ${detail}`;
+  if (process.env.NODE_ENV === 'production') {
+    // errorLogger top-level の `const db = admin.firestore()` が admin 未初期化環境で throw
+    // するため、load 失敗を try/catch し console.error fallback。prod runtime (Cloud Functions)
+    // では admin 初期化済みのため通常到達せず、万一の失敗も主処理を abort させない。
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { safeLogError } = require('./errorLogger') as typeof import('./errorLogger');
+      void safeLogError({
+        error: new Error(message),
+        source: 'ocr',
+        functionName: 'capPageResultsAggregate',
+      });
+    } catch (loadErr) {
+      console.error(
+        '[textCap] failed to load errorLogger for prod invariant report:',
+        loadErr,
+        message,
+      );
+    }
+    return;
+  }
+  throw new Error(message);
+}
+
+/**
  * dev-assert: capPageResultsAggregate の戻り値 1 要素が SummaryField discriminated union の
- * 不変条件を満たしているか runtime 検証する (production no-op)。
+ * 不変条件を満たしているか runtime 検証する。
  *
  * - truncated は boolean
  * - text は string
@@ -89,11 +131,13 @@ export type CappedAggregatePage<T extends SummaryField> =
  * caller が narrow 型 T を渡し、コード変更で discriminated union 契約を破った場合の早期検知。
  * capPageText L39-43 の dev-assert と対 (#284 Option B)。引数を unknown にし runtime 型 guard で
  * narrowing することで、戻り値型が厳格になっても追加 cast 不要にしている。
+ *
+ * #288 item 6: prod でも `handleAggregateInvariantViolation` 経由で safeLogError emit に格上げ。
  */
 function assertAggregatePageInvariant(page: unknown): void {
-  if (process.env.NODE_ENV === 'production') return;
   if (typeof page !== 'object' || page === null) {
-    throw new Error('capPageResultsAggregate invariant violation: not an object');
+    handleAggregateInvariantViolation('not an object');
+    return;
   }
   const record = page as Record<string, unknown>;
   const textOk = typeof record.text === 'string';
@@ -104,9 +148,8 @@ function assertAggregatePageInvariant(page: unknown): void {
       ? typeof record.originalLength === 'number'
       : !('originalLength' in record);
   if (!textOk || !truncatedOk || !originalLengthOk) {
-    throw new Error(
-      `capPageResultsAggregate invariant violation: text=${typeof record.text} ` +
-        `truncated=${String(truncated)} originalLengthKey=${'originalLength' in record}`,
+    handleAggregateInvariantViolation(
+      `text=${typeof record.text} truncated=${String(truncated)} originalLengthKey=${'originalLength' in record}`,
     );
   }
 }

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -454,7 +454,12 @@ describe('textCap', () => {
         expect(() => capPageResultsAggregate([invalidPage])).to.throw(/invariant violation/);
       });
 
-      it('production では dev-assert が no-op (invalid 入力でも throw しない)', () => {
+      // #288 item 6: prod では throw せず safeLogError fire-and-forget で emit (observability 格上げ)。
+      // 本 runtime test は「throw しない」契約のみ runtime で確認し、safeLogError 実呼出しの検証は
+      // grep-based contract (textCapProdInvariantContract.test.ts) で lock-in。動的 invocation test は
+      // Phase 3 (#288 item 1) で追加。errorLogger load は prod 分岐内で try/catch fallback 済みなので
+      // unit test 環境 (admin 未初期化) でも throw は伝播しない。
+      it('production では invalid 入力でも throw しない (safeLogError 経由で emit)', () => {
         const original = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
         try {

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -454,11 +454,8 @@ describe('textCap', () => {
         expect(() => capPageResultsAggregate([invalidPage])).to.throw(/invariant violation/);
       });
 
-      // #288 item 6: prod では throw せず safeLogError fire-and-forget で emit (observability 格上げ)。
-      // 本 runtime test は「throw しない」契約のみ runtime で確認し、safeLogError 実呼出しの検証は
-      // grep-based contract (textCapProdInvariantContract.test.ts) で lock-in。動的 invocation test は
-      // Phase 3 (#288 item 1) で追加。errorLogger load は prod 分岐内で try/catch fallback 済みなので
-      // unit test 環境 (admin 未初期化) でも throw は伝播しない。
+      // #288 item 6: prod は throw せず safeLogError emit。実呼出検証は
+      // textCapProdInvariantContract.test.ts (grep) + Phase 3 (動的) で二段 lock-in。
       it('production では invalid 入力でも throw しない (safeLogError 経由で emit)', () => {
         const original = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
@@ -472,6 +469,12 @@ describe('textCap', () => {
         } finally {
           process.env.NODE_ENV = original;
         }
+      });
+
+      // #288 item 6 silent-failure-hunter S2 + Codex MED: context.documentId 伝搬 signature 拡張。
+      it('context.documentId を受け取り throw しない (signature 互換)', () => {
+        const pages: SummaryField[] = [{ text: 'short', truncated: false }];
+        expect(() => capPageResultsAggregate(pages, { documentId: 'doc-123' })).to.not.throw();
       });
     });
   });

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -1,0 +1,208 @@
+/**
+ * textCap assertAggregatePageInvariant の prod observability 格上げ契約テスト (Issue #288 item 6)
+ *
+ * 目的: prod で silent early return だった invariant 検証を safeLogError emit に格上げした
+ * 変更 (#288 item 6) の回帰を grep-based で防止する。
+ *
+ * 背景 (#288 item 6 / PR #290 silent-failure-hunter S1 CRITICAL):
+ * 既存 (#284) の assertAggregatePageInvariant は `process.env.NODE_ENV === 'production'` で
+ * early return していたため、Firestore 旧データ由来の discriminated union 違反 (#209 型)
+ * が prod で silent に伝播する経路が残っていた。本契約は prod 分岐で safeLogError を
+ * 経由して errors collection に記録する shape を lock-in する。
+ *
+ * 方式選定:
+ * assertAggregatePageInvariant 関数本体を brace-nesting で抽出し、production 分岐内の
+ * safeLogError 呼出と params (source: 'ocr', functionName: 'capPageResultsAggregate') を
+ * 静的検証する。Phase 1 (#276) / #283 (aggregateCapLogErrorContract.test.ts) と同一手法。
+ *
+ * Phase 3 (Issue #288 item 1) で動的 safeLogError invocation test を追加し、本 grep 契約を
+ * runtime 挙動と二段で lock-in する予定。現時点では admin.firestore() top-level 依存のため
+ * unit test 環境から safeLogError を runtime 実行するのが不適 (buildPageResult 設計方針参照)。
+ */
+
+import { expect } from 'chai';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const TEXT_CAP_PATH = 'src/utils/textCap.ts';
+
+/**
+ * assertAggregatePageInvariant 関数本体 (function 宣言直後の `{...}`) を抽出する。
+ * anchor 消失/リネーム時は空文字を返し、caller 側で明示失敗させる。
+ */
+function extractAssertFunctionBody(source: string): string {
+  const ANCHOR = /function\s+assertAggregatePageInvariant\s*\([^)]*\)\s*:\s*void\s*\{/;
+  const match = source.match(ANCHOR);
+  if (!match || match.index === undefined) return '';
+
+  const openBraceIdx = source.indexOf('{', match.index);
+  if (openBraceIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openBraceIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openBraceIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * handleAggregateInvariantViolation helper 関数本体を抽出する (#288 item 6 で導入予定)。
+ * 実装で helper 分離した場合、prod 分岐はこちらに移る想定。存在しない場合は空文字を返す。
+ */
+function extractHelperFunctionBody(source: string): string {
+  const ANCHOR = /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
+  const match = source.match(ANCHOR);
+  if (!match || match.index === undefined) return '';
+
+  const openBraceIdx = source.indexOf('{', match.index);
+  if (openBraceIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openBraceIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openBraceIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * prod 分岐ブロック (`if (process.env.NODE_ENV === 'production') { ... }`) を抽出。
+ * ==='production' と !== 'production' の両形を許容する前方一致。
+ */
+function extractProdBranch(block: string): string {
+  const ANCHOR = /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
+  const match = block.match(ANCHOR);
+  if (!match || match.index === undefined) return '';
+
+  const openBraceIdx = block.indexOf('{', match.index);
+  if (openBraceIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openBraceIdx; i < block.length; i++) {
+    const ch = block[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return block.slice(openBraceIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * safeLogError 呼出の引数ブロック (括弧内) を抽出。
+ * aggregateCapLogErrorContract.test.ts の同名 helper と同一仕様。
+ */
+function extractSafeLogErrorArgs(block: string): string {
+  const match = block.match(/\bsafeLogError\s*\(/);
+  if (!match || match.index === undefined) return '';
+
+  const openParenIdx = block.indexOf('(', match.index);
+  if (openParenIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openParenIdx; i < block.length; i++) {
+    const ch = block[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) {
+        return block.slice(openParenIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+describe('textCap prod invariant observability contract (#288 item 6)', () => {
+  let source = '';
+
+  before(() => {
+    const absPath = resolve(process.cwd(), TEXT_CAP_PATH);
+    expect(existsSync(absPath), `${TEXT_CAP_PATH} が見つからない`).to.be.true;
+    source = readFileSync(absPath, 'utf-8');
+  });
+
+  it('assertAggregatePageInvariant 関数定義が存在する (anchor 保護)', () => {
+    const body = extractAssertFunctionBody(source);
+    expect(body, 'assertAggregatePageInvariant 関数の anchor が消失 — リネームなら本契約更新').to
+      .not.equal('');
+  });
+
+  it('prod 分岐 (process.env.NODE_ENV === "production") が存在する', () => {
+    // helper 分離の場合は helper 本体、未分離なら assert 本体を探索。
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const searchScope = helperBody || assertBody;
+    const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch, 'prod 分岐が検出されない — silent return に回帰している可能性').to.not.equal(
+      '',
+    );
+  });
+
+  it('prod 分岐内に safeLogError 呼出が存在する', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const searchScope = helperBody || assertBody;
+    const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch).to.match(
+      /\bsafeLogError\s*\(/,
+      'prod 分岐内に safeLogError 呼出が見つからない — silent 回帰',
+    );
+  });
+
+  it('prod 分岐の safeLogError 引数に source: "ocr" が含まれる', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const searchScope = helperBody || assertBody;
+    const prodBranch = extractProdBranch(searchScope);
+    const args = extractSafeLogErrorArgs(prodBranch);
+    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.equal('');
+    expect(args).to.match(/source\s*:\s*['"]ocr['"]/);
+  });
+
+  it('prod 分岐の safeLogError 引数に functionName: "capPageResultsAggregate" が含まれる', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const searchScope = helperBody || assertBody;
+    const prodBranch = extractProdBranch(searchScope);
+    const args = extractSafeLogErrorArgs(prodBranch);
+    expect(args).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
+  });
+
+  it('prod 分岐内で throw が発生しない (throw 文がない)', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const searchScope = helperBody || assertBody;
+    const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch).to.not.match(
+      /\bthrow\s+(?:new\s+)?Error\b/,
+      'prod 分岐に throw が残存 — fire-and-forget 方針に違反',
+    );
+  });
+
+  it('dev 経路では throw が維持されている (assert 本体 or helper 本体に throw が存在)', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const combined = `${assertBody}\n${helperBody}`;
+    expect(combined).to.match(
+      /\bthrow\s+new\s+Error\b/,
+      'dev throw が消滅 — 既存 #284 契約が壊れている',
+    );
+  });
+});

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -53,8 +53,8 @@ function extractAssertFunctionBody(source: string): string {
 }
 
 /**
- * handleAggregateInvariantViolation helper 関数本体を抽出する (#288 item 6 で導入予定)。
- * 実装で helper 分離した場合、prod 分岐はこちらに移る想定。存在しない場合は空文字を返す。
+ * handleAggregateInvariantViolation helper 関数本体を抽出する (#288 item 6 で導入)。
+ * 実装で helper 分離した場合、prod 分岐はこちらに移る。存在しない場合は空文字を返す。
  */
 function extractHelperFunctionBody(source: string): string {
   const ANCHOR = /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
@@ -203,6 +203,30 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     expect(combined).to.match(
       /\bthrow\s+new\s+Error\b/,
       'dev throw が消滅 — 既存 #284 契約が壊れている',
+    );
+  });
+
+  // Codex second opinion (MED): helper が残ったまま assert が silent return に回帰する
+  // パターンを検知するため、assert 本体からの helper 呼出を grep で lock-in。
+  it('assertAggregatePageInvariant 本体から handleAggregateInvariantViolation が呼ばれる', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    expect(assertBody).to.match(
+      /\bhandleAggregateInvariantViolation\s*\(/,
+      'assert 本体から helper 呼出が消失 — silent return 回帰の可能性',
+    );
+  });
+
+  // silent-failure-hunter S2 + Codex MED: errors collection triage のため documentId 伝搬を
+  // lock-in。context?.documentId または documentId キー自体の存在を検証する。
+  it('prod 分岐の safeLogError 引数に documentId が含まれる (triage 伝搬)', () => {
+    const assertBody = extractAssertFunctionBody(source);
+    const helperBody = extractHelperFunctionBody(source);
+    const searchScope = helperBody || assertBody;
+    const prodBranch = extractProdBranch(searchScope);
+    const args = extractSafeLogErrorArgs(prodBranch);
+    expect(args).to.match(
+      /\bdocumentId\b/,
+      'safeLogError 引数に documentId が含まれない — 違反 document の特定不可',
     );
   });
 });


### PR DESCRIPTION
## Summary

- `assertAggregatePageInvariant` の prod silent early return を `safeLogError` emit に格上げし、#209 型 Firestore 旧データの silent 伝播を observable 化
- `AggregateInvariantContext` で caller から `documentId` を伝搬し、errors collection の triage を可能化
- PR #290 silent-failure-hunter **S1 (CRITICAL)** 指摘対応

## Motivation

旧実装 (#284) は `NODE_ENV === 'production'` で silent early return のため、Firestore 旧データ由来の discriminated union 違反が prod で silent 伝播していた。本 PR で `safeLogError` 経由で errors collection に記録し、alert/dashboard で捕捉可能に。

## Design

### dev/prod 分岐集約
- `handleAggregateInvariantViolation(detail, context?)` helper に分岐集約
  - dev: `throw new Error(...)` (#284 契約)
  - prod: `void safeLogError({source, functionName, documentId})` fire-and-forget

### context.documentId 伝搬 (silent-failure-hunter S2 + Codex MED 対応)
- `AggregateInvariantContext { documentId?: string }` interface 新設
- `capPageResultsAggregate<T>(pages, context?)` signature 拡張
- caller `ocrProcessor.ts:152` で `{ documentId: docId }` を渡す

### errorLogger dynamic require
- errorLogger は top-level で `admin.firestore()` を呼ぶため、unit test 環境で module load が失敗
- prod path に限定した `require('./errorLogger')` で load を遅延 (buildPageResult.ts 方針と整合)
- load 失敗は try/catch で console.error fallback

## Test plan

### 新規 grep-based contract (`test/textCapProdInvariantContract.test.ts`, 9 cases)
- [x] `assertAggregatePageInvariant` anchor 保護
- [x] prod 分岐 (`NODE_ENV === 'production'`) の存在検証
- [x] prod 分岐内の `safeLogError` 呼出存在
- [x] 呼出引数に `source: 'ocr'` / `functionName: 'capPageResultsAggregate'` / `documentId`
- [x] prod 分岐に throw が残存しない
- [x] dev 経路で throw が維持されている
- [x] **assert 本体から helper 呼出を grep** (Codex MED: helper 未使用回帰検知)

### Runtime test
- [x] `dev-assert (#284)` 既存 test タイトル更新
- [x] `context.documentId` signature 互換 test 追加

### Acceptance Criteria
- [x] AC1: prod + invalid → throw なし
- [x] AC2: prod + invalid → safeLogError + source + functionName + **documentId** (grep)
- [x] AC3: dev + invalid → 従来通り throw
- [x] AC4: dev + valid → no throw
- [x] AC5: ocrProcessor caller 更新済 (既存テスト PASS)
- [x] AC6: tsc --noEmit PASS
- [x] **523 tests PASS**

## Impact

| 項目 | 内容 |
|---|---|
| 変更ファイル | `functions/src/utils/textCap.ts`, `functions/src/ocr/ocrProcessor.ts`, `functions/test/textCap.test.ts`, `functions/test/textCapProdInvariantContract.test.ts` |
| ファイル数 | 4 |
| FE/BE境界 | 影響なし |
| DB 書込 | prod 時に `errors` collection への best-effort 書込 |

## Risks & Mitigations

| リスク | 対処 |
|---|---|
| `void safeLogError` の unhandled rejection | errorLogger.ts:141-151 で catch 済み + 保険 try/catch |
| errorLogger load 失敗 | try/catch + console.error fallback |
| 循環 import | 構造上なし |
| **fire-and-forget flush 保証 (Codex HIGH)** | caller (ocrProcessor:152) 以降の await chain により通常経路は flush される。**instance crash 耐性は #297 で follow-up** (Option A/B/C 選定予定) |
| prod log spam | 違反頻度はレア。rate limit は必要に応じて follow-up |

## Reviews Summary

- **code-reviewer**: PASS (Critical/Important なし)
- **pr-test-analyzer**: Rating 8/10 (Phase 3 deferral OK)
- **silent-failure-hunter (self-audit)**: S2 (documentId) → **本 PR で解消**
- **comment-analyzer**: minor suggestions → **本 PR で対応**
- **Codex (GPT second opinion)**: HIGH (flush) → **#297 follow-up**、MED (documentId / helper 呼出) → **本 PR で解消**

## Refs

- Parent: #288 (observability follow-up bundle)
- Preceding: #287 / PR #290 (silent-failure-hunter S1 指摘元)
- Follow-up: #297 (flush 保証)、#288 item 1 (Phase 3 動的 invocation test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)