### PR TITLE
test(textCap): safeLogError 動的 invocation + fallback runtime test (#288 item 1)

### DIFF
--- a/functions/test/textCapProdInvariantDynamic.test.ts
+++ b/functions/test/textCapProdInvariantDynamic.test.ts
@@ -1,29 +1,20 @@
 /**
  * textCap assertAggregatePageInvariant の prod observability 動的 invocation テスト (#288 item 1)
  *
- * 目的: Phase 2 (PR #296) で導入した grep-based contract を runtime 挙動で補強する。
- * grep は shape を lock-in するが、条件分岐 reversal や helper 未使用回帰を runtime で
- * 検知できないため、動的 mock を用いて safeLogError 呼出の事実と引数を直接検証する。
+ * grep contract (textCapProdInvariantContract.test.ts) と二段 lock-in:
+ * - grep: shape (token 存在) + anchor 保護
+ * - runtime (本 test): 条件分岐 reversal / callCount / 引数 propagation / console.error fallback
  *
- * 手法:
- * - `requireCjs.cache` 差し替えで `../src/utils/errorLogger` module を stub 化 (sinon/proxyquire
- *   等の追加依存なし)
- * - prod / dev / fallback 各経路を runtime 実行し callCount / args を検証
- * - afterEach で module cache を clean up し他 test への漏洩を防止
- *
- * Phase 2 grep contract (textCapProdInvariantContract.test.ts) との二段 lock-in:
- * - grep: shape (token 存在)、anchor 保護
- * - runtime (本 test): 条件分岐 reversal 検知、callCount、引数 shape
+ * mocha は default で file 内逐次実行のため module cache 差し替えは安全。並列実行を有効化する場合は
+ * 本ファイルを分離必須（cache は Node global singleton）。
  */
 
 import { expect } from 'chai';
 import { createRequire } from 'module';
 import type { SummaryField } from '../../shared/types';
 
-// ts-node の ESM モードで require を使うため createRequire 経由で取得。
-// Node.js module cache は global singleton のため、requireCjs.cache と Node 内部の
-// requireCjs.cache は同一 object を参照し、本 test で注入した stub は textCap.ts 内部の
-// dynamic require(...) にも反映される。
+// ts-node ESM モードで CJS require を得るため createRequire を使用。
+// cache は Node 内部と同一参照のため stub が textCap.ts 内部の dynamic require に反映される。
 const requireCjs = createRequire(import.meta.url);
 const ERROR_LOGGER_PATH = requireCjs.resolve('../src/utils/errorLogger');
 const TEXT_CAP_PATH = requireCjs.resolve('../src/utils/textCap');
@@ -42,16 +33,15 @@ interface StubState {
 
 /**
  * requireCjs.cache に errorLogger の stub module を注入する。
- * `stubState.throwOnLoad=true` の場合は require 時に throw (console.error fallback path 検証用)。
+ * `state.throwOnLoad=true` の場合は require 時に throw (console.error fallback path 検証用)。
+ * accessor/data どちらも `delete` で除去可能なので cleanup は単一経路で OK。
  */
 function installErrorLoggerStub(state: StubState): void {
-  // stub 注入前に既存 cache を除去 (他 test で load 済みの場合を考慮)
+  // 前回テストの cache 残留を除去（stub 反映 & 新規 load 誘発）
   delete requireCjs.cache[ERROR_LOGGER_PATH];
-  // textCap.ts も cache から外して「次の require で新規 load させる」
   delete requireCjs.cache[TEXT_CAP_PATH];
 
   if (state.throwOnLoad) {
-    // require 時に throw させるため getter を介して exports を提供
     Object.defineProperty(requireCjs.cache, ERROR_LOGGER_PATH, {
       configurable: true,
       get() {
@@ -79,7 +69,6 @@ function installErrorLoggerStub(state: StubState): void {
 }
 
 function uninstallErrorLoggerStub(): void {
-  // getter 形式も delete で両対応
   delete requireCjs.cache[ERROR_LOGGER_PATH];
   delete requireCjs.cache[TEXT_CAP_PATH];
 }
@@ -90,7 +79,12 @@ function withNodeEnv<T>(env: string, fn: () => T): T {
   try {
     return fn();
   } finally {
-    process.env.NODE_ENV = original;
+    // original が undefined のとき代入すると文字列 'undefined' に coerce されるため delete で復元
+    if (original === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = original;
+    }
   }
 }
 
@@ -147,7 +141,7 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
       expect(call?.error.message).to.match(/capPageResultsAggregate invariant violation/);
     });
 
-    it('prod + context.documentId 指定時に safeLogError 引数へ伝搬される (silent-failure-hunter S2)', () => {
+    it('prod + context.documentId 指定時に safeLogError 引数へ伝搬され、単一 emit される', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
@@ -161,6 +155,9 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
         capPageResultsAggregate([invalidPage], { documentId: 'doc-xyz-123' });
       });
 
+      // silent-failure-hunter S2 + Codex: 伝搬 propagation を assertion、
+      // かつ二重 emit mutation を length 固定で捕捉
+      expect(state.calls.length).to.equal(1);
       expect(state.calls[0]?.documentId).to.equal('doc-xyz-123');
     });
 
@@ -198,19 +195,26 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
     });
   });
 
