### PR TITLE
refactor(test): extractBraceBlock API 改善 + caller null 対応 (#312)

### DIFF
--- a/functions/test/aggregateCapLogErrorContract.test.ts
+++ b/functions/test/aggregateCapLogErrorContract.test.ts
@@ -25,7 +25,8 @@ const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
 const AGGREGATE_CAP_ANCHOR =
   /if\s*\(\s*afterAggregateChars\s*<\s*beforeAggregateChars\s*\)\s*\{/;
 
-const extractAggregateCapBlock = (source: string) =>
+// #312: helper が anchor 不在時に null を返すため、alias wrapper も string | null を透過する。
+const extractAggregateCapBlock = (source: string): string | null =>
   extractBraceBlock(source, AGGREGATE_CAP_ANCHOR);
 
 describe('aggregate cap safeLogError contract (#283)', () => {
@@ -44,16 +45,17 @@ describe('aggregate cap safeLogError contract (#283)', () => {
   const safeLogErrorArgs = extractParenBlock(capBlock, /\bsafeLogError\s*\(/);
 
   it('aggregate cap block が抽出できる', () => {
-    expect(capBlock.length).to.be.greaterThan(
-      0,
+    expect(
+      capBlock,
       '`if (afterAggregateChars < beforeAggregateChars) { ... }` anchor が見つからない。' +
         '変数名リネーム/条件書き換え時は本契約の見直しが必要。'
-    );
+    ).to.not.be.null;
   });
 
   it('aggregate cap block 内に safeLogError 呼出がある', () => {
     const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
-    expect(SAFE_LOG_ERROR_CALL.test(capBlock)).to.equal(
+    expect(capBlock, 'capBlock 抽出失敗 (上位 it を確認)').to.not.be.null;
+    expect(SAFE_LOG_ERROR_CALL.test(capBlock!)).to.equal(
       true,
       'aggregate cap block 内で safeLogError 呼出が見つからない。' +
         'errors collection への記録が消失すると #209 型実害の再発を認知できない (#283 silent failure)。'
@@ -64,7 +66,8 @@ describe('aggregate cap safeLogError contract (#283)', () => {
   // 実行終了前に Firestore 書込が truncate される。await 付き呼出を契約化。
   it('aggregate cap block 内の safeLogError 呼出に await が付いている', () => {
     const AWAITED_SAFE_LOG_ERROR = /\bawait\s+safeLogError\s*\(/;
-    expect(AWAITED_SAFE_LOG_ERROR.test(capBlock)).to.equal(
+    expect(capBlock, 'capBlock 抽出失敗').to.not.be.null;
+    expect(AWAITED_SAFE_LOG_ERROR.test(capBlock!)).to.equal(
       true,
       'aggregate cap block 内の safeLogError 呼出に await が付いていない。' +
         'Cloud Functions 実行終了前に Firestore 書込が truncate される silent failure リスクあり。'
@@ -72,16 +75,17 @@ describe('aggregate cap safeLogError contract (#283)', () => {
   });
 
   it('safeLogError 引数ブロックが抽出できる', () => {
-    expect(safeLogErrorArgs.length).to.be.greaterThan(
-      0,
+    expect(
+      safeLogErrorArgs,
       'safeLogError(...) の引数ブロックが抽出できない。' +
         '呼出形式の変更 (spread 展開等) の可能性あり — 本契約の見直しが必要。'
-    );
+    ).to.not.be.null;
   });
 
   it('safeLogError 引数に error が渡されている', () => {
     const ERROR_PARAM = /\berror\s*[,:}]/;
-    expect(ERROR_PARAM.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(ERROR_PARAM.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に error が含まれていない。' +
         'stack trace が errors collection に残らず原因追跡不能になる。'
@@ -90,7 +94,8 @@ describe('aggregate cap safeLogError contract (#283)', () => {
 
   it('safeLogError 引数に source: \'ocr\' が含まれる', () => {
     const SOURCE_OCR = /source:\s*['"]ocr['"]/;
-    expect(SOURCE_OCR.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(SOURCE_OCR.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に source: \'ocr\' が見つからない。' +
         'errors collection の絞込/集計で欠落する。'
@@ -99,7 +104,8 @@ describe('aggregate cap safeLogError contract (#283)', () => {
 
   it('safeLogError 引数に documentId が渡されている', () => {
     const DOCUMENT_ID_PARAM = /\bdocumentId\s*[,:}]/;
-    expect(DOCUMENT_ID_PARAM.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(DOCUMENT_ID_PARAM.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に documentId が見つからない。' +
         'エラーとドキュメントの紐付けが失われる。'
@@ -108,7 +114,8 @@ describe('aggregate cap safeLogError contract (#283)', () => {
 
   it('safeLogError 引数に functionName が渡されている', () => {
     const FUNCTION_NAME_PARAM = /\bfunctionName\s*[,:}]/;
-    expect(FUNCTION_NAME_PARAM.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(FUNCTION_NAME_PARAM.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に functionName が見つからない。' +
         'どの呼出元で発生したエラーか特定できなくなる。'
@@ -125,9 +132,10 @@ if (afterAggregateChars < beforeAggregateChars) {
 }
 `;
       const block = extractAggregateCapBlock(fixture);
-      expect(block).to.include('safeLogError');
-      expect(block.startsWith('{')).to.equal(true);
-      expect(block.endsWith('}')).to.equal(true);
+      expect(block, 'block 抽出失敗').to.not.be.null;
+      expect(block!).to.include('safeLogError');
+      expect(block!.startsWith('{')).to.equal(true);
+      expect(block!.endsWith('}')).to.equal(true);
     });
 
     it('positive: ネストしたブロック (try-catch 等) を正しくカウントする', () => {
@@ -137,13 +145,14 @@ if (afterAggregateChars < beforeAggregateChars) {
 }
 `;
       const block = extractAggregateCapBlock(fixture);
-      expect(block).to.include('try');
-      expect(block).to.include('catch');
+      expect(block, 'block 抽出失敗').to.not.be.null;
+      expect(block!).to.include('try');
+      expect(block!).to.include('catch');
     });
 
-    it('negative: anchor 不在時は空文字', () => {
+    it('negative: anchor 不在時は null', () => {
       const fixture = `const x = 1;`;
-      expect(extractAggregateCapBlock(fixture)).to.equal('');
+      expect(extractAggregateCapBlock(fixture)).to.be.null;
     });
 
     it('scope: block 外の safeLogError は検知対象外', () => {
@@ -155,7 +164,8 @@ if (afterAggregateChars < beforeAggregateChars) {
 }
 `;
       const block = extractAggregateCapBlock(fixture);
-      expect(/\bsafeLogError\s*\(/.test(block)).to.equal(
+      expect(block, 'block 抽出失敗').to.not.be.null;
+      expect(/\bsafeLogError\s*\(/.test(block!)).to.equal(
         false,
         'block 外の safeLogError 呼出が block 抽出結果に含まれてはならない'
       );

--- a/functions/test/handleProcessingErrorContract.test.ts
+++ b/functions/test/handleProcessingErrorContract.test.ts
@@ -34,9 +34,10 @@ const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 // brace/paren 抽出は共通 helper (extractBraceBlock / extractParenBlock) を使用 (#302)。
 // 関数本体の抽出 = brace-nesting、safeLogError 引数の抽出 = paren-nesting で scope を絞ることで
 // 無関係な同名変数・他 logger 呼出・文字列リテラルへの偽陽性を回避する。
-const extractFunctionBody = (source: string, signaturePrefix: string) =>
+// #312: helper が anchor 不在時に null を返すため、alias wrapper も string | null を透過する。
+const extractFunctionBody = (source: string, signaturePrefix: string): string | null =>
   extractBraceBlock(source, signaturePrefix);
-const extractSafeLogErrorArgs = (functionBody: string) =>
+const extractSafeLogErrorArgs = (functionBody: string): string | null =>
   extractParenBlock(functionBody, SAFE_LOG_ERROR_CALL);
 
 describe('handleProcessingError safeLogError contract (#276)', () => {
@@ -58,16 +59,17 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
   const safeLogErrorArgs = extractParenBlock(functionBody, /\bsafeLogError\s*\(/);
 
   it('handleProcessingError 関数本体が抽出できる', () => {
-    expect(functionBody.length).to.be.greaterThan(
-      0,
+    expect(
+      functionBody,
       '`export async function handleProcessingError(` 宣言が見つからない。' +
         'リネーム/シグネチャ変更時は本契約の見直しが必要。'
-    );
+    ).to.not.be.null;
   });
 
   it('handleProcessingError 本体内に safeLogError 呼出がある', () => {
     const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
-    expect(SAFE_LOG_ERROR_CALL.test(functionBody)).to.equal(
+    expect(functionBody, 'functionBody 抽出失敗 (上位 it を確認)').to.not.be.null;
+    expect(SAFE_LOG_ERROR_CALL.test(functionBody!)).to.equal(
       true,
       'handleProcessingError 内で safeLogError 呼出が見つからない。' +
         'errors collection への記録が消失すると #266/#271 同系の silent failure を招く。'
@@ -75,18 +77,19 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
   });
 
   it('safeLogError 引数ブロックが抽出できる', () => {
-    expect(safeLogErrorArgs.length).to.be.greaterThan(
-      0,
+    expect(
+      safeLogErrorArgs,
       'safeLogError(...) の引数ブロックが抽出できない。' +
         '呼出形式の変更 (spread 展開等) の可能性あり — 本契約の見直しが必要。'
-    );
+    ).to.not.be.null;
   });
 
   it('safeLogError 引数に error が渡されている', () => {
     // shorthand `error,` / explicit `error: something` の両方を許容。
     // `error` object 自体が欠落すると stack trace・原因追跡が失われる。
     const ERROR_PARAM = /\berror\s*[,:}]/;
-    expect(ERROR_PARAM.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗 (上位 it を確認)').to.not.be.null;
+    expect(ERROR_PARAM.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に error が含まれていない。' +
         'error object 欠落で stack trace が errors collection に残らない。'
@@ -95,7 +98,8 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
 
   it('safeLogError 引数に source: \'ocr\' が含まれる', () => {
     const SOURCE_OCR = /source:\s*['"]ocr['"]/;
-    expect(SOURCE_OCR.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(SOURCE_OCR.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に source: \'ocr\' が見つからない。' +
         'errors collection の絞込/集計で欠落する。'
@@ -104,7 +108,8 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
 
   it('safeLogError 引数に documentId が渡されている', () => {
     const DOCUMENT_ID_PARAM = /\bdocumentId\s*[,:}]/;
-    expect(DOCUMENT_ID_PARAM.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(DOCUMENT_ID_PARAM.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に documentId が見つからない。' +
         'エラーとドキュメントの紐付けが失われる。'
@@ -113,7 +118,8 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
 
   it('safeLogError 引数に functionName が渡されている', () => {
     const FUNCTION_NAME_PARAM = /\bfunctionName\s*[,:}]/;
-    expect(FUNCTION_NAME_PARAM.test(safeLogErrorArgs)).to.equal(
+    expect(safeLogErrorArgs, 'safeLogErrorArgs 抽出失敗').to.not.be.null;
+    expect(FUNCTION_NAME_PARAM.test(safeLogErrorArgs!)).to.equal(
       true,
       'safeLogError 引数に functionName が見つからない。' +
         'どの呼出元で発生したエラーか特定できなくなる。'
@@ -129,9 +135,10 @@ export async function foo() {
 }
 `;
       const body = extractFunctionBody(fixture, 'export async function foo(');
-      expect(body).to.include('const x = 1');
-      expect(body.startsWith('{')).to.equal(true);
-      expect(body.endsWith('}')).to.equal(true);
+      expect(body, '関数本体が抽出できていない').to.not.be.null;
+      expect(body!).to.include('const x = 1');
+      expect(body!.startsWith('{')).to.equal(true);
+      expect(body!.endsWith('}')).to.equal(true);
     });
 
     it('positive: ネストしたブロックを正しくカウントする', () => {
@@ -144,14 +151,15 @@ export async function foo() {
 }
 `;
       const body = extractFunctionBody(fixture, 'export async function foo(');
-      expect(body).to.include('break');
-      expect(body).to.include('return 1');
+      expect(body, '関数本体が抽出できていない').to.not.be.null;
+      expect(body!).to.include('break');
+      expect(body!).to.include('return 1');
     });
 
-    it('negative: 関数宣言不在時は空文字', () => {
+    it('negative: 関数宣言不在時は null', () => {
       const fixture = `const x = 1;`;
       const body = extractFunctionBody(fixture, 'export async function foo(');
-      expect(body).to.equal('');
+      expect(body).to.be.null;
     });
   });
 
@@ -159,22 +167,24 @@ export async function foo() {
     it('positive: 単純な呼出から引数ブロックを抽出する', () => {
       const fixture = `await safeLogError({ error, source: 'ocr' });`;
       const args = extractSafeLogErrorArgs(fixture);
-      expect(args.startsWith('(')).to.equal(true);
-      expect(args.endsWith(')')).to.equal(true);
-      expect(args).to.include("source: 'ocr'");
+      expect(args, '引数ブロックが抽出できていない').to.not.be.null;
+      expect(args!.startsWith('(')).to.equal(true);
+      expect(args!.endsWith(')')).to.equal(true);
+      expect(args!).to.include("source: 'ocr'");
     });
 
     it('positive: 引数内の括弧 (関数呼出等) をネストカウントする', () => {
       const fixture = `safeLogError({ error: wrap(raw), source: 'ocr' });`;
       const args = extractSafeLogErrorArgs(fixture);
-      expect(args).to.include('wrap(raw)');
-      expect(args.endsWith(')')).to.equal(true);
+      expect(args, '引数ブロックが抽出できていない').to.not.be.null;
+      expect(args!).to.include('wrap(raw)');
+      expect(args!.endsWith(')')).to.equal(true);
     });
 
-    it('negative: safeLogError 呼出不在時は空文字', () => {
+    it('negative: safeLogError 呼出不在時は null', () => {
       const fixture = `console.error('failed');`;
       const args = extractSafeLogErrorArgs(fixture);
-      expect(args).to.equal('');
+      expect(args).to.be.null;
     });
 
     it('scope: 関数本体内の無関係な functionName 変数は検知対象外', () => {
@@ -184,8 +194,9 @@ export async function foo() {
         `safeLogError({ error, source: 'ocr', documentId: id });`,
       ].join('\n');
       const args = extractSafeLogErrorArgs(fixture);
-      expect(args).to.not.include("'fake'");
-      expect(/\bfunctionName\s*[,:}]/.test(args)).to.equal(
+      expect(args, '引数ブロックが抽出できていない').to.not.be.null;
+      expect(args!).to.not.include("'fake'");
+      expect(/\bfunctionName\s*[,:}]/.test(args!)).to.equal(
         false,
         '引数ブロック外の functionName 変数が含まれてはならない (偽陽性防御)'
       );

--- a/functions/test/helpers/extractBraceBlock.test.ts
+++ b/functions/test/helpers/extractBraceBlock.test.ts
@@ -1,21 +1,23 @@
 /**
- * extractBraceBlock helper 単体テスト (#311 review I3 対応)
+ * extractBraceBlock helper 単体テスト (#311 review I3 + #312 API 改善対応)
  *
  * 本 helper は 5 ファイルの contract test から依存される共通基盤。将来の改修で
- * silent regression (空文字返却の意味論変化、startAfterAnchor の挙動反転 等) を
+ * silent regression (null 返却の意味論変化、anchorMode の挙動反転 等) を
  * 直接検知する fixture を配置する。contract test 側 (aggregateCapLogErrorContract)
  * の `extractAggregateCapBlock detection logic` describe は実コード対象のため残置、
  * 本ファイルは helper 単体の挙動のみを狭く lock-in する。
+ *
+ * #312: anchor/開き文字不在は空文字ではなく `null` を返す (silent PASS 防御)。
  */
 
 import { expect } from 'chai';
 import { extractBraceBlock, extractParenBlock } from './extractBraceBlock';
 
 describe('extractBraceBlock helper', () => {
-  describe('startAfterAnchor: true (制御フロー近接性)', () => {
+  describe("anchorMode: 'after-match' (制御フロー近接性)", () => {
     it('anchor 末尾を起点に次の `{` から block を抽出する', () => {
-      // anchor は `catch (e) ` で終わり `{` を含まない。通常 (startAfterAnchor: false) だと
-      // `match.index` から探索して try の `{` を拾ってしまう。true で `match[0].length` 後から
+      // anchor は `catch (e) ` で終わり `{` を含まない。通常 ('from-start') だと
+      // `match.index` から探索して try の `{` を拾ってしまう。'after-match' で `match[0].length` 後から
       // 探索することで catch 本体の `{` を正しく拾う。
       const source = `try { inner } catch (e) { safeLogError(); }`;
       const anchor = /try\s*\{[\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*/;
@@ -23,34 +25,34 @@ describe('extractBraceBlock helper', () => {
       const withoutOpt = extractBraceBlock(source, anchor);
       expect(withoutOpt, 'default は anchor 先頭起点で try 本体を拾う').to.equal('{ inner }');
 
-      const withOpt = extractBraceBlock(source, anchor, { startAfterAnchor: true });
-      expect(withOpt, 'startAfterAnchor: true で catch 本体を拾う').to.equal(
+      const withOpt = extractBraceBlock(source, anchor, { anchorMode: 'after-match' });
+      expect(withOpt, "anchorMode: 'after-match' で catch 本体を拾う").to.equal(
         '{ safeLogError(); }',
       );
     });
 
-    it('anchor 末尾以降に `{` が無い場合は空文字', () => {
+    it('anchor 末尾以降に `{` が無い場合は null', () => {
       const source = `try { inner } catch (e) `;
       const anchor = /try\s*\{[\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*/;
-      expect(extractBraceBlock(source, anchor, { startAfterAnchor: true })).to.equal('');
+      expect(extractBraceBlock(source, anchor, { anchorMode: 'after-match' })).to.be.null;
     });
 
-    it('string anchor でも startAfterAnchor が機能する', () => {
+    it("string anchor でも anchorMode: 'after-match' が機能する", () => {
       const source = `FOO BAR { inner }`;
-      expect(extractBraceBlock(source, 'FOO BAR', { startAfterAnchor: true })).to.equal(
+      expect(extractBraceBlock(source, 'FOO BAR', { anchorMode: 'after-match' })).to.equal(
         '{ inner }',
       );
     });
   });
 
-  describe('extractBraceBlock (default startAfterAnchor: false)', () => {
-    it('anchor 不在時は空文字を返す', () => {
-      expect(extractBraceBlock('const x = 1;', /nomatch/)).to.equal('');
-      expect(extractBraceBlock('const x = 1;', 'nomatch')).to.equal('');
+  describe("extractBraceBlock (default anchorMode: 'from-start')", () => {
+    it('anchor 不在時は null を返す', () => {
+      expect(extractBraceBlock('const x = 1;', /nomatch/)).to.be.null;
+      expect(extractBraceBlock('const x = 1;', 'nomatch')).to.be.null;
     });
 
-    it('anchor ヒットしても後続に `{` が無ければ空文字', () => {
-      expect(extractBraceBlock('const x = 1;', /const/)).to.equal('');
+    it('anchor ヒットしても後続に `{` が無ければ null', () => {
+      expect(extractBraceBlock('const x = 1;', /const/)).to.be.null;
     });
 
     it('ネストした `{}` を balance させて block 全体を返す', () => {
@@ -59,9 +61,9 @@ describe('extractBraceBlock helper', () => {
       expect(block).to.equal('{ if (x) { y(); } else { z(); } }');
     });
 
-    it('unbalanced な `{` は空文字を返す (loop 完走時)', () => {
+    it('unbalanced な `{` は null を返す (loop 完走時)', () => {
       const source = `function f() { if (x) { y(); `;
-      expect(extractBraceBlock(source, 'function f()')).to.equal('');
+      expect(extractBraceBlock(source, 'function f()')).to.be.null;
     });
   });
 
@@ -77,8 +79,8 @@ describe('extractBraceBlock helper', () => {
       expect(extractParenBlock(source, 'f')).to.equal('(g(1, 2), h(3))');
     });
 
-    it('anchor 不在時は空文字', () => {
-      expect(extractParenBlock('const x = 1;', /nomatch/)).to.equal('');
+    it('anchor 不在時は null', () => {
+      expect(extractParenBlock('const x = 1;', /nomatch/)).to.be.null;
     });
   });
 });

--- a/functions/test/helpers/extractBraceBlock.test.ts
+++ b/functions/test/helpers/extractBraceBlock.test.ts
@@ -111,6 +111,28 @@ describe('extractBraceBlock helper', () => {
     });
   });
 
+  // #312 CodeRabbit Minor: global flag (/g) 付き RegExp は match.index が undefined になるため
+  // silent に anchor 不在扱いになる silent PASS 経路。明示的 throw で regression を可視化。
+  describe('global flag (/g) RegExp anchor の reject', () => {
+    it('extractBraceBlock: /g 付き anchor は throw する', () => {
+      expect(() => extractBraceBlock('function f() { return 1; }', /function\s+f/g)).to.throw(
+        /global flag.*非対応/,
+      );
+    });
+
+    it('extractParenBlock: /g 付き anchor は throw する', () => {
+      expect(() => extractParenBlock('f()', /f/g)).to.throw(/global flag.*非対応/);
+    });
+
+    it('/gi など /g を含む複合 flag も reject する', () => {
+      expect(() => extractBraceBlock('FUNC F() {}', /FUNC/gi)).to.throw(/global flag.*非対応/);
+    });
+
+    it('/i など /g 以外の flag は通常通り動作', () => {
+      expect(extractBraceBlock('FUNC F() { inner }', /func/i)).to.equal('{ inner }');
+    });
+  });
+
   // #312 pr-test-analyzer C1 (Critical): null source passthrough は JSDoc で契約しているが
   // 本 helper 単体テストでの回帰ガードが欠如していた。alias wrapper 経由の chain 入力
   // (extractProdBranch(helperBody) で helperBody が null) が実運用で発生するため必須 lock-in。

--- a/functions/test/helpers/extractBraceBlock.test.ts
+++ b/functions/test/helpers/extractBraceBlock.test.ts
@@ -43,6 +43,22 @@ describe('extractBraceBlock helper', () => {
         '{ inner }',
       );
     });
+
+    // #312 pr-test-analyzer I3: string anchor + 'after-match' + anchor 不在のケース lock-in。
+    it("string anchor + 'after-match' で anchor 不在時は null", () => {
+      expect(
+        extractBraceBlock('no anchor here', 'MISSING', { anchorMode: 'after-match' }),
+      ).to.be.null;
+    });
+
+    // #312 pr-test-analyzer I4: 'from-start' 明示指定の挙動を lock-in (default と同一動作)。
+    it("anchorMode: 'from-start' 明示指定は default と同じ挙動", () => {
+      const source = `try { inner } catch (e) { outer }`;
+      const anchor = /try\s*\{[\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*/;
+      expect(extractBraceBlock(source, anchor, { anchorMode: 'from-start' })).to.equal(
+        '{ inner }',
+      );
+    });
   });
 
   describe("extractBraceBlock (default anchorMode: 'from-start')", () => {
@@ -65,6 +81,12 @@ describe('extractBraceBlock helper', () => {
       const source = `function f() { if (x) { y(); `;
       expect(extractBraceBlock(source, 'function f()')).to.be.null;
     });
+
+    // #312 pr-test-analyzer I2: 空 source の退化ケースを lock-in。
+    it('空 source は null を返す', () => {
+      expect(extractBraceBlock('', /const/)).to.be.null;
+      expect(extractBraceBlock('', 'const')).to.be.null;
+    });
   });
 
   describe('extractParenBlock', () => {
@@ -81,6 +103,29 @@ describe('extractBraceBlock helper', () => {
 
     it('anchor 不在時は null', () => {
       expect(extractParenBlock('const x = 1;', /nomatch/)).to.be.null;
+    });
+
+    // #312 pr-test-analyzer I1: brace 側の unbalanced テストと対称に paren 側も lock-in。
+    it('unbalanced な `(` は null を返す (loop 完走時)', () => {
+      expect(extractParenBlock('f(g(1, 2', 'f')).to.be.null;
+    });
+  });
+
+  // #312 pr-test-analyzer C1 (Critical): null source passthrough は JSDoc で契約しているが
+  // 本 helper 単体テストでの回帰ガードが欠如していた。alias wrapper 経由の chain 入力
+  // (extractProdBranch(helperBody) で helperBody が null) が実運用で発生するため必須 lock-in。
+  describe('null source passthrough (chain 用途)', () => {
+    it('extractBraceBlock(null, ...) は常に null を返す', () => {
+      expect(extractBraceBlock(null, /anything/)).to.be.null;
+      expect(extractBraceBlock(null, 'anything')).to.be.null;
+      expect(extractBraceBlock(null, /anything/, { anchorMode: 'after-match' })).to.be.null;
+      expect(extractBraceBlock(null, 'anything', { anchorMode: 'from-start' })).to.be.null;
+    });
+
+    it('extractParenBlock(null, ...) も null を透過する', () => {
+      expect(extractParenBlock(null, /anything/)).to.be.null;
+      expect(extractParenBlock(null, 'anything')).to.be.null;
+      expect(extractParenBlock(null, /anything/, { anchorMode: 'after-match' })).to.be.null;
     });
   });
 });

--- a/functions/test/helpers/extractBraceBlock.ts
+++ b/functions/test/helpers/extractBraceBlock.ts
@@ -1,23 +1,28 @@
 /**
  * grep-based contract test で使う brace / paren nesting 抽出 helper
- * (Issue #302, PR #301 /simplify HIGH + codex Low 1 follow-up)
+ * (Issue #302, PR #301 /simplify HIGH + codex Low 1 follow-up, Issue #312 API 改善)
  *
  * 5 ファイルで同一実装が重複していた extractFunctionBody / extractAggregateCapBlock /
  * extractAssertFunctionBody / extractHelperFunctionBody / extractProdBranch を
  * 共通化する。anchor (RegExp | string) と nesting 種別 (brace / paren) のみが差分。
  *
  * 詳細な位置づけは docs/context/test-strategy.md (#308) を参照。
+ *
+ * #312 API 改善:
+ * - `startAfterAnchor: boolean` → `anchorMode: 'from-start' | 'after-match'` (boolean-blindness 解消)
+ * - 戻り値 `string` → `string | null` (anchor/開き文字不在を型で表現、caller の silent PASS 防御)
+ * - `ExtractOptions` は外部参照ゼロのためインライン型に降格
  */
 
-export interface ExtractOptions {
-  /**
-   * true の場合、anchor マッチの**末尾** (match.index + match[0].length) から
-   * 最初の開き文字を探す。anchor 自体が「開始位置の目印となるテキスト」を末尾に含む
-   * ケース (例: `try {...} catch (e) ` の先で catch 本体のみを抽出したいケース) に使う。
-   * デフォルト false: anchor マッチ**先頭** (match.index) から最初の開き文字を探す。
-   */
-  startAfterAnchor?: boolean;
-}
+/**
+ * anchor マッチから開き文字 (`{` / `(`) を探索する起点の指定方法。
+ *
+ * - `'from-start'` (デフォルト): anchor マッチ**先頭** (match.index) から最初の開き文字を探す。
+ * - `'after-match'`: anchor マッチ**末尾** (match.index + match[0].length) から最初の開き文字を探す。
+ *   anchor 自体が「開始位置の目印となるテキスト」を末尾に含み、anchor 直後の block のみを狭く
+ *   抽出したいケース (例: `try {...} catch (e) ` の先で catch 本体のみを抽出) に使う。
+ */
+type AnchorMode = 'from-start' | 'after-match';
 
 /**
  * source 内で anchor にマッチした位置以降の最初の `{` から、対応する `}` までを抽出する。
@@ -26,17 +31,21 @@ export interface ExtractOptions {
  * テンプレートリテラル内に裸の `{` `}` を含む場合は誤判定する可能性があるため、
  * 将来そのケースに遭遇したら AST ベース抽出への移行を検討する。
  *
- * @param source - 対象ソース全体
+ * @param source - 対象ソース全体。直前の extract 呼出結果を chain する用途で `null` も受け取り、
+ *                 その場合は `null` を透過する (caller で都度 null ガードする boilerplate を回避)。
  * @param anchor - RegExp または string。string の場合は完全一致 (`indexOf`) で検索する。
  *                 RegExp の場合は `match.index` からブロック開始位置を決める。
- * @param options.startAfterAnchor - anchor マッチ末尾から探索する (制御フロー近接性の lock-in 用)
- * @returns 抽出したブロック文字列 (`{` から `}` を両端に含む)、anchor 不在時は空文字
+ * @param options.anchorMode - 起点指定 (`'from-start'` (default) / `'after-match'`)
+ * @returns 抽出したブロック文字列 (`{` から `}` を両端に含む)、source が `null` もしくは
+ *          anchor/開き文字/対応する閉じ文字が見つからない場合は `null`。caller は
+ *          `expect(block).to.not.be.null` で failure を明示化すること (silent PASS 防御、
+ *          #311 C1/C2 教訓)。
  */
 export function extractBraceBlock(
-  source: string,
+  source: string | null,
   anchor: RegExp | string,
-  options: ExtractOptions = {},
-): string {
+  options: { anchorMode?: AnchorMode } = {},
+): string | null {
   return extractBalancedBlock(source, anchor, '{', '}', options);
 }
 
@@ -46,31 +55,36 @@ export function extractBraceBlock(
  * `safeLogError(...)` 等の呼出引数ブロックに scope を絞り、関数本体全体を対象にした
  * 正規表現での偽陽性 (同名ローカル変数・他 logger 呼出・文字列リテラル等) を防ぐ。
  *
- * @param source - 対象ソース (関数本体等)
+ * @param source - 対象ソース (関数本体等)。`null` 入力は透過して `null` を返す (chain 用途)。
  * @param anchor - RegExp または string。RegExp 推奨 (例: `/\bsafeLogError\s*\(/`)
- * @param options.startAfterAnchor - anchor マッチ末尾から探索する
- * @returns 抽出したブロック文字列 (`(` から `)` を両端に含む)、anchor 不在時は空文字
+ * @param options.anchorMode - 起点指定 (`'from-start'` (default) / `'after-match'`)
+ * @returns 抽出したブロック文字列 (`(` から `)` を両端に含む)、source が `null` もしくは
+ *          anchor/開き文字/対応する閉じ文字が見つからない場合は `null`。caller は
+ *          `expect(args).to.not.be.null` で failure を明示化すること (silent PASS 防御、
+ *          #311 C1/C2 / #312 Evaluator AC7 教訓)。
  */
 export function extractParenBlock(
-  source: string,
+  source: string | null,
   anchor: RegExp | string,
-  options: ExtractOptions = {},
-): string {
+  options: { anchorMode?: AnchorMode } = {},
+): string | null {
   return extractBalancedBlock(source, anchor, '(', ')', options);
 }
 
 function extractBalancedBlock(
-  source: string,
+  source: string | null,
   anchor: RegExp | string,
   openCh: string,
   closeCh: string,
-  options: ExtractOptions,
-): string {
-  const startIdx = resolveAnchorIndex(source, anchor, options.startAfterAnchor ?? false);
-  if (startIdx === -1) return '';
+  options: { anchorMode?: AnchorMode },
+): string | null {
+  if (source === null) return null;
+  const mode = options.anchorMode ?? 'from-start';
+  const startIdx = resolveAnchorIndex(source, anchor, mode);
+  if (startIdx === -1) return null;
 
   const openIdx = source.indexOf(openCh, startIdx);
-  if (openIdx === -1) return '';
+  if (openIdx === -1) return null;
 
   let depth = 0;
   for (let i = openIdx; i < source.length; i++) {
@@ -83,20 +97,20 @@ function extractBalancedBlock(
       }
     }
   }
-  return '';
+  return null;
 }
 
 function resolveAnchorIndex(
   source: string,
   anchor: RegExp | string,
-  startAfterAnchor: boolean,
+  mode: AnchorMode,
 ): number {
   if (typeof anchor === 'string') {
     const idx = source.indexOf(anchor);
     if (idx === -1) return -1;
-    return startAfterAnchor ? idx + anchor.length : idx;
+    return mode === 'after-match' ? idx + anchor.length : idx;
   }
   const match = source.match(anchor);
   if (!match || match.index === undefined) return -1;
-  return startAfterAnchor ? match.index + match[0].length : match.index;
+  return mode === 'after-match' ? match.index + match[0].length : match.index;
 }

--- a/functions/test/helpers/extractBraceBlock.ts
+++ b/functions/test/helpers/extractBraceBlock.ts
@@ -116,6 +116,17 @@ function resolveAnchorIndex(
     if (baseIdx === -1) return -1;
     matchLen = anchor.length;
   } else {
+    // #312 CodeRabbit Minor: global flag (/g) 付き RegExp は String.prototype.match が index を
+    // 含まない配列を返し、silent に「anchor 不在」扱い (return -1) に退化する。現状 caller は
+    // /g を使っていないが、本 helper の silent PASS 防御精神 (#311 C1/C2, #312 AC2) と整合する
+    // よう明示的に reject して early throw で regression を可視化する。
+    if (anchor.flags.includes('g')) {
+      throw new Error(
+        `[extractBalancedBlock] global flag (/g) 付き RegExp anchor は非対応 — ` +
+          `match.index が undefined になり silent に anchor 不在扱いになる。` +
+          `anchor.source: ${anchor.source}, flags: ${anchor.flags}`,
+      );
+    }
     const match = source.match(anchor);
     if (!match || match.index === undefined) return -1;
     baseIdx = match.index;

--- a/functions/test/helpers/extractBraceBlock.ts
+++ b/functions/test/helpers/extractBraceBlock.ts
@@ -21,8 +21,10 @@
  * - `'after-match'`: anchor マッチ**末尾** (match.index + match[0].length) から最初の開き文字を探す。
  *   anchor 自体が「開始位置の目印となるテキスト」を末尾に含み、anchor 直後の block のみを狭く
  *   抽出したいケース (例: `try {...} catch (e) ` の先で catch 本体のみを抽出) に使う。
+ *
+ * #312 type-design-analyzer 推奨 #2: 外部 caller が mode 値を型安全に使うため export する。
  */
-type AnchorMode = 'from-start' | 'after-match';
+export type AnchorMode = 'from-start' | 'after-match';
 
 /**
  * source 内で anchor にマッチした位置以降の最初の `{` から、対応する `}` までを抽出する。
@@ -33,13 +35,14 @@ type AnchorMode = 'from-start' | 'after-match';
  *
  * @param source - 対象ソース全体。直前の extract 呼出結果を chain する用途で `null` も受け取り、
  *                 その場合は `null` を透過する (caller で都度 null ガードする boilerplate を回避)。
- * @param anchor - RegExp または string。string の場合は完全一致 (`indexOf`) で検索する。
+ * @param anchor - RegExp または string。string の場合は substring 検索 (`indexOf`、最初の出現位置)。
  *                 RegExp の場合は `match.index` からブロック開始位置を決める。
  * @param options.anchorMode - 起点指定 (`'from-start'` (default) / `'after-match'`)
  * @returns 抽出したブロック文字列 (`{` から `}` を両端に含む)、source が `null` もしくは
- *          anchor/開き文字/対応する閉じ文字が見つからない場合は `null`。caller は
+ *          anchor/開き文字/対応する閉じ文字/balance 不成立のいずれかで `null`。caller は
  *          `expect(block).to.not.be.null` で failure を明示化すること (silent PASS 防御、
- *          #311 C1/C2 教訓)。
+ *          #311 C1/C2 教訓)。とくに `.to.not.match(re)` は chai で `null` に対し silent PASS
+ *          するため、同一 `it` 内で先行 null ガードが必須 (#312 silent-failure-hunter I1)。
  */
 export function extractBraceBlock(
   source: string | null,
@@ -59,9 +62,10 @@ export function extractBraceBlock(
  * @param anchor - RegExp または string。RegExp 推奨 (例: `/\bsafeLogError\s*\(/`)
  * @param options.anchorMode - 起点指定 (`'from-start'` (default) / `'after-match'`)
  * @returns 抽出したブロック文字列 (`(` から `)` を両端に含む)、source が `null` もしくは
- *          anchor/開き文字/対応する閉じ文字が見つからない場合は `null`。caller は
+ *          anchor/開き文字/対応する閉じ文字/balance 不成立のいずれかで `null`。caller は
  *          `expect(args).to.not.be.null` で failure を明示化すること (silent PASS 防御、
- *          #311 C1/C2 / #312 Evaluator AC7 教訓)。
+ *          #311 C1/C2 / #312 Evaluator AC7 教訓)。`.to.not.match(re)` の null silent PASS
+ *          経路は extractBraceBlock と同様 (#312 silent-failure-hunter I1)。
  */
 export function extractParenBlock(
   source: string | null,
@@ -105,12 +109,28 @@ function resolveAnchorIndex(
   anchor: RegExp | string,
   mode: AnchorMode,
 ): number {
+  let baseIdx: number;
+  let matchLen: number;
   if (typeof anchor === 'string') {
-    const idx = source.indexOf(anchor);
-    if (idx === -1) return -1;
-    return mode === 'after-match' ? idx + anchor.length : idx;
+    baseIdx = source.indexOf(anchor);
+    if (baseIdx === -1) return -1;
+    matchLen = anchor.length;
+  } else {
+    const match = source.match(anchor);
+    if (!match || match.index === undefined) return -1;
+    baseIdx = match.index;
+    matchLen = match[0].length;
   }
-  const match = source.match(anchor);
-  if (!match || match.index === undefined) return -1;
-  return mode === 'after-match' ? match.index + match[0].length : match.index;
+  // #312 type-design-analyzer 推奨 #3: 新しい AnchorMode 追加時に silent に 'from-start' 扱いに
+  // 回帰しないよう exhaustive check で lock-in する。
+  switch (mode) {
+    case 'from-start':
+      return baseIdx;
+    case 'after-match':
+      return baseIdx + matchLen;
+    default: {
+      const _exhaustive: never = mode;
+      return _exhaustive;
+    }
+  }
 }

--- a/functions/test/ocrProcessorAggregateCallerContract.test.ts
+++ b/functions/test/ocrProcessorAggregateCallerContract.test.ts
@@ -23,7 +23,7 @@ const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
 
 // 制御フロー近接性 lock-in (#302 codex Low 1): capPageResultsAggregate 呼出 → catch ブロックを
 // 1 anchor で束ね、別所の catch ブロックや不整合な順序に回帰した場合に fail させる。
-// anchor 末尾は `catch (e) ` で終わり、そこから startAfterAnchor で最初の `{` を拾う。
+// anchor 末尾は `catch (e) ` で終わり、そこから anchorMode: 'after-match' で最初の `{` を拾う。
 //
 // 前提: ocrProcessor.ts 内で capPageResultsAggregate を参照する try/catch は 1 箇所のみ。
 // 将来 2 つ目が追加された場合、source.match() は最初のマッチを返すため、本 anchor は
@@ -81,30 +81,28 @@ describe('ocrProcessor aggregate caller wrapper contract (#293 + #297)', () => {
     // capPageResultsAggregate 呼出 → catch ブロックを 1 anchor で束ねて抽出する。
     // 別の catch ブロックや順序の回帰があれば anchor マッチ自体が失敗する (#302 codex Low 1)。
     const catchBlock = extractBraceBlock(source, CAP_AGG_CATCH_ANCHOR, {
-      startAfterAnchor: true,
+      anchorMode: 'after-match',
     });
-    expect(catchBlock, 'capPageResultsAggregate 呼出直後の catch ブロックが抽出できない').to.not.equal(
-      '',
-    );
-    expect(catchBlock).to.match(
+    expect(catchBlock, 'capPageResultsAggregate 呼出直後の catch ブロックが抽出できない').to.not.be.null;
+    expect(catchBlock!).to.match(
       /\bsafeLogError\s*\(/,
       'catch 内で safeLogError 呼出が見つからない — dev throw が silent に失われる',
     );
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /source\s*:\s*['"]ocr['"]/,
       'catch 内 safeLogError に source: "ocr" が含まれない',
     );
     // 命名規則: 既存 `:aggregateCap` (正常系 truncation summary) と区別する suffix。
     // 既知 invariant は `:aggregateCap:invariant`、予期外エラーは `:aggregateCap:unexpected` に分類。
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /aggregateCap:invariant/,
       'catch 内 safeLogError の functionName に :aggregateCap:invariant suffix が現れない — 既知 invariant triage 不能',
     );
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /aggregateCap:unexpected/,
       'catch 内 safeLogError の functionName に :aggregateCap:unexpected suffix が現れない — 予期外エラーが既知 invariant と混線',
     );
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /documentId\s*:\s*docId/,
       'catch 内 safeLogError に documentId: docId が含まれない — triage 不能',
     );

--- a/functions/test/textCapDrainSinkContract.test.ts
+++ b/functions/test/textCapDrainSinkContract.test.ts
@@ -59,7 +59,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
       interfaceBlock,
       'AggregateInvariantContext interface block が抽出できない — anchor 消失',
     ).to.not.be.null;
-    expect(interfaceBlock).to.not.match(
+    expect(interfaceBlock!).to.not.match(
       /\bpendingLogs\b/,
       'AggregateInvariantContext に旧名 pendingLogs が残存 — #304 rename が不完全',
     );
@@ -74,7 +74,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
     ).to.not.be.null;
     // `const <var> = safeLogError(...)` または `let <var> = safeLogError(...)` の形を検査。
     // fire-and-forget 直書き `void safeLogError(` に regression した場合に fail させる。
-    expect(prodBranch).to.match(
+    expect(prodBranch!).to.match(
       /(?:const|let)\s+\w+\s*=\s*safeLogError\s*\(/,
       'safeLogError の戻り値が変数束縛されていない — fire-and-forget に回帰している可能性',
     );
@@ -84,7 +84,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    expect(prodBranch).to.match(
+    expect(prodBranch!).to.match(
       /context\?\.drainSink[\s\S]*?\.push\s*\(/,
       'context?.drainSink への push 呼出が見つからない — drain 経路が欠損',
     );
@@ -96,7 +96,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     // legacy caller (drainSink 未渡し) では intentionally fire-and-forget を維持する。
     // `void logPromise;` は完了保証ではなく「意図的に discard」を明示するマーカー。
-    expect(prodBranch).to.match(
+    expect(prodBranch!).to.match(
       /\bvoid\s+\w+\s*;?/,
       'drainSink 未渡し時の void fallback が見つからない — 後方互換が壊れている可能性',
     );
@@ -110,7 +110,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
       prodBranch,
       'prod 分岐が抽出できない — anchor 消失 (#311 review C2 対応)',
     ).to.not.be.null;
-    expect(prodBranch).to.not.match(
+    expect(prodBranch!).to.not.match(
       /\bvoid\s+safeLogError\s*\(/,
       'void safeLogError( 直叩きが残存 — fire-and-forget 回帰、#297 対応が崩れている',
     );

--- a/functions/test/textCapDrainSinkContract.test.ts
+++ b/functions/test/textCapDrainSinkContract.test.ts
@@ -23,9 +23,10 @@ const HELPER_BODY_ANCHOR =
 const PROD_BRANCH_ANCHOR =
   /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
 
-const extractHelperFunctionBody = (source: string) =>
+// #312: helper が anchor/null 入力を透過して null を返すため、alias wrapper は直接委譲する。
+const extractHelperFunctionBody = (source: string): string | null =>
   extractBraceBlock(source, HELPER_BODY_ANCHOR);
-const extractProdBranch = (block: string) =>
+const extractProdBranch = (block: string | null): string | null =>
   extractBraceBlock(block, PROD_BRANCH_ANCHOR);
 
 describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
@@ -57,7 +58,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
     expect(
       interfaceBlock,
       'AggregateInvariantContext interface block が抽出できない — anchor 消失',
-    ).to.not.equal('');
+    ).to.not.be.null;
     expect(interfaceBlock).to.not.match(
       /\bpendingLogs\b/,
       'AggregateInvariantContext に旧名 pendingLogs が残存 — #304 rename が不完全',
@@ -67,9 +68,10 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   it('prod 分岐内で safeLogError の戻り値が変数束縛されている (void 直叩きではない)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
-    expect(prodBranch, 'handleAggregateInvariantViolation の prod 分岐が抽出できない').to.not.equal(
-      '',
-    );
+    expect(
+      prodBranch,
+      'handleAggregateInvariantViolation の prod 分岐が抽出できない',
+    ).to.not.be.null;
     // `const <var> = safeLogError(...)` または `let <var> = safeLogError(...)` の形を検査。
     // fire-and-forget 直書き `void safeLogError(` に regression した場合に fail させる。
     expect(prodBranch).to.match(
@@ -81,7 +83,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   it('prod 分岐内で context?.drainSink への push 呼出が存在する', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.equal('');
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     expect(prodBranch).to.match(
       /context\?\.drainSink[\s\S]*?\.push\s*\(/,
       'context?.drainSink への push 呼出が見つからない — drain 経路が欠損',
@@ -91,7 +93,7 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   it('drainSink 未渡し時の fallback (void 形) が存在する (後方互換維持)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.equal('');
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     // legacy caller (drainSink 未渡し) では intentionally fire-and-forget を維持する。
     // `void logPromise;` は完了保証ではなく「意図的に discard」を明示するマーカー。
     expect(prodBranch).to.match(
@@ -103,10 +105,11 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   it('prod 分岐に直接 `void safeLogError(` 形が残っていない (regression guard)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const prodBranch = extractProdBranch(helperBody);
-    // anchor 消失で prodBranch が空文字のまま to.not.match(...) が silent PASS する経路を防ぐ。
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失 (#311 review C2 対応)').to.not.equal(
-      '',
-    );
+    // anchor 消失で prodBranch が null のまま to.not.match(...) が silent PASS する経路を防ぐ。
+    expect(
+      prodBranch,
+      'prod 分岐が抽出できない — anchor 消失 (#311 review C2 対応)',
+    ).to.not.be.null;
     expect(prodBranch).to.not.match(
       /\bvoid\s+safeLogError\s*\(/,
       'void safeLogError( 直叩きが残存 — fire-and-forget 回帰、#297 対応が崩れている',

--- a/functions/test/textCapErrorLoggerFallbackContract.test.ts
+++ b/functions/test/textCapErrorLoggerFallbackContract.test.ts
@@ -35,10 +35,11 @@ const HELPER_BODY_ANCHOR =
   /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
 const LOADERR_CATCH_ANCHOR = /catch\s*\(\s*loadErr\s*\)\s*/;
 
-const extractHelperFunctionBody = (source: string) =>
+// #312: helper が anchor/null 入力を透過して null を返すため、alias wrapper は直接委譲する。
+const extractHelperFunctionBody = (source: string): string | null =>
   extractBraceBlock(source, HELPER_BODY_ANCHOR);
-const extractLoadErrCatch = (block: string) =>
-  extractBraceBlock(block, LOADERR_CATCH_ANCHOR, { startAfterAnchor: true });
+const extractLoadErrCatch = (block: string | null): string | null =>
+  extractBraceBlock(block, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
 
 describe('textCap errorLogger require failure fallback contract (#303 + #319 review)', () => {
   let source = '';
@@ -51,15 +52,15 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
 
   it('handleAggregateInvariantViolation の catch (loadErr) ブロックが抽出できる (anchor 保護)', () => {
     const helperBody = extractHelperFunctionBody(source);
-    expect(helperBody, 'handleAggregateInvariantViolation 関数本体が抽出できない').to.not.equal('');
+    expect(helperBody, 'handleAggregateInvariantViolation 関数本体が抽出できない').to.not.be.null;
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない — anchor 消失').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない — anchor 消失').to.not.be.null;
   });
 
   it('loader 失敗時の先行 console.error が保持される (AC-11, rules/error-handling.md §1)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // Cloud Logging alert grep 契約: `[textCap] failed to load errorLogger` prefix を lock-in。
     // prefix drift (例: 英語化、モジュール名変更) は operational alert を壊すため regression 検知。
     expect(catchBlock).to.match(
@@ -71,7 +72,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('catch (loadErr) 内で admin.firestore() が呼ばれている (fallback 書込経路)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     expect(catchBlock).to.match(
       /admin\.firestore\s*\(\s*\)/,
       'catch (loadErr) 内で admin.firestore() 呼出が見つからない — fallback 書込経路が欠損',
@@ -81,7 +82,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('catch (loadErr) 内で errors collection への add 呼出がある (errors 書込先)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     expect(catchBlock).to.match(
       /\.collection\s*\(\s*['"]errors['"]\s*\)/,
       'catch (loadErr) 内で errors collection への書込先が特定されていない',
@@ -95,11 +96,11 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('write reject 時の .catch handler で console.error により失敗を surface (#319 review C1)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // `.catch(() => {})` による完全 silent swallow (PERMISSION_DENIED / RESOURCE_EXHAUSTED /
     // UNAVAILABLE / INVALID_ARGUMENT 等の operational signal が消失する regression) を防ぐ。
     // .add(...).catch の handler body 内に console.error が存在することを lock-in。
-    const addCatchMatch = catchBlock.match(
+    const addCatchMatch = catchBlock!.match(
       /\.add\s*\([\s\S]*?\)[\s\S]*?\.catch\s*\(\s*(?:\([^)]*\)|[^=]+)\s*=>\s*\{([\s\S]*?)\}\s*\)/,
     );
     expect(
@@ -121,11 +122,11 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('外側 catch(fallbackSetupErr) で setup 失敗も console.error で surface (#319 review I1)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // 外側 try/catch: `try { admin.firestore()... } catch (fallbackSetupErr) { ... }`。
     // bare `catch {}` による silent swallow regression を防ぐ (require('firebase-admin') /
     // admin.firestore() / FieldValue 同期失敗の区別可能化)。
-    const outerCatchMatch = catchBlock.match(/\}\s*catch\s*\(\s*(\w+)\s*\)\s*\{([\s\S]*?)\}\s*$/);
+    const outerCatchMatch = catchBlock!.match(/\}\s*catch\s*\(\s*(\w+)\s*\)\s*\{([\s\S]*?)\}\s*$/);
     expect(outerCatchMatch, '外側 catch(...) block が抽出できない').to.not.be.null;
     expect(outerCatchMatch![1]).to.not.equal(
       '',
@@ -145,7 +146,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('fallback record に triage 必須 field が含まれる (#319 review I2: schema lock-in)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // errors collection triage dashboard が集計に使う key field を lock-in。
     expect(catchBlock).to.match(/status\s*:\s*['"]pending['"]/, 'status: pending 欠落 — triage queue invisible');
     expect(catchBlock).to.match(/severity\s*:\s*['"]critical['"]/, 'severity: critical drift');
@@ -165,7 +166,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('loaderError が構造化され String(loadErr) 直接代入されていない (#319 review I3)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // String(loadErr) 直接代入は Error 以外の throw で `[object Object]` になる silent 情報欠損、
     // FirebaseAppError.code 等の triage 重要フィールド drop の原因となる。
     // instanceof Error ブランチで name/message/code を抽出する形へ regression しないよう lock-in。
@@ -182,7 +183,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   it('fallback write Promise が drainSink に push される (#319 review I2: 対称化)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
-    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.equal('');
+    expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // 主経路 (safeLogError) と対称に fallback も drainSink に push して drain 保証。
     // fire-and-forget 非対称性 (Cloud Functions freeze 時の partial delivery) に回帰しないよう lock-in。
     expect(catchBlock).to.match(

--- a/functions/test/textCapErrorLoggerFallbackContract.test.ts
+++ b/functions/test/textCapErrorLoggerFallbackContract.test.ts
@@ -63,7 +63,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // Cloud Logging alert grep 契約: `[textCap] failed to load errorLogger` prefix を lock-in。
     // prefix drift (例: 英語化、モジュール名変更) は operational alert を壊すため regression 検知。
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /console\.error\s*\(\s*['"]\[textCap\]\s+failed\s+to\s+load\s+errorLogger/,
       'catch (loadErr) 冒頭の先行 console.error が消失 or prefix drift — Cloud Logging alert が壊れる',
     );
@@ -73,7 +73,7 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /admin\.firestore\s*\(\s*\)/,
       'catch (loadErr) 内で admin.firestore() 呼出が見つからない — fallback 書込経路が欠損',
     );
@@ -83,11 +83,11 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
     const helperBody = extractHelperFunctionBody(source);
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /\.collection\s*\(\s*['"]errors['"]\s*\)/,
       'catch (loadErr) 内で errors collection への書込先が特定されていない',
     );
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /\.add\s*\(/,
       'catch (loadErr) 内で .add( 呼出が見つからない — errors collection への書込が欠損',
     );
@@ -148,16 +148,16 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
     const catchBlock = extractLoadErrCatch(helperBody);
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // errors collection triage dashboard が集計に使う key field を lock-in。
-    expect(catchBlock).to.match(/status\s*:\s*['"]pending['"]/, 'status: pending 欠落 — triage queue invisible');
-    expect(catchBlock).to.match(/severity\s*:\s*['"]critical['"]/, 'severity: critical drift');
-    expect(catchBlock).to.match(/category\s*:\s*['"]fatal['"]/, 'category: fatal drift');
-    expect(catchBlock).to.match(/source\s*:\s*['"]ocr['"]/, 'source: ocr drift');
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(/status\s*:\s*['"]pending['"]/, 'status: pending 欠落 — triage queue invisible');
+    expect(catchBlock!).to.match(/severity\s*:\s*['"]critical['"]/, 'severity: critical drift');
+    expect(catchBlock!).to.match(/category\s*:\s*['"]fatal['"]/, 'category: fatal drift');
+    expect(catchBlock!).to.match(/source\s*:\s*['"]ocr['"]/, 'source: ocr drift');
+    expect(catchBlock!).to.match(
       /functionName\s*:\s*['"]capPageResultsAggregate:loaderFailed['"]/,
       'functionName suffix drift — triage filter 壊れ',
     );
-    expect(catchBlock).to.match(/errorCode\s*:\s*['"]LOADER_FAILED['"]/, 'errorCode drift');
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(/errorCode\s*:\s*['"]LOADER_FAILED['"]/, 'errorCode drift');
+    expect(catchBlock!).to.match(
       /documentId\s*:\s*context\?\.documentId\s*\?\?\s*null/,
       'documentId 正規化 `?? null` が消失 — undefined で Firestore 書込 reject or document 紐付け不可',
     );
@@ -170,11 +170,11 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
     // String(loadErr) 直接代入は Error 以外の throw で `[object Object]` になる silent 情報欠損、
     // FirebaseAppError.code 等の triage 重要フィールド drop の原因となる。
     // instanceof Error ブランチで name/message/code を抽出する形へ regression しないよう lock-in。
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /loadErr\s+instanceof\s+Error/,
       'instanceof Error 分岐が消失 — String(loadErr) 直代入 regression で triage 情報欠損',
     );
-    expect(catchBlock).to.not.match(
+    expect(catchBlock!).to.not.match(
       /loaderError\s*:\s*String\s*\(\s*loadErr\s*\)/,
       'loaderError: String(loadErr) 直代入に回帰 — [object Object] silent 情報欠損が再発',
     );
@@ -186,12 +186,12 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // 主経路 (safeLogError) と対称に fallback も drainSink に push して drain 保証。
     // fire-and-forget 非対称性 (Cloud Functions freeze 時の partial delivery) に回帰しないよう lock-in。
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /context\?\.drainSink[\s\S]*?\.push\s*\(/,
       'fallback 内で drainSink.push() が消失 — fire-and-forget 非対称性に回帰 (Cloud Functions freeze 時 partial delivery リスク)',
     );
     // .then(() => undefined) で Promise<void> に正規化されていること (drainSink の型整合)。
-    expect(catchBlock).to.match(
+    expect(catchBlock!).to.match(
       /\.then\s*\(\s*\(\s*\)\s*=>\s*undefined\s*\)/,
       '.then(() => undefined) による Promise<void> 正規化が消失 — drainSink 型整合が壊れる',
     );

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -28,13 +28,14 @@ const PROD_BRANCH_ANCHOR =
   /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
 const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 
-const extractAssertFunctionBody = (source: string) =>
+// #312: helper が anchor/null 入力を透過して null を返すため、alias wrapper は直接委譲する。
+const extractAssertFunctionBody = (source: string): string | null =>
   extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-const extractHelperFunctionBody = (source: string) =>
+const extractHelperFunctionBody = (source: string): string | null =>
   extractBraceBlock(source, HELPER_BODY_ANCHOR);
-const extractProdBranch = (block: string) =>
+const extractProdBranch = (block: string | null): string | null =>
   extractBraceBlock(block, PROD_BRANCH_ANCHOR);
-const extractSafeLogErrorArgs = (block: string) =>
+const extractSafeLogErrorArgs = (block: string | null): string | null =>
   extractParenBlock(block, SAFE_LOG_ERROR_CALL);
 
 describe('textCap prod invariant observability contract (#288 item 6)', () => {
@@ -49,7 +50,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   it('assertAggregatePageInvariant 関数定義が存在する (anchor 保護)', () => {
     const body = extractAssertFunctionBody(source);
     expect(body, 'assertAggregatePageInvariant 関数の anchor が消失 — リネームなら本契約更新').to
-      .not.equal('');
+      .not.be.null;
   });
 
   it('prod 分岐 (process.env.NODE_ENV === "production") が存在する', () => {
@@ -58,9 +59,10 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
-    expect(prodBranch, 'prod 分岐が検出されない — silent return に回帰している可能性').to.not.equal(
-      '',
-    );
+    expect(
+      prodBranch,
+      'prod 分岐が検出されない — silent return に回帰している可能性',
+    ).to.not.be.null;
   });
 
   it('prod 分岐内に safeLogError 呼出が存在する', () => {
@@ -68,6 +70,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     expect(prodBranch).to.match(
       /\bsafeLogError\s*\(/,
       'prod 分岐内に safeLogError 呼出が見つからない — silent 回帰',
@@ -79,8 +82,9 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     const args = extractSafeLogErrorArgs(prodBranch);
-    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.equal('');
+    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
     expect(args).to.match(/source\s*:\s*['"]ocr['"]/);
   });
 
@@ -89,7 +93,9 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     const args = extractSafeLogErrorArgs(prodBranch);
+    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
     expect(args).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
   });
 
@@ -98,10 +104,11 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
-    // anchor 消失で prodBranch が空文字のまま to.not.match(...) が silent PASS する経路を防ぐ。
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失 (#311 review C1 対応)').to.not.equal(
-      '',
-    );
+    // anchor 消失で prodBranch が null のまま to.not.match(...) が silent PASS する経路を防ぐ。
+    expect(
+      prodBranch,
+      'prod 分岐が抽出できない — anchor 消失 (#311 review C1 対応)',
+    ).to.not.be.null;
     expect(prodBranch).to.not.match(
       /\bthrow\s+(?:new\s+)?Error\b/,
       'prod 分岐に throw が残存 — fire-and-forget 方針に違反',
@@ -111,7 +118,13 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   it('dev 経路では throw が維持されている (assert 本体 or helper 本体に throw が存在)', () => {
     const assertBody = extractAssertFunctionBody(source);
     const helperBody = extractHelperFunctionBody(source);
-    const combined = `${assertBody}\n${helperBody}`;
+    // 両方 null (anchor 消失) の場合は assertion を silent に通過させないため、少なくとも一方は
+    // 抽出できていることを先に担保する。null 連結で `"null"` 文字列が混入する false PASS 経路を防ぐ。
+    expect(
+      assertBody !== null || helperBody !== null,
+      'assert/helper の両方が抽出できない — anchor 両方消失で throw 検証が silent PASS する',
+    ).to.equal(true);
+    const combined = `${assertBody ?? ''}\n${helperBody ?? ''}`;
     expect(combined).to.match(
       /\bthrow\s+new\s+Error\b/,
       'dev throw が消滅 — 既存 #284 契約が壊れている',
@@ -122,6 +135,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   // パターンを検知するため、assert 本体からの helper 呼出を grep で lock-in。
   it('assertAggregatePageInvariant 本体から handleAggregateInvariantViolation が呼ばれる', () => {
     const assertBody = extractAssertFunctionBody(source);
+    expect(assertBody, 'assert 本体が抽出できない — anchor 消失').to.not.be.null;
     expect(assertBody).to.match(
       /\bhandleAggregateInvariantViolation\s*\(/,
       'assert 本体から helper 呼出が消失 — silent return 回帰の可能性',
@@ -135,7 +149,9 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const helperBody = extractHelperFunctionBody(source);
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
+    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     const args = extractSafeLogErrorArgs(prodBranch);
+    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
     expect(args).to.match(
       /\bdocumentId\b/,
       'safeLogError 引数に documentId が含まれない — 違反 document の特定不可',

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -71,7 +71,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     const searchScope = helperBody || assertBody;
     const prodBranch = extractProdBranch(searchScope);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    expect(prodBranch).to.match(
+    expect(prodBranch!).to.match(
       /\bsafeLogError\s*\(/,
       'prod 分岐内に safeLogError 呼出が見つからない — silent 回帰',
     );
@@ -85,7 +85,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     const args = extractSafeLogErrorArgs(prodBranch);
     expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
-    expect(args).to.match(/source\s*:\s*['"]ocr['"]/);
+    expect(args!).to.match(/source\s*:\s*['"]ocr['"]/);
   });
 
   it('prod 分岐の safeLogError 引数に functionName: "capPageResultsAggregate" が含まれる', () => {
@@ -96,7 +96,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     const args = extractSafeLogErrorArgs(prodBranch);
     expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
-    expect(args).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
+    expect(args!).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
   });
 
   it('prod 分岐内で throw が発生しない (throw 文がない)', () => {
@@ -109,7 +109,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
       prodBranch,
       'prod 分岐が抽出できない — anchor 消失 (#311 review C1 対応)',
     ).to.not.be.null;
-    expect(prodBranch).to.not.match(
+    expect(prodBranch!).to.not.match(
       /\bthrow\s+(?:new\s+)?Error\b/,
       'prod 分岐に throw が残存 — fire-and-forget 方針に違反',
     );
@@ -136,7 +136,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   it('assertAggregatePageInvariant 本体から handleAggregateInvariantViolation が呼ばれる', () => {
     const assertBody = extractAssertFunctionBody(source);
     expect(assertBody, 'assert 本体が抽出できない — anchor 消失').to.not.be.null;
-    expect(assertBody).to.match(
+    expect(assertBody!).to.match(
       /\bhandleAggregateInvariantViolation\s*\(/,
       'assert 本体から helper 呼出が消失 — silent return 回帰の可能性',
     );
@@ -152,7 +152,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     const args = extractSafeLogErrorArgs(prodBranch);
     expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
-    expect(args).to.match(
+    expect(args!).to.match(
       /\bdocumentId\b/,
       'safeLogError 引数に documentId が含まれない — 違反 document の特定不可',
     );


### PR DESCRIPTION
## Summary

Issue #312 の contract test helper API 改善のうち **PR-1 (helper API 型変更 + caller null 対応)**。alias 削除 (PR-2) は別 PR で対応。

- 戻り値 `string` → `string | null` (空文字 fallback 撤廃、silent PASS 防御)
- `startAfterAnchor: boolean` → `anchorMode: 'from-start' | 'after-match'` (boolean-blindness 解消)
- `ExtractOptions` interface → inline 型 (外部参照ゼロのため降格)
- helper 第一引数 `string | null` 許容 (chain 用途で null 透過)
- 6 caller の空文字比較を null 比較に統一
- alias wrapper の冗長な null ガードを撤廃

## Acceptance Criteria 達成状況

| # | 基準 | 判定 |
|---|------|------|
| AC1 | `extractBraceBlock(source, anchor)` が anchor 不在時に `null` を返す | ✅ PASS (extractBraceBlock.test.ts 新規ケースで検証) |
| AC2 | 全 caller が `.to.not.be.null` で失敗モード明示 | ✅ PASS (Evaluator 指摘後に textCapProdInvariantContract を追加対応) |
| AC3 | `anchorMode: 'after-match'` が旧 `startAfterAnchor: true` と同一挙動 | ✅ PASS |
| AC4 | `startAfterAnchor` 残存ゼロ | ✅ PASS (grep 結果: コメント内の移行注記 1 件のみ) |
| AC5 | alias 削除は PR-2 スコープのため本 PR では残置 | ✅ scope 外 |
| AC6 | 既存 CI + helper test 全 PASS | ✅ **580 passing** (前回 548 → +32) |
| AC7 | helper JSDoc に null 返却条件を明記 | ✅ PASS (extractParenBlock も Evaluator 指摘後に追記) |

## Evaluator 第三者評価対応履歴

rules/quality-gate.md の発動条件 (5 ファイル以上) により `evaluator` エージェントを独立コンテキストで起動。REQUEST_CHANGES 判定の指摘を全て反映:

- **AC2 FAIL**: textCapProdInvariantContract で 4 箇所のガード漏れ → prodBranch/assertBody/args に `.to.not.be.null` 追加
- **AC7 FAIL**: extractParenBlock JSDoc に caller 規約欠落 → `expect(args).to.not.be.null` 必須を追記
- **MEDIUM**: `\`${assertBody}\n${helperBody}\`` の null 文字列化リスク → 両方 null の事前 assertion + `?? ''` で防御
- **MEDIUM**: alias wrapper の null ガードスタイル不一致 → helper の null 透過を活用し直接委譲に統一

## Test plan

- [x] `npx tsc --noEmit` 通過 (functions/)
- [x] `npx tsc --noEmit -p tsconfig.test.json` 通過
- [x] `npm test` 580 passing (helper 単体 +32 ケース含む)
- [x] Evaluator REQUEST_CHANGES → 全指摘対応後に整合性再確認
- [ ] CI green 確認 (main 比較)

## 後続 PR

PR-2 (予定): Local alias 削除。`extractFunctionBody` / `extractAggregateCapBlock` / `extractHelperFunctionBody` 等の 1 行 wrapper を削除し `extractBraceBlock(source, ANCHOR)` 直接呼出に統一。機械的置換中心で Evaluator 分離は不要。

Refs #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test helper functions to return null for extraction failures instead of empty strings, improving error handling clarity.
  * Enhanced extraction utility configuration options with refined anchor-positioning control.
  * Reinforced test assertions to properly validate null extraction results across multiple test suites.

* **Refactor**
  * Improved extraction utility APIs for better null-safety and consistent failure semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->