### PR TITLE
refactor(ocr): capPageResultsAggregate caller try/catch + flush 保証 (#293 #297)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -163,8 +163,13 @@ export async function processDocument(
     });
   } catch (err) {
     const baseError = err instanceof Error ? err : new Error(String(err));
+    // catch boundary は広いため、既知 invariant (textCap.ts handleAggregateInvariantViolation 由来) と
+    // 予期外エラー (TypeError 等の実装バグ) を suffix で分類して triage を容易にする。
+    const isKnownInvariant = baseError.message.startsWith(
+      'capPageResultsAggregate invariant violation:',
+    );
+    const suffix = isKnownInvariant ? 'aggregateCap:invariant' : 'aggregateCap:unexpected';
     // errors collection triage 文脈: pages 件数と合計 chars を message に含めて原因特定を容易に。
-    // functionName suffix は既存 `:aggregateCap` (正常系 truncation) と区別する `:aggregateCap:invariant`。
     const enriched = new Error(
       `${baseError.message} (pages=${pageResults.length}, totalChars=${beforeAggregateChars})`,
     );
@@ -172,7 +177,7 @@ export async function processDocument(
     await safeLogError({
       error: enriched,
       source: 'ocr',
-      functionName: `${functionName}:aggregateCap:invariant`,
+      functionName: `${functionName}:${suffix}`,
       documentId: docId,
     });
   }

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -162,17 +162,34 @@ export async function processDocument(
       pendingLogs: pendingInvariantLogs,
     });
   } catch (err) {
+    const baseError = err instanceof Error ? err : new Error(String(err));
+    // errors collection triage 文脈: pages 件数と合計 chars を message に含めて原因特定を容易に。
     // functionName suffix は既存 `:aggregateCap` (正常系 truncation) と区別する `:aggregateCap:invariant`。
+    const enriched = new Error(
+      `${baseError.message} (pages=${pageResults.length}, totalChars=${beforeAggregateChars})`,
+    );
+    if (baseError.stack) enriched.stack = baseError.stack;
     await safeLogError({
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: enriched,
       source: 'ocr',
       functionName: `${functionName}:aggregateCap:invariant`,
       documentId: docId,
     });
   }
   // #297: invariant violation の safeLogError Firestore 書込を Cloud Functions handler 終了前に flush。
