### PR TITLE
refactor(test): withNodeEnv helper で NODE_ENV toggle 独立性を担保 (#306)

### DIFF
--- a/functions/test/helpers/withNodeEnv.test.ts
+++ b/functions/test/helpers/withNodeEnv.test.ts
@@ -64,6 +64,20 @@ describe('withNodeEnv helper', () => {
       const result = withNodeEnv('production', () => 42);
       expect(result).to.equal(42);
     });
+
+    it('nested 呼出は LIFO 順で復元される', () => {
+      // inner 終了時に outer の value (prod) に戻り、outer 終了時に元値 (test) に戻る。
+      // helper が public で再帰呼出可能な以上、LIFO semantics を lock-in する。
+      process.env.NODE_ENV = 'test';
+      withNodeEnv('production', () => {
+        expect(process.env.NODE_ENV).to.equal('production');
+        withNodeEnv('development', () => {
+          expect(process.env.NODE_ENV).to.equal('development');
+        });
+        expect(process.env.NODE_ENV, 'inner 終了時に outer の値へ').to.equal('production');
+      });
+      expect(process.env.NODE_ENV, 'outer 終了時に元値へ').to.equal('test');
+    });
   });
 
   describe('withNodeEnvAsync', () => {
@@ -89,6 +103,28 @@ describe('withNodeEnv helper', () => {
       }
       expect(threw).to.equal(true);
       expect(process.env.NODE_ENV).to.equal('test');
+    });
+
+    it('async fn が await 前に同期 throw しても finally で復元される', async () => {
+      // `return await fn()` は fn() が同期 throw した場合 try 内で捕捉され finally が走る。
+      // `return fn()` に退行すると同期 throw は await 前に発生し Promise 化されずに抜ける。
+      // 本テストは前者の挙動を lock-in する (`return fn()` への退行で fail)。
+      process.env.NODE_ENV = 'test';
+      let threw = false;
+      try {
+        await withNodeEnvAsync('production', () => {
+          throw new Error('sync boom inside async helper');
+        });
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(process.env.NODE_ENV).to.equal('test');
+    });
+
+    it('async fn の戻り値を透過する', async () => {
+      const result = await withNodeEnvAsync('production', async () => 99);
+      expect(result).to.equal(99);
     });
   });
 });

--- a/functions/test/helpers/withNodeEnv.test.ts
+++ b/functions/test/helpers/withNodeEnv.test.ts
@@ -1,0 +1,94 @@
+/**
+ * withNodeEnv helper 単体テスト (#306 + PR #311 review I3 教訓先取り)
+ *
+ * contract test 側での間接検証では拾いきれない helper 固有の挙動 (undefined 完全復元、
+ * throw 経路での復元、async 版) を直接 lock-in する。
+ */
+
+import { expect } from 'chai';
+import { withNodeEnv, withNodeEnvAsync } from './withNodeEnv';
+
+describe('withNodeEnv helper', () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = saved;
+  });
+
+  describe('withNodeEnv (sync)', () => {
+    it('fn 実行中は指定値に切替わる', () => {
+      process.env.NODE_ENV = 'test';
+      const observed = withNodeEnv('production', () => process.env.NODE_ENV);
+      expect(observed).to.equal('production');
+    });
+
+    it('fn 実行後に元値に復元される', () => {
+      process.env.NODE_ENV = 'test';
+      withNodeEnv('production', () => void 0);
+      expect(process.env.NODE_ENV).to.equal('test');
+    });
+
+    it('original が undefined の場合は delete で復元される (「undefined」文字列化しない)', () => {
+      delete process.env.NODE_ENV;
+      withNodeEnv('production', () => void 0);
+      expect(process.env.NODE_ENV).to.equal(undefined);
+      expect('NODE_ENV' in process.env).to.equal(false);
+    });
+
+    it('fn が throw しても finally で復元される', () => {
+      process.env.NODE_ENV = 'test';
+      expect(() =>
+        withNodeEnv('production', () => {
+          throw new Error('boom');
+        }),
+      ).to.throw('boom');
+      expect(process.env.NODE_ENV).to.equal('test');
+    });
+
+    it('throw + original undefined の組合せでも delete 復元される', () => {
+      delete process.env.NODE_ENV;
+      expect(() =>
+        withNodeEnv('production', () => {
+          throw new Error('boom');
+        }),
+      ).to.throw('boom');
+      expect('NODE_ENV' in process.env).to.equal(false);
+    });
+
+    it('fn の戻り値を透過する', () => {
+      const result = withNodeEnv('production', () => 42);
+      expect(result).to.equal(42);
+    });
+  });
+
+  describe('withNodeEnvAsync', () => {
+    it('await 対応し fn 実行中は指定値に切替わる', async () => {
+      process.env.NODE_ENV = 'test';
+      const observed = await withNodeEnvAsync('production', async () => {
+        await Promise.resolve();
+        return process.env.NODE_ENV;
+      });
+      expect(observed).to.equal('production');
+      expect(process.env.NODE_ENV).to.equal('test');
+    });
+
+    it('async fn が reject しても finally で復元される', async () => {
+      process.env.NODE_ENV = 'test';
+      let threw = false;
+      try {
+        await withNodeEnvAsync('production', async () => {
+          throw new Error('async boom');
+        });
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+      expect(process.env.NODE_ENV).to.equal('test');
+    });
+  });
+});