-  describe('errorLogger load 失敗時の console.error fallback (Codex S3)', () => {
-    it('prod + errorLogger require 失敗時に console.error ([textCap] prefix) で fallback', () => {
+  describe('errorLogger load 失敗時の console.error fallback', () => {
+    // console.error を一時 spy 化し、args を取得して復元する helper
+    function withConsoleErrorSpy<T>(fn: (calls: unknown[][]) => T): T {
+      const original = console.error;
+      const calls: unknown[][] = [];
+      console.error = (...args: unknown[]): void => {
+        calls.push(args);
+      };
+      try {
+        return fn(calls);
+      } finally {
+        console.error = original;
+      }
+    }
+
+    it('prod + errorLogger require 失敗 + invalid page → console.error ([textCap] prefix + invariant message) で fallback', () => {
       state = { calls: [], throwOnLoad: true };
       installErrorLoggerStub(state);
 
-      // console.error を spy 化
-      const originalConsoleError = console.error;
-      const errorCalls: unknown[][] = [];
-      console.error = (...args: unknown[]): void => {
-        errorCalls.push(args);
-      };
-
-      try {
+      const errorCalls = withConsoleErrorSpy((calls) => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
@@ -223,14 +227,37 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
         withNodeEnv('production', () => {
           expect(() => capPageResultsAggregate([invalidPage])).to.not.throw();
         });
+        return calls;
+      });
 
-        // console.error が [textCap] prefix で呼ばれていること
-        expect(errorCalls.length).to.be.at.least(1);
-        const firstCall = errorCalls[0];
-        expect(String(firstCall?.[0] ?? '')).to.match(/\[textCap\]/);
-      } finally {
-        console.error = originalConsoleError;
-      }
+      // prefix
+      expect(errorCalls.length).to.be.at.least(1);
+      const firstCall = errorCalls[0] ?? [];
+      expect(String(firstCall[0] ?? '')).to.match(/\[textCap\]/);
+      // message 引数 drop regression 捕捉: 引数いずれかに invariant violation 文字列が含まれる
+      const joined = firstCall.map((a) => String(a)).join(' | ');
+      expect(joined).to.match(/invariant violation/);
+    });
+
+    // pr-test-analyzer Important #1: valid path で fallback が発火しない対称テスト。
+    // try/catch が prod 分岐外に hoist された mutation を捕捉。
+    it('prod + errorLogger require 失敗 + valid page → console.error が呼ばれない (false positive 防止)', () => {
+      state = { calls: [], throwOnLoad: true };
+      installErrorLoggerStub(state);
+
+      const errorCalls = withConsoleErrorSpy((calls) => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+        const validPages: SummaryField[] = [{ text: 'short', truncated: false }];
+
+        withNodeEnv('production', () => {
+          capPageResultsAggregate(validPages);
+        });
+        return calls;
+      });
+
+      expect(errorCalls.length).to.equal(0);
     });
   });
 });