+  // safeLogError 自体は reject しない設計 (errorLogger.ts:141-151) だが、将来 reject 経路が
+  // 追加された場合に silent にならないよう rejected 件数を防御的に監視する。
   if (pendingInvariantLogs.length > 0) {
-    await Promise.allSettled(pendingInvariantLogs);
+    const settled = await Promise.allSettled(pendingInvariantLogs);
+    const rejected = settled.filter(
+      (r): r is PromiseRejectedResult => r.status === 'rejected',
+    );
+    if (rejected.length > 0) {
+      console.error(
+        `[ocrProcessor] ${rejected.length}/${settled.length} invariant log(s) rejected for doc ${docId}:`,
+        rejected.map((r) => r.reason),
+      );
+    }
   }
   const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   if (afterAggregateChars < beforeAggregateChars) {

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -149,8 +149,31 @@ export async function processDocument(
 
   // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御。
   const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
-  // #288 item 6: invariant violation 発生時の errors collection triage のため docId を伝搬。
-  pageResults = capPageResultsAggregate(pageResults, { documentId: docId });
+  // #288 item 6: invariant violation の errors collection triage のため docId を伝搬。
+  // #297 (Codex HIGH): pendingInvariantLogs を渡して fire-and-forget を廃止、後段で drain する。
+  // #293 (silent-failure-hunter S2): dev 環境での invariant throw を caller で捕捉し、
+  //   rules/error-handling.md §1「状態復旧 > ログ記録」に従って他ページ処理を継続する。
+  //   pageResults は cap 前のまま pass-through (per-page cap 適用済で暴走リスクなし)。
+  //   prod 分岐は handleAggregateInvariantViolation 内で safeLogError emit するため throw しない。
+  const pendingInvariantLogs: Promise<void>[] = [];
+  try {
+    pageResults = capPageResultsAggregate(pageResults, {
+      documentId: docId,
+      pendingLogs: pendingInvariantLogs,
+    });
+  } catch (err) {
+    // functionName suffix は既存 `:aggregateCap` (正常系 truncation) と区別する `:aggregateCap:invariant`。
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:aggregateCap:invariant`,
+      documentId: docId,
+    });
+  }
+  // #297: invariant violation の safeLogError Firestore 書込を Cloud Functions handler 終了前に flush。
+  if (pendingInvariantLogs.length > 0) {
+    await Promise.allSettled(pendingInvariantLogs);
+  }
   const afterAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   if (afterAggregateChars < beforeAggregateChars) {
     // #283: 集約サマリの observability を console.warn → safeLogError に格上げ。

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -81,9 +81,16 @@ export type CappedAggregatePage<T extends SummaryField> =
  * capPageResultsAggregate の observability context。
  * documentId を caller から伝搬させ、errors collection の triage を可能にする
  * (#288 item 6 + silent-failure-hunter/Codex S2 指摘対応)。
+ *
+ * #297 (Codex HIGH): prod 分岐の `safeLogError` fire-and-forget は Cloud Functions handler
+ * Promise 解決後の未 await async work を完了保証しない。caller が `pendingLogs` mutable array
+ * を渡すと、`handleAggregateInvariantViolation` が Promise を push し、caller 側で
+ * `await Promise.allSettled(pendingLogs)` による drain で flush 可能になる。
+ * 未渡しの場合は従来通り fire-and-forget（既存 caller への後方互換維持）。
  */
 export interface AggregateInvariantContext {
   documentId?: string;
+  pendingLogs?: Promise<void>[];
 }
 
 /**
@@ -106,12 +113,18 @@ function handleAggregateInvariantViolation(
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { safeLogError } = require('./errorLogger') as typeof import('./errorLogger');
-      void safeLogError({
+      const logPromise = safeLogError({
         error: new Error(message),
         source: 'ocr',
         functionName: 'capPageResultsAggregate',
         documentId: context?.documentId,
       });
+      if (context?.pendingLogs) {
+        context.pendingLogs.push(logPromise);
+      } else {
+        // 後方互換 fallback: pendingLogs 未渡し caller には従来通り fire-and-forget を維持する。
+        void logPromise;
+      }
     } catch (loadErr) {
       console.error(
         '[textCap] failed to load errorLogger for prod invariant report:',

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -1,6 +1,6 @@
 /**
  * ocrProcessor aggregate caller try/catch + pendingLogs drain 契約テスト
- * (Issue #293 silent-failure-hunter S2 + #297 Codex HIGH, 2026-04-20 session19)
+ * (Issue #293 + #297 統合対応)
  *
  * 目的: processDocument 内 capPageResultsAggregate 呼出周辺に:
  *   1. try/catch で dev invariant throw を捕捉 → safeLogError で errors collection 記録
@@ -11,9 +11,9 @@
  * 方式選定:
  * ocrProcessor.ts のソース全体から capPageResultsAggregate 呼出周辺ブロック
  * (try { ... } catch { ... } ... Promise.allSettled) を抽出し、必須要素の存在を
- * grep で検証する。Phase 1 (#276) / #283 / #288 item 6 と同一手法。
+ * grep で検証する。
  *
- * #299 (Phase 4) で動的 runtime test により caller の throw 捕捉挙動を二段 lock-in 予定。
+ * 動的 runtime test による caller throw 捕捉挙動の verify は Issue #299 で追加予定。
  */
 
 import { expect } from 'chai';

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ocrProcessor aggregate caller try/catch + pendingLogs drain 契約テスト
+ * (Issue #293 silent-failure-hunter S2 + #297 Codex HIGH, 2026-04-20 session19)
+ *
+ * 目的: processDocument 内 capPageResultsAggregate 呼出周辺に:
+ *   1. try/catch で dev invariant throw を捕捉 → safeLogError で errors collection 記録
+ *   2. pendingInvariantLogs array を渡して fire-and-forget を廃止 (#297)
+ *   3. `await Promise.allSettled(pendingInvariantLogs)` による flush 保証
+ * を追加した設計を grep-based で lock-in する。
+ *
+ * 方式選定:
+ * ocrProcessor.ts のソース全体から capPageResultsAggregate 呼出周辺ブロック
+ * (try { ... } catch { ... } ... Promise.allSettled) を抽出し、必須要素の存在を
+ * grep で検証する。Phase 1 (#276) / #283 / #288 item 6 と同一手法。
+ *
+ * #299 (Phase 4) で動的 runtime test により caller の throw 捕捉挙動を二段 lock-in 予定。
+ */
+
+import { expect } from 'chai';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
+
+describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
+  let source = '';
+
+  before(() => {
+    const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
+    expect(existsSync(absPath), `${OCR_PROCESSOR_PATH} が見つからない`).to.be.true;
+    source = readFileSync(absPath, 'utf-8');
+  });
+
+  it('pendingInvariantLogs: Promise<void>[] の宣言が存在する (#297)', () => {
+    // caller 側で pendingLogs array を生成して textCap に渡す起点。
+    // 変数名が変わった場合はリネームに応じて本契約を更新すること。
+    expect(source).to.match(
+      /const\s+pendingInvariantLogs\s*:\s*Promise\s*<\s*void\s*>\s*\[\s*\]\s*=\s*\[\s*\]/,
+      'pendingInvariantLogs 配列の宣言が見つからない — #297 drain 経路が欠損',
+    );
+  });
+
+  it('capPageResultsAggregate 呼出が try ブロック内にある (#293)', () => {
+    // `try { ... capPageResultsAggregate(...) ... }` の形を検証。
+    // try/catch を剥がして plain call に回帰した場合に fail させる。
+    expect(source).to.match(
+      /try\s*\{[\s\S]*?capPageResultsAggregate\s*\([\s\S]*?\}\s*catch\s*\(/,
+      'capPageResultsAggregate 呼出が try/catch に包まれていない — dev throw 捕捉が欠損',
+    );
+  });
+
+  it('capPageResultsAggregate 呼出時に pendingLogs を渡している (#297)', () => {
+    // `capPageResultsAggregate(..., { ..., pendingLogs: pendingInvariantLogs })` 形を検証。
+    expect(source).to.match(
+      /capPageResultsAggregate\s*\([\s\S]*?pendingLogs\s*:\s*pendingInvariantLogs/,
+      'capPageResultsAggregate 呼出で pendingLogs が渡されていない — fire-and-forget に回帰',
+    );
+  });
+
+  it('catch ブロック内に safeLogError 呼出が存在する (#293 errors collection 記録)', () => {
+    // try/catch 直後の catch ブロック本体を抽出して内部の safeLogError を検証。
+    const TRY_ANCHOR = /try\s*\{[\s\S]*?capPageResultsAggregate\s*\([\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*\{/;
+    const match = source.match(TRY_ANCHOR);
+    expect(match, 'try/catch ブロックの anchor が抽出できない').to.not.be.null;
+
+    if (!match || match.index === undefined) return;
+    const catchOpenIdx = source.indexOf('{', match.index + match[0].length - 1);
+    if (catchOpenIdx === -1) return;
+
+    let depth = 0;
+    let catchEnd = -1;
+    for (let i = catchOpenIdx; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          catchEnd = i + 1;
+          break;
+        }
+      }
+    }
+    expect(catchEnd, 'catch ブロック終端が検出できない').to.be.greaterThan(catchOpenIdx);
+    const catchBlock = source.slice(catchOpenIdx, catchEnd);
+    expect(catchBlock).to.match(
+      /\bsafeLogError\s*\(/,
+      'catch 内で safeLogError 呼出が見つからない — dev throw が silent に失われる',
+    );
+    expect(catchBlock).to.match(
+      /source\s*:\s*['"]ocr['"]/,
+      'catch 内 safeLogError に source: "ocr" が含まれない',
+    );
+    // 命名規則: 既存 `:aggregateCap` (正常系 truncation summary) と区別する `:aggregateCap:invariant` suffix。
+    expect(catchBlock).to.match(
+      /functionName\s*:[\s\S]*?aggregateCap:invariant/,
+      'catch 内 safeLogError の functionName が :aggregateCap:invariant suffix を含まない — 正常系と区別不能',
+    );
+    expect(catchBlock).to.match(
+      /documentId\s*:\s*docId/,
+      'catch 内 safeLogError に documentId: docId が含まれない — triage 不能',
+    );
+  });
+
+  it('try/catch 直後に await Promise.allSettled(pendingInvariantLogs) が存在する (#297 flush)', () => {
+    // drain 欠損で fire-and-forget 回帰を防ぐ。変数名が変わった場合は pendingInvariantLogs
+    // のリネームに追従すること。
+    expect(source).to.match(
+      /await\s+Promise\.allSettled\s*\(\s*pendingInvariantLogs\s*\)/,
+      'await Promise.allSettled(pendingInvariantLogs) が見つからない — drain 欠損',
+    );
+  });
+});

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -90,10 +90,15 @@ describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
       /source\s*:\s*['"]ocr['"]/,
       'catch 内 safeLogError に source: "ocr" が含まれない',
     );
-    // 命名規則: 既存 `:aggregateCap` (正常系 truncation summary) と区別する `:aggregateCap:invariant` suffix。
+    // 命名規則: 既存 `:aggregateCap` (正常系 truncation summary) と区別する suffix。
+    // 既知 invariant は `:aggregateCap:invariant`、予期外エラーは `:aggregateCap:unexpected` に分類。
     expect(catchBlock).to.match(
-      /functionName\s*:[\s\S]*?aggregateCap:invariant/,
-      'catch 内 safeLogError の functionName が :aggregateCap:invariant suffix を含まない — 正常系と区別不能',
+      /aggregateCap:invariant/,
+      'catch 内 safeLogError の functionName に :aggregateCap:invariant suffix が現れない — 既知 invariant triage 不能',
+    );
+    expect(catchBlock).to.match(
+      /aggregateCap:unexpected/,
+      'catch 内 safeLogError の functionName に :aggregateCap:unexpected suffix が現れない — 予期外エラーが既知 invariant と混線',
     );
     expect(catchBlock).to.match(
       /documentId\s*:\s*docId/,

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -476,6 +476,57 @@ describe('textCap', () => {
         const pages: SummaryField[] = [{ text: 'short', truncated: false }];
         expect(() => capPageResultsAggregate(pages, { documentId: 'doc-123' })).to.not.throw();
       });
+
+      // #297 Codex HIGH + #293: context.pendingLogs 渡し signature 拡張。fire-and-forget 廃止対応。
+      // prod 分岐で handleAggregateInvariantViolation が pendingLogs array に Promise を push する
+      // 経路と、caller が await drain 可能になる後方互換 signature を lock-in する。
+      // push 本体の動的検証は environment/require 依存が大きいため #299 + grep contract に委譲し、
+      // 本ブロックは signature/throw 挙動の最小 runtime 契約のみ保持する。
+      it('context.pendingLogs を受け取り throw しない (signature 互換)', () => {
+        const pages: SummaryField[] = [{ text: 'short', truncated: false }];
+        const pendingLogs: Promise<void>[] = [];
+        expect(() =>
+          capPageResultsAggregate(pages, { documentId: 'doc-456', pendingLogs }),
+        ).to.not.throw();
+      });
+
+      it('prod 環境 + invalid 入力 + pendingLogs 渡しで throw しない (#297 drain 経路)', () => {
+        const original = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        try {
+          const invalidPage = {
+            text: 'short',
+            truncated: false,
+            originalLength: 999_999,
+          } as unknown as SummaryField;
+          const pendingLogs: Promise<void>[] = [];
+          expect(() =>
+            capPageResultsAggregate([invalidPage], {
+              documentId: 'doc-789',
+              pendingLogs,
+            }),
+          ).to.not.throw();
+        } finally {
+          process.env.NODE_ENV = original;
+        }
+      });
+
+      it('dev 環境 + invalid 入力 + pendingLogs 渡しでも従来通り throw する (#284 契約維持)', () => {
+        const invalidPage = {
+          text: 'short',
+          truncated: false,
+          originalLength: 999_999,
+        } as unknown as SummaryField;
+        const pendingLogs: Promise<void>[] = [];
+        expect(() =>
+          capPageResultsAggregate([invalidPage], {
+            documentId: 'doc-dev',
+            pendingLogs,
+          }),
+        ).to.throw(/invariant violation/);
+        // dev 分岐は throw のみで push せず (prod 分岐専用) — pendingLogs は空のまま。
+        expect(pendingLogs.length).to.equal(0);
+      });
     });
   });
 

--- a/functions/test/textCapPendingLogsContract.test.ts
+++ b/functions/test/textCapPendingLogsContract.test.ts
@@ -1,6 +1,6 @@
 /**
  * textCap handleAggregateInvariantViolation の pendingLogs drain 対応契約テスト
- * (Issue #297 Codex HIGH + #293 統合対応, 2026-04-20 session19)
+ * (Issue #297 + #293 統合対応)
  *
  * 目的: `void safeLogError(...)` fire-and-forget を `context.pendingLogs` array に push する
  * 形へ変更した回帰を grep-based で防止する。caller (ocrProcessor.ts) が
@@ -12,9 +12,9 @@
  *   1. safeLogError の戻り値を変数束縛 (fire-and-forget `void` 直叩きではない)
  *   2. context?.pendingLogs への push 呼出が存在
  *   3. pendingLogs 未渡し時の fallback (void logPromise or ?.push 形) で後方互換維持
- * を grep 検証する。Phase 1 (#276) / #283 / #288 item 6 と同一手法。
+ * を grep 検証する。
  *
- * #299 (Phase 4) で動的 safeLogError invocation test により runtime 挙動と二段 lock-in 予定。
+ * 動的 safeLogError invocation test は Issue #299 で追加予定。
  */
 
 import { expect } from 'chai';

--- a/functions/test/textCapPendingLogsContract.test.ts
+++ b/functions/test/textCapPendingLogsContract.test.ts
@@ -117,8 +117,8 @@ describe('textCap pendingLogs drain contract (#297 + #293)', () => {
   it('pendingLogs 未渡し時の fallback (void 形) が存在する (後方互換維持)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
-    // `void logPromise;` または else 分岐で void 形を許容。
-    // push 呼出のない caller に対して promise が silent に leak しないための after-guard。
+    // legacy caller (pendingLogs 未渡し) では intentionally fire-and-forget を維持する。
+    // `void logPromise;` は完了保証ではなく「意図的に discard」を明示するマーカー。
     expect(prodBranch).to.match(
       /\bvoid\s+\w+\s*;?/,
       'pendingLogs 未渡し時の void fallback が見つからない — 後方互換が壊れている可能性',

--- a/functions/test/textCapPendingLogsContract.test.ts
+++ b/functions/test/textCapPendingLogsContract.test.ts
@@ -1,0 +1,136 @@
+/**
+ * textCap handleAggregateInvariantViolation の pendingLogs drain 対応契約テスト
+ * (Issue #297 Codex HIGH + #293 統合対応, 2026-04-20 session19)
+ *
+ * 目的: `void safeLogError(...)` fire-and-forget を `context.pendingLogs` array に push する
+ * 形へ変更した回帰を grep-based で防止する。caller (ocrProcessor.ts) が
+ * `await Promise.allSettled(pendingLogs)` で drain することで Cloud Functions handler
+ * 終了前の flush を保証する設計を静的に lock-in する。
+ *
+ * 方式選定:
+ * handleAggregateInvariantViolation 本体を brace-nesting で抽出し、production 分岐内で:
+ *   1. safeLogError の戻り値を変数束縛 (fire-and-forget `void` 直叩きではない)
+ *   2. context?.pendingLogs への push 呼出が存在
+ *   3. pendingLogs 未渡し時の fallback (void logPromise or ?.push 形) で後方互換維持
+ * を grep 検証する。Phase 1 (#276) / #283 / #288 item 6 と同一手法。
+ *
+ * #299 (Phase 4) で動的 safeLogError invocation test により runtime 挙動と二段 lock-in 予定。
+ */
+
+import { expect } from 'chai';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const TEXT_CAP_PATH = 'src/utils/textCap.ts';
+
+/**
+ * handleAggregateInvariantViolation 関数本体 (`{...}`) を抽出する。
+ * anchor 消失/リネーム時は空文字を返し、caller 側で明示失敗させる。
+ */
+function extractHelperFunctionBody(source: string): string {
+  const ANCHOR = /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
+  const match = source.match(ANCHOR);
+  if (!match || match.index === undefined) return '';
+
+  const openBraceIdx = source.indexOf('{', match.index);
+  if (openBraceIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openBraceIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openBraceIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * prod 分岐ブロック (`if (process.env.NODE_ENV === 'production') { ... }`) を抽出。
+ */
+function extractProdBranch(block: string): string {
+  const ANCHOR = /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
+  const match = block.match(ANCHOR);
+  if (!match || match.index === undefined) return '';
+
+  const openBraceIdx = block.indexOf('{', match.index);
+  if (openBraceIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openBraceIdx; i < block.length; i++) {
+    const ch = block[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return block.slice(openBraceIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+describe('textCap pendingLogs drain contract (#297 + #293)', () => {
+  let source = '';
+
+  before(() => {
+    const absPath = resolve(process.cwd(), TEXT_CAP_PATH);
+    expect(existsSync(absPath), `${TEXT_CAP_PATH} が見つからない`).to.be.true;
+    source = readFileSync(absPath, 'utf-8');
+  });
+
+  it('AggregateInvariantContext に pendingLogs?: Promise<void>[] フィールドが存在する', () => {
+    // signature 変更 regression 検知: fire-and-forget 廃止対応で必須のフィールド。
+    expect(source).to.match(
+      /pendingLogs\?\s*:\s*Promise\s*<\s*void\s*>\s*\[\s*\]/,
+      'AggregateInvariantContext に pendingLogs?: Promise<void>[] が見つからない — #297 設計変更が消失',
+    );
+  });
+
+  it('prod 分岐内で safeLogError の戻り値が変数束縛されている (void 直叩きではない)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const prodBranch = extractProdBranch(helperBody);
+    expect(prodBranch, 'handleAggregateInvariantViolation の prod 分岐が抽出できない').to.not.equal(
+      '',
+    );
+    // `const <var> = safeLogError(...)` または `let <var> = safeLogError(...)` の形を検査。
+    // fire-and-forget 直書き `void safeLogError(` に regression した場合に fail させる。
+    expect(prodBranch).to.match(
+      /(?:const|let)\s+\w+\s*=\s*safeLogError\s*\(/,
+      'safeLogError の戻り値が変数束縛されていない — fire-and-forget に回帰している可能性',
+    );
+  });
+
+  it('prod 分岐内で context?.pendingLogs への push 呼出が存在する', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const prodBranch = extractProdBranch(helperBody);
+    expect(prodBranch).to.match(
+      /context\?\.pendingLogs[\s\S]*?\.push\s*\(/,
+      'context?.pendingLogs への push 呼出が見つからない — drain 経路が欠損',
+    );
+  });
+
+  it('pendingLogs 未渡し時の fallback (void 形) が存在する (後方互換維持)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const prodBranch = extractProdBranch(helperBody);
+    // `void logPromise;` または else 分岐で void 形を許容。
+    // push 呼出のない caller に対して promise が silent に leak しないための after-guard。
+    expect(prodBranch).to.match(
+      /\bvoid\s+\w+\s*;?/,
+      'pendingLogs 未渡し時の void fallback が見つからない — 後方互換が壊れている可能性',
+    );
+  });
+
+  it('prod 分岐に直接 `void safeLogError(` 形が残っていない (regression guard)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const prodBranch = extractProdBranch(helperBody);
+    expect(prodBranch).to.not.match(
+      /\bvoid\s+safeLogError\s*\(/,
+      'void safeLogError( 直叩きが残存 — fire-and-forget 回帰、#297 対応が崩れている',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **#293** (silent-failure-hunter S2): ocrProcessor caller の try/catch wrapper で dev invariant throw を捕捉、errors collection に記録して他ページ処理を継続
- **#297** (Codex HIGH): `AggregateInvariantContext.pendingLogs?: Promise<void>[]` で fire-and-forget を廃止、caller で `await Promise.allSettled(pendingLogs)` による flush 保証
- 既存 caller の後方互換維持（pendingLogs 未渡し時は従来通り fire-and-forget）

## 設計判断

設計根拠は Issue #293 / #297 の 2026-04-20 session19 コメントを参照。

**却下案**:
- throw → warn+return 緩和: #284 契約 (dev throw) が壊れる
- `capPageResultsAggregate` signature async 化: 内部 map の runningTotal 順序依存で diff 広がる
- 戻り値を `{results, pendingLogs}` に変更: 既存 textCap.test.ts 10+ 箇所で戻り値を直接使用、破壊的

**採用 (Option B')**: AggregateInvariantContext に mutable array 追加で signature 維持 + caller drain

## 変更ファイル

| # | ファイル | 種別 | 規模 |
|---|---------|------|------|
| 1 | `functions/src/utils/textCap.ts` | signature 拡張 + push 処理 | +15/-5 |
| 2 | `functions/src/ocr/ocrProcessor.ts` | caller try/catch + drain | +22/-2 |
| 3 | `functions/test/textCap.test.ts` | runtime test 3 件追加 | +51/-0 |
| 4 | `functions/test/textCapPendingLogsContract.test.ts` | 新規 grep 契約 5 件 | +135/-0 |
| 5 | `functions/test/ocrProcessorAggregateCallerContract.test.ts` | 新規 grep 契約 5 件 | +110/-0 |

## Quality Gate

- `/simplify` (reuse/quality/efficiency 3 並列): 10 指摘中 3 件採用 (functionName 命名統一 `:aggregateCap:invariant` / allSettled 空配列短絡 / コメント重複削減)
- `/safe-refactor`: 5 観点すべて clean
- Evaluator 分離 (rules/quality-gate.md 発動条件 5 ファイル該当): APPROVED WITH SUGGESTIONS

## Known Limitations (Evaluator HIGH 指摘)

1. **AC-1 動的検証は #299 に委譲**: `pendingLogs.length === 1` の runtime assert は ts-node/esm 環境整備が必要で、本 PR では grep contract で push 処理の存在のみ lock-in
2. **AC-5 dev catch 後の pageResults pass-through**: dev 環境で invariant throw を捕捉した場合、pageResults は cap 前のまま Firestore 書込に回る。per-page cap 適用済なので暴走リスクなしだが、100 ページ全 invalid の理論最悪ケースで Firestore 1 MiB 超過の可能性あり。prod では本 PR 前から同挙動（#288 item 6 で safeLogError emit + pass-through）、dev は開発者が気付く契機となるため意図的設計

## Follow-up

- contract test の brace-nesting extract helper が 5 ファイルで重複 (Simplify HIGH 指摘)。本 PR scope 外として別 Issue で一括共通化予定

## Test plan

- [x] `cd functions && npm run build` 成功 (tsc)
- [x] `cd functions && npm test` 全件 PASS (536 passing / 0 failing、新規 13 件含む)
- [x] `cd functions && npm run lint` 0 errors
- [x] 既存 textCapProdInvariantContract.test.ts (9 cases) / aggregateCapLogErrorContract.test.ts の回帰なし
- [x] 既存 textCapAsCastContract.test.ts (#284 signature lock-in) の回帰なし
- [ ] CI 通過確認（GitHub Actions Deploy / CI）

Closes #293
Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OCR document processing with improved error handling that collects and logs processing failures, allowing documents to continue processing even when validation violations occur.

* **Tests**
  * Added contract tests to verify proper error logging behavior for document processing validation violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Follow-up Issues

本 PR で scope 外と判定した review 指摘は別 Issue として起票済:

- #302: contract test brace-nesting extract helper の 5 ファイル横断共通化 (/simplify HIGH + codex Low 1)
- #303: errorLogger require 失敗時の errors collection fallback (silent-failure-hunter HIGH)
- #304: AggregateInvariantContext 型設計改善 (drainSink リネーム / brand type, type-design-analyzer)

