### PR TITLE
refactor(test): contract test helper alias 削除 (#312 PR-2)

### DIFF
--- a/functions/test/aggregateCapLogErrorContract.test.ts
+++ b/functions/test/aggregateCapLogErrorContract.test.ts
@@ -25,10 +25,6 @@ const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
 const AGGREGATE_CAP_ANCHOR =
   /if\s*\(\s*afterAggregateChars\s*<\s*beforeAggregateChars\s*\)\s*\{/;
 
-// #312: helper が anchor 不在時に null を返すため、alias wrapper も string | null を透過する。
-const extractAggregateCapBlock = (source: string): string | null =>
-  extractBraceBlock(source, AGGREGATE_CAP_ANCHOR);
-
 describe('aggregate cap safeLogError contract (#283)', () => {
   before(() => {
     const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
@@ -122,7 +118,7 @@ describe('aggregate cap safeLogError contract (#283)', () => {
     );
   });
 
-  describe('extractAggregateCapBlock detection logic', () => {
+  describe('aggregate cap block 抽出ロジック (AGGREGATE_CAP_ANCHOR 検出)', () => {
     it('positive: 通常の if block を抽出する', () => {
       const fixture = `
 const before = 100;
@@ -131,7 +127,7 @@ if (afterAggregateChars < beforeAggregateChars) {
   await safeLogError({ error, source: 'ocr' });
 }
 `;
-      const block = extractAggregateCapBlock(fixture);
+      const block = extractBraceBlock(fixture, AGGREGATE_CAP_ANCHOR);
       expect(block, 'block 抽出失敗').to.not.be.null;
       expect(block!).to.include('safeLogError');
       expect(block!.startsWith('{')).to.equal(true);
@@ -144,7 +140,7 @@ if (afterAggregateChars < beforeAggregateChars) {
   try { await safeLogError({ error }); } catch (e) { console.error(e); }
 }
 `;
-      const block = extractAggregateCapBlock(fixture);
+      const block = extractBraceBlock(fixture, AGGREGATE_CAP_ANCHOR);
       expect(block, 'block 抽出失敗').to.not.be.null;
       expect(block!).to.include('try');
       expect(block!).to.include('catch');
@@ -152,7 +148,7 @@ if (afterAggregateChars < beforeAggregateChars) {
 
     it('negative: anchor 不在時は null', () => {
       const fixture = `const x = 1;`;
-      expect(extractAggregateCapBlock(fixture)).to.be.null;
+      expect(extractBraceBlock(fixture, AGGREGATE_CAP_ANCHOR)).to.be.null;
     });
 
     it('scope: block 外の safeLogError は検知対象外', () => {
@@ -163,7 +159,7 @@ if (afterAggregateChars < beforeAggregateChars) {
   console.warn('truncated');
 }
 `;
-      const block = extractAggregateCapBlock(fixture);
+      const block = extractBraceBlock(fixture, AGGREGATE_CAP_ANCHOR);
       expect(block, 'block 抽出失敗').to.not.be.null;
       expect(/\bsafeLogError\s*\(/.test(block!)).to.equal(
         false,

--- a/functions/test/aggregateCapLogErrorContract.test.ts
+++ b/functions/test/aggregateCapLogErrorContract.test.ts
@@ -118,6 +118,11 @@ describe('aggregate cap safeLogError contract (#283)', () => {
     );
   });
 
+  // #312 PR-2 B2 方針 (pr-test-analyzer S1): ANCHOR 正規表現 (AGGREGATE_CAP_ANCHOR) 自体の挙動を
+  // lock-in する目的で残置。extractBraceBlock.test.ts の helper 単体テストでは ANCHOR 変更の
+  // regression を検知できない (helper は入力にのみ依存) ため、本 describe が ANCHOR 正規表現の
+  // 変更回帰を直接捕捉する。将来 B1 (集約) への移行や削除を検討する際はこの責務を
+  // どこに移すかを明示すること。
   describe('aggregate cap block 抽出ロジック (AGGREGATE_CAP_ANCHOR 検出)', () => {
     it('positive: 通常の if block を抽出する', () => {
       const fixture = `

--- a/functions/test/handleProcessingErrorContract.test.ts
+++ b/functions/test/handleProcessingErrorContract.test.ts
@@ -14,7 +14,7 @@
  * handleProcessingError は console.error アンカーと safeLogError 呼出が数十行離れて
  * おり、summaryCatchLogErrorContract の ANCHOR_WINDOW_LINES=8 線形検知は適用不可。
  * 本テストは以下 2 段階の scope 縮約で検証する:
- *   1. 関数本体を brace-nesting で抽出 (extractFunctionBody)
+ *   1. 関数本体を brace-nesting で抽出 (extractBraceBlock + signature prefix)
  *   2. 関数本体内の safeLogError(...) 引数ブロックを paren-nesting で抽出し、
  *      そのブロック内で各 param の存在を検証
  * これにより関数本体内の無関係な同名変数/コメントへの偽陽性を回避する。
@@ -34,11 +34,6 @@ const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 // brace/paren 抽出は共通 helper (extractBraceBlock / extractParenBlock) を使用 (#302)。
 // 関数本体の抽出 = brace-nesting、safeLogError 引数の抽出 = paren-nesting で scope を絞ることで
 // 無関係な同名変数・他 logger 呼出・文字列リテラルへの偽陽性を回避する。
-// #312: helper が anchor 不在時に null を返すため、alias wrapper も string | null を透過する。
-const extractFunctionBody = (source: string, signaturePrefix: string): string | null =>
-  extractBraceBlock(source, signaturePrefix);
-const extractSafeLogErrorArgs = (functionBody: string): string | null =>
-  extractParenBlock(functionBody, SAFE_LOG_ERROR_CALL);
 
 describe('handleProcessingError safeLogError contract (#276)', () => {
   before(() => {
@@ -67,7 +62,8 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
   });
 
   it('handleProcessingError 本体内に safeLogError 呼出がある', () => {
-    const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
+    // #312 PR-2 (comment-analyzer Important 3): 以前 block 内に再宣言していた SAFE_LOG_ERROR_CALL を
+    // file-level 定数 (L32) に統一。
     expect(functionBody, 'functionBody 抽出失敗 (上位 it を確認)').to.not.be.null;
     expect(SAFE_LOG_ERROR_CALL.test(functionBody!)).to.equal(
       true,
@@ -126,7 +122,7 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
     );
   });
 
-  describe('extractFunctionBody detection logic', () => {
+  describe('関数本体抽出ロジック (extractBraceBlock + signature prefix)', () => {
     it('positive: 通常の関数本体を抽出する', () => {
       const fixture = `
 export async function foo() {
@@ -134,7 +130,7 @@ export async function foo() {
   return x;
 }
 `;
-      const body = extractFunctionBody(fixture, 'export async function foo(');
+      const body = extractBraceBlock(fixture, 'export async function foo(');
       expect(body, '関数本体が抽出できていない').to.not.be.null;
       expect(body!).to.include('const x = 1');
       expect(body!.startsWith('{')).to.equal(true);
@@ -150,7 +146,7 @@ export async function foo() {
   return 1;
 }
 `;
-      const body = extractFunctionBody(fixture, 'export async function foo(');
+      const body = extractBraceBlock(fixture, 'export async function foo(');
       expect(body, '関数本体が抽出できていない').to.not.be.null;
       expect(body!).to.include('break');
       expect(body!).to.include('return 1');
@@ -158,15 +154,15 @@ export async function foo() {
 
     it('negative: 関数宣言不在時は null', () => {
       const fixture = `const x = 1;`;
-      const body = extractFunctionBody(fixture, 'export async function foo(');
+      const body = extractBraceBlock(fixture, 'export async function foo(');
       expect(body).to.be.null;
     });
   });
 
-  describe('extractSafeLogErrorArgs detection logic', () => {
+  describe('safeLogError 引数ブロック抽出ロジック (extractParenBlock + SAFE_LOG_ERROR_CALL)', () => {
     it('positive: 単純な呼出から引数ブロックを抽出する', () => {
       const fixture = `await safeLogError({ error, source: 'ocr' });`;
-      const args = extractSafeLogErrorArgs(fixture);
+      const args = extractParenBlock(fixture, SAFE_LOG_ERROR_CALL);
       expect(args, '引数ブロックが抽出できていない').to.not.be.null;
       expect(args!.startsWith('(')).to.equal(true);
       expect(args!.endsWith(')')).to.equal(true);
@@ -175,7 +171,7 @@ export async function foo() {
 
     it('positive: 引数内の括弧 (関数呼出等) をネストカウントする', () => {
       const fixture = `safeLogError({ error: wrap(raw), source: 'ocr' });`;
-      const args = extractSafeLogErrorArgs(fixture);
+      const args = extractParenBlock(fixture, SAFE_LOG_ERROR_CALL);
       expect(args, '引数ブロックが抽出できていない').to.not.be.null;
       expect(args!).to.include('wrap(raw)');
       expect(args!.endsWith(')')).to.equal(true);
@@ -183,7 +179,7 @@ export async function foo() {
 
     it('negative: safeLogError 呼出不在時は null', () => {
       const fixture = `console.error('failed');`;
-      const args = extractSafeLogErrorArgs(fixture);
+      const args = extractParenBlock(fixture, SAFE_LOG_ERROR_CALL);
       expect(args).to.be.null;
     });
 
@@ -193,7 +189,7 @@ export async function foo() {
         `const functionName = 'fake';`,
         `safeLogError({ error, source: 'ocr', documentId: id });`,
       ].join('\n');
-      const args = extractSafeLogErrorArgs(fixture);
+      const args = extractParenBlock(fixture, SAFE_LOG_ERROR_CALL);
       expect(args, '引数ブロックが抽出できていない').to.not.be.null;
       expect(args!).to.not.include("'fake'");
       expect(/\bfunctionName\s*[,:}]/.test(args!)).to.equal(

--- a/functions/test/handleProcessingErrorContract.test.ts
+++ b/functions/test/handleProcessingErrorContract.test.ts
@@ -51,7 +51,7 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
     source,
     'export async function handleProcessingError('
   );
-  const safeLogErrorArgs = extractParenBlock(functionBody, /\bsafeLogError\s*\(/);
+  const safeLogErrorArgs = extractParenBlock(functionBody, SAFE_LOG_ERROR_CALL);
 
   it('handleProcessingError 関数本体が抽出できる', () => {
     expect(
@@ -122,6 +122,9 @@ describe('handleProcessingError safeLogError contract (#276)', () => {
     );
   });
 
+  // #312 PR-2 B2 方針 (pr-test-analyzer S1): signature prefix anchor の挙動を lock-in する目的で
+  // 残置。extractBraceBlock.test.ts の helper 単体テストでは ANCHOR (= signature string) 変更の
+  // regression を検知できないため、本 describe が直接捕捉する。positive/nested/negative を網羅。
   describe('関数本体抽出ロジック (extractBraceBlock + signature prefix)', () => {
     it('positive: 通常の関数本体を抽出する', () => {
       const fixture = `
@@ -159,6 +162,10 @@ export async function foo() {
     });
   });
 
+  // #312 PR-2 B2 方針 (pr-test-analyzer S1): SAFE_LOG_ERROR_CALL anchor の挙動を lock-in する
+  // 目的で残置。positive/nested/negative/scope で偽陽性防御 (関数本体内の無関係な functionName
+  // 変数を引数ブロック抽出で除外) を保証。helper 単体テストでは ANCHOR 変更の regression を
+  // 検知できないため本 describe が直接捕捉する。
   describe('safeLogError 引数ブロック抽出ロジック (extractParenBlock + SAFE_LOG_ERROR_CALL)', () => {
     it('positive: 単純な呼出から引数ブロックを抽出する', () => {
       const fixture = `await safeLogError({ error, source: 'ocr' });`;

--- a/functions/test/helpers/extractBraceBlock.test.ts
+++ b/functions/test/helpers/extractBraceBlock.test.ts
@@ -133,9 +133,10 @@ describe('extractBraceBlock helper', () => {
     });
   });
 
-  // #312 pr-test-analyzer C1 (Critical): null source passthrough は JSDoc で契約しているが
-  // 本 helper 単体テストでの回帰ガードが欠如していた。alias wrapper 経由の chain 入力
-  // (extractBraceBlock(extractBraceBlock(...), ...) で内側が null) が実運用で発生するため必須 lock-in。
+  // #312 pr-test-analyzer C1 (Critical) + comment-analyzer S4: null source passthrough は
+  // JSDoc で契約しているが本 helper 単体テストでの回帰ガードが欠如していた。chain 呼出
+  // (`extractBraceBlock(extractBraceBlock(...), ...)` で内側が null) が実運用で発生するため
+  // 必須 lock-in (#312 PR-2 で caller 側 alias wrapper を撤去、helper 側 null 透過に集約済)。
   describe('null source passthrough (chain 用途)', () => {
     it('extractBraceBlock(null, ...) は常に null を返す', () => {
       expect(extractBraceBlock(null, /anything/)).to.be.null;

--- a/functions/test/helpers/extractBraceBlock.test.ts
+++ b/functions/test/helpers/extractBraceBlock.test.ts
@@ -3,9 +3,9 @@
  *
  * 本 helper は 5 ファイルの contract test から依存される共通基盤。将来の改修で
  * silent regression (null 返却の意味論変化、anchorMode の挙動反転 等) を
- * 直接検知する fixture を配置する。contract test 側 (aggregateCapLogErrorContract)
- * の `extractAggregateCapBlock detection logic` describe は実コード対象のため残置、
- * 本ファイルは helper 単体の挙動のみを狭く lock-in する。
+ * 直接検知する fixture を配置する。contract test 側の detection logic describe
+ * (aggregateCapLogErrorContract 等) は実コード対象のため残置、本ファイルは helper
+ * 単体の挙動のみを狭く lock-in する。
  *
  * #312: anchor/開き文字不在は空文字ではなく `null` を返す (silent PASS 防御)。
  */
@@ -135,7 +135,7 @@ describe('extractBraceBlock helper', () => {
 
   // #312 pr-test-analyzer C1 (Critical): null source passthrough は JSDoc で契約しているが
   // 本 helper 単体テストでの回帰ガードが欠如していた。alias wrapper 経由の chain 入力
-  // (extractProdBranch(helperBody) で helperBody が null) が実運用で発生するため必須 lock-in。
+  // (extractBraceBlock(extractBraceBlock(...), ...) で内側が null) が実運用で発生するため必須 lock-in。
   describe('null source passthrough (chain 用途)', () => {
     it('extractBraceBlock(null, ...) は常に null を返す', () => {
       expect(extractBraceBlock(null, /anything/)).to.be.null;

--- a/functions/test/helpers/extractBraceBlock.ts
+++ b/functions/test/helpers/extractBraceBlock.ts
@@ -2,9 +2,10 @@
  * grep-based contract test で使う brace / paren nesting 抽出 helper
  * (Issue #302, PR #301 /simplify HIGH + codex Low 1 follow-up, Issue #312 API 改善)
  *
- * 5 ファイルで同一実装が重複していた extractFunctionBody / extractAggregateCapBlock /
- * extractAssertFunctionBody / extractHelperFunctionBody / extractProdBranch を
+ * 5 ファイルで同一実装が重複していた contract test の関数本体/ブロック抽出ロジックを
  * 共通化する。anchor (RegExp | string) と nesting 種別 (brace / paren) のみが差分。
+ * #302 で helper 化し、#312 PR-2 で caller 側の local alias wrapper (extractFunctionBody 等) を
+ * 撤去して extractBraceBlock(source, ANCHOR) 直接呼出に統一した。
  *
  * 詳細な位置づけは docs/context/test-strategy.md (#308) を参照。
  *

--- a/functions/test/textCapDrainSinkContract.test.ts
+++ b/functions/test/textCapDrainSinkContract.test.ts
@@ -23,12 +23,6 @@ const HELPER_BODY_ANCHOR =
 const PROD_BRANCH_ANCHOR =
   /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
 
-// #312: helper が anchor/null 入力を透過して null を返すため、alias wrapper は直接委譲する。
-const extractHelperFunctionBody = (source: string): string | null =>
-  extractBraceBlock(source, HELPER_BODY_ANCHOR);
-const extractProdBranch = (block: string | null): string | null =>
-  extractBraceBlock(block, PROD_BRANCH_ANCHOR);
-
 describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   let source = '';
 
@@ -66,8 +60,8 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   });
 
   it('prod 分岐内で safeLogError の戻り値が変数束縛されている (void 直叩きではない)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const prodBranch = extractProdBranch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const prodBranch = extractBraceBlock(helperBody, PROD_BRANCH_ANCHOR);
     expect(
       prodBranch,
       'handleAggregateInvariantViolation の prod 分岐が抽出できない',
@@ -81,8 +75,8 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   });
 
   it('prod 分岐内で context?.drainSink への push 呼出が存在する', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const prodBranch = extractProdBranch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const prodBranch = extractBraceBlock(helperBody, PROD_BRANCH_ANCHOR);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     expect(prodBranch!).to.match(
       /context\?\.drainSink[\s\S]*?\.push\s*\(/,
@@ -91,8 +85,8 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   });
 
   it('drainSink 未渡し時の fallback (void 形) が存在する (後方互換維持)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const prodBranch = extractProdBranch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const prodBranch = extractBraceBlock(helperBody, PROD_BRANCH_ANCHOR);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     // legacy caller (drainSink 未渡し) では intentionally fire-and-forget を維持する。
     // `void logPromise;` は完了保証ではなく「意図的に discard」を明示するマーカー。
@@ -103,8 +97,8 @@ describe('textCap drainSink contract (#297 + #293, #304 rename)', () => {
   });
 
   it('prod 分岐に直接 `void safeLogError(` 形が残っていない (regression guard)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const prodBranch = extractProdBranch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const prodBranch = extractBraceBlock(helperBody, PROD_BRANCH_ANCHOR);
     // anchor 消失で prodBranch が null のまま to.not.match(...) が silent PASS する経路を防ぐ。
     expect(
       prodBranch,

--- a/functions/test/textCapErrorLoggerFallbackContract.test.ts
+++ b/functions/test/textCapErrorLoggerFallbackContract.test.ts
@@ -35,12 +35,6 @@ const HELPER_BODY_ANCHOR =
   /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
 const LOADERR_CATCH_ANCHOR = /catch\s*\(\s*loadErr\s*\)\s*/;
 
-// #312: helper が anchor/null 入力を透過して null を返すため、alias wrapper は直接委譲する。
-const extractHelperFunctionBody = (source: string): string | null =>
-  extractBraceBlock(source, HELPER_BODY_ANCHOR);
-const extractLoadErrCatch = (block: string | null): string | null =>
-  extractBraceBlock(block, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
-
 describe('textCap errorLogger require failure fallback contract (#303 + #319 review)', () => {
   let source = '';
 
@@ -51,15 +45,15 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('handleAggregateInvariantViolation の catch (loadErr) ブロックが抽出できる (anchor 保護)', () => {
-    const helperBody = extractHelperFunctionBody(source);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     expect(helperBody, 'handleAggregateInvariantViolation 関数本体が抽出できない').to.not.be.null;
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない — anchor 消失').to.not.be.null;
   });
 
   it('loader 失敗時の先行 console.error が保持される (AC-11, rules/error-handling.md §1)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // Cloud Logging alert grep 契約: `[textCap] failed to load errorLogger` prefix を lock-in。
     // prefix drift (例: 英語化、モジュール名変更) は operational alert を壊すため regression 検知。
@@ -70,8 +64,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('catch (loadErr) 内で admin.firestore() が呼ばれている (fallback 書込経路)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     expect(catchBlock!).to.match(
       /admin\.firestore\s*\(\s*\)/,
@@ -80,8 +74,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('catch (loadErr) 内で errors collection への add 呼出がある (errors 書込先)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     expect(catchBlock!).to.match(
       /\.collection\s*\(\s*['"]errors['"]\s*\)/,
@@ -94,8 +88,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('write reject 時の .catch handler で console.error により失敗を surface (#319 review C1)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // `.catch(() => {})` による完全 silent swallow (PERMISSION_DENIED / RESOURCE_EXHAUSTED /
     // UNAVAILABLE / INVALID_ARGUMENT 等の operational signal が消失する regression) を防ぐ。
@@ -120,8 +114,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('外側 catch(fallbackSetupErr) で setup 失敗も console.error で surface (#319 review I1)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // 外側 try/catch: `try { admin.firestore()... } catch (fallbackSetupErr) { ... }`。
     // bare `catch {}` による silent swallow regression を防ぐ (require('firebase-admin') /
@@ -144,8 +138,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('fallback record に triage 必須 field が含まれる (#319 review I2: schema lock-in)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // errors collection triage dashboard が集計に使う key field を lock-in。
     expect(catchBlock!).to.match(/status\s*:\s*['"]pending['"]/, 'status: pending 欠落 — triage queue invisible');
@@ -164,8 +158,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('loaderError が構造化され String(loadErr) 直接代入されていない (#319 review I3)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // String(loadErr) 直接代入は Error 以外の throw で `[object Object]` になる silent 情報欠損、
     // FirebaseAppError.code 等の triage 重要フィールド drop の原因となる。
@@ -181,8 +175,8 @@ describe('textCap errorLogger require failure fallback contract (#303 + #319 rev
   });
 
   it('fallback write Promise が drainSink に push される (#319 review I2: 対称化)', () => {
-    const helperBody = extractHelperFunctionBody(source);
-    const catchBlock = extractLoadErrCatch(helperBody);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const catchBlock = extractBraceBlock(helperBody, LOADERR_CATCH_ANCHOR, { anchorMode: 'after-match' });
     expect(catchBlock, 'catch (loadErr) ブロックが抽出できない').to.not.be.null;
     // 主経路 (safeLogError) と対称に fallback も drainSink に push して drain 保証。
     // fire-and-forget 非対称性 (Cloud Functions freeze 時の partial delivery) に回帰しないよう lock-in。

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -28,16 +28,6 @@ const PROD_BRANCH_ANCHOR =
   /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
 const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 
-// #312: helper が anchor/null 入力を透過して null を返すため、alias wrapper は直接委譲する。
-const extractAssertFunctionBody = (source: string): string | null =>
-  extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-const extractHelperFunctionBody = (source: string): string | null =>
-  extractBraceBlock(source, HELPER_BODY_ANCHOR);
-const extractProdBranch = (block: string | null): string | null =>
-  extractBraceBlock(block, PROD_BRANCH_ANCHOR);
-const extractSafeLogErrorArgs = (block: string | null): string | null =>
-  extractParenBlock(block, SAFE_LOG_ERROR_CALL);
-
 describe('textCap prod invariant observability contract (#288 item 6)', () => {
   let source = '';
 
@@ -48,17 +38,17 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   });
 
   it('assertAggregatePageInvariant 関数定義が存在する (anchor 保護)', () => {
-    const body = extractAssertFunctionBody(source);
+    const body = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
     expect(body, 'assertAggregatePageInvariant 関数の anchor が消失 — リネームなら本契約更新').to
       .not.be.null;
   });
 
   it('prod 分岐 (process.env.NODE_ENV === "production") が存在する', () => {
     // helper 分離の場合は helper 本体、未分離なら assert 本体を探索。
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     const searchScope = helperBody || assertBody;
-    const prodBranch = extractProdBranch(searchScope);
+    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     expect(
       prodBranch,
       'prod 分岐が検出されない — silent return に回帰している可能性',
@@ -66,10 +56,10 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   });
 
   it('prod 分岐内に safeLogError 呼出が存在する', () => {
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     const searchScope = helperBody || assertBody;
-    const prodBranch = extractProdBranch(searchScope);
+    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
     expect(prodBranch!).to.match(
       /\bsafeLogError\s*\(/,
@@ -78,32 +68,32 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   });
 
   it('prod 分岐の safeLogError 引数に source: "ocr" が含まれる', () => {
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     const searchScope = helperBody || assertBody;
-    const prodBranch = extractProdBranch(searchScope);
+    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    const args = extractSafeLogErrorArgs(prodBranch);
+    const args = extractParenBlock(prodBranch, SAFE_LOG_ERROR_CALL);
     expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
     expect(args!).to.match(/source\s*:\s*['"]ocr['"]/);
   });
 
   it('prod 分岐の safeLogError 引数に functionName: "capPageResultsAggregate" が含まれる', () => {
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     const searchScope = helperBody || assertBody;
-    const prodBranch = extractProdBranch(searchScope);
+    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    const args = extractSafeLogErrorArgs(prodBranch);
+    const args = extractParenBlock(prodBranch, SAFE_LOG_ERROR_CALL);
     expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
     expect(args!).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
   });
 
   it('prod 分岐内で throw が発生しない (throw 文がない)', () => {
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     const searchScope = helperBody || assertBody;
-    const prodBranch = extractProdBranch(searchScope);
+    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     // anchor 消失で prodBranch が null のまま to.not.match(...) が silent PASS する経路を防ぐ。
     expect(
       prodBranch,
@@ -116,8 +106,8 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   });
 
   it('dev 経路では throw が維持されている (assert 本体 or helper 本体に throw が存在)', () => {
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     // 両方 null (anchor 消失) の場合は assertion を silent に通過させないため、少なくとも一方は
     // 抽出できていることを先に担保する。null 連結で `"null"` 文字列が混入する false PASS 経路を防ぐ。
     expect(
@@ -134,7 +124,7 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   // Codex second opinion (MED): helper が残ったまま assert が silent return に回帰する
   // パターンを検知するため、assert 本体からの helper 呼出を grep で lock-in。
   it('assertAggregatePageInvariant 本体から handleAggregateInvariantViolation が呼ばれる', () => {
-    const assertBody = extractAssertFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
     expect(assertBody, 'assert 本体が抽出できない — anchor 消失').to.not.be.null;
     expect(assertBody!).to.match(
       /\bhandleAggregateInvariantViolation\s*\(/,
@@ -145,12 +135,12 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   // silent-failure-hunter S2 + Codex MED: errors collection triage のため documentId 伝搬を
   // lock-in。context?.documentId または documentId キー自体の存在を検証する。
   it('prod 分岐の safeLogError 引数に documentId が含まれる (triage 伝搬)', () => {
-    const assertBody = extractAssertFunctionBody(source);
-    const helperBody = extractHelperFunctionBody(source);
+    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     const searchScope = helperBody || assertBody;
-    const prodBranch = extractProdBranch(searchScope);
+    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    const args = extractSafeLogErrorArgs(prodBranch);
+    const args = extractParenBlock(prodBranch, SAFE_LOG_ERROR_CALL);
     expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
     expect(args!).to.match(
       /\bdocumentId\b/,


### PR DESCRIPTION
## Summary

Issue #312 の contract test helper API 改善のうち **PR-2 (alias 削除、機械的置換)**。PR-1 (#323) の helper API 型安全化後の仕上げ。

- 6 caller の local alias wrapper (11 個) を削除
- `extractBraceBlock(source, ANCHOR)` / `extractParenBlock(source, ANCHOR)` 直接呼出に統一
- detection logic describe (aggregateCapLogErrorContract 等) は実コード対象のため**残置** (#312 提案4 B2 方針)、describe タイトルのみアンカー名明示形式に変更
- `handleProcessingErrorContract.test.ts:70` の `SAFE_LOG_ERROR_CALL` block 内再宣言を file-level 定数に統一 (PR-1 review comment-analyzer Important 3 対応)

## 変更対象 (7 files)

| File | 削除 alias | 備考 |
|------|-----------|------|
| aggregateCapLogErrorContract.test.ts | extractAggregateCapBlock | 1 alias |
| handleProcessingErrorContract.test.ts | extractFunctionBody / extractSafeLogErrorArgs | 2 alias + shadow 解消 |
| textCapProdInvariantContract.test.ts | extractAssertFunctionBody / extractHelperFunctionBody / extractProdBranch / extractSafeLogErrorArgs | 4 alias (最大) |
| textCapErrorLoggerFallbackContract.test.ts | extractHelperFunctionBody / extractLoadErrCatch | 2 alias |
| textCapDrainSinkContract.test.ts | extractHelperFunctionBody / extractProdBranch | 2 alias |
| extractBraceBlock.ts (JSDoc) | - | 旧 alias 名参照を整理 |
| extractBraceBlock.test.ts (コメント) | - | 旧 alias 名参照を整理 |

## 効果

- 1 caller あたり 4-11 行削減 (合計 -104 insertions / +75、net **-29 行**)
- 「これは wrapper か直接呼出か」を読む側で迷わない (#302 helper 化の意図を直接的に表す)
- 新しい caller 追加時に alias を立てる誘惑を構造的に排除

## Acceptance Criteria 達成状況 (#312 全体)

| # | 基準 | PR-1 | PR-2 |
|---|------|------|------|
| AC1-AC4 | API 型変更 + null 対応 | ✅ | — |
| AC5 | Local alias 撤去、`extractBraceBlock(source, ANCHOR)` 直接呼出に統一 | scope 外 | ✅ **PASS** |
| AC6 | CI 548 件 + helper test 全 PASS | ✅ 580 | ✅ 590 (PR-1 polish +6 + /g reject +4 を含む) |
| AC7 | JSDoc に null 返却条件明記 | ✅ | — |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.test.json` EXIT 0
- [x] `npm test` 590 passing (PR-1 と同数、機械的置換のためケース変化なし)
- [x] grep で alias 残存ゼロ確認 (`extractFunctionBody` 等)
- [ ] CI green 確認 (main 比較)

## 補足

PR #323 (PR-1) と同じ helper (extractBraceBlock.ts) を参照しており、**PR #323 merge 後** に本 PR を作成しています。PR-1 で指摘されたレビュー事項 (`SAFE_LOG_ERROR_CALL` shadow) も本 PR で併せて解消。

Refs #312, related to #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated test utility helpers and eliminated code duplication across multiple test files.
  * Standardized extraction helper functions with improved parameter handling and null-safety for better reliability.
  * Simplified test code by removing intermediate wrapper layers and using direct helper calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->