--- a/functions/test/helpers/withNodeEnv.ts
+++ b/functions/test/helpers/withNodeEnv.ts
@@ -6,10 +6,10 @@
  * 1. **undefined の文字列化**: 元値 `undefined` の場合 `process.env.NODE_ENV = original` は
  *    `"undefined"` 文字列を代入し、後続 test に leak する。完全復元には
  *    `delete process.env.NODE_ENV` が必要。
- * 2. **並列実行時の race**: Mocha `--parallel` 有効化時、NODE_ENV の toggle は test 間で
- *    interleave する危険あり。本 helper は process global を触るため `--parallel` 非対応。
- *    並列実行を採用する場合は helper 全体を module isolation で囲むか、env-specific
- *    assert を mock 注入に置き換える必要がある。
+ * 2. **並行実行時の race**: 同一プロセス内で別 test が NODE_ENV を参照/変更する場合、
+ *    process global への代入が interleave する。本 helper は process.env を直接触るため
+ *    同期/直列実行専用。Mocha `--parallel` は worker process を spawn するため本 helper は
+ *    worker 内では安全だが、同一 worker の他 test と並行する構成 (非 Mocha runner 等) は非対応。
  */
 
 /**

--- a/functions/test/helpers/withNodeEnv.ts
+++ b/functions/test/helpers/withNodeEnv.ts
@@ -1,0 +1,49 @@
+/**
+ * NODE_ENV を一時的に切り替えて fn を実行し、確実に復元する helper
+ * (Issue #306, PR #305 review code-reviewer + codex Low follow-up)
+ *
+ * 問題:
+ * 1. **undefined の文字列化**: 元値 `undefined` の場合 `process.env.NODE_ENV = original` は
+ *    `"undefined"` 文字列を代入し、後続 test に leak する。完全復元には
+ *    `delete process.env.NODE_ENV` が必要。
+ * 2. **並列実行時の race**: Mocha `--parallel` 有効化時、NODE_ENV の toggle は test 間で
+ *    interleave する危険あり。本 helper は process global を触るため `--parallel` 非対応。
+ *    並列実行を採用する場合は helper 全体を module isolation で囲むか、env-specific
+ *    assert を mock 注入に置き換える必要がある。
+ */
+
+/**
+ * NODE_ENV を value に切替えて fn を同期実行し、finally で元値に復元する。
+ *
+ * `try/finally` で throw 経路も保護する。original が undefined の場合は `delete` で復元する。
+ *
+ * @param value - 一時的に設定する NODE_ENV 値 (`'production'` / `'test'` 等)
+ * @param fn - 切替中に実行する処理 (戻り値はそのまま返す)
+ */
+export function withNodeEnv<T>(value: string, fn: () => T): T {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = value;
+  try {
+    return fn();
+  } finally {
+    if (original === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = original;
+  }
+}
+
+/**
+ * `withNodeEnv` の async 版。await 対応。
+ */
+export async function withNodeEnvAsync<T>(
+  value: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = value;
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = original;
+  }
+}

