### PR TITLE
refactor(test): contract test 共通基盤 - brace/paren helper + SummaryField fixture 集約 (#302 #307)

### DIFF
--- a/functions/test/aggregateCapLogErrorContract.test.ts
+++ b/functions/test/aggregateCapLogErrorContract.test.ts
@@ -20,63 +20,14 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBraceBlock, extractParenBlock } from './helpers/extractBraceBlock';
 
 const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
+const AGGREGATE_CAP_ANCHOR =
+  /if\s*\(\s*afterAggregateChars\s*<\s*beforeAggregateChars\s*\)\s*\{/;
 
-/**
- * aggregate cap の truncation 検知ブロック本体 (if 文 then 節) を抽出する。
- *
- * `if (afterAggregateChars < beforeAggregateChars)` を anchor にし、続く `{...}` を
- * brace-nesting で切り出す。anchor 消失/リネーム時は空文字を返し、caller 側で
- * 明示失敗させる。
- */
-function extractAggregateCapBlock(source: string): string {
-  const ANCHOR = /if\s*\(\s*afterAggregateChars\s*<\s*beforeAggregateChars\s*\)\s*\{/;
-  const match = source.match(ANCHOR);
-  if (!match || match.index === undefined) return '';
-
-  const openBraceIdx = source.indexOf('{', match.index);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return source.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
-
-/**
- * block 内の `safeLogError(...)` 呼出の引数ブロック (括弧内) を抽出する。
- * Phase 1 (#276) handleProcessingErrorContract.test.ts の同名 helper と同一仕様。
- * 無関係な同名変数や他 logger 呼出への偽陽性を引数ブロックへの scope 縮約で防ぐ。
- */
-function extractSafeLogErrorArgs(block: string): string {
-  const match = block.match(/\bsafeLogError\s*\(/);
-  if (!match || match.index === undefined) return '';
-
-  const openParenIdx = block.indexOf('(', match.index);
-  if (openParenIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openParenIdx; i < block.length; i++) {
-    const ch = block[i];
-    if (ch === '(') depth++;
-    else if (ch === ')') {
-      depth--;
-      if (depth === 0) {
-        return block.slice(openParenIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
+const extractAggregateCapBlock = (source: string) =>
+  extractBraceBlock(source, AGGREGATE_CAP_ANCHOR);
 
 describe('aggregate cap safeLogError contract (#283)', () => {
   before(() => {
@@ -90,8 +41,8 @@ describe('aggregate cap safeLogError contract (#283)', () => {
 
   const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
   const source = readFileSync(absPath, 'utf-8');
-  const capBlock = extractAggregateCapBlock(source);
-  const safeLogErrorArgs = extractSafeLogErrorArgs(capBlock);
+  const capBlock = extractBraceBlock(source, AGGREGATE_CAP_ANCHOR);
+  const safeLogErrorArgs = extractParenBlock(capBlock, /\bsafeLogError\s*\(/);
 
   it('aggregate cap block が抽出できる', () => {
     expect(capBlock.length).to.be.greaterThan(

--- a/functions/test/handleProcessingErrorContract.test.ts
+++ b/functions/test/handleProcessingErrorContract.test.ts
@@ -23,66 +23,18 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBraceBlock, extractParenBlock } from './helpers/extractBraceBlock';
 
 const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
+const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 
-/**
- * `export async function handleProcessingError(` から始まる関数の本体を抽出する。
- *
- * 波括弧のネストカウントで関数終端を特定するシンプル実装。対象の ocrProcessor.ts
- * は文字列/正規表現/テンプレートリテラル内に `{` `}` を含まないため実用上は安全。
- * 将来ここにリテラル波括弧が混入した場合は AST ベース抽出への移行が必要。
- *
- * 抽出失敗時は空文字を返し、caller 側で「occurrence 0」として明示失敗させる。
- */
-function extractFunctionBody(source: string, signaturePrefix: string): string {
-  const startIdx = source.indexOf(signaturePrefix);
-  if (startIdx === -1) return '';
-
-  const openBraceIdx = source.indexOf('{', startIdx);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return source.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
-
-/**
- * 関数本体内の `safeLogError(...)` 呼出の引数ブロック (括弧内) を抽出する。
- *
- * 関数本体全体を対象にした regex だと、無関係な同名ローカル変数・他 logger 呼出・
- * 文字列リテラルなどに偽陽性が出る (silent-failure-hunter 指摘)。本関数で引数
- * ブロックに scope を絞ることで、params 検証の精度を上げる。
- */
-function extractSafeLogErrorArgs(functionBody: string): string {
-  const match = functionBody.match(/\bsafeLogError\s*\(/);
-  if (!match || match.index === undefined) return '';
-
-  const openParenIdx = functionBody.indexOf('(', match.index);
-  if (openParenIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openParenIdx; i < functionBody.length; i++) {
-    const ch = functionBody[i];
-    if (ch === '(') depth++;
-    else if (ch === ')') {
-      depth--;
-      if (depth === 0) {
-        return functionBody.slice(openParenIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
+// brace/paren 抽出は共通 helper (extractBraceBlock / extractParenBlock) を使用 (#302)。
+// 関数本体の抽出 = brace-nesting、safeLogError 引数の抽出 = paren-nesting で scope を絞ることで
+// 無関係な同名変数・他 logger 呼出・文字列リテラルへの偽陽性を回避する。
+const extractFunctionBody = (source: string, signaturePrefix: string) =>
+  extractBraceBlock(source, signaturePrefix);
+const extractSafeLogErrorArgs = (functionBody: string) =>
+  extractParenBlock(functionBody, SAFE_LOG_ERROR_CALL);
 
 describe('handleProcessingError safeLogError contract (#276)', () => {
   before(() => {
@@ -96,11 +48,11 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
 
   const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
   const source = readFileSync(absPath, 'utf-8');
-  const functionBody = extractFunctionBody(
+  const functionBody = extractBraceBlock(
     source,
     'export async function handleProcessingError('
   );
-  const safeLogErrorArgs = extractSafeLogErrorArgs(functionBody);
+  const safeLogErrorArgs = extractParenBlock(functionBody, /\bsafeLogError\s*\(/);
 
   it('handleProcessingError 関数本体が抽出できる', () => {
     expect(functionBody.length).to.be.greaterThan(

--- a/functions/test/helpers/extractBraceBlock.test.ts
+++ b/functions/test/helpers/extractBraceBlock.test.ts
@@ -1,0 +1,84 @@
+/**
+ * extractBraceBlock helper 単体テスト (#311 review I3 対応)
+ *
+ * 本 helper は 5 ファイルの contract test から依存される共通基盤。将来の改修で
+ * silent regression (空文字返却の意味論変化、startAfterAnchor の挙動反転 等) を
+ * 直接検知する fixture を配置する。contract test 側 (aggregateCapLogErrorContract)
+ * の `extractAggregateCapBlock detection logic` describe は実コード対象のため残置、
+ * 本ファイルは helper 単体の挙動のみを狭く lock-in する。
+ */
+
+import { expect } from 'chai';
+import { extractBraceBlock, extractParenBlock } from './extractBraceBlock';
+
+describe('extractBraceBlock helper', () => {
+  describe('startAfterAnchor: true (制御フロー近接性)', () => {
+    it('anchor 末尾を起点に次の `{` から block を抽出する', () => {
+      // anchor は `catch (e) ` で終わり `{` を含まない。通常 (startAfterAnchor: false) だと
+      // `match.index` から探索して try の `{` を拾ってしまう。true で `match[0].length` 後から
+      // 探索することで catch 本体の `{` を正しく拾う。
+      const source = `try { inner } catch (e) { safeLogError(); }`;
+      const anchor = /try\s*\{[\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*/;
+
+      const withoutOpt = extractBraceBlock(source, anchor);
+      expect(withoutOpt, 'default は anchor 先頭起点で try 本体を拾う').to.equal('{ inner }');
+
+      const withOpt = extractBraceBlock(source, anchor, { startAfterAnchor: true });
+      expect(withOpt, 'startAfterAnchor: true で catch 本体を拾う').to.equal(
+        '{ safeLogError(); }',
+      );
+    });
+
+    it('anchor 末尾以降に `{` が無い場合は空文字', () => {
+      const source = `try { inner } catch (e) `;
+      const anchor = /try\s*\{[\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*/;
+      expect(extractBraceBlock(source, anchor, { startAfterAnchor: true })).to.equal('');
+    });
+
+    it('string anchor でも startAfterAnchor が機能する', () => {
+      const source = `FOO BAR { inner }`;
+      expect(extractBraceBlock(source, 'FOO BAR', { startAfterAnchor: true })).to.equal(
+        '{ inner }',
+      );
+    });
+  });
+
+  describe('extractBraceBlock (default startAfterAnchor: false)', () => {
+    it('anchor 不在時は空文字を返す', () => {
+      expect(extractBraceBlock('const x = 1;', /nomatch/)).to.equal('');
+      expect(extractBraceBlock('const x = 1;', 'nomatch')).to.equal('');
+    });
+
+    it('anchor ヒットしても後続に `{` が無ければ空文字', () => {
+      expect(extractBraceBlock('const x = 1;', /const/)).to.equal('');
+    });
+
+    it('ネストした `{}` を balance させて block 全体を返す', () => {
+      const source = `function f() { if (x) { y(); } else { z(); } }`;
+      const block = extractBraceBlock(source, 'function f()');
+      expect(block).to.equal('{ if (x) { y(); } else { z(); } }');
+    });
+
+    it('unbalanced な `{` は空文字を返す (loop 完走時)', () => {
+      const source = `function f() { if (x) { y(); `;
+      expect(extractBraceBlock(source, 'function f()')).to.equal('');
+    });
+  });
+
+  describe('extractParenBlock', () => {
+    it('anchor 後の `(...)` を抽出する', () => {
+      const source = `await safeLogError({ source: 'ocr' });`;
+      const args = extractParenBlock(source, /\bsafeLogError\s*\(/);
+      expect(args).to.equal(`({ source: 'ocr' })`);
+    });
+
+    it('ネストした `()` を balance させる', () => {
+      const source = `f(g(1, 2), h(3));`;
+      expect(extractParenBlock(source, 'f')).to.equal('(g(1, 2), h(3))');
+    });
+
+    it('anchor 不在時は空文字', () => {
+      expect(extractParenBlock('const x = 1;', /nomatch/)).to.equal('');
+    });
+  });
+});

--- a/functions/test/helpers/extractBraceBlock.ts
+++ b/functions/test/helpers/extractBraceBlock.ts
@@ -1,0 +1,102 @@
+/**
+ * grep-based contract test で使う brace / paren nesting 抽出 helper
+ * (Issue #302, PR #301 /simplify HIGH + codex Low 1 follow-up)
+ *
+ * 5 ファイルで同一実装が重複していた extractFunctionBody / extractAggregateCapBlock /
+ * extractAssertFunctionBody / extractHelperFunctionBody / extractProdBranch を
+ * 共通化する。anchor (RegExp | string) と nesting 種別 (brace / paren) のみが差分。
+ *
+ * 詳細な位置づけは docs/context/test-strategy.md (#308) を参照。
+ */
+
+export interface ExtractOptions {
+  /**
+   * true の場合、anchor マッチの**末尾** (match.index + match[0].length) から
+   * 最初の開き文字を探す。anchor 自体が「開始位置の目印となるテキスト」を末尾に含む
+   * ケース (例: `try {...} catch (e) ` の先で catch 本体のみを抽出したいケース) に使う。
+   * デフォルト false: anchor マッチ**先頭** (match.index) から最初の開き文字を探す。
+   */
+  startAfterAnchor?: boolean;
+}
+
+/**
+ * source 内で anchor にマッチした位置以降の最初の `{` から、対応する `}` までを抽出する。
+ *
+ * 波括弧のネストカウントで範囲を特定するシンプル実装。対象ソースが文字列/正規表現/
+ * テンプレートリテラル内に裸の `{` `}` を含む場合は誤判定する可能性があるため、
+ * 将来そのケースに遭遇したら AST ベース抽出への移行を検討する。
+ *
+ * @param source - 対象ソース全体
+ * @param anchor - RegExp または string。string の場合は完全一致 (`indexOf`) で検索する。
+ *                 RegExp の場合は `match.index` からブロック開始位置を決める。
+ * @param options.startAfterAnchor - anchor マッチ末尾から探索する (制御フロー近接性の lock-in 用)
+ * @returns 抽出したブロック文字列 (`{` から `}` を両端に含む)、anchor 不在時は空文字
+ */
+export function extractBraceBlock(
+  source: string,
+  anchor: RegExp | string,
+  options: ExtractOptions = {},
+): string {
+  return extractBalancedBlock(source, anchor, '{', '}', options);
+}
+
+/**
+ * source 内で anchor にマッチした位置以降の最初の `(` から、対応する `)` までを抽出する。
+ *
+ * `safeLogError(...)` 等の呼出引数ブロックに scope を絞り、関数本体全体を対象にした
+ * 正規表現での偽陽性 (同名ローカル変数・他 logger 呼出・文字列リテラル等) を防ぐ。
+ *
+ * @param source - 対象ソース (関数本体等)
+ * @param anchor - RegExp または string。RegExp 推奨 (例: `/\bsafeLogError\s*\(/`)
+ * @param options.startAfterAnchor - anchor マッチ末尾から探索する
+ * @returns 抽出したブロック文字列 (`(` から `)` を両端に含む)、anchor 不在時は空文字
+ */
+export function extractParenBlock(
+  source: string,
+  anchor: RegExp | string,
+  options: ExtractOptions = {},
+): string {
+  return extractBalancedBlock(source, anchor, '(', ')', options);
+}
+
+function extractBalancedBlock(
+  source: string,
+  anchor: RegExp | string,
+  openCh: string,
+  closeCh: string,
+  options: ExtractOptions,
+): string {
+  const startIdx = resolveAnchorIndex(source, anchor, options.startAfterAnchor ?? false);
+  if (startIdx === -1) return '';
+
+  const openIdx = source.indexOf(openCh, startIdx);
+  if (openIdx === -1) return '';
+
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === openCh) depth++;
+    else if (ch === closeCh) {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openIdx, i + 1);
+      }
+    }
+  }
+  return '';
+}
+
+function resolveAnchorIndex(
+  source: string,
+  anchor: RegExp | string,
+  startAfterAnchor: boolean,
+): number {
+  if (typeof anchor === 'string') {
+    const idx = source.indexOf(anchor);
+    if (idx === -1) return -1;
+    return startAfterAnchor ? idx + anchor.length : idx;
+  }
+  const match = source.match(anchor);
+  if (!match || match.index === undefined) return -1;
+  return startAfterAnchor ? match.index + match[0].length : match.index;
+}

--- a/functions/test/helpers/textCapFixtures.ts
+++ b/functions/test/helpers/textCapFixtures.ts
@@ -1,0 +1,56 @@
+/**
+ * textCap / OCR invariant test 用 fixture helper
+ * (Issue #307, PR #305 /simplify Quality #7 + code-reviewer Suggestions follow-up)
+ *
+ * `as unknown as SummaryField` cast は、Firestore 旧データ由来の discriminated union
+ * 違反 (#209 型, originalLength が valid page に混入) を test 側で再現するための意図的な
+ * bypass。cast が 9 箇所 (textCap.test.ts 8 + ocrAggregateCallerPattern.runtime.test.ts 1)
+ * に点在していたため、将来 cast 形状変更時 (例: `as never as ...`) の blast radius を
+ * 局所化する目的で集約した。
+ *
+ * cast を使う理由は SummaryField が `{ text, truncated: true, originalLength }` と
+ * `{ text, truncated: false }` の 2 ケース union で、invalid (`truncated: false` なのに
+ * `originalLength` 付き) を直接組み立てられないため。本 helper 内 1 箇所の cast のみが
+ * SummaryField signature 変更時の touch 対象となる。
+ *
+ * 詳細な位置づけは docs/context/test-strategy.md (#308) を参照。
+ */
+
+import type { SummaryField } from '../../../shared/types';
+
+/**
+ * invariant 違反 page (discriminated union 違反: `truncated:false` なのに `originalLength` 付き) を生成。
+ *
+ * Firestore 旧データ相当。`assertAggregatePageInvariant` の検出対象となる形状。
+ *
+ * @param originalLength - 違反を示すフィールド値 (通常は invariant に引っかかる正の数)
+ * @param text - page 本文 (識別用、デフォルト `'invalid'`)
+ */
+export function makeInvalidPage(
+  originalLength: number,
+  text = 'invalid',
+): SummaryField {
+  return {
+    text,
+    truncated: false,
+    originalLength,
+  } as unknown as SummaryField;
+}
+
+/**
+ * mixed-input fixture: `[valid, invalid, valid, invalid, ...]` の順で交互生成。
+ *
+ * `originalLengths` 要素数分 invalid を差し込み、両端と間に valid を挿入する。
+ * #294 mixed-input invariant test / #297 pendingLogs drain test 等の caller wrapper
+ * 再現シナリオで使用。
+ *
+ * @param originalLengths - invalid page の originalLength 一覧 (デフォルト `[999]`)
+ */
+export function makeMixedPages(originalLengths: number[] = [999]): SummaryField[] {
+  const pages: SummaryField[] = [{ text: 'valid1', truncated: false }];
+  originalLengths.forEach((len, i) => {
+    pages.push(makeInvalidPage(len, `invalid${i + 1}`));
+    pages.push({ text: `valid${i + 2}`, truncated: false });
+  });
+  return pages;
+}

--- a/functions/test/ocrAggregateCallerPattern.runtime.test.ts
+++ b/functions/test/ocrAggregateCallerPattern.runtime.test.ts
@@ -19,31 +19,7 @@ import { expect } from 'chai';
 import { capPageResultsAggregate } from '../src/utils/textCap';
 import type { LogErrorParams } from '../src/utils/errorLogger';
 import type { SummaryField } from '../../shared/types';
-
-/**
- * test 用 invalid page fixture. truncated=false なのに originalLength が残存する
- * Firestore 旧データ相当を SummaryField 型に流すためのキャスト吸収。
- */
-function makeInvalidPage(originalLength: number, text = 'invalid'): SummaryField {
-  return {
-    text,
-    truncated: false,
-    originalLength,
-  } as unknown as SummaryField;
-}
-
-/**
- * mixed-input fixture. [valid, invalid, valid, invalid, ...] の順で交互生成。
- * `originalLengths` 要素数分 invalid を差し込み、両端と間に valid を挿入する。
- */
-function makeMixedPages(originalLengths: number[] = [999]): SummaryField[] {
-  const pages: SummaryField[] = [{ text: 'valid1', truncated: false }];
-  originalLengths.forEach((len, i) => {
-    pages.push(makeInvalidPage(len, `invalid${i + 1}`));
-    pages.push({ text: `valid${i + 2}`, truncated: false });
-  });
-  return pages;
-}
+import { makeMixedPages } from './helpers/textCapFixtures';
 
 /**
  * caller wrapper の想定シグネチャ (test 用最小再現、AC-4/AC-5 相当)。

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -44,6 +44,14 @@ describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
     source = readFileSync(absPath, 'utf-8');
   });
 
+  it('capPageResultsAggregate 呼出は ocrProcessor.ts 全体で 1 箇所のみ (CAP_AGG_CATCH_ANCHOR 前提、#311 review I4)', () => {
+    // CAP_AGG_CATCH_ANCHOR の `[\s\S]*?` 非貪欲マッチは最初の try/catch にヒットする。
+    // 2 箇所以上存在すると anchor が先行ブロックにロックインされ、意図しないブロックを
+    // 検証する silent 誤検知が発生。2 つ目が追加された時点で fail させて narrow 更新を強制する。
+    const callCount = (source.match(/capPageResultsAggregate\s*\(/g) ?? []).length;
+    expect(callCount, '2 つ目以降の呼出は anchor narrow が必要 (#302 コメント参照)').to.equal(1);
+  });
+
   it('pendingInvariantLogs: Promise<void>[] の宣言が存在する (#297)', () => {
     // caller 側で pendingLogs array を生成して textCap に渡す起点。
     // 変数名が変わった場合はリネームに応じて本契約を更新すること。

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -19,8 +19,21 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
 
 const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
+
+// 制御フロー近接性 lock-in (#302 codex Low 1): capPageResultsAggregate 呼出 → catch ブロックを
+// 1 anchor で束ね、別所の catch ブロックや不整合な順序に回帰した場合に fail させる。
+// anchor 末尾は `catch (e) ` で終わり、そこから startAfterAnchor で最初の `{` を拾う。
+//
+// 前提: ocrProcessor.ts 内で capPageResultsAggregate を参照する try/catch は 1 箇所のみ。
+// 将来 2 つ目が追加された場合、source.match() は最初のマッチを返すため、本 anchor は
+// 先行 try/catch を拾う。意図したブロックが検証されなくなる silent 誤検知リスクあり。
+// 2 つ目が追加される時は本 anchor を processDocument 固有の文脈 (例: pendingInvariantLogs 宣言)
+// 直後に narrow する必要がある。
+const CAP_AGG_CATCH_ANCHOR =
+  /try\s*\{[\s\S]*?capPageResultsAggregate\s*\([\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*/;
 
 describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
   let source = '';
@@ -58,30 +71,14 @@ describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
   });
 
   it('catch ブロック内に safeLogError 呼出が存在する (#293 errors collection 記録)', () => {
-    // try/catch 直後の catch ブロック本体を抽出して内部の safeLogError を検証。
-    const TRY_ANCHOR = /try\s*\{[\s\S]*?capPageResultsAggregate\s*\([\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*\{/;
-    const match = source.match(TRY_ANCHOR);
-    expect(match, 'try/catch ブロックの anchor が抽出できない').to.not.be.null;
-
-    if (!match || match.index === undefined) return;
-    const catchOpenIdx = source.indexOf('{', match.index + match[0].length - 1);
-    if (catchOpenIdx === -1) return;
-
-    let depth = 0;
-    let catchEnd = -1;
-    for (let i = catchOpenIdx; i < source.length; i++) {
-      const ch = source[i];
-      if (ch === '{') depth++;
-      else if (ch === '}') {
-        depth--;
-        if (depth === 0) {
-          catchEnd = i + 1;
-          break;
-        }
-      }
-    }
-    expect(catchEnd, 'catch ブロック終端が検出できない').to.be.greaterThan(catchOpenIdx);
-    const catchBlock = source.slice(catchOpenIdx, catchEnd);
+    // capPageResultsAggregate 呼出 → catch ブロックを 1 anchor で束ねて抽出する。
+    // 別の catch ブロックや順序の回帰があれば anchor マッチ自体が失敗する (#302 codex Low 1)。
+    const catchBlock = extractBraceBlock(source, CAP_AGG_CATCH_ANCHOR, {
+      startAfterAnchor: true,
+    });
+    expect(catchBlock, 'capPageResultsAggregate 呼出直後の catch ブロックが抽出できない').to.not.equal(
+      '',
+    );
     expect(catchBlock).to.match(
       /\bsafeLogError\s*\(/,
       'catch 内で safeLogError 呼出が見つからない — dev throw が silent に失われる',

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -444,9 +444,6 @@ describe('textCap', () => {
       });
 
       it('short-path で originalLength が混入した不正入力は dev 環境で throw する (evaluator LOW 指摘対応)', () => {
-        // Firestore 旧データから truncated=false なのに originalLength が残存した状態を simulate。
-        // SummaryField 型契約ではあり得ないが `as unknown as` で bypass し、dev-assert が
-        // 実際に invariant violation を検知することを lock-in する。
         const invalidPage = makeInvalidPage(999_999, 'short');
         expect(() => capPageResultsAggregate([invalidPage])).to.throw(/invariant violation/);
       });

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -14,6 +14,7 @@ import {
   MAX_SUMMARY_LENGTH,
 } from '../src/utils/textCap';
 import type { SummaryField } from '../../shared/types';
+import { makeInvalidPage } from './helpers/textCapFixtures';
 
 // #255 Evaluator 指摘対応: discriminated union narrowing を `if (result.truncated)` で
 // 行うと、実装バグで truncated=false が返った場合にアサート群がスキップされ、テスト全体が
@@ -446,11 +447,7 @@ describe('textCap', () => {
         // Firestore 旧データから truncated=false なのに originalLength が残存した状態を simulate。
         // SummaryField 型契約ではあり得ないが `as unknown as` で bypass し、dev-assert が
         // 実際に invariant violation を検知することを lock-in する。
-        const invalidPage = {
-          text: 'short',
-          truncated: false,
-          originalLength: 999_999,
-        } as unknown as SummaryField;
+        const invalidPage = makeInvalidPage(999_999, 'short');
         expect(() => capPageResultsAggregate([invalidPage])).to.throw(/invariant violation/);
       });
 
@@ -460,11 +457,7 @@ describe('textCap', () => {
         const original = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
         try {
-          const invalidPage = {
-            text: 'short',
-            truncated: false,
-            originalLength: 999_999,
-          } as unknown as SummaryField;
+          const invalidPage = makeInvalidPage(999_999, 'short');
           expect(() => capPageResultsAggregate([invalidPage])).to.not.throw();
         } finally {
           process.env.NODE_ENV = original;
@@ -494,11 +487,7 @@ describe('textCap', () => {
         const original = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
         try {
-          const invalidPage = {
-            text: 'short',
-            truncated: false,
-            originalLength: 999_999,
-          } as unknown as SummaryField;
+          const invalidPage = makeInvalidPage(999_999, 'short');
           const pendingLogs: Promise<void>[] = [];
           expect(() =>
             capPageResultsAggregate([invalidPage], {
@@ -512,11 +501,7 @@ describe('textCap', () => {
       });
 
       it('dev 環境 + invalid 入力 + pendingLogs 渡しでも従来通り throw する (#284 契約維持)', () => {
-        const invalidPage = {
-          text: 'short',
-          truncated: false,
-          originalLength: 999_999,
-        } as unknown as SummaryField;
+        const invalidPage = makeInvalidPage(999_999, 'short');
         const pendingLogs: Promise<void>[] = [];
         expect(() =>
           capPageResultsAggregate([invalidPage], {
@@ -536,11 +521,7 @@ describe('textCap', () => {
       it('mixed-input [valid, invalid, valid] で dev 環境は invariant violation で throw する', () => {
         const pages: SummaryField[] = [
           { text: 'valid1', truncated: false },
-          {
-            text: 'invalid',
-            truncated: false,
-            originalLength: 999,
-          } as unknown as SummaryField,
+          makeInvalidPage(999, 'invalid'),
           { text: 'valid2', truncated: false },
         ];
         expect(() => capPageResultsAggregate(pages)).to.throw(/invariant violation/);
@@ -552,11 +533,7 @@ describe('textCap', () => {
         try {
           const pages: SummaryField[] = [
             { text: 'valid1', truncated: false },
-            {
-              text: 'invalid',
-              truncated: false,
-              originalLength: 999,
-            } as unknown as SummaryField,
+            makeInvalidPage(999, 'invalid'),
             { text: 'valid2', truncated: false },
           ];
           const result = capPageResultsAggregate(pages);
@@ -581,17 +558,9 @@ describe('textCap', () => {
         try {
           const pages: SummaryField[] = [
             { text: 'valid1', truncated: false },
-            {
-              text: 'invalid1',
-              truncated: false,
-              originalLength: 111,
-            } as unknown as SummaryField,
+            makeInvalidPage(111, 'invalid1'),
             { text: 'valid2', truncated: false },
-            {
-              text: 'invalid2',
-              truncated: false,
-              originalLength: 222,
-            } as unknown as SummaryField,
+            makeInvalidPage(222, 'invalid2'),
           ];
           const pendingLogs: Promise<void>[] = [];
           const result = capPageResultsAggregate(pages, {

--- a/functions/test/textCapPendingLogsContract.test.ts
+++ b/functions/test/textCapPendingLogsContract.test.ts
@@ -88,6 +88,10 @@ describe('textCap pendingLogs drain contract (#297 + #293)', () => {
   it('prod 分岐に直接 `void safeLogError(` 形が残っていない (regression guard)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
+    // anchor 消失で prodBranch が空文字のまま to.not.match(...) が silent PASS する経路を防ぐ。
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失 (#311 review C2 対応)').to.not.equal(
+      '',
+    );
     expect(prodBranch).to.not.match(
       /\bvoid\s+safeLogError\s*\(/,
       'void safeLogError( 直叩きが残存 — fire-and-forget 回帰、#297 対応が崩れている',

--- a/functions/test/textCapPendingLogsContract.test.ts
+++ b/functions/test/textCapPendingLogsContract.test.ts
@@ -20,59 +20,19 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
 
 const TEXT_CAP_PATH = 'src/utils/textCap.ts';
 
-/**
- * handleAggregateInvariantViolation 関数本体 (`{...}`) を抽出する。
- * anchor 消失/リネーム時は空文字を返し、caller 側で明示失敗させる。
- */
-function extractHelperFunctionBody(source: string): string {
-  const ANCHOR = /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
-  const match = source.match(ANCHOR);
-  if (!match || match.index === undefined) return '';
+const HELPER_BODY_ANCHOR =
+  /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
+const PROD_BRANCH_ANCHOR =
+  /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
 
-  const openBraceIdx = source.indexOf('{', match.index);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return source.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
-
-/**
- * prod 分岐ブロック (`if (process.env.NODE_ENV === 'production') { ... }`) を抽出。
- */
-function extractProdBranch(block: string): string {
-  const ANCHOR = /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
-  const match = block.match(ANCHOR);
-  if (!match || match.index === undefined) return '';
-
-  const openBraceIdx = block.indexOf('{', match.index);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < block.length; i++) {
-    const ch = block[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return block.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
+const extractHelperFunctionBody = (source: string) =>
+  extractBraceBlock(source, HELPER_BODY_ANCHOR);
+const extractProdBranch = (block: string) =>
+  extractBraceBlock(block, PROD_BRANCH_ANCHOR);
 
 describe('textCap pendingLogs drain contract (#297 + #293)', () => {
   let source = '';

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -105,6 +105,10 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
+    // anchor 消失で prodBranch が空文字のまま to.not.match(...) が silent PASS する経路を防ぐ。
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失 (#311 review C1 対応)').to.not.equal(
+      '',
+    );
     expect(prodBranch).to.not.match(
       /\bthrow\s+(?:new\s+)?Error\b/,
       'prod 分岐に throw が残存 — fire-and-forget 方針に違反',

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -23,111 +23,26 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { extractBraceBlock, extractParenBlock } from './helpers/extractBraceBlock';
 
 const TEXT_CAP_PATH = 'src/utils/textCap.ts';
 
-/**
- * assertAggregatePageInvariant 関数本体 (function 宣言直後の `{...}`) を抽出する。
- * anchor 消失/リネーム時は空文字を返し、caller 側で明示失敗させる。
- */
-function extractAssertFunctionBody(source: string): string {
-  const ANCHOR = /function\s+assertAggregatePageInvariant\s*\([^)]*\)\s*:\s*void\s*\{/;
-  const match = source.match(ANCHOR);
-  if (!match || match.index === undefined) return '';
+const ASSERT_BODY_ANCHOR =
+  /function\s+assertAggregatePageInvariant\s*\([^)]*\)\s*:\s*void\s*\{/;
+const HELPER_BODY_ANCHOR =
+  /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
+const PROD_BRANCH_ANCHOR =
+  /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
+const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 
-  const openBraceIdx = source.indexOf('{', match.index);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return source.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
-
-/**
- * handleAggregateInvariantViolation helper 関数本体を抽出する (#288 item 6 で導入)。
- * 実装で helper 分離した場合、prod 分岐はこちらに移る。存在しない場合は空文字を返す。
- */
-function extractHelperFunctionBody(source: string): string {
-  const ANCHOR = /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
-  const match = source.match(ANCHOR);
-  if (!match || match.index === undefined) return '';
-
-  const openBraceIdx = source.indexOf('{', match.index);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return source.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
-
-/**
- * prod 分岐ブロック (`if (process.env.NODE_ENV === 'production') { ... }`) を抽出。
- * ==='production' と !== 'production' の両形を許容する前方一致。
- */
-function extractProdBranch(block: string): string {
-  const ANCHOR = /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
-  const match = block.match(ANCHOR);
-  if (!match || match.index === undefined) return '';
-
-  const openBraceIdx = block.indexOf('{', match.index);
-  if (openBraceIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openBraceIdx; i < block.length; i++) {
-    const ch = block[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return block.slice(openBraceIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
-
-/**
- * safeLogError 呼出の引数ブロック (括弧内) を抽出。
- * aggregateCapLogErrorContract.test.ts の同名 helper と同一仕様。
- */
-function extractSafeLogErrorArgs(block: string): string {
-  const match = block.match(/\bsafeLogError\s*\(/);
-  if (!match || match.index === undefined) return '';
-
-  const openParenIdx = block.indexOf('(', match.index);
-  if (openParenIdx === -1) return '';
-
-  let depth = 0;
-  for (let i = openParenIdx; i < block.length; i++) {
-    const ch = block[i];
-    if (ch === '(') depth++;
-    else if (ch === ')') {
-      depth--;
-      if (depth === 0) {
-        return block.slice(openParenIdx, i + 1);
-      }
-    }
-  }
-  return '';
-}
+const extractAssertFunctionBody = (source: string) =>
+  extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+const extractHelperFunctionBody = (source: string) =>
+  extractBraceBlock(source, HELPER_BODY_ANCHOR);
+const extractProdBranch = (block: string) =>
+  extractBraceBlock(block, PROD_BRANCH_ANCHOR);
+const extractSafeLogErrorArgs = (block: string) =>
+  extractParenBlock(block, SAFE_LOG_ERROR_CALL);
 
 describe('textCap prod invariant observability contract (#288 item 6)', () => {
   let source = '';


### PR DESCRIPTION
## Summary

Phase 1 (Contract test 共通基盤整備) の PR-1。4 Issue のうち #302 + #307 を一括対応。

- **#302**: brace/paren nesting 抽出 helper を `functions/test/helpers/extractBraceBlock.ts` に共通化 (5ファイル横断)
- **#307**: `as unknown as SummaryField` cast fixture を `functions/test/helpers/textCapFixtures.ts` に集約 (9箇所 → 1箇所)
- **codex Low 1 追加対応**: `ocrProcessorAggregateCallerContract` で try/catch を 1 anchor で束ね制御フロー近接性を lock-in

## 変更内容

### 新規
- `functions/test/helpers/extractBraceBlock.ts`: `extractBraceBlock` / `extractParenBlock` (RegExp|string 両対応 + `startAfterAnchor` option)
- `functions/test/helpers/textCapFixtures.ts`: `makeInvalidPage(originalLength, text?)` / `makeMixedPages(originalLengths?)`

### 移行
- 5 contract test が helper 経由で brace/paren nesting 抽出に変更
- `textCap.test.ts` (8箇所) + `ocrAggregateCallerPattern.runtime.test.ts` が helper 経由で fixture 生成
- 既存の `extractAggregateCapBlock` / `extractFunctionBody` / `extractSafeLogErrorArgs` は local alias (ワンライナー) として保持 (unit test 互換性)

### Diff stat
- 7 files modified + 2 new = 9 files
- +233 / -355 = 純減 122 行 (重複削除の成果)

## Quality Gate

- [x] テスト: 548 passing (回帰なし、実行時間 129ms)
- [x] type-check: PASS
- [x] lint: 0 errors, 20 warnings (既存のみ)
- [x] `/simplify`: reuse/quality/efficiency 3観点並列レビュー済、4件 skip 判断 (2件は follow-up Issue 化予定)
  - Q4 (`SAFE_LOG_ERROR_CALL` 統一) / E2 (`textCapProdInvariantContract` 抽出キャッシュ) は follow-up Issue
- [x] Evaluator 分離プロトコル: **APPROVE**
  - AC1 (`let depth` 除去): PASS
  - AC2 (`as unknown as SummaryField` 除去): PASS
  - AC5 (全テスト PASS): PASS
  - AC6 (helper エッジケース): PASS
  - MEDIUM 1件 (CAP_AGG_CATCH_ANCHOR 将来 ambiguity) → コメント補強で対応済

## Test plan

- [ ] CI: functions test (548 passing) + type-check + lint が全て success
- [ ] CI: Firestore rules test は影響なし (test ファイル未変更)
- [ ] (次 PR-2 着手時) 本 helper が他の contract test でも自然に使えることを確認

## Follow-up (別 Issue として起票予定)

- `SAFE_LOG_ERROR_CALL` 定数を `helpers/` に集約し各 contract test から import (Q4)
- `textCapProdInvariantContract` で `assertBody` / `helperBody` / `prodBranch` を before hook でキャッシュ (E2、40%削減)

## Phase 1 残り

- **PR-2** (#306): `withNodeEnv` helper 化 (4 ファイル)
- **PR-3** (#308): `docs/context/test-strategy.md` 新規 + docstring 簡素化 (6 ファイル)

Closes #302
Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extracted shared utilities for test helper functions to reduce code duplication across test files.
  * Centralized test fixture builders to standardize the construction of test data objects used in multiple tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->