--- a/functions/test/textCapProdInvariantDynamic.test.ts
+++ b/functions/test/textCapProdInvariantDynamic.test.ts
@@ -1,0 +1,236 @@
+/**
+ * textCap assertAggregatePageInvariant の prod observability 動的 invocation テスト (#288 item 1)
+ *
+ * 目的: Phase 2 (PR #296) で導入した grep-based contract を runtime 挙動で補強する。
+ * grep は shape を lock-in するが、条件分岐 reversal や helper 未使用回帰を runtime で
+ * 検知できないため、動的 mock を用いて safeLogError 呼出の事実と引数を直接検証する。
+ *
+ * 手法:
+ * - `requireCjs.cache` 差し替えで `../src/utils/errorLogger` module を stub 化 (sinon/proxyquire
+ *   等の追加依存なし)
+ * - prod / dev / fallback 各経路を runtime 実行し callCount / args を検証
+ * - afterEach で module cache を clean up し他 test への漏洩を防止
+ *
+ * Phase 2 grep contract (textCapProdInvariantContract.test.ts) との二段 lock-in:
+ * - grep: shape (token 存在)、anchor 保護
+ * - runtime (本 test): 条件分岐 reversal 検知、callCount、引数 shape
+ */
+
+import { expect } from 'chai';
+import { createRequire } from 'module';
+import type { SummaryField } from '../../shared/types';
+
+// ts-node の ESM モードで require を使うため createRequire 経由で取得。
+// Node.js module cache は global singleton のため、requireCjs.cache と Node 内部の
+// requireCjs.cache は同一 object を参照し、本 test で注入した stub は textCap.ts 内部の
+// dynamic require(...) にも反映される。
+const requireCjs = createRequire(import.meta.url);
+const ERROR_LOGGER_PATH = requireCjs.resolve('../src/utils/errorLogger');
+const TEXT_CAP_PATH = requireCjs.resolve('../src/utils/textCap');
+
+interface SafeLogErrorParams {
+  error: Error;
+  source: string;
+  functionName: string;
+  documentId?: string;
+}
+
+interface StubState {
+  calls: SafeLogErrorParams[];
+  throwOnLoad: boolean;
+}
+
+/**
+ * requireCjs.cache に errorLogger の stub module を注入する。
+ * `stubState.throwOnLoad=true` の場合は require 時に throw (console.error fallback path 検証用)。
+ */
+function installErrorLoggerStub(state: StubState): void {
+  // stub 注入前に既存 cache を除去 (他 test で load 済みの場合を考慮)
+  delete requireCjs.cache[ERROR_LOGGER_PATH];
+  // textCap.ts も cache から外して「次の require で新規 load させる」
+  delete requireCjs.cache[TEXT_CAP_PATH];
+
+  if (state.throwOnLoad) {
+    // require 時に throw させるため getter を介して exports を提供
+    Object.defineProperty(requireCjs.cache, ERROR_LOGGER_PATH, {
+      configurable: true,
+      get() {
+        throw new Error('simulated errorLogger load failure');
+      },
+    });
+    return;
+  }
+
+  const stubExports = {
+    safeLogError: async (params: SafeLogErrorParams): Promise<void> => {
+      state.calls.push(params);
+    },
+  };
+
+  requireCjs.cache[ERROR_LOGGER_PATH] = {
+    id: ERROR_LOGGER_PATH,
+    filename: ERROR_LOGGER_PATH,
+    loaded: true,
+    parent: null,
+    children: [],
+    exports: stubExports,
+    paths: [],
+  } as unknown as NodeJS.Module;
+}
+
+function uninstallErrorLoggerStub(): void {
+  // getter 形式も delete で両対応
+  delete requireCjs.cache[ERROR_LOGGER_PATH];
+  delete requireCjs.cache[TEXT_CAP_PATH];
+}
+
+function withNodeEnv<T>(env: string, fn: () => T): T {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = env;
+  try {
+    return fn();
+  } finally {
+    process.env.NODE_ENV = original;
+  }
+}
+
+describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
+  let state: StubState;
+
+  afterEach(() => {
+    uninstallErrorLoggerStub();
+  });
+
+  describe('production 分岐の safeLogError 動的検証', () => {
+    beforeEach(() => {
+      state = { calls: [], throwOnLoad: false };
+      installErrorLoggerStub(state);
+    });
+
+    it('prod + invalid page で safeLogError が callCount=1 で呼ばれる', () => {
+      // 新規 load された textCap を取得 (stub を反映)
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+      const invalidPage = {
+        text: 'short',
+        truncated: false,
+        originalLength: 999_999,
+      } as unknown as SummaryField;
+
+      withNodeEnv('production', () => {
+        expect(() => capPageResultsAggregate([invalidPage])).to.not.throw();
+      });
+
+      expect(state.calls.length).to.equal(1);
+    });
+
+    it('prod + invalid page の safeLogError 引数に source:"ocr" / functionName:"capPageResultsAggregate" / error 含有', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+      const invalidPage = {
+        text: 'short',
+        truncated: false,
+        originalLength: 999_999,
+      } as unknown as SummaryField;
+
+      withNodeEnv('production', () => {
+        capPageResultsAggregate([invalidPage]);
+      });
+
+      expect(state.calls.length).to.be.at.least(1);
+      const call = state.calls[0];
+      expect(call?.source).to.equal('ocr');
+      expect(call?.functionName).to.equal('capPageResultsAggregate');
+      expect(call?.error).to.be.instanceOf(Error);
+      expect(call?.error.message).to.match(/capPageResultsAggregate invariant violation/);
+    });
+
+    it('prod + context.documentId 指定時に safeLogError 引数へ伝搬される (silent-failure-hunter S2)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+      const invalidPage = {
+        text: 'short',
+        truncated: false,
+        originalLength: 999_999,
+      } as unknown as SummaryField;
+
+      withNodeEnv('production', () => {
+        capPageResultsAggregate([invalidPage], { documentId: 'doc-xyz-123' });
+      });
+
+      expect(state.calls[0]?.documentId).to.equal('doc-xyz-123');
+    });
+
+    it('prod + valid page では safeLogError は呼ばれない (false positive 防止)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+      const validPages: SummaryField[] = [
+        { text: 'short1', truncated: false },
+        { text: 'short2', truncated: false },
+      ];
+
+      withNodeEnv('production', () => {
+        capPageResultsAggregate(validPages);
+      });
+
+      expect(state.calls.length).to.equal(0);
+    });
+
+    it('dev + invalid page では safeLogError は呼ばれず throw する (prod 分岐のみ emit)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+      const invalidPage = {
+        text: 'short',
+        truncated: false,
+        originalLength: 999_999,
+      } as unknown as SummaryField;
+
+      withNodeEnv('development', () => {
+        expect(() => capPageResultsAggregate([invalidPage])).to.throw(/invariant violation/);
+      });
+
+      expect(state.calls.length).to.equal(0);
+    });
+  });
+
+  describe('errorLogger load 失敗時の console.error fallback (Codex S3)', () => {
+    it('prod + errorLogger require 失敗時に console.error ([textCap] prefix) で fallback', () => {
+      state = { calls: [], throwOnLoad: true };
+      installErrorLoggerStub(state);
+
+      // console.error を spy 化
+      const originalConsoleError = console.error;
+      const errorCalls: unknown[][] = [];
+      console.error = (...args: unknown[]): void => {
+        errorCalls.push(args);
+      };
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
+
+        const invalidPage = {
+          text: 'short',
+          truncated: false,
+          originalLength: 999_999,
+        } as unknown as SummaryField;
+
+        withNodeEnv('production', () => {
+          expect(() => capPageResultsAggregate([invalidPage])).to.not.throw();
+        });
+
+        // console.error が [textCap] prefix で呼ばれていること
+        expect(errorCalls.length).to.be.at.least(1);
+        const firstCall = errorCalls[0];
+        expect(String(firstCall?.[0] ?? '')).to.match(/\[textCap\]/);
+      } finally {
+        console.error = originalConsoleError;
+      }
+    });
+  });
+});