--- a/functions/test/ocrAggregateCallerPattern.runtime.test.ts
+++ b/functions/test/ocrAggregateCallerPattern.runtime.test.ts
@@ -20,6 +20,7 @@ import { capPageResultsAggregate } from '../src/utils/textCap';
 import type { LogErrorParams } from '../src/utils/errorLogger';
 import type { SummaryField } from '../../shared/types';
 import { makeMixedPages } from './helpers/textCapFixtures';
+import { withNodeEnvAsync } from './helpers/withNodeEnv';
 
 /**
  * caller wrapper の想定シグネチャ (test 用最小再現、AC-4/AC-5 相当)。
@@ -130,13 +131,11 @@ describe('aggregate caller wrapper runtime pattern (#294)', () => {
 
   describe('prod 環境: caller は throw を受けず pendingLogs drain (#297)', () => {
     it('prod で invalid 混入 → safeLogError spy は catch 経由では呼ばれない (throw しないため)', async () => {
-      const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
       const calls: LogErrorParams[] = [];
       const spy = async (p: LogErrorParams): Promise<void> => {
         calls.push(p);
       };
-      try {
+      await withNodeEnvAsync('production', async () => {
         const pages = makeMixedPages();
         const result = await aggregateWithCallerWrapper(
           pages,
@@ -146,11 +145,7 @@ describe('aggregate caller wrapper runtime pattern (#294)', () => {
         expect(result).to.have.length(pages.length);
         // prod は handleAggregateInvariantViolation 内で emit されるため caller catch は通らない。
         expect(calls).to.have.length(0);
-      } finally {
-        // NODE_ENV が元々 undefined の場合 `= undefined` は "undefined" 文字列化する ため delete で完全復元。
-        if (originalEnv === undefined) delete process.env.NODE_ENV;
-        else process.env.NODE_ENV = originalEnv;
-      }
+      });
     });
   });
 });

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/utils/textCap';
 import type { SummaryField } from '../../shared/types';
 import { makeInvalidPage } from './helpers/textCapFixtures';
+import { withNodeEnv } from './helpers/withNodeEnv';
 
 // #255 Evaluator 指摘対応: discriminated union narrowing を `if (result.truncated)` で
 // 行うと、実装バグで truncated=false が返った場合にアサート群がスキップされ、テスト全体が
@@ -451,14 +452,10 @@ describe('textCap', () => {
       // #288 item 6: prod は throw せず safeLogError emit。実呼出検証は
       // textCapProdInvariantContract.test.ts (grep) + Phase 3 (動的) で二段 lock-in。
       it('production では invalid 入力でも throw しない (safeLogError 経由で emit)', () => {
-        const original = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
-        try {
+        withNodeEnv('production', () => {
           const invalidPage = makeInvalidPage(999_999, 'short');
           expect(() => capPageResultsAggregate([invalidPage])).to.not.throw();
-        } finally {
-          process.env.NODE_ENV = original;
-        }
+        });
       });
 
       // #288 item 6 silent-failure-hunter S2 + Codex MED: context.documentId 伝搬 signature 拡張。
@@ -481,9 +478,7 @@ describe('textCap', () => {
       });
 
       it('prod 環境 + invalid 入力 + pendingLogs 渡しで throw しない (#297 drain 経路)', () => {
-        const original = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
-        try {
+        withNodeEnv('production', () => {
           const invalidPage = makeInvalidPage(999_999, 'short');
           const pendingLogs: Promise<void>[] = [];
           expect(() =>
@@ -492,9 +487,7 @@ describe('textCap', () => {
               pendingLogs,
             }),
           ).to.not.throw();
-        } finally {
-          process.env.NODE_ENV = original;
-        }
+        });
       });
 
       it('dev 環境 + invalid 入力 + pendingLogs 渡しでも従来通り throw する (#284 契約維持)', () => {
@@ -525,9 +518,7 @@ describe('textCap', () => {
       });
 
       it('mixed-input prod 環境では全ページを return し invalid 要素は pass-through (AC-5 継続保証)', () => {
-        const originalEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
-        try {
+        withNodeEnv('production', () => {
           const pages: SummaryField[] = [
             { text: 'valid1', truncated: false },
             makeInvalidPage(999, 'invalid'),
@@ -537,11 +528,7 @@ describe('textCap', () => {
           expect(result).to.have.length(3);
           expect(result[0]?.text).to.equal('valid1');
           expect(result[2]?.text).to.equal('valid2');
-        } finally {
-          // NODE_ENV が元々 undefined の場合 `= undefined` は "undefined" 文字列化する ため delete で完全復元。
-          if (originalEnv === undefined) delete process.env.NODE_ENV;
-          else process.env.NODE_ENV = originalEnv;
-        }
+        });
       });
 
       it('mixed-input prod で errorLogger require 失敗時は push 0 件 + console.error fallback (unit test 環境)', () => {
@@ -550,9 +537,7 @@ describe('textCap', () => {
         // textCap.ts:131 の catch (loadErr) に落ちて console.error fallback する。
         // push 経路は走らないため pendingLogs.length === 0 が決定論的。
         // 実運用 (admin 初期化済み) での push 2 件動作検証は Issue #299 で担保予定。
-        const originalEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
-        try {
+        withNodeEnv('production', () => {
           const pages: SummaryField[] = [
             { text: 'valid1', truncated: false },
             makeInvalidPage(111, 'invalid1'),
@@ -566,10 +551,7 @@ describe('textCap', () => {
           });
           expect(result).to.have.length(4);
           expect(pendingLogs.length).to.equal(0);
-        } finally {
-          if (originalEnv === undefined) delete process.env.NODE_ENV;
-          else process.env.NODE_ENV = originalEnv;
-        }
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Phase 1 PR-2 (#306 withNodeEnv helper 化)。PR #311 (#302 + #307) の直後、NODE_ENV toggle パターン 5 箇所を helper 経由に統一する。

- **`withNodeEnv` / `withNodeEnvAsync`** を `functions/test/helpers/withNodeEnv.ts` に追加
- 既存 5 箇所の `try/finally` パターンを helper 呼出に置換
- helper 固有の挙動 (undefined 完全復元 / throw 経路復元 / async 復元) を lock-in する単体 test 8 件を追加 (PR #311 review I3 教訓先取り)

## 変更内容

### 新規
- `functions/test/helpers/withNodeEnv.ts`: sync/async 2 関数。`original === undefined` の場合は `delete` で復元、finally で throw 時も確実復元
- `functions/test/helpers/withNodeEnv.test.ts`: sync 6 + async 2 ケース

### 移行 (5 箇所)
| # | 箇所 | 由来 | パターン |
|---|------|------|---------|
| 1 | `textCap.test.ts` L454-462 | Phase 2 | `= original` (undefined 未考慮、Phase 2 由来) |
| 2 | `textCap.test.ts` L484-498 | Phase 2 | `= original` (undefined 未考慮) |
| 3 | `textCap.test.ts` L520-538 | Phase 3 | `if (undefined) delete` (修正済、統一) |
| 4 | `textCap.test.ts` L540-566 | Phase 3 | `if (undefined) delete` (修正済、統一) |
| 5 | `ocrAggregateCallerPattern.runtime.test.ts` L131-154 | Phase 3 | async 版、`withNodeEnvAsync` 採用 |

## Quality Gate

- [x] テスト: **567 passing** (559 既存 + withNodeEnv 単体 test 8)
- [x] type-check: PASS
- [x] lint: 0 errors, 20 warnings (既存のみ)
- [x] `/simplify`: reuse/quality/efficiency 3観点並列レビュー済、**改善提案なし**
- [x] Evaluator 分離: **不要** (4 ファイル、発動条件 5 ファイル未満)

## PR #311 review 教訓の先取り

- PR #311 で pr-test-analyzer から `startAfterAnchor` fixture 追加を指摘された教訓を受け、本 PR では withNodeEnv 単体 test を初手で追加
- sync/async 二重化は型安全性 (async 版は `Promise<T>` 強制) のため維持判断 (Quality agent 合意)
- Mocha `--parallel` 非対応を docstring に明記 (将来の互換性想定)

## Test plan

- [ ] CI: functions test (567 passing) + type-check + lint success
- [ ] (マージ後) main 同期、PR-3 (#308 docs/context/test-strategy.md) 着手
- [ ] (将来) Mocha `--parallel` 有効化検討時、本 helper を module isolation で分離

## Phase 1 残り

- **PR-3** (#308): `docs/context/test-strategy.md` 新規 + 6 contract test の docstring 簡素化

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)