### PR TITLE
refactor(textCap): drainSink rename + errorLogger require failure fallback (#304 #303)

### DIFF
--- a/docs/context/test-strategy.md
+++ b/docs/context/test-strategy.md
@@ -26,7 +26,7 @@
 | 手法 | `readFileSync` でソース全文を読み、brace-nesting / paren-nesting で対象ブロックを抽出 → 必須要素を正規表現で検証 |
 | 適用 | prod 分岐 / silent failure 対策 / caller wiring |
 | 依存 helper | [`functions/test/helpers/extractBraceBlock.ts`](../../functions/test/helpers/extractBraceBlock.ts) (`extractBraceBlock` / `extractParenBlock`, Issue #302 で共通化) |
-| 既存例 | `textCapProdInvariantContract.test.ts` (#288 item 6), `aggregateCapLogErrorContract.test.ts` (#283), `handleProcessingErrorContract.test.ts` (#276), `textCapDrainSinkContract.test.ts` (#293 + #297、#304 naming refactor), `ocrProcessorAggregateCallerContract.test.ts` (#293 + #297) |
+| 既存例 | `textCapProdInvariantContract.test.ts` (#288 item 6), `aggregateCapLogErrorContract.test.ts` (#283), `handleProcessingErrorContract.test.ts` (#276), `textCapDrainSinkContract.test.ts` (#293 + #297、#304 naming refactor), `textCapErrorLoggerFallbackContract.test.ts` (#303 errorLogger require failure fallback), `ocrProcessorAggregateCallerContract.test.ts` (#293 + #297) |
 | 限界 | 文字列/正規表現/テンプレートリテラル内の裸 `{` `}` で誤判定の可能性。将来そのケースに遭遇したら AST ベース抽出への移行を検討 |
 
 **偽陽性対策**: 関数本体全体を対象にした regex だと無関係な同名ローカル変数 / 他 logger 呼出 / 文字列リテラルに偽陽性が出る ([silent-failure-hunter 指摘])。`extractBraceBlock` で scope を絞る + anchor を narrow することで精度を上げる。

--- a/docs/context/test-strategy.md
+++ b/docs/context/test-strategy.md
@@ -26,7 +26,7 @@
 | 手法 | `readFileSync` でソース全文を読み、brace-nesting / paren-nesting で対象ブロックを抽出 → 必須要素を正規表現で検証 |
 | 適用 | prod 分岐 / silent failure 対策 / caller wiring |
 | 依存 helper | [`functions/test/helpers/extractBraceBlock.ts`](../../functions/test/helpers/extractBraceBlock.ts) (`extractBraceBlock` / `extractParenBlock`, Issue #302 で共通化) |
-| 既存例 | `textCapProdInvariantContract.test.ts` (#288 item 6), `aggregateCapLogErrorContract.test.ts` (#283), `handleProcessingErrorContract.test.ts` (#276), `textCapPendingLogsContract.test.ts` (#293 + #297), `ocrProcessorAggregateCallerContract.test.ts` (#293 + #297) |
+| 既存例 | `textCapProdInvariantContract.test.ts` (#288 item 6), `aggregateCapLogErrorContract.test.ts` (#283), `handleProcessingErrorContract.test.ts` (#276), `textCapDrainSinkContract.test.ts` (#293 + #297、#304 naming refactor), `ocrProcessorAggregateCallerContract.test.ts` (#293 + #297) |
 | 限界 | 文字列/正規表現/テンプレートリテラル内の裸 `{` `}` で誤判定の可能性。将来そのケースに遭遇したら AST ベース抽出への移行を検討 |
 
 **偽陽性対策**: 関数本体全体を対象にした regex だと無関係な同名ローカル変数 / 他 logger 呼出 / 文字列リテラルに偽陽性が出る ([silent-failure-hunter 指摘])。`extractBraceBlock` で scope を絞る + anchor を narrow することで精度を上げる。

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -151,6 +151,8 @@ export async function processDocument(
   const beforeAggregateChars = pageResults.reduce((sum, p) => sum + p.text.length, 0);
   // #288 item 6: invariant violation の errors collection triage のため docId を伝搬。
   // #297 (Codex HIGH): pendingInvariantLogs を渡して fire-and-forget を廃止、後段で drain する。
+  // #304 naming: context field 名は drainSink (pendingLogs からリネーム)。caller ローカル変数名は
+  //   drain 責務を明示する従来命名 pendingInvariantLogs を維持。
   // #293 (silent-failure-hunter S2): dev 環境での invariant throw を caller で捕捉し、
   //   rules/error-handling.md §1「状態復旧 > ログ記録」に従って他ページ処理を継続する。
   //   pageResults は cap 前のまま pass-through (per-page cap 適用済で暴走リスクなし)。
@@ -159,7 +161,7 @@ export async function processDocument(
   try {
     pageResults = capPageResultsAggregate(pageResults, {
       documentId: docId,
-      pendingLogs: pendingInvariantLogs,
+      drainSink: pendingInvariantLogs,
     });
   } catch (err) {
     const baseError = err instanceof Error ? err : new Error(String(err));

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -14,10 +14,13 @@
  */
 
 import type { SummaryField } from '../../../shared/types';
-// type-only imports: runtime では erased されるため errorLogger.ts の top-level `admin.firestore()`
+// type-only import: runtime では erased されるため errorLogger.ts の top-level `admin.firestore()`
 // 副作用を誘発しない。#303 fallback の stringly-typed を compile-time drift 検知に格上げする。
-import type * as adminTypes from 'firebase-admin';
-import type { ErrorCategory, ErrorSeverity, ErrorSource } from './errorLogger';
+// `ErrorLog` 本体を import することで union 値の drift だけでなく interface shape drift (必須
+// field 追加、property rename 等) も tsc エラーとして検知可能化 (PR #319 CodeRabbit Major 対応)。
+// `ErrorLog.createdAt: admin.firestore.FieldValue` が透過的に引き継がれるため firebase-admin の
+// type-only import は不要。
+import type { ErrorLog } from './errorLogger';
 
 export const MAX_PAGE_TEXT_LENGTH = 50_000;
 
@@ -170,12 +173,17 @@ function handleAggregateInvariantViolation(
       try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const admin = require('firebase-admin') as typeof import('firebase-admin');
-        // schema drift 部分検知: errorLogger.ts の union 型 (ErrorSource/ErrorSeverity/
-        // ErrorCategory) を type-only import で share し、union allowed values の drift を
-        // compile-time で検知する。ErrorLog interface の shape drift (field 追加/削除、
-        // property rename) は本 annotation ではカバー外 (contract test 層で別途 lock-in)。
-        // fallback は loaderError を含む errorLogger 非対称拡張 schema のため、`ErrorLog` 型
-        // 全体とは構造的にバインドしない。
+        // schema drift 完全検知: `ErrorLog` interface (errorLogger.ts の primary schema) の shape
+        // を `Omit<ErrorLog, ...> & { loaderError; documentId: string | null }` で連動 binding する。
+        // - fallback では logError 側で自動採番される `id` / 解決後に付く `resolvedAt` / 発生コンテキスト
+        //   の `fileId` / prod では含めない `stackTrace` / 手動解決系の `resolution`/`resolvedBy` は
+        //   `Omit` で除外 (fallback 時点では取得不能)。
+        // - fallback 固有の拡張 `loaderError: string` は ErrorLog に存在しない診断専用 field。
+        //   将来 ErrorLog に標準化された場合 (`logError` 側でも同形式で使う) は本追加フィールドを外す。
+        // - `documentId` は ErrorLog で optional string だが、Firestore が undefined を拒否するため
+        //   fallback では null 正規化 (rules/error-handling.md §2)。型も override で明示する。
+        // これにより ErrorLog 側で必須 field 追加 / property rename が行われた瞬間、本 annotation が
+        // tsc エラーで追従を強制する (PR #319 CodeRabbit Major 対応)。
         //
         // loaderError 構造化 (#303): `String(loadErr)` は Error 以外が throw された場合に
         // `[object Object]` になる silent 情報欠損、および `FirebaseAppError.code` 等の triage
@@ -189,19 +197,14 @@ function handleAggregateInvariantViolation(
                 code: (loadErr as { code?: string }).code ?? null,
               }
             : { raw: String(loadErr) };
-        const fallbackRecord: {
-          source: ErrorSource;
-          functionName: string;
-          severity: ErrorSeverity;
-          category: ErrorCategory;
-          status: 'pending' | 'resolved' | 'ignored';
-          errorCode: string;
-          errorMessage: string;
-          loaderError: string;
+        type FallbackErrorRecord = Omit<
+          ErrorLog,
+          'id' | 'resolvedAt' | 'fileId' | 'stackTrace' | 'resolution' | 'resolvedBy' | 'documentId'
+        > & {
           documentId: string | null;
-          retryCount: number;
-          createdAt: adminTypes.firestore.FieldValue;
-        } = {
+          loaderError: string;
+        };
+        const fallbackRecord: FallbackErrorRecord = {
           source: 'ocr',
           functionName: 'capPageResultsAggregate:loaderFailed',
           severity: 'critical',

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -101,8 +101,11 @@ export type CappedAggregatePage<T extends SummaryField> =
  * - Option B (brand type `DrainSink = Promise<void>[] & { __mustDrain }`):
  *   grep 誤用検知は既存 contract test (textCapDrainSinkContract / ocrProcessorAggregateCallerContract)
  *   で代替可能。branded cast の caller 側コスト増に見合う恩恵なし。見送り。
- * - Option C (名称変更のみ): 採用。diff 最小 + 役割伝達。type-design-analyzer Enforcement 1/5 は
- *   contract test 層でカバーする方針を維持。
+ * - Option C (名称変更のみ): 採用。diff 最小 + 役割伝達。caller に drain 責務を型レベルで強制する
+ *   enforcement (drainSink を渡した caller が `Promise.allSettled` で drain することの強制) は
+ *   見送り、代わりに contract test 層 (textCapDrainSinkContract + ocrProcessorAggregateCallerContract)
+ *   の grep-based 検証でカバーする方針を維持。本判断は caller が ocrProcessor.ts 単一で
+ *   あることを前提とするため、caller が 2 箇所以上に増えた場合は Option A 再評価のトリガーとする。
  */
 export interface AggregateInvariantContext {
   documentId?: string;
@@ -118,16 +121,17 @@ export interface AggregateInvariantContext {
  *      未渡し時は後方互換 fire-and-forget (`void logPromise`) を維持 (#288 item 6)。
  *   2. `require('./errorLogger')` が失敗した場合は `admin.firestore().collection('errors').add()`
  *      直接書込 fallback で救う (#303)。bundler regression / 初期化 race で errorLogger 経路が
- *      壊れた場合の silent 消失を防ぐ。fallback 書込は意図的に drainSink に push しない
- *      fire-and-forget — Cloud Functions handler 終了前の完了保証なし。主経路 (safeLogError) は
- *      drainSink で drain 保証される設計と非対称だが、fallback は「最終手段 (last resort)」で
- *      即時プロセス継続を最優先するため pragmatic な選択。完了保証が必要になった場合は別 Issue 化。
- *   3. fallback 書込自体も silent swallow でプロセス継続保証。console.error は fallback 前に
- *      先行して最低限ログを残す (rules/error-handling.md §1)。
+ *      壊れた場合の silent 消失を防ぐ。fallback 書込 Promise も主経路と対称に drainSink に
+ *      push し、caller の `Promise.allSettled(drainSink)` で Cloud Functions freeze 前の完了
+ *      保証。drainSink 未渡し時のみ fire-and-forget (後方互換)。
+ *   3. fallback 書込が reject した場合は `.catch((writeErr) => console.error(...))` で
+ *      loader 失敗と区別できる一意タグで surface (PERMISSION_DENIED / RESOURCE_EXHAUSTED 等の
+ *      operational signal を silent に落とさない)。require('firebase-admin') / admin.firestore()
+ *      の同期失敗も外側 catch で console.error 出力し区別可能化 (rules/error-handling.md §1)。
  *
  * errorLogger は top-level で admin.firestore() を呼ぶため prod path に限定した
  * dynamic require で unit test (admin 未初期化) への影響を回避 (buildPageResult.ts 方針と整合)。
- * safeLogError 内部で try/catch 済み (errorLogger.ts:141-151) なので reject せず処理継続。
+ * safeLogError 内部で try/catch 済み (errorLogger.ts の `safeLogError` 関数) なので reject せず処理継続。
  */
 function handleAggregateInvariantViolation(
   detail: string,
@@ -166,9 +170,25 @@ function handleAggregateInvariantViolation(
       try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const admin = require('firebase-admin') as typeof import('firebase-admin');
-        // ErrorLog schema drift 検知: errorLogger.ts の union 型 (ErrorSource/ErrorSeverity/
-        // ErrorCategory) を type-only import で share し、fallback 書込 object を compile-time
-        // 検証。errorLogger.ts の型が変わった瞬間 fallback も tsc エラーで追従が強制される。
+        // schema drift 部分検知: errorLogger.ts の union 型 (ErrorSource/ErrorSeverity/
+        // ErrorCategory) を type-only import で share し、union allowed values の drift を
+        // compile-time で検知する。ErrorLog interface の shape drift (field 追加/削除、
+        // property rename) は本 annotation ではカバー外 (contract test 層で別途 lock-in)。
+        // fallback は loaderError を含む errorLogger 非対称拡張 schema のため、`ErrorLog` 型
+        // 全体とは構造的にバインドしない。
+        //
+        // loaderError 構造化 (#303): `String(loadErr)` は Error 以外が throw された場合に
+        // `[object Object]` になる silent 情報欠損、および `FirebaseAppError.code` 等の triage
+        // 重要フィールドが落ちる問題がある。name/message/code を抽出して JSON で保存する。
+        // stack は production path のため含めない (errorLogger.ts の stack 保持方針と整合)。
+        const loaderErrInfo =
+          loadErr instanceof Error
+            ? {
+                name: loadErr.name,
+                message: loadErr.message,
+                code: (loadErr as { code?: string }).code ?? null,
+              }
+            : { raw: String(loadErr) };
         const fallbackRecord: {
           source: ErrorSource;
           functionName: string;
@@ -189,20 +209,44 @@ function handleAggregateInvariantViolation(
           status: 'pending',
           errorCode: 'LOADER_FAILED',
           errorMessage: message,
-          loaderError: String(loadErr),
+          loaderError: JSON.stringify(loaderErrInfo),
+          // Firestore は undefined を拒否するため null に正規化 (rules/error-handling.md §2)。
           documentId: context?.documentId ?? null,
           retryCount: 0,
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
         };
-        admin
+        // write Promise を drainSink に push し主経路と対称化 (#303 revisit:
+        // silent-failure-hunter I2)。drainSink 未渡し caller のみ fire-and-forget。
+        // write reject 時は loader 失敗と区別できる一意タグで surface することで、
+        // PERMISSION_DENIED / RESOURCE_EXHAUSTED / UNAVAILABLE / INVALID_ARGUMENT 等の
+        // operational signal を silent に落とさない (silent-failure-hunter C1)。
+        const fallbackWritePromise: Promise<void> = admin
           .firestore()
           .collection('errors')
           .add(fallbackRecord)
-          .catch(() => {
-            /* 書込失敗は silent swallow: 既に console.error でローカル記録済、さらなる fallback なし */
+          .then(() => undefined)
+          .catch((writeErr: unknown) => {
+            console.error(
+              '[textCap] fallback errors-collection write also failed:',
+              writeErr,
+              { loaderError: loaderErrInfo, invariant: message, documentId: context?.documentId ?? null },
+            );
           });
-      } catch {
-        /* require('firebase-admin') 自体の失敗も silent swallow: プロセス継続を最優先 */
+        if (context?.drainSink) {
+          context.drainSink.push(fallbackWritePromise);
+        } else {
+          void fallbackWritePromise;
+        }
+      } catch (fallbackSetupErr) {
+        // require('firebase-admin') / admin.firestore() / FieldValue の同期失敗。
+        // loader 失敗とは別タグで記録することで、Cloud Logging alert 上で
+        // 「loader も fallback setup も共に壊れている」状態を triage 可能化する。
+        // さらなる fallback 経路は存在しないためプロセス継続のみ保証。
+        console.error(
+          '[textCap] fallback setup itself failed (admin load / firestore init):',
+          fallbackSetupErr,
+          message,
+        );
       }
     }
     return;

--- a/functions/src/utils/textCap.ts
+++ b/functions/src/utils/textCap.ts
@@ -14,6 +14,10 @@
  */
 
 import type { SummaryField } from '../../../shared/types';
+// type-only imports: runtime では erased されるため errorLogger.ts の top-level `admin.firestore()`
+// 副作用を誘発しない。#303 fallback の stringly-typed を compile-time drift 検知に格上げする。
+import type * as adminTypes from 'firebase-admin';
+import type { ErrorCategory, ErrorSeverity, ErrorSource } from './errorLogger';
 
 export const MAX_PAGE_TEXT_LENGTH = 50_000;
 
@@ -83,22 +87,43 @@ export type CappedAggregatePage<T extends SummaryField> =
  * (#288 item 6 + silent-failure-hunter/Codex S2 指摘対応)。
  *
  * #297 (Codex HIGH): prod 分岐の `safeLogError` fire-and-forget は Cloud Functions handler
- * Promise 解決後の未 await async work を完了保証しない。caller が `pendingLogs` mutable array
+ * Promise 解決後の未 await async work を完了保証しない。caller が `drainSink` mutable array
  * を渡すと、`handleAggregateInvariantViolation` が Promise を push し、caller 側で
- * `await Promise.allSettled(pendingLogs)` による drain で flush 可能になる。
+ * `await Promise.allSettled(drainSink)` による drain で flush 可能になる。
  * 未渡しの場合は従来通り fire-and-forget（既存 caller への後方互換維持）。
+ *
+ * #304 naming: `pendingLogs` → `drainSink` にリネーム。役割 (caller が drain 責務を負う
+ * output channel) を名前から伝える (OpenTelemetry / Zod ctx.addIssue と整合)。
+ *
+ * #304 Option 採否:
+ * - Option A (interface 分離 AggregateObservabilityContext/AggregateDrainContext):
+ *   caller が 1 箇所 (ocrProcessor.ts) のみで、役割分離の型レベル強制は過剰。見送り。
+ * - Option B (brand type `DrainSink = Promise<void>[] & { __mustDrain }`):
+ *   grep 誤用検知は既存 contract test (textCapDrainSinkContract / ocrProcessorAggregateCallerContract)
+ *   で代替可能。branded cast の caller 側コスト増に見合う恩恵なし。見送り。
+ * - Option C (名称変更のみ): 採用。diff 最小 + 役割伝達。type-design-analyzer Enforcement 1/5 は
+ *   contract test 層でカバーする方針を維持。
  */
 export interface AggregateInvariantContext {
   documentId?: string;
-  pendingLogs?: Promise<void>[];
+  drainSink?: Promise<void>[];
 }
 
 /**
  * invariant violation 検出時の dev/prod 分岐ハンドラ。
  *
  * - dev: throw で early fail (#284 契約)
- * - prod: throw せず safeLogError fire-and-forget で errors collection に記録
- *   (#288 item 6, PR #290 silent-failure-hunter S1 対応)
+ * - prod: throw せず errors collection に記録。以下 3 段階で observability を確保:
+ *   1. `safeLogError` を呼び、戻り Promise を caller の drainSink に push (#297)。drainSink
+ *      未渡し時は後方互換 fire-and-forget (`void logPromise`) を維持 (#288 item 6)。
+ *   2. `require('./errorLogger')` が失敗した場合は `admin.firestore().collection('errors').add()`
+ *      直接書込 fallback で救う (#303)。bundler regression / 初期化 race で errorLogger 経路が
+ *      壊れた場合の silent 消失を防ぐ。fallback 書込は意図的に drainSink に push しない
+ *      fire-and-forget — Cloud Functions handler 終了前の完了保証なし。主経路 (safeLogError) は
+ *      drainSink で drain 保証される設計と非対称だが、fallback は「最終手段 (last resort)」で
+ *      即時プロセス継続を最優先するため pragmatic な選択。完了保証が必要になった場合は別 Issue 化。
+ *   3. fallback 書込自体も silent swallow でプロセス継続保証。console.error は fallback 前に
+ *      先行して最低限ログを残す (rules/error-handling.md §1)。
  *
  * errorLogger は top-level で admin.firestore() を呼ぶため prod path に限定した
  * dynamic require で unit test (admin 未初期化) への影響を回避 (buildPageResult.ts 方針と整合)。
@@ -119,18 +144,66 @@ function handleAggregateInvariantViolation(
         functionName: 'capPageResultsAggregate',
         documentId: context?.documentId,
       });
-      if (context?.pendingLogs) {
-        context.pendingLogs.push(logPromise);
+      if (context?.drainSink) {
+        context.drainSink.push(logPromise);
       } else {
-        // 後方互換 fallback: pendingLogs 未渡し caller には従来通り fire-and-forget を維持する。
+        // 後方互換 fallback: drainSink 未渡し caller には従来通り fire-and-forget を維持する。
         void logPromise;
       }
     } catch (loadErr) {
+      // 最低限のローカルログは確実に残す (rules/error-handling.md §1:
+      // "最低限のconsole.error はtry-catch外で先に実行")。以降の fallback 書込失敗でも
+      // このログは残存するため、Cloud Logging alert から原因特定可能。
       console.error(
         '[textCap] failed to load errorLogger for prod invariant report:',
         loadErr,
         message,
       );
+      // #303: bundler/esbuild config 変更や admin.firestore() 初期化 race で dynamic require が
+      // 壊れた場合、errorLogger 経路で失われる invariant violation を errors collection に直接
+      // 書込で救う fallback。二重失敗は silent swallow (rules/error-handling.md §1「状態復旧 >
+      // ログ記録 > 通知」優先順位: さらに上位の fallback は不存在、プロセス継続のみ保証)。
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const admin = require('firebase-admin') as typeof import('firebase-admin');
+        // ErrorLog schema drift 検知: errorLogger.ts の union 型 (ErrorSource/ErrorSeverity/
+        // ErrorCategory) を type-only import で share し、fallback 書込 object を compile-time
+        // 検証。errorLogger.ts の型が変わった瞬間 fallback も tsc エラーで追従が強制される。
+        const fallbackRecord: {
+          source: ErrorSource;
+          functionName: string;
+          severity: ErrorSeverity;
+          category: ErrorCategory;
+          status: 'pending' | 'resolved' | 'ignored';
+          errorCode: string;
+          errorMessage: string;
+          loaderError: string;
+          documentId: string | null;
+          retryCount: number;
+          createdAt: adminTypes.firestore.FieldValue;
+        } = {
+          source: 'ocr',
+          functionName: 'capPageResultsAggregate:loaderFailed',
+          severity: 'critical',
+          category: 'fatal',
+          status: 'pending',
+          errorCode: 'LOADER_FAILED',
+          errorMessage: message,
+          loaderError: String(loadErr),
+          documentId: context?.documentId ?? null,
+          retryCount: 0,
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        };
+        admin
+          .firestore()
+          .collection('errors')
+          .add(fallbackRecord)
+          .catch(() => {
+            /* 書込失敗は silent swallow: 既に console.error でローカル記録済、さらなる fallback なし */
+          });
+      } catch {
+        /* require('firebase-admin') 自体の失敗も silent swallow: プロセス継続を最優先 */
+      }
     }
     return;
   }

--- a/functions/test/helpers/textCapFixtures.ts
+++ b/functions/test/helpers/textCapFixtures.ts
@@ -41,7 +41,7 @@ export function makeInvalidPage(
  * mixed-input fixture: `[valid, invalid, valid, invalid, ...]` の順で交互生成。
  *
  * `originalLengths` 要素数分 invalid を差し込み、両端と間に valid を挿入する。
- * #294 mixed-input invariant test / #297 pendingLogs drain test 等の caller wrapper
+ * #294 mixed-input invariant test / #297 drainSink drain test 等の caller wrapper
  * 再現シナリオで使用。
  *
  * @param originalLengths - invalid page の originalLength 一覧 (デフォルト `[999]`)

--- a/functions/test/ocrAggregateCallerPattern.runtime.test.ts
+++ b/functions/test/ocrAggregateCallerPattern.runtime.test.ts
@@ -1,8 +1,9 @@
 /**
- * aggregate caller wrapper パターンの runtime 契約テスト (Issue #294 item 8, #293/#297 補完)
+ * aggregate caller wrapper パターンの runtime 契約テスト (Issue #294 item 8, #293/#297 補完、
+ * #304 naming refactor で `pendingLogs` → `drainSink`)
  *
  * 目的: processDocument 内の `capPageResultsAggregate` 呼出周辺パターン (try/catch +
- * pendingLogs drain + 継続保証) を admin 非依存で runtime 検証する。
+ * drainSink drain + 継続保証) を admin 非依存で runtime 検証する。
  *
  * 背景: 本物の processDocument は admin.firestore() / storage.bucket() / Vertex AI に広範囲
  * 依存するため unit test 環境から直接呼べない。本テストは期待される caller パターンを inline
@@ -23,7 +24,7 @@ import { withNodeEnvAsync } from './helpers/withNodeEnv';
 /**
  * caller wrapper の想定シグネチャ (test 用最小再現、AC-4/AC-5 相当)。
  * ocrProcessor.ts:158-186 の try/catch + drain block と**主要 semantics のみ**一致:
- *   - pendingLogs 配列の生成と drain
+ *   - drainSink 配列の生成と drain (#304 naming: 旧 pendingLogs → drainSink)
  *   - try/catch で dev throw を捕捉、enriched message で safeLogError 呼出
  *   - invariant/unexpected の suffix 分岐
  *
@@ -35,13 +36,13 @@ async function aggregateWithCallerWrapper<T extends SummaryField>(
   context: { documentId: string; functionName: string },
   safeLogErrorStub: (params: LogErrorParams) => Promise<void>,
 ): Promise<T[]> {
-  const pendingLogs: Promise<void>[] = [];
+  const drainSink: Promise<void>[] = [];
   const beforeAggregateChars = pages.reduce((sum, p) => sum + p.text.length, 0);
   let resultPages = pages;
   try {
     resultPages = capPageResultsAggregate(pages, {
       documentId: context.documentId,
-      pendingLogs,
+      drainSink,
     }) as unknown as T[];
   } catch (err) {
     const baseError = err instanceof Error ? err : new Error(String(err));
@@ -61,8 +62,8 @@ async function aggregateWithCallerWrapper<T extends SummaryField>(
       documentId: context.documentId,
     });
   }
-  if (pendingLogs.length > 0) {
-    await Promise.allSettled(pendingLogs);
+  if (drainSink.length > 0) {
+    await Promise.allSettled(drainSink);
   }
   return resultPages;
 }
@@ -127,7 +128,7 @@ describe('aggregate caller wrapper runtime pattern (#294)', () => {
     });
   });
 
-  describe('prod 環境: caller は throw を受けず pendingLogs drain (#297)', () => {
+  describe('prod 環境: caller は throw を受けず drainSink drain (#297, #304 rename)', () => {
     it('prod で invalid 混入 → safeLogError spy は catch 経由では呼ばれない (throw しないため)', async () => {
       const calls: LogErrorParams[] = [];
       const spy = async (p: LogErrorParams): Promise<void> => {

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -1,11 +1,14 @@
 /**
- * ocrProcessor aggregate caller try/catch + pendingLogs drain 契約テスト
- * (Issue #293 + #297 統合対応)
+ * ocrProcessor aggregate caller try/catch + drainSink 契約テスト
+ * (Issue #293 + #297 統合対応、#304 naming refactor で context field `pendingLogs` → `drainSink`)
  *
  * 目的: processDocument 内 capPageResultsAggregate 呼出周辺に (1) try/catch で dev throw
- * 捕捉 → safeLogError 記録, (2) pendingInvariantLogs array 渡しで fire-and-forget 廃止,
- * (3) `await Promise.allSettled(pendingInvariantLogs)` による flush 保証、を追加した設計を
- * 静的に lock-in する。
+ * 捕捉 → safeLogError 記録, (2) pendingInvariantLogs array を context.drainSink として渡し
+ * fire-and-forget 廃止, (3) `await Promise.allSettled(pendingInvariantLogs)` による flush 保証、
+ * を追加した設計を静的に lock-in する。
+ *
+ * 注: caller ローカル変数名 `pendingInvariantLogs` は drain 責務を明示する従来命名を維持。
+ * context field 名 `drainSink` (#304) とは分離された命名である。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
  * 将来委譲: 動的 runtime test による caller throw 捕捉の verify は Issue #299 で追加予定。
@@ -65,11 +68,12 @@ describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
     );
   });
 
-  it('capPageResultsAggregate 呼出時に pendingLogs を渡している (#297)', () => {
-    // `capPageResultsAggregate(..., { ..., pendingLogs: pendingInvariantLogs })` 形を検証。
+  it('capPageResultsAggregate 呼出時に drainSink を渡している (#297, #304 rename)', () => {
+    // `capPageResultsAggregate(..., { ..., drainSink: pendingInvariantLogs })` 形を検証。
+    // #304 naming: context field `pendingLogs` → `drainSink` にリネーム済。
     expect(source).to.match(
-      /capPageResultsAggregate\s*\([\s\S]*?pendingLogs\s*:\s*pendingInvariantLogs/,
-      'capPageResultsAggregate 呼出で pendingLogs が渡されていない — fire-and-forget に回帰',
+      /capPageResultsAggregate\s*\([\s\S]*?drainSink\s*:\s*pendingInvariantLogs/,
+      'capPageResultsAggregate 呼出で drainSink が渡されていない — fire-and-forget に回帰 or #304 rename 未追従',
     );
   });
 

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -464,43 +464,44 @@ describe('textCap', () => {
         expect(() => capPageResultsAggregate(pages, { documentId: 'doc-123' })).to.not.throw();
       });
 
-      // #297 Codex HIGH + #293: context.pendingLogs 渡し signature 拡張。fire-and-forget 廃止対応。
-      // prod 分岐で handleAggregateInvariantViolation が pendingLogs array に Promise を push する
+      // #297 Codex HIGH + #293: context.drainSink 渡し signature 拡張。fire-and-forget 廃止対応。
+      // prod 分岐で handleAggregateInvariantViolation が drainSink array に Promise を push する
       // 経路と、caller が await drain 可能になる後方互換 signature を lock-in する。
       // push 本体の動的検証は environment/require 依存が大きいため #299 + grep contract に委譲し、
       // 本ブロックは signature/throw 挙動の最小 runtime 契約のみ保持する。
-      it('context.pendingLogs を受け取り throw しない (signature 互換)', () => {
+      // #304 naming: context field `pendingLogs` → `drainSink` にリネーム済。
+      it('context.drainSink を受け取り throw しない (signature 互換)', () => {
         const pages: SummaryField[] = [{ text: 'short', truncated: false }];
-        const pendingLogs: Promise<void>[] = [];
+        const drainSink: Promise<void>[] = [];
         expect(() =>
-          capPageResultsAggregate(pages, { documentId: 'doc-456', pendingLogs }),
+          capPageResultsAggregate(pages, { documentId: 'doc-456', drainSink }),
         ).to.not.throw();
       });
 
-      it('prod 環境 + invalid 入力 + pendingLogs 渡しで throw しない (#297 drain 経路)', () => {
+      it('prod 環境 + invalid 入力 + drainSink 渡しで throw しない (#297 drain 経路)', () => {
         withNodeEnv('production', () => {
           const invalidPage = makeInvalidPage(999_999, 'short');
-          const pendingLogs: Promise<void>[] = [];
+          const drainSink: Promise<void>[] = [];
           expect(() =>
             capPageResultsAggregate([invalidPage], {
               documentId: 'doc-789',
-              pendingLogs,
+              drainSink,
             }),
           ).to.not.throw();
         });
       });
 
-      it('dev 環境 + invalid 入力 + pendingLogs 渡しでも従来通り throw する (#284 契約維持)', () => {
+      it('dev 環境 + invalid 入力 + drainSink 渡しでも従来通り throw する (#284 契約維持)', () => {
         const invalidPage = makeInvalidPage(999_999, 'short');
-        const pendingLogs: Promise<void>[] = [];
+        const drainSink: Promise<void>[] = [];
         expect(() =>
           capPageResultsAggregate([invalidPage], {
             documentId: 'doc-dev',
-            pendingLogs,
+            drainSink,
           }),
         ).to.throw(/invariant violation/);
-        // dev 分岐は throw のみで push せず (prod 分岐専用) — pendingLogs は空のまま。
-        expect(pendingLogs.length).to.equal(0);
+        // dev 分岐は throw のみで push せず (prod 分岐専用) — drainSink は空のまま。
+        expect(drainSink.length).to.equal(0);
       });
     });
 
@@ -534,8 +535,8 @@ describe('textCap', () => {
       it('mixed-input prod で errorLogger require 失敗時は push 0 件 + console.error fallback (unit test 環境)', () => {
         // 本 unit test 環境 (mocha + ts-node、admin 未初期化) では errorLogger の top-level
         // `admin.firestore()` が FirebaseAppError を throw → `require('./errorLogger')` が
-        // textCap.ts:131 の catch (loadErr) に落ちて console.error fallback する。
-        // push 経路は走らないため pendingLogs.length === 0 が決定論的。
+        // textCap.ts の catch (loadErr) に落ちて console.error fallback する。
+        // push 経路は走らないため drainSink.length === 0 が決定論的。
         // 実運用 (admin 初期化済み) での push 2 件動作検証は Issue #299 で担保予定。
         withNodeEnv('production', () => {
           const pages: SummaryField[] = [
@@ -544,13 +545,13 @@ describe('textCap', () => {
             { text: 'valid2', truncated: false },
             makeInvalidPage(222, 'invalid2'),
           ];
-          const pendingLogs: Promise<void>[] = [];
+          const drainSink: Promise<void>[] = [];
           const result = capPageResultsAggregate(pages, {
             documentId: 'mixed-doc',
-            pendingLogs,
+            drainSink,
           });
           expect(result).to.have.length(4);
-          expect(pendingLogs.length).to.equal(0);
+          expect(drainSink.length).to.equal(0);
         });
       });
     });

--- a/functions/test/textCapDrainSinkContract.test.ts
+++ b/functions/test/textCapDrainSinkContract.test.ts
@@ -1,13 +1,13 @@
 /**
- * textCap handleAggregateInvariantViolation の pendingLogs drain 対応契約テスト
- * (Issue #297 + #293 統合対応)
+ * textCap handleAggregateInvariantViolation の drainSink 契約テスト
+ * (Issue #297 + #293 統合対応、#304 naming refactor で `pendingLogs` → `drainSink`)
  *
- * 目的: `void safeLogError(...)` fire-and-forget を `context.pendingLogs` array に push する
- * 形へ変更した回帰を防止する。caller (ocrProcessor.ts) が `await Promise.allSettled(pendingLogs)`
+ * 目的: `void safeLogError(...)` fire-and-forget を `context.drainSink` array に push する
+ * 形へ変更した回帰を防止する。caller (ocrProcessor.ts) が `await Promise.allSettled(drainSink)`
  * で drain し、Cloud Functions handler 終了前の flush を保証する設計を静的に lock-in する。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。prod 分岐内で (1) 戻り値束縛,
- * (2) context?.pendingLogs.push, (3) 未渡し時の void fallback の 3 要素を検証。
+ * (2) context?.drainSink.push, (3) 未渡し時の void fallback の 3 要素を検証。
  * 将来委譲: 動的 safeLogError invocation test は Issue #299 で追加予定。
  */
 
@@ -28,7 +28,7 @@ const extractHelperFunctionBody = (source: string) =>
 const extractProdBranch = (block: string) =>
   extractBraceBlock(block, PROD_BRANCH_ANCHOR);
 
-describe('textCap pendingLogs drain contract (#297 + #293)', () => {
+describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   let source = '';
 
   before(() => {
@@ -37,11 +37,30 @@ describe('textCap pendingLogs drain contract (#297 + #293)', () => {
     source = readFileSync(absPath, 'utf-8');
   });
 
-  it('AggregateInvariantContext に pendingLogs?: Promise<void>[] フィールドが存在する', () => {
+  it('AggregateInvariantContext に drainSink?: Promise<void>[] フィールドが存在する (#304)', () => {
     // signature 変更 regression 検知: fire-and-forget 廃止対応で必須のフィールド。
+    // #304 naming: `pendingLogs` → `drainSink` へリネーム済。旧名に逆戻りしたら fail させる。
     expect(source).to.match(
-      /pendingLogs\?\s*:\s*Promise\s*<\s*void\s*>\s*\[\s*\]/,
-      'AggregateInvariantContext に pendingLogs?: Promise<void>[] が見つからない — #297 設計変更が消失',
+      /drainSink\?\s*:\s*Promise\s*<\s*void\s*>\s*\[\s*\]/,
+      'AggregateInvariantContext に drainSink?: Promise<void>[] が見つからない — #304 naming が消失',
+    );
+  });
+
+  it('AggregateInvariantContext に旧 pendingLogs フィールドが存在しない (#304 rename regression guard)', () => {
+    // #304 リネーム回帰防止: interface 定義ブロックを抽出し、そのブロック内に pendingLogs が
+    // 残存していないことを検証する。JSDoc/コメント内の移行メモ (`pendingLogs` → `drainSink`) は
+    // interface block の外側にあるため false positive にならない。
+    const interfaceBlock = extractBraceBlock(
+      source,
+      /export\s+interface\s+AggregateInvariantContext\s*\{/,
+    );
+    expect(
+      interfaceBlock,
+      'AggregateInvariantContext interface block が抽出できない — anchor 消失',
+    ).to.not.equal('');
+    expect(interfaceBlock).to.not.match(
+      /\bpendingLogs\b/,
+      'AggregateInvariantContext に旧名 pendingLogs が残存 — #304 rename が不完全',
     );
   });
 
@@ -59,23 +78,25 @@ describe('textCap pendingLogs drain contract (#297 + #293)', () => {
     );
   });
 
-  it('prod 分岐内で context?.pendingLogs への push 呼出が存在する', () => {
+  it('prod 分岐内で context?.drainSink への push 呼出が存在する', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.equal('');
     expect(prodBranch).to.match(
-      /context\?\.pendingLogs[\s\S]*?\.push\s*\(/,
-      'context?.pendingLogs への push 呼出が見つからない — drain 経路が欠損',
+      /context\?\.drainSink[\s\S]*?\.push\s*\(/,
+      'context?.drainSink への push 呼出が見つからない — drain 経路が欠損',
     );
   });
 
-  it('pendingLogs 未渡し時の fallback (void 形) が存在する (後方互換維持)', () => {
+  it('drainSink 未渡し時の fallback (void 形) が存在する (後方互換維持)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
-    // legacy caller (pendingLogs 未渡し) では intentionally fire-and-forget を維持する。
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.equal('');
+    // legacy caller (drainSink 未渡し) では intentionally fire-and-forget を維持する。
     // `void logPromise;` は完了保証ではなく「意図的に discard」を明示するマーカー。
     expect(prodBranch).to.match(
       /\bvoid\s+\w+\s*;?/,
-      'pendingLogs 未渡し時の void fallback が見つからない — 後方互換が壊れている可能性',
+      'drainSink 未渡し時の void fallback が見つからない — 後方互換が壊れている可能性',
     );
   });
 

--- a/functions/test/textCapErrorLoggerFallbackContract.test.ts
+++ b/functions/test/textCapErrorLoggerFallbackContract.test.ts
@@ -1,0 +1,110 @@
+/**
+ * textCap handleAggregateInvariantViolation の errorLogger require 失敗時 fallback 契約テスト
+ * (Issue #303、PR #301 silent-failure-hunter HIGH #2 follow-up)
+ *
+ * 目的: `require('./errorLogger')` が失敗した場合でも errors collection に最低 1 レコード
+ * 記録される fallback 経路を静的に lock-in する。bundler/esbuild config 変更や admin.firestore()
+ * 初期化 race で dynamic require が壊れた場合、従来実装では console.error のみで observability
+ * から消失する silent path が残存していた (#288 item 6 効果の相殺)。
+ *
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。handleAggregateInvariantViolation
+ * の catch (loadErr) ブロックを抽出し、以下 4 要素を検証:
+ *   (1) admin.firestore() 直接呼出による fallback 書込
+ *   (2) errors collection への add 呼出
+ *   (3) 書込失敗時の silent swallow (二重失敗時にプロセス継続)
+ *   (4) 既存 console.error の保持 (fallback 失敗時の最低限ログ)
+ *
+ * 将来委譲: 動的 invocation test (bundler mock で require 失敗を模擬して fallback 書込を verify)
+ * は Issue #299 の runtime test 整備で追加予定。
+ */
+
+import { expect } from 'chai';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const TEXT_CAP_PATH = 'src/utils/textCap.ts';
+
+const HELPER_BODY_ANCHOR =
+  /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
+// catch (loadErr) { ... } ブロック anchor。catch 引数名は loadErr に固定 (既存実装整合)。
+const LOADERR_CATCH_ANCHOR = /catch\s*\(\s*loadErr\s*\)\s*/;
+
+const extractHelperFunctionBody = (source: string) =>
+  extractBraceBlock(source, HELPER_BODY_ANCHOR);
+const extractLoadErrCatch = (block: string) =>
+  extractBraceBlock(block, LOADERR_CATCH_ANCHOR, { startAfterAnchor: true });
+
+describe('textCap errorLogger require failure fallback contract (#303)', () => {
+  let source = '';
+
+  before(() => {
+    const absPath = resolve(process.cwd(), TEXT_CAP_PATH);
+    expect(existsSync(absPath), `${TEXT_CAP_PATH} が見つからない`).to.be.true;
+    source = readFileSync(absPath, 'utf-8');
+  });
+
+  it('handleAggregateInvariantViolation の catch (loadErr) ブロックが抽出できる (anchor 保護)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    expect(helperBody, 'handleAggregateInvariantViolation 関数本体が抽出できない').to.not.equal('');
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない — anchor 消失').to.not.equal('');
+  });
+
+  it('既存 console.error による fallback 失敗時の最低限ログが保持されている (AC-11)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // console.error の消失で silent 化する regression を防ぐ。fallback 成否に関わらず最低限の
+    // ローカルログは残す (rules/error-handling.md §1: 最低限のconsole.error はtry-catch外で先に実行)。
+    expect(catchBlock).to.match(
+      /console\.error\s*\(/,
+      'catch (loadErr) 内の console.error が消失 — fallback 失敗時の最低限ログが残らない',
+    );
+  });
+
+  it('catch (loadErr) 内で admin.firestore() が呼ばれている (fallback 書込経路)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // `require('firebase-admin')` から admin.firestore() を呼ぶパターンを検出。
+    // require 呼出経由 + 直接 import どちらのパターンでも `admin.firestore()` 形でマッチする想定。
+    expect(catchBlock).to.match(
+      /admin\.firestore\s*\(\s*\)/,
+      'catch (loadErr) 内で admin.firestore() 呼出が見つからない — fallback 書込経路が欠損',
+    );
+  });
+
+  it('catch (loadErr) 内で errors collection への add 呼出がある (errors 書込先)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // `.collection('errors')` + `.add(` の両方を同一ブロック内で検証。
+    // collection 名 drift (例: `error_logs` 等) への回帰を防ぐ。
+    expect(catchBlock).to.match(
+      /\.collection\s*\(\s*['"]errors['"]\s*\)/,
+      'catch (loadErr) 内で errors collection への書込先が特定されていない',
+    );
+    expect(catchBlock).to.match(
+      /\.add\s*\(/,
+      'catch (loadErr) 内で .add( 呼出が見つからない — errors collection への書込が欠損',
+    );
+  });
+
+  it('catch (loadErr) 内で fallback 書込失敗時の silent swallow パターンが存在する (AC-7)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // 二重失敗時のプロセス継続保証:
+    //   Pattern A: `.add({...}).catch(...)` で add Promise の reject を silent swallow
+    //   Pattern B: `try { admin.firestore()...add() } catch { ... }` で synchronous require 失敗
+    //              含めて ブロック全体を try/catch で囲む
+    // どちらかのパターンが存在すれば AC-7 を満たす。
+    const hasPromiseCatch = /\.add\s*\([\s\S]*?\)\s*\.catch\s*\(/.test(catchBlock);
+    const hasNestedTryCatch = /try\s*\{[\s\S]*?admin\.firestore[\s\S]*?\}\s*catch/.test(catchBlock);
+    expect(
+      hasPromiseCatch || hasNestedTryCatch,
+      'fallback 書込の silent swallow パターンが見つからない — 二重失敗時にプロセスが throw する可能性',
+    ).to.be.true;
+  });
+});

--- a/functions/test/textCapErrorLoggerFallbackContract.test.ts
+++ b/functions/test/textCapErrorLoggerFallbackContract.test.ts
@@ -1,18 +1,24 @@
 /**
  * textCap handleAggregateInvariantViolation の errorLogger require 失敗時 fallback 契約テスト
- * (Issue #303、PR #301 silent-failure-hunter HIGH #2 follow-up)
+ * (Issue #303、PR #301 silent-failure-hunter HIGH #2 follow-up、PR #319 review 追加強化)
  *
  * 目的: `require('./errorLogger')` が失敗した場合でも errors collection に最低 1 レコード
- * 記録される fallback 経路を静的に lock-in する。bundler/esbuild config 変更や admin.firestore()
- * 初期化 race で dynamic require が壊れた場合、従来実装では console.error のみで observability
- * から消失する silent path が残存していた (#288 item 6 効果の相殺)。
+ * 記録される fallback 経路と、fallback 自体の失敗観測性を静的に lock-in する。bundler/esbuild
+ * config 変更や admin.firestore() 初期化 race で dynamic require が壊れた場合、従来実装では
+ * console.error のみで observability から消失する silent path が残存していた (#288 item 6 効果の
+ * 相殺)。PR #319 review では fallback 内 `.catch(() => {})` による write 失敗の silent 消失
+ * (silent-failure-hunter C1) と fire-and-forget による Cloud Functions freeze 時の partial delivery
+ * リスク (I2) が指摘され、write reject 時の console.error surface と drainSink push 対称化で解消済。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。handleAggregateInvariantViolation
- * の catch (loadErr) ブロックを抽出し、以下 4 要素を検証:
- *   (1) admin.firestore() 直接呼出による fallback 書込
- *   (2) errors collection への add 呼出
- *   (3) 書込失敗時の silent swallow (二重失敗時にプロセス継続)
- *   (4) 既存 console.error の保持 (fallback 失敗時の最低限ログ)
+ * の catch (loadErr) ブロックを抽出し、以下 6 観点を検証:
+ *   (1) loader 失敗時の console.error 先行ログ (rules/error-handling.md §1)
+ *   (2) admin.firestore() 直接呼出による fallback 書込経路 (+ errors collection への add 呼出)
+ *   (3) write reject 時の .catch((writeErr) => console.error(...)) による失敗 surface (C1)
+ *   (4) 外側 catch(fallbackSetupErr) の console.error による setup 失敗の triage 可能化 (I1)
+ *   (5) fallback record の schema triage 必須 field (severity/category/status/errorCode 等)
+ *   (6) drainSink への write Promise push による主経路との対称化 (I2)
+ *   (7) loaderError 構造化 (String(loadErr) 直接代入で [object Object] 情報欠損する regression 防止)
  *
  * 将来委譲: 動的 invocation test (bundler mock で require 失敗を模擬して fallback 書込を verify)
  * は Issue #299 の runtime test 整備で追加予定。
@@ -27,7 +33,6 @@ const TEXT_CAP_PATH = 'src/utils/textCap.ts';
 
 const HELPER_BODY_ANCHOR =
   /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
-// catch (loadErr) { ... } ブロック anchor。catch 引数名は loadErr に固定 (既存実装整合)。
 const LOADERR_CATCH_ANCHOR = /catch\s*\(\s*loadErr\s*\)\s*/;
 
 const extractHelperFunctionBody = (source: string) =>
@@ -35,7 +40,7 @@ const extractHelperFunctionBody = (source: string) =>
 const extractLoadErrCatch = (block: string) =>
   extractBraceBlock(block, LOADERR_CATCH_ANCHOR, { startAfterAnchor: true });
 
-describe('textCap errorLogger require failure fallback contract (#303)', () => {
+describe('textCap errorLogger require failure fallback contract (#303 + #319 review)', () => {
   let source = '';
 
   before(() => {
@@ -51,15 +56,15 @@ describe('textCap errorLogger require failure fallback contract (#303)', () => {
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない — anchor 消失').to.not.equal('');
   });
 
-  it('既存 console.error による fallback 失敗時の最低限ログが保持されている (AC-11)', () => {
+  it('loader 失敗時の先行 console.error が保持される (AC-11, rules/error-handling.md §1)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
-    // console.error の消失で silent 化する regression を防ぐ。fallback 成否に関わらず最低限の
-    // ローカルログは残す (rules/error-handling.md §1: 最低限のconsole.error はtry-catch外で先に実行)。
+    // Cloud Logging alert grep 契約: `[textCap] failed to load errorLogger` prefix を lock-in。
+    // prefix drift (例: 英語化、モジュール名変更) は operational alert を壊すため regression 検知。
     expect(catchBlock).to.match(
-      /console\.error\s*\(/,
-      'catch (loadErr) 内の console.error が消失 — fallback 失敗時の最低限ログが残らない',
+      /console\.error\s*\(\s*['"]\[textCap\]\s+failed\s+to\s+load\s+errorLogger/,
+      'catch (loadErr) 冒頭の先行 console.error が消失 or prefix drift — Cloud Logging alert が壊れる',
     );
   });
 
@@ -67,8 +72,6 @@ describe('textCap errorLogger require failure fallback contract (#303)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
-    // `require('firebase-admin')` から admin.firestore() を呼ぶパターンを検出。
-    // require 呼出経由 + 直接 import どちらのパターンでも `admin.firestore()` 形でマッチする想定。
     expect(catchBlock).to.match(
       /admin\.firestore\s*\(\s*\)/,
       'catch (loadErr) 内で admin.firestore() 呼出が見つからない — fallback 書込経路が欠損',
@@ -79,8 +82,6 @@ describe('textCap errorLogger require failure fallback contract (#303)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
-    // `.collection('errors')` + `.add(` の両方を同一ブロック内で検証。
-    // collection 名 drift (例: `error_logs` 等) への回帰を防ぐ。
     expect(catchBlock).to.match(
       /\.collection\s*\(\s*['"]errors['"]\s*\)/,
       'catch (loadErr) 内で errors collection への書込先が特定されていない',
@@ -91,20 +92,107 @@ describe('textCap errorLogger require failure fallback contract (#303)', () => {
     );
   });
 
-  it('catch (loadErr) 内で fallback 書込失敗時の silent swallow パターンが存在する (AC-7)', () => {
+  it('write reject 時の .catch handler で console.error により失敗を surface (#319 review C1)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
-    // 二重失敗時のプロセス継続保証:
-    //   Pattern A: `.add({...}).catch(...)` で add Promise の reject を silent swallow
-    //   Pattern B: `try { admin.firestore()...add() } catch { ... }` で synchronous require 失敗
-    //              含めて ブロック全体を try/catch で囲む
-    // どちらかのパターンが存在すれば AC-7 を満たす。
-    const hasPromiseCatch = /\.add\s*\([\s\S]*?\)\s*\.catch\s*\(/.test(catchBlock);
-    const hasNestedTryCatch = /try\s*\{[\s\S]*?admin\.firestore[\s\S]*?\}\s*catch/.test(catchBlock);
+    // `.catch(() => {})` による完全 silent swallow (PERMISSION_DENIED / RESOURCE_EXHAUSTED /
+    // UNAVAILABLE / INVALID_ARGUMENT 等の operational signal が消失する regression) を防ぐ。
+    // .add(...).catch の handler body 内に console.error が存在することを lock-in。
+    const addCatchMatch = catchBlock.match(
+      /\.add\s*\([\s\S]*?\)[\s\S]*?\.catch\s*\(\s*(?:\([^)]*\)|[^=]+)\s*=>\s*\{([\s\S]*?)\}\s*\)/,
+    );
     expect(
-      hasPromiseCatch || hasNestedTryCatch,
-      'fallback 書込の silent swallow パターンが見つからない — 二重失敗時にプロセスが throw する可能性',
-    ).to.be.true;
+      addCatchMatch,
+      '.add().catch() handler が抽出できない — Promise chain が壊れている可能性',
+    ).to.not.be.null;
+    const handlerBody = addCatchMatch![1];
+    expect(handlerBody).to.match(
+      /console\.error\s*\(/,
+      '.add().catch() handler 内の console.error が消失 — write 失敗 (PERMISSION_DENIED 等) が silent 化',
+    );
+    // surface メッセージの prefix を lock-in (Cloud Logging alert grep の安定性)。
+    expect(handlerBody).to.match(
+      /\[textCap\]\s+fallback\s+errors-collection\s+write\s+also\s+failed/,
+      'write 失敗 console.error の prefix が消失 or drift — loader 失敗との区別が効かない',
+    );
+  });
+
+  it('外側 catch(fallbackSetupErr) で setup 失敗も console.error で surface (#319 review I1)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // 外側 try/catch: `try { admin.firestore()... } catch (fallbackSetupErr) { ... }`。
+    // bare `catch {}` による silent swallow regression を防ぐ (require('firebase-admin') /
+    // admin.firestore() / FieldValue 同期失敗の区別可能化)。
+    const outerCatchMatch = catchBlock.match(/\}\s*catch\s*\(\s*(\w+)\s*\)\s*\{([\s\S]*?)\}\s*$/);
+    expect(outerCatchMatch, '外側 catch(...) block が抽出できない').to.not.be.null;
+    expect(outerCatchMatch![1]).to.not.equal(
+      '',
+      '外側 catch に引数がない (bare catch{}) — setup 失敗が silent 化',
+    );
+    const outerBody = outerCatchMatch![2];
+    expect(outerBody).to.match(
+      /console\.error\s*\(/,
+      '外側 catch(fallbackSetupErr) に console.error がない — admin load / firestore init 失敗が silent 化',
+    );
+    expect(outerBody).to.match(
+      /\[textCap\]\s+fallback\s+setup\s+itself\s+failed/,
+      '外側 catch の console.error prefix が消失 or drift — loader 失敗・write 失敗・setup 失敗の区別が壊れる',
+    );
+  });
+
+  it('fallback record に triage 必須 field が含まれる (#319 review I2: schema lock-in)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // errors collection triage dashboard が集計に使う key field を lock-in。
+    expect(catchBlock).to.match(/status\s*:\s*['"]pending['"]/, 'status: pending 欠落 — triage queue invisible');
+    expect(catchBlock).to.match(/severity\s*:\s*['"]critical['"]/, 'severity: critical drift');
+    expect(catchBlock).to.match(/category\s*:\s*['"]fatal['"]/, 'category: fatal drift');
+    expect(catchBlock).to.match(/source\s*:\s*['"]ocr['"]/, 'source: ocr drift');
+    expect(catchBlock).to.match(
+      /functionName\s*:\s*['"]capPageResultsAggregate:loaderFailed['"]/,
+      'functionName suffix drift — triage filter 壊れ',
+    );
+    expect(catchBlock).to.match(/errorCode\s*:\s*['"]LOADER_FAILED['"]/, 'errorCode drift');
+    expect(catchBlock).to.match(
+      /documentId\s*:\s*context\?\.documentId\s*\?\?\s*null/,
+      'documentId 正規化 `?? null` が消失 — undefined で Firestore 書込 reject or document 紐付け不可',
+    );
+  });
+
+  it('loaderError が構造化され String(loadErr) 直接代入されていない (#319 review I3)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // String(loadErr) 直接代入は Error 以外の throw で `[object Object]` になる silent 情報欠損、
+    // FirebaseAppError.code 等の triage 重要フィールド drop の原因となる。
+    // instanceof Error ブランチで name/message/code を抽出する形へ regression しないよう lock-in。
+    expect(catchBlock).to.match(
+      /loadErr\s+instanceof\s+Error/,
+      'instanceof Error 分岐が消失 — String(loadErr) 直代入 regression で triage 情報欠損',
+    );
+    expect(catchBlock).to.not.match(
+      /loaderError\s*:\s*String\s*\(\s*loadErr\s*\)/,
+      'loaderError: String(loadErr) 直代入に回帰 — [object Object] silent 情報欠損が再発',
+    );
+  });
+
+  it('fallback write Promise が drainSink に push される (#319 review I2: 対称化)', () => {
+    const helperBody = extractHelperFunctionBody(source);
+    const catchBlock = extractLoadErrCatch(helperBody);
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    // 主経路 (safeLogError) と対称に fallback も drainSink に push して drain 保証。
+    // fire-and-forget 非対称性 (Cloud Functions freeze 時の partial delivery) に回帰しないよう lock-in。
+    expect(catchBlock).to.match(
+      /context\?\.drainSink[\s\S]*?\.push\s*\(/,
+      'fallback 内で drainSink.push() が消失 — fire-and-forget 非対称性に回帰 (Cloud Functions freeze 時 partial delivery リスク)',
+    );
+    // .then(() => undefined) で Promise<void> に正規化されていること (drainSink の型整合)。
+    expect(catchBlock).to.match(
+      /\.then\s*\(\s*\(\s*\)\s*=>\s*undefined\s*\)/,
+      '.then(() => undefined) による Promise<void> 正規化が消失 — drainSink 型整合が壊れる',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 Cluster B: AggregateInvariantContext 観測性強化。PR #301 follow-up 2 件を同一 PR で完結。

- **#304**: `AggregateInvariantContext.pendingLogs` → `drainSink` リネーム (Option C 採用、A/B は cost-benefit で見送り、JSDoc に採否理由記録)
- **#303**: `handleAggregateInvariantViolation` の `catch (loadErr)` 節に `admin.firestore().collection('errors').add()` 直接書込 fallback を追加。bundler regression / 初期化 race で errorLogger 経路が壊れた場合の silent 消失を防ぐ

## Design Decisions

### #304 Option 採否
| Option | 判定 | 理由 |
|--------|------|------|
| A (interface 分離) | 見送り | caller が 1 箇所 (ocrProcessor.ts) のみで、役割分離の型レベル強制は過剰 |
| B (brand type DrainSink) | 見送り | grep 誤用検知は既存 contract test でカバー済、cast コスト > 恩恵 |
| **C (名称変更のみ)** | **採用** | diff 最小 + 役割伝達 (OpenTelemetry / Zod ctx.addIssue 整合)。type-design-analyzer Enforcement 1/5 は contract test 層で引き続きカバー |

### #303 fallback 設計
- 主経路 (safeLogError) は drainSink に push して drain 保証。fallback は fire-and-forget (last resort のため pragmatic 選択、完了保証が必要な場合は別 Issue 化)
- 二重失敗 (firebase-admin require 失敗 / .add() reject) は silent swallow
- `console.error` は fallback 前に先行 (rules/error-handling.md §1)
- type-only import で `ErrorSource`/`ErrorSeverity`/`ErrorCategory` を share し schema drift を compile-time 検知

## Changes

| ファイル | 内容 |
|---------|------|
| `functions/src/utils/textCap.ts` | interface rename + JSDoc + fallback 実装 + type-only import |
| `functions/src/ocr/ocrProcessor.ts` | caller context key `drainSink:` へ更新 |
| `functions/test/textCapDrainSinkContract.test.ts` | renamed from `textCapPendingLogsContract.test.ts`、anchor 追従 + 旧 pendingLogs 残存 regression guard 追加 |
| `functions/test/textCapErrorLoggerFallbackContract.test.ts` | **新規**。catch(loadErr) 内の fallback 書込パスを 5 assertion で lock-in |
| `functions/test/textCap.test.ts` | context key + local var `drainSink` 追従 |
| `functions/test/ocrProcessorAggregateCallerContract.test.ts` | grep pattern `drainSink: pendingInvariantLogs` 更新 |
| `functions/test/ocrAggregateCallerPattern.runtime.test.ts` | wrapper 内 `drainSink` 追従 |
| `functions/test/helpers/textCapFixtures.ts` | JSDoc 移行メモ |
| `docs/context/test-strategy.md` | 既存例リスト追従 |

## Quality Gate

- `/simplify` 3 並列レビュー完了:
  - **reuse**: クリーン (既存 helper 活用済)
  - **quality**: Stringly-typed 指摘 → type-only import で対応。copy-paste with errorLogger.ts 指摘は循環依存回避のため inline 維持 (follow-up 候補)
  - **efficiency**: クリーン (hot path 影響なし、silent PASS guard 全箇所確認済)
- **Evaluator 第三者評価**: 全 11 AC PASS + **APPROVE**
  - LOW 2 件: (1) AC-9 基準曖昧さ → 現実装 12 assertion で余裕、将来対応、(2) fallback の drainSink 非対称性 → JSDoc に意図明記で対応

## Test plan

- [x] `npm test`: **576 passing** (baseline 570 + rename guard 1 + fallback contract 5)、failing 0
- [x] `npm run build` (tsc): 0 errors
- [x] `npm run lint`: 0 errors (21 warnings はすべて pre-existing)
- [x] `grep "pendingLogs" functions/src/`: interface field / context key ともに 0 件（移行メモコメントのみ残存）
- [x] `grep "drainSink" functions/src/`: interface field + handler 参照で正常ヒット
- [x] Evaluator 全 AC PASS (AC-1〜AC-11)
- [ ] CI (Deploy + 契約テスト) グリーン確認

## 関連 Issue / PR

- Closes #304
- Closes #303
- 由来: PR #301 (type-design-analyzer + silent-failure-hunter レビュー follow-up)
- 関連: #288 item 6 / #297 (drain 導入) / #293 (caller try/catch) / #284 (dev throw 契約)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback error logging mechanism to prevent log loss when the primary error service is unavailable.

* **Bug Fixes**
  * Improved error handling to gracefully handle service failures without interrupting system processes.

* **Tests**
  * Enhanced test coverage for error logging fallback scenarios and reliability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->