--- a/functions/test/textCapProdInvariantDynamic.test.ts
+++ b/functions/test/textCapProdInvariantDynamic.test.ts
@@ -13,8 +13,13 @@ import { expect } from 'chai';
 import { createRequire } from 'module';
 import type { SummaryField } from '../../shared/types';
 
-// ts-node ESM モードで CJS require を得るため createRequire を使用。
-// cache は Node 内部と同一参照のため stub が textCap.ts 内部の dynamic require に反映される。
+// ts-node runtime は mocha esm-utils 経由で ESM モード実行 (require 未定義) だが、
+// tsc は package.json type 未設定 + tsconfig module:NodeNext を CJS 出力と判定し
+// `import.meta` を TS1470 で reject する。runtime では ESM として解決可能なので
+// @ts-expect-error で tsc エラーを抑制 (実害なし)。Node module cache は global
+// singleton のため、textCap.ts 内部 dynamic require('./errorLogger') にも stub が
+// 反映される。
+// @ts-expect-error TS1470: tsc は CJS 出力と判定するが runtime は ESM で解決可能
 const requireCjs = createRequire(import.meta.url);
 const ERROR_LOGGER_PATH = requireCjs.resolve('../src/utils/errorLogger');
 const TEXT_CAP_PATH = requireCjs.resolve('../src/utils/textCap');
