### PR TITLE
docs(test): contract test docstring 共通パターン抽出 + test-strategy.md 新規 (#308)

### DIFF
--- a/docs/context/test-strategy.md
+++ b/docs/context/test-strategy.md
@@ -1,0 +1,119 @@
+# テスト戦略 (DocSplit functions/)
+
+このドキュメントは DocSplit の `functions/` 配下で採用している **契約テスト (contract test)** の 3 系統の役割・手法・使い分けを一元化する。個別の contract test ファイルの docstring から本ドキュメントを参照することで、共通説明の重複を削減する。
+
+---
+
+## 1. 契約テストの位置づけ
+
+`functions/` の OCR / 書類処理パスは以下の要因で unit test のみでは contract を保護できない:
+
+- `admin.firestore()` / `storage.bucket()` / Vertex AI など **top-level で admin 初期化**する副作用を持つモジュールが多く、単体から runtime 呼出が難しい
+- Firestore 旧データ (型変更前の document) 由来の discriminated union 違反が **silent に prod 分岐を通過**し Cloud Logging alert にも拾われない silent failure 経路が過去発生 ([Issue #209 / #288 item 6])
+- PR merge 後の **code レベル回帰** (例: `void safeLogError(...)` 直叩き回帰 / try/catch 剥離 / anchor rename) を CI で検知する必要がある
+
+これらを補う最小コストの層として contract test を配置している。
+
+---
+
+## 2. 3 系統の使い分け
+
+### 2.1 grep-based contract test
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | source 構造の回帰防止 (関数名 / anchor / 文字列 pattern) |
+| 手法 | `readFileSync` でソース全文を読み、brace-nesting / paren-nesting で対象ブロックを抽出 → 必須要素を正規表現で検証 |
+| 適用 | prod 分岐 / silent failure 対策 / caller wiring |
+| 依存 helper | [`functions/test/helpers/extractBraceBlock.ts`](../../functions/test/helpers/extractBraceBlock.ts) (`extractBraceBlock` / `extractParenBlock`, Issue #302 で共通化) |
+| 既存例 | `textCapProdInvariantContract.test.ts` (#288 item 6), `aggregateCapLogErrorContract.test.ts` (#283), `handleProcessingErrorContract.test.ts` (#276), `textCapPendingLogsContract.test.ts` (#293 + #297), `ocrProcessorAggregateCallerContract.test.ts` (#293 + #297) |
+| 限界 | 文字列/正規表現/テンプレートリテラル内の裸 `{` `}` で誤判定の可能性。将来そのケースに遭遇したら AST ベース抽出への移行を検討 |
+
+**偽陽性対策**: 関数本体全体を対象にした regex だと無関係な同名ローカル変数 / 他 logger 呼出 / 文字列リテラルに偽陽性が出る ([silent-failure-hunter 指摘])。`extractBraceBlock` で scope を絞る + anchor を narrow することで精度を上げる。
+
+**silent PASS リスク**: helper が空文字を返した場合 `expect(block).to.not.match(...)` は常に PASS する。各 `it` で `expect(block).to.not.equal('')` の non-empty guard を先に実行すること ([PR #311 review C1/C2])。
+
+### 2.2 `@ts-expect-error` 型契約 test
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | 型レベル不変条件の lock-in (union 分解 / generics 制約) |
+| 手法 | `@ts-expect-error` コメント + `tsc --noEmit` (`tsconfig.test.json` で明示検証) |
+| 適用 | discriminated union 不変条件 / generics 制約 / 戻り値型の union 広がり |
+| 既存例 | `functions/test/types/pageOcrResult.types.test.ts`, `textCapAsCastContract.test.ts` (#284), `textCapGenericsContract.test.ts` (#294) |
+| 限界 | tsd 等の専用ライブラリは未導入。本 test は baseline として機能し、より精密な型 assert が必要になった時点で tsd 導入を別 Issue 化 |
+
+### 2.3 Runtime pattern test
+
+| 項目 | 内容 |
+|------|------|
+| 目的 | admin 非依存で実 runtime 挙動を lock-in (統合 test の代替) |
+| 手法 | 期待される caller パターンを inline で最小再現し、spy 注入で呼出内容を検証 |
+| 適用 | caller wrapper / E2E の最小再現 / admin 初期化を避けたい箇所 |
+| 既存例 | `functions/test/ocrAggregateCallerPattern.runtime.test.ts` (#294 item 8, #293/#297 補完) |
+| 将来 | 完全な統合 test は `ts-node/esm` 環境整備 + `admin` mock で Issue #299 に委譲。それまでは runtime pattern test を二段防御の一翼として保持 |
+
+### 2.4 共通 helper
+
+| Helper | 用途 | Issue |
+|--------|------|-------|
+| [`extractBraceBlock`](../../functions/test/helpers/extractBraceBlock.ts) / `extractParenBlock` | grep-based test の brace/paren nesting 抽出 | #302 |
+| [`makeInvalidPage`](../../functions/test/helpers/textCapFixtures.ts) / `makeMixedPages` | `as unknown as SummaryField` cast を集約した fixture | #307 |
+| [`withNodeEnv`](../../functions/test/helpers/withNodeEnv.ts) / `withNodeEnvAsync` | `process.env.NODE_ENV` 切替の確実復元 (undefined 文字列化防止) | #306 |
+
+各 helper には `functions/test/helpers/*.test.ts` で単体 test を配置し、helper 固有の挙動 (復元順序 / async 経路 / startAfterAnchor option) を直接 lock-in している。
+
+---
+
+## 3. 選定フロー
+
+新規 contract を追加する際の判断フロー:
+
+```
+Q1. source 構造 (関数名 / anchor / 呼出の存在) を保護したいか
+ → Yes: grep-based (§2.1)
+ → No:  Q2 へ
+
+Q2. 型レベル不変条件を保護したいか (union / generics / 戻り値型)
+ → Yes: @ts-expect-error (§2.2)
+ → No:  Q3 へ
+
+Q3. runtime 挙動を実コード無しで検証したいか (admin 依存を避けたい)
+ → Yes: runtime pattern (§2.3)
+ → No:  通常の unit test / integration test を検討
+```
+
+複数系統の二段防御が適切なケース (例: grep + runtime) は、両方を `Refs:` コメントで相互参照する。
+
+---
+
+## 4. docstring テンプレート
+
+各 contract test ファイルの docstring は以下の最小テンプレートに従う:
+
+```typescript
+/**
+ * <対象関数/モジュール名> の <契約の目的> テスト (Issue #XXX)
+ *
+ * 目的: <何を検証するか。1-2 文>
+ *
+ * 背景: <なぜこの contract が必要か。過去の silent failure や回帰事例を 1-3 文>
+ *
+ * 方式: <grep-based / @ts-expect-error / runtime pattern のどれか>
+ *        <docs/context/test-strategy.md §2.X> 参照
+ *
+ * 将来委譲: <動的 test / 統合 test への移行計画がある場合のみ記載、Issue 番号付き>
+ */
+```
+
+「方式選定」節で 3 系統の使い分け理由を毎回書かず、本 docstring から `test-strategy.md §2.X` にリンクすることで重複を削減する。
+
+---
+
+## 5. 参考 Issue
+
+- [#302](https://github.com/yasushi-honda/doc-split/issues/302) brace-nesting helper 共通化
+- [#306](https://github.com/yasushi-honda/doc-split/issues/306) withNodeEnv helper
+- [#307](https://github.com/yasushi-honda/doc-split/issues/307) SummaryField fixture 集約
+- [#308](https://github.com/yasushi-honda/doc-split/issues/308) 本ドキュメント (docstring 共通パターン抽出)
+- [#299](https://github.com/yasushi-honda/doc-split/issues/299) 動的 safeLogError invocation test (将来)

--- a/docs/context/test-strategy.md
+++ b/docs/context/test-strategy.md
@@ -40,7 +40,7 @@
 | 目的 | 型レベル不変条件の lock-in (union 分解 / generics 制約) |
 | 手法 | `@ts-expect-error` コメント + `tsc --noEmit` (`tsconfig.test.json` で明示検証) |
 | 適用 | discriminated union 不変条件 / generics 制約 / 戻り値型の union 広がり |
-| 既存例 | `functions/test/types/pageOcrResult.types.test.ts`, `textCapAsCastContract.test.ts` (#284), `textCapGenericsContract.test.ts` (#294) |
+| 既存例 | [`functions/test/types/pageOcrResult.types.test.ts`](../../functions/test/types/pageOcrResult.types.test.ts), [`textCapAsCastContract.test.ts`](../../functions/test/types/textCapAsCastContract.test.ts) (#284), [`textCapGenericsContract.test.ts`](../../functions/test/types/textCapGenericsContract.test.ts) (#294) |
 | 限界 | tsd 等の専用ライブラリは未導入。本 test は baseline として機能し、より精密な型 assert が必要になった時点で tsd 導入を別 Issue 化 |
 
 ### 2.3 Runtime pattern test
@@ -50,7 +50,7 @@
 | 目的 | admin 非依存で実 runtime 挙動を lock-in (統合 test の代替) |
 | 手法 | 期待される caller パターンを inline で最小再現し、spy 注入で呼出内容を検証 |
 | 適用 | caller wrapper / E2E の最小再現 / admin 初期化を避けたい箇所 |
-| 既存例 | `functions/test/ocrAggregateCallerPattern.runtime.test.ts` (#294 item 8, #293/#297 補完) |
+| 既存例 | [`functions/test/ocrAggregateCallerPattern.runtime.test.ts`](../../functions/test/ocrAggregateCallerPattern.runtime.test.ts) (#294 item 8, #293/#297 補完) |
 | 将来 | 完全な統合 test は `ts-node/esm` 環境整備 + `admin` mock で Issue #299 に委譲。それまでは runtime pattern test を二段防御の一翼として保持 |
 
 ### 2.4 共通 helper
@@ -61,7 +61,7 @@
 | [`makeInvalidPage`](../../functions/test/helpers/textCapFixtures.ts) / `makeMixedPages` | `as unknown as SummaryField` cast を集約した fixture | #307 |
 | [`withNodeEnv`](../../functions/test/helpers/withNodeEnv.ts) / `withNodeEnvAsync` | `process.env.NODE_ENV` 切替の確実復元 (undefined 文字列化防止) | #306 |
 
-各 helper には `functions/test/helpers/*.test.ts` で単体 test を配置し、helper 固有の挙動 (復元順序 / async 経路 / startAfterAnchor option) を直接 lock-in している。
+ロジック持ちの helper (`extractBraceBlock` / `withNodeEnv`) には `functions/test/helpers/*.test.ts` で単体 test を配置し、helper 固有の挙動 (復元順序 / async 経路 / startAfterAnchor option) を直接 lock-in している。pure fixture の helper (`textCapFixtures`) は消費側 contract test での利用で十分と判断し専用 test は配置しない。
 
 ---
 

--- a/functions/test/aggregateCapLogErrorContract.test.ts
+++ b/functions/test/aggregateCapLogErrorContract.test.ts
@@ -4,17 +4,13 @@
  * 目的: ocrProcessor.processDocument 内の aggregate cap block が、truncation 発動時に
  * safeLogError (errors collection + 通知) を呼び続けることを静的検証で保証する。
  *
- * 背景 (#283):
- * 既存実装 (#282 マージ時点) は aggregate cap 発動時に ocrProcessor.ts L152-154 で
- * 単発 console.warn を出すのみ。warn level は Cloud Logging alert に拾われにくく、
- * Issue #209 型実害 (Vertex AI 暴走 1.1M chars) が運用側で認知できない silent failure
- * 経路が残っていた。本契約は safeLogError 格上げ (#283 Option B) を lock-in する。
+ * 背景: 既存実装 (#282 マージ時点) は aggregate cap 発動時に console.warn のみを出しており、
+ * warn level は Cloud Logging alert に拾われにくく、Issue #209 型実害 (Vertex AI 暴走 1.1M chars)
+ * が運用側で認知できない silent failure 経路が残っていた。本契約は safeLogError 格上げ
+ * (#283 Option B) を lock-in する。
  *
- * 方式選定:
- * aggregate cap block は `if (afterAggregateChars < beforeAggregateChars) { ... }`
- * 条件ブロック内。このブロックを brace-nesting で抽出し、block 内での safeLogError
- * 呼出と params (source: 'ocr' / documentId / functionName) を検証する。
- * Phase 1 (#276) の extractFunctionBody / extractSafeLogErrorArgs と同一手法。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * anchor: `if (afterAggregateChars < beforeAggregateChars) { ... }`
  */
 
 import { expect } from 'chai';

--- a/functions/test/ocrAggregateCallerPattern.runtime.test.ts
+++ b/functions/test/ocrAggregateCallerPattern.runtime.test.ts
@@ -1,18 +1,16 @@
 /**
  * aggregate caller wrapper パターンの runtime 契約テスト (Issue #294 item 8, #293/#297 補完)
  *
- * 目的: ocrProcessor.processDocument 内の `capPageResultsAggregate` 呼出周辺パターン
- * (try/catch + pendingLogs drain + 継続保証) を admin 非依存で runtime 検証する。
+ * 目的: processDocument 内の `capPageResultsAggregate` 呼出周辺パターン (try/catch +
+ * pendingLogs drain + 継続保証) を admin 非依存で runtime 検証する。
  *
- * 制約: 本物の processDocument は admin.firestore() / storage.bucket() / Vertex AI に
- * 広範囲に依存するため、unit test 環境から直接呼べない。本テストは **期待される caller
- * パターン** を inline で再現し、capPageResultsAggregate との結合動作を lock-in する。
+ * 背景: 本物の processDocument は admin.firestore() / storage.bucket() / Vertex AI に広範囲
+ * 依存するため unit test 環境から直接呼べない。本テストは期待される caller パターンを inline
+ * 再現し、`ocrProcessorAggregateCallerContract.test.ts` (grep 契約) と組み合わせて二段防御
+ * とする (#301 Evaluator HIGH 指摘への部分的対応)。
  *
- * #301 Evaluator HIGH 指摘 (AC-4/AC-5 動的 assert 不在) への部分的対応。
- * ocrProcessor 側の実装が本パターンから逸脱した場合は `ocrProcessorAggregateCallerContract.test.ts`
- * (grep 契約) で検知される。両者を組み合わせて二段防御とする。
- *
- * 完全な processDocument 統合 test は Issue #299 (ts-node/esm 環境整備 + admin mock) に委譲。
+ * 方式: runtime pattern test (docs/context/test-strategy.md §2.3 参照)。
+ * 将来委譲: 完全な processDocument 統合 test は Issue #299 (ts-node/esm 環境整備 + admin mock) に委譲。
  */
 
 import { expect } from 'chai';

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -2,18 +2,13 @@
  * ocrProcessor aggregate caller try/catch + pendingLogs drain 契約テスト
  * (Issue #293 + #297 統合対応)
  *
- * 目的: processDocument 内 capPageResultsAggregate 呼出周辺に:
- *   1. try/catch で dev invariant throw を捕捉 → safeLogError で errors collection 記録
- *   2. pendingInvariantLogs array を渡して fire-and-forget を廃止 (#297)
- *   3. `await Promise.allSettled(pendingInvariantLogs)` による flush 保証
- * を追加した設計を grep-based で lock-in する。
+ * 目的: processDocument 内 capPageResultsAggregate 呼出周辺に (1) try/catch で dev throw
+ * 捕捉 → safeLogError 記録, (2) pendingInvariantLogs array 渡しで fire-and-forget 廃止,
+ * (3) `await Promise.allSettled(pendingInvariantLogs)` による flush 保証、を追加した設計を
+ * 静的に lock-in する。
  *
- * 方式選定:
- * ocrProcessor.ts のソース全体から capPageResultsAggregate 呼出周辺ブロック
- * (try { ... } catch { ... } ... Promise.allSettled) を抽出し、必須要素の存在を
- * grep で検証する。
- *
- * 動的 runtime test による caller throw 捕捉挙動の verify は Issue #299 で追加予定。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * 将来委譲: 動的 runtime test による caller throw 捕捉の verify は Issue #299 で追加予定。
  */
 
 import { expect } from 'chai';

--- a/functions/test/summaryBuilderCallerContract.test.ts
+++ b/functions/test/summaryBuilderCallerContract.test.ts
@@ -9,7 +9,8 @@
  * regenerateSummary は generateSummaryCore() 経由に統一。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
- * 既知の limitation: 型 alias 経由や分割代入は未検出。caller 追加時は CALLER_FILES の手動追記が必要。
+ * 既知の limitation: 型 alias 経由 (const gen = model.generateContent; gen(...)) や分割代入は
+ * 未検出。caller 追加時は CALLER_FILES / CORE_CALLERS への手動追記が必要 (grep 動的検出は未導入)。
  * 昇格条件: false negative が 1 件でも実発生した時点で sinon spy (案A) へ切替。
  */
 

--- a/functions/test/summaryBuilderCallerContract.test.ts
+++ b/functions/test/summaryBuilderCallerContract.test.ts
@@ -1,22 +1,15 @@
 /**
  * generateSummary caller-side 契約テスト (Issue #225, #214)
  *
- * builder 側 canary は builder の契約を固定するが、caller 側で builder を経由
- * しなくなると canary は PASS のまま Issue #209 (Vertex AI summary 暴走) が再発する。
- * 本テストは caller 側の呼び出しパターンを構文検証して bypass を検出する。
+ * 目的: caller 側で builder を bypass (Vertex AI 直呼) する回帰を検知する (Issue #209 型の
+ * summary 暴走再発防止)。builder 側 canary だけでは caller bypass を見逃すため、caller
+ * 呼出パターンを静的に lock-in する。
  *
- * 方式: grep-based (静的検証)。
+ * 背景 (#214 リファクタ): summaryGenerator.ts が唯一の Vertex AI caller、ocrProcessor /
+ * regenerateSummary は generateSummaryCore() 経由に統一。
  *
- * Issue #214 リファクタ後の構造:
- * - `src/ocr/summaryGenerator.ts` が `model.generateContent(buildSummaryGenerationRequest(...))` を
- *   一箇所に集約する唯一の caller。
- * - `ocrProcessor.ts` / `regenerateSummary.ts` は `generateSummaryCore()` 経由で要約を生成し、
- *   Vertex AI を直接呼ばない (bypass 防止)。
- *
- * 既知の limitation:
- * - 型 alias 経由 (const gen = model.generateContent; gen(...)) や分割代入の呼び出しは未検出
- * - caller 追加時は CALLER_FILES / CORE_CALLERS への手動追記が必要 (grep 動的検出は未導入)
- *
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * 既知の limitation: 型 alias 経由や分割代入は未検出。caller 追加時は CALLER_FILES の手動追記が必要。
  * 昇格条件: false negative が 1 件でも実発生した時点で sinon spy (案A) へ切替。
  */
 

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -9,7 +9,8 @@
  * デバッグで原因不明となる silent failure を構造的に防ぐ。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。console.error メッセージを
- * anchor に、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を検知する。
+ * anchor に、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を検知する。anchor メッセージ変更で
+ * test が失敗するが、意図的変更のメンテナンス負荷は silent swallow 防止の価値と trade-off。
  */
 
 import { expect } from 'chai';

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -1,17 +1,15 @@
 /**
  * summary 経路 catch 句 logError 呼出契約テスト (Issue #266)
  *
- * 目的: ocrProcessor / regenerateSummary の summary 生成失敗 catch 句で、
- * console.error だけでなく logError (errors collection + 通知) が呼ばれ続けることを保証する。
+ * 目的: ocrProcessor / regenerateSummary の summary 生成失敗 catch 句で、console.error だけで
+ * なく logError (errors collection + 通知) が呼ばれ続けることを静的に lock-in する。
  *
- * 背景 (#178/#209 教訓):
- * Vertex AI のクォータ枯渇・認証失効・暴走系エラーが silently swallow されると、
- * documents は status:processed で完了し「summary が空」としか見えない。
- * 6 ヶ月後のデバッグで原因不明となる silent failure を構造的に防ぐ。
+ * 背景 (#178/#209 教訓): Vertex AI のクォータ枯渇・認証失効・暴走系エラーが silently swallow
+ * されると、documents は status:processed で完了し「summary が空」としか見えない。6 ヶ月後の
+ * デバッグで原因不明となる silent failure を構造的に防ぐ。
  *
- * 方式: grep-based (静的検証)。`summaryWritePayloadContract.test.ts` (#259) と同方針。
- * console.error メッセージをアンカーに、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を検知する。
- * メッセージ変更時は test 失敗するが、意図的変更なのでメンテナンス負荷は許容範囲。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。console.error メッセージを
+ * anchor に、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を検知する。
  */
 
 import { expect } from 'chai';

--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -1,24 +1,18 @@
 /**
  * summary 書込経路 caller-side 契約テスト (Issue #255 + #259)
  *
- * 目的: ocrProcessor / regenerateSummary の Firestore 書込呼出で、
- * 以下 3 要素が同時に含まれ続けることを保証する:
- *   1. `summary: buildSummaryFields(...)` — 新 discriminated union ネスト書込 (#215)
- *   2. `summaryTruncated: FieldValue.delete()` — 旧フラットフィールドの削除
- *   3. `summaryOriginalLength: FieldValue.delete()` — 旧フラットフィールドの削除
+ * 目的: ocrProcessor / regenerateSummary の Firestore 書込呼出で 3 要素を同時保持することを
+ * lock-in する: (1) `summary: buildSummaryFields(...)` (新 discriminated union, #215),
+ * (2) `summaryTruncated: FieldValue.delete()` (旧フラット削除), (3) `summaryOriginalLength:
+ * FieldValue.delete()`。#259: builder bypass (object literal 直書込) / .set() / .create() /
+ * merge:true 等のバイパス経路も検知対象。
  *
- * #259: 加えて `buildSummaryFields` を経由しない直接書込 (`summary: { ... }` object literal)
- * を anti-pattern として検知。`.update()` だけでなく `.set()` / `.create()` 経路も対象とし、
- * `merge: true` 等のバイパスで派生フィールド整合が崩れる経路を塞ぐ。
+ * 背景 (#178 教訓): 派生フィールドの一括書込が壊れると FE 表示が崩れる。旧フィールド delete
+ * 忘れで Firestore に残留し後方互換読込に無限依存するリスクを防ぐ。
  *
- * 背景 (#178 教訓):
- * 派生フィールドの一括書込が壊れると FE 表示が崩れる。#215 で新形式への移行
- * + 旧フィールド delete を徹底したが、将来のリファクタで delete 忘れが起きると
- * Firestore に旧フィールドが残留し、後方互換読込に無限依存するリスクがある。
- *
- * 方式: grep-based (静的検証)。`summaryBuilderCallerContract.test.ts` (#214)
- * と同じ方針。false negative 発生時に sinon spy へ昇格。既知の grep limitation
- * (コメント/文字列リテラル内の偽陽性、quoted key、CJK prefix) は follow-up Issue で扱う。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * 昇格条件: false negative 発生時に sinon spy へ。grep limitation (コメント/文字列偽陽性,
+ * quoted key, CJK prefix) は follow-up Issue で扱う。
  */
 
 import { expect } from 'chai';

--- a/functions/test/textCapPendingLogsContract.test.ts
+++ b/functions/test/textCapPendingLogsContract.test.ts
@@ -3,18 +3,12 @@
  * (Issue #297 + #293 統合対応)
  *
  * 目的: `void safeLogError(...)` fire-and-forget を `context.pendingLogs` array に push する
- * 形へ変更した回帰を grep-based で防止する。caller (ocrProcessor.ts) が
- * `await Promise.allSettled(pendingLogs)` で drain することで Cloud Functions handler
- * 終了前の flush を保証する設計を静的に lock-in する。
+ * 形へ変更した回帰を防止する。caller (ocrProcessor.ts) が `await Promise.allSettled(pendingLogs)`
+ * で drain し、Cloud Functions handler 終了前の flush を保証する設計を静的に lock-in する。
  *
- * 方式選定:
- * handleAggregateInvariantViolation 本体を brace-nesting で抽出し、production 分岐内で:
- *   1. safeLogError の戻り値を変数束縛 (fire-and-forget `void` 直叩きではない)
- *   2. context?.pendingLogs への push 呼出が存在
- *   3. pendingLogs 未渡し時の fallback (void logPromise or ?.push 形) で後方互換維持
- * を grep 検証する。
- *
- * 動的 safeLogError invocation test は Issue #299 で追加予定。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。prod 分岐内で (1) 戻り値束縛,
+ * (2) context?.pendingLogs.push, (3) 未渡し時の void fallback の 3 要素を検証。
+ * 将来委譲: 動的 safeLogError invocation test は Issue #299 で追加予定。
  */
 
 import { expect } from 'chai';

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -2,22 +2,14 @@
  * textCap assertAggregatePageInvariant の prod observability 格上げ契約テスト (Issue #288 item 6)
  *
  * 目的: prod で silent early return だった invariant 検証を safeLogError emit に格上げした
- * 変更 (#288 item 6) の回帰を grep-based で防止する。
+ * 変更 (#288 item 6) の回帰を静的検証で防止する。
  *
- * 背景 (#288 item 6 / PR #290 silent-failure-hunter S1 CRITICAL):
- * 既存 (#284) の assertAggregatePageInvariant は `process.env.NODE_ENV === 'production'` で
- * early return していたため、Firestore 旧データ由来の discriminated union 違反 (#209 型)
- * が prod で silent に伝播する経路が残っていた。本契約は prod 分岐で safeLogError を
- * 経由して errors collection に記録する shape を lock-in する。
+ * 背景: 既存 (#284) の assertAggregatePageInvariant は prod で early return していたため、
+ * Firestore 旧データ由来の discriminated union 違反 (#209 型) が silent に伝播する経路が
+ * 残っていた (PR #290 silent-failure-hunter S1 CRITICAL)。
  *
- * 方式選定:
- * assertAggregatePageInvariant 関数本体を brace-nesting で抽出し、production 分岐内の
- * safeLogError 呼出と params (source: 'ocr', functionName: 'capPageResultsAggregate') を
- * 静的検証する。Phase 1 (#276) / #283 (aggregateCapLogErrorContract.test.ts) と同一手法。
- *
- * Phase 3 (Issue #288 item 1) で動的 safeLogError invocation test を追加し、本 grep 契約を
- * runtime 挙動と二段で lock-in する予定。現時点では admin.firestore() top-level 依存のため
- * unit test 環境から safeLogError を runtime 実行するのが不適 (buildPageResult 設計方針参照)。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * 将来委譲: Phase 3 (#288 item 1) で動的 safeLogError invocation test と二段で lock-in 予定。
  */
 
 import { expect } from 'chai';

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -8,7 +8,8 @@
  * Firestore 旧データ由来の discriminated union 違反 (#209 型) が silent に伝播する経路が
  * 残っていた (PR #290 silent-failure-hunter S1 CRITICAL)。
  *
- * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。prod 分岐内の safeLogError 呼出と
+ * params (source: 'ocr', functionName: 'capPageResultsAggregate') の存在を静的検証する。
  * 将来委譲: Phase 3 (#288 item 1) で動的 safeLogError invocation test と二段で lock-in 予定。
  */
 

--- a/functions/test/types/textCapGenericsContract.test.ts
+++ b/functions/test/types/textCapGenericsContract.test.ts
@@ -1,16 +1,14 @@
 /**
  * capPageResultsAggregate の generics 型契約テスト (Issue #294)
  *
- * 目的: `<T extends SummaryField>` 制約と戻り値型 `CappedAggregatePage<T>[]`
- * (= `Omit<T, 'text' | 'truncated' | 'originalLength'> & SummaryField`) の
- * 型レベル契約を lock-in する。
+ * 目的: `<T extends SummaryField>` 制約と戻り値型 `CappedAggregatePage<T>[]` の型レベル契約を
+ * lock-in する (narrow 型 T を渡しても戻り値の SummaryField 部は union に広がり、caller は
+ * narrowing なしで originalLength にアクセスできない)。
  *
- * 背景 (#284): `as T` cast 排除で戻り値を SummaryField フル union に戻す設計に変更。
- * narrow 型 T を渡しても、戻り値の SummaryField 部は union に広がり、caller は
- * `if (result.truncated)` 等の narrowing なしで originalLength にアクセスできない契約。
+ * 背景: #284 の `as T` cast 排除で戻り値を SummaryField フル union に戻す設計に変更した
+ * 不変条件を型レベルで lock-in する。
  *
- * 方式: `@ts-expect-error` + `tsc --noEmit` (既存 pageOcrResult.types.test.ts パターン)。
- * tsd 導入は別 Issue とし、本テストは baseline として機能。
+ * 方式: `@ts-expect-error` 型契約 test (docs/context/test-strategy.md §2.2 参照)。
  */
 
 import { expect } from 'chai';


### PR DESCRIPTION
## Summary

Phase 1 最終 PR (#308)。contract test 3 系統の役割を一元化した `docs/context/test-strategy.md` を新規作成し、9 ファイルの docstring から reinvent されていた共通説明を `test-strategy.md §2.X 参照` で置換する。

## 変更内容

### 新規
- **`docs/context/test-strategy.md`** (119 行): contract test 戦略の一元化ドキュメント
  - §1 位置づけ (silent failure 経路の具体例、Issue #209 / #288 item 6 引用)
  - §2 3 系統: grep-based / @ts-expect-error / runtime pattern の手法・適用・限界
  - §2.4 共通 helper: extractBraceBlock / textCapFixtures / withNodeEnv のマッピング
  - §3 選定フロー (Q&A 形式で新規 contract test 追加時の判断を支援)
  - §4 docstring テンプレート (4 節構造「目的 / 背景 / 方式 / 将来委譲」)
  - §5 参考 Issue

### docstring 簡素化 (9 ファイル)

| ファイル | 系統 | 削減行数 |
|---------|------|---------|
| textCapProdInvariantContract | grep-based | -12 |
| aggregateCapLogErrorContract | grep-based | -10 |
| textCapPendingLogsContract | grep-based | -9 |
| ocrProcessorAggregateCallerContract | grep-based | -9 |
| types/textCapGenericsContract | @ts-expect-error | -8 |
| ocrAggregateCallerPattern.runtime | runtime pattern | -10 |
| summaryBuilderCallerContract (追加) | grep-based | -12 |
| summaryCatchLogErrorContract (追加) | grep-based | -9 |
| summaryWritePayloadContract (追加) | grep-based | -15 |

**当初 scope 6 ファイル → 9 ファイルに拡張**: `/simplify` Reuse + Quality agent が「summary 系 3 ファイルも同じ簡素化が適用可能」と指摘。低コスト (各 5-10 行削減) で 9 ファイル全 contract test で統一感を実現するため本 PR に追加。

## Quality Gate

- [x] テスト: **570 passing** 維持 (docstring 変更のみ、挙動不変)
- [x] type-check / lint: PASS (0 errors, 20 warnings 既存のみ)
- [x] `/simplify`: reuse/quality/efficiency 3観点レビュー
  - Reuse: summary 系 3 ファイルも簡素化推奨 → **本 PR で追加対応**
  - Quality: 4 節構造に統一、全ファイルで link 形式統一
  - Efficiency: build 時間無影響、新規 contract 追加時の執筆コスト 4-6min/ファイル短縮見込み
- [x] Evaluator 分離: **不要** (CLAUDE.md quality-gate.md「ドキュメントのみの変更」「テストコードのみの変更」に該当)

## Test plan

- [ ] CI: functions test 570 passing + type-check + lint success
- [ ] (マージ後) `docs/context/test-strategy.md` のリンクが GitHub 上で正しく render されるか確認
- [ ] (Phase 1 完了後) #312 / #313 / #315 follow-up Issue の実装方針検討

## Phase 1 完了報告

本 PR マージで Phase 1 (Contract test 共通基盤整備) が完了:
- **PR #311** (#302 + #307): brace/paren helper + SummaryField fixture 集約
- **PR #314** (#306): withNodeEnv helper
- **PR #315** (本 PR, #308): test-strategy.md + docstring 統一

累計: 548 → 570 passing (+22)、helper 3 ファイル + 単体 test 18 件、9 contract test docstring 統一。

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive testing strategy documentation standardizing three contract testing approaches: source-structure validation using pattern matching, type-level contract testing, and runtime pattern testing with minimal dependencies.
  * Updated contract test documentation across multiple files to align with and reference the new standardized testing strategy guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->