@@ -103,7 +108,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
 
     it('prod + invalid page で safeLogError が callCount=1 で呼ばれる', () => {
       // 新規 load された textCap を取得 (stub を反映)
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
       const invalidPage = {
@@ -120,7 +124,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
     });
 
     it('prod + invalid page の safeLogError 引数に source:"ocr" / functionName:"capPageResultsAggregate" / error 含有', () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
       const invalidPage = {
@@ -142,7 +145,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
     });
 
     it('prod + context.documentId 指定時に safeLogError 引数へ伝搬され、単一 emit される', () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
       const invalidPage = {
@@ -162,7 +164,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
     });
 
     it('prod + valid page では safeLogError は呼ばれない (false positive 防止)', () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
       const validPages: SummaryField[] = [
@@ -178,7 +179,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
     });
 
     it('dev + invalid page では safeLogError は呼ばれず throw する (prod 分岐のみ emit)', () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
       const invalidPage = {
@@ -215,7 +215,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
       installErrorLoggerStub(state);
 
       const errorCalls = withConsoleErrorSpy((calls) => {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
         const invalidPage = {
@@ -246,7 +245,6 @@ describe('textCap prod invariant dynamic invocation (#288 item 1)', () => {
       installErrorLoggerStub(state);
 
       const errorCalls = withConsoleErrorSpy((calls) => {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
         const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
 
         const validPages: SummaryField[] = [{ text: 'short', truncated: false }];


### PR DESCRIPTION
## Summary

- Phase 2 (PR #296) の grep-based contract を runtime 挙動で補強する 6 test cases を追加
- `require.cache` 差し替えで `errorLogger` を stub 化（sinon/proxyquire 等の追加依存なし）
- Codex S3 指摘の console.error fallback path も網羅
- **#288 の Phase 3 完遂 → `Closes #288`**

## Motivation

Phase 2 (#288 item 6) の grep contract は shape を lock-in するが、以下は runtime でしか検知できない:
- 条件分岐 reversal (prod 分岐内で `if (!condition)` に mutate された regression)
- `handleAggregateInvariantViolation` helper が呼ばれない silent 回帰
- `documentId` 伝搬の actual propagation
- errorLogger load 失敗時の console.error fallback

本 PR で動的 mock を用いた runtime test を追加し、grep contract と二段 lock-in を構築する。

## Design: 追加依存なしの mock 戦略

```ts
import { createRequire } from 'module';
const requireCjs = createRequire(import.meta.url);

// stub 注入
requireCjs.cache[ERROR_LOGGER_PATH] = { exports: { safeLogError: stub }, ... } as NodeModule;

// textCap を新規 load (stub 反映)
const { capPageResultsAggregate } = requireCjs('../src/utils/textCap') as typeof import('../src/utils/textCap');
```

- Node.js module cache は global singleton のため、stub は textCap.ts 内部の dynamic `require('./errorLogger')` に反映される
- afterEach で `delete requireCjs.cache[...]` により他 test への漏洩を防止
- sinon / proxyquire は不使用 → devDependency 増加なし（マルチクライアント運用でのライセンス/セキュリティ監査コスト回避）

## Test plan (6 cases)

### `production 分岐の safeLogError 動的検証` (5 cases)
- [x] prod + invalid → `callCount=1`
- [x] prod + invalid → 引数 `source:'ocr'` / `functionName:'capPageResultsAggregate'` / `error instanceof Error`
- [x] prod + `context.documentId` → safeLogError 引数へ伝搬 (silent-failure-hunter S2 runtime 補強)
- [x] prod + valid → safeLogError 呼ばれない (false positive 防止)
- [x] dev + invalid → safeLogError 呼ばれず throw (prod 分岐のみ emit)

### `errorLogger load 失敗時の console.error fallback` (Codex S3 対応)
- [x] prod + require 失敗 → console.error `[textCap]` prefix で fallback

## Acceptance Criteria (#288 全体)

| Phase | Issue | PR | 状態 |
|---|---|---|---|
| Phase 1 | #288 item 2 | PR #295 | ✅ merged |
| Phase 2 | #288 item 6 | PR #296 | ✅ merged |
| Phase 3 | #288 item 1 | **本 PR** | 本 PR で完遂 → `Closes #288` |

## Impact

| 項目 | 内容 |
|---|---|
| 変更ファイル | `functions/test/textCapProdInvariantDynamic.test.ts` (新規 +236) |
| ファイル数 | 1 (test のみ、実装変更なし) |
| 追加依存 | **なし** |
| FE/BE境界 | 影響なし |
| 既存 test 回帰 | なし (523 → 529 PASS) |

## Risks & Mitigations

| リスク | 対処 |
|---|---|
| module cache 差し替えが他 test に漏洩 | afterEach で全 cache entry を delete |
| ts-node ESM モードで `require` 不可 | `createRequire(import.meta.url)` で CJS require 取得 |
| stub 注入前に textCap が cache 済み | stub installation で textCap も cache から delete |

## Refs

- Parent: #288 (Closes)
- Preceding: PR #295 (Phase 1)、PR #296 (Phase 2)
- Related: #293 (caller try/catch)、#294 (integration test)、#297 (flush 保証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating error handling, logging behavior, and fallback mechanisms across production and development environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->