### PR TITLE
docs(test): test-strategy.md の silent PASS 説明を null 返却ベースに更新 (#324)

### DIFF
--- a/docs/context/test-strategy.md
+++ b/docs/context/test-strategy.md
@@ -31,9 +31,11 @@
 
 **偽陽性対策**: 関数本体全体を対象にした regex だと無関係な同名ローカル変数 / 他 logger 呼出 / 文字列リテラルに偽陽性が出る ([silent-failure-hunter 指摘])。`extractBraceBlock` で scope を絞る + anchor を narrow することで精度を上げる。
 
-**silent PASS リスク**: helper が空文字を返した場合 `expect(block).to.not.match(...)` は常に PASS する。各 `it` で `expect(block).to.not.equal('')` の non-empty guard を先に実行すること ([PR #311 review C1/C2])。
+**silent PASS リスク**: helper が `null` を返した場合 `expect(block).to.not.match(...)` は chai で常に silent PASS する。各 `it` で `expect(block).to.not.be.null` の null guard を先に実行すること ([PR #311 review C1/C2], [PR #312 silent-failure-hunter I1])。
 
-> **適用範囲**: 本警告は `extractBraceBlock` / `extractParenBlock` で事前抽出したブロックを `.to.not.match(...)` で検証する **brace-extracted block tests** のみに該当する (例: `textCapProdInvariantContract` / `textCapDrainSinkContract` / `textCapErrorLoggerFallbackContract` / `aggregateCapLogErrorContract` / `handleProcessingErrorContract` / `ocrProcessorAggregateCallerContract`)。以下 3 パターンは抽出結果の空文字返却という失敗モードを構造的に持たず免疫である:
+> **API 履歴**: 旧 API (PR #311 時点) は helper が失敗時に空文字 `''` を返しており、caller は `.to.not.equal('')` で guard していた。PR #312 で戻り値を `string | null` に型安全化、ガードは `.to.not.be.null` に移行。[旧 `.to.not.equal('')` パターンは撤去済](https://github.com/yasushi-honda/doc-split/pull/323)、新規 contract test 追加時は `null` ベースを採用すること。
+
+> **適用範囲**: 本警告は `extractBraceBlock` / `extractParenBlock` で事前抽出したブロックを `.to.not.match(...)` で検証する **brace-extracted block tests** のみに該当する (例: `textCapProdInvariantContract` / `textCapDrainSinkContract` / `textCapErrorLoggerFallbackContract` / `aggregateCapLogErrorContract` / `handleProcessingErrorContract` / `ocrProcessorAggregateCallerContract`)。以下 3 パターンは抽出結果の `null` 返却という失敗モードを構造的に持たず免疫である:
 > - **anchor-window スライド**: ソース全文を anchor 周辺 ±N 行のウィンドウでスキャン (`summaryCatchLogErrorContract` の `ANCHOR_WINDOW_LINES=8`)
 > - **adjacency window スライド**: ソース全文を複数 pattern 共存判定のウィンドウでスキャン (`summaryWritePayloadContract` の `ADJACENCY_WINDOW_LINES=30`)
 > - **count-based match**: ソース全文 (コメント除外後) に対する `countMatches >= 1` 形式 (`summaryBuilderCallerContract`、`.at.least(1)` assertion で空マッチが即 FAIL)

--- a/docs/context/test-strategy.md
+++ b/docs/context/test-strategy.md
@@ -31,9 +31,9 @@
 
 **偽陽性対策**: 関数本体全体を対象にした regex だと無関係な同名ローカル変数 / 他 logger 呼出 / 文字列リテラルに偽陽性が出る ([silent-failure-hunter 指摘])。`extractBraceBlock` で scope を絞る + anchor を narrow することで精度を上げる。
 
-**silent PASS リスク**: helper が `null` を返した場合 `expect(block).to.not.match(...)` は chai で常に silent PASS する。各 `it` で `expect(block).to.not.be.null` の null guard を先に実行すること ([PR #311 review C1/C2], [PR #312 silent-failure-hunter I1])。
+**silent PASS リスク**: helper が `null` を返した場合 `expect(block).to.not.match(...)` は chai で常に silent PASS する。各 `it` で `expect(block).to.not.be.null` の null guard を先に実行すること ([PR #311 review C1/C2], [Issue #312 silent-failure-hunter I1])。
 
-> **API 履歴**: 旧 API (PR #311 時点) は helper が失敗時に空文字 `''` を返しており、caller は `.to.not.equal('')` で guard していた。PR #312 で戻り値を `string | null` に型安全化、ガードは `.to.not.be.null` に移行。[旧 `.to.not.equal('')` パターンは撤去済](https://github.com/yasushi-honda/doc-split/pull/323)、新規 contract test 追加時は `null` ベースを採用すること。
+> **API 履歴**: 旧 API (PR #311 時点) は helper が失敗時に空文字 `''` を返しており、caller は `.to.not.equal('')` で guard していた。PR #323 (Issue #312) で戻り値を `string | null` に型安全化、ガードは `.to.not.be.null` に移行。[旧 `.to.not.equal('')` パターンは撤去済](https://github.com/yasushi-honda/doc-split/pull/323)、新規 contract test 追加時は `null` ベースを採用すること。
 
 > **適用範囲**: 本警告は `extractBraceBlock` / `extractParenBlock` で事前抽出したブロックを `.to.not.match(...)` で検証する **brace-extracted block tests** のみに該当する (例: `textCapProdInvariantContract` / `textCapDrainSinkContract` / `textCapErrorLoggerFallbackContract` / `aggregateCapLogErrorContract` / `handleProcessingErrorContract` / `ocrProcessorAggregateCallerContract`)。以下 3 パターンは抽出結果の `null` 返却という失敗モードを構造的に持たず免疫である:
 > - **anchor-window スライド**: ソース全文を anchor 周辺 ±N 行のウィンドウでスキャン (`summaryCatchLogErrorContract` の `ANCHOR_WINDOW_LINES=8`)


### PR DESCRIPTION
## Summary

Issue #324 の follow-up。PR #312 で extractBraceBlock / extractParenBlock の戻り値を `string` → `string | null` に型安全化した際、`docs/context/test-strategy.md §2.1` の silent PASS 防御の説明が**旧 API 前提** (空文字返却、`.to.not.equal('')` guard) のまま残存していた。

## 変更

- `silent PASS リスク` の説明を `null` 返却ベースに書き換え (`expect(block).to.not.be.null`)
- 旧 API の history note を追加 (#311 時点の空文字返却 → #312 で null 化への経緯)
  + PR #323 link で移行済を明示
- 適用範囲の説明文中「空文字返却」→「null 返却」へ追従

## 背景

PR #323 (#312) の 6-agent review で comment-analyzer が Important として指摘:
> `test-strategy.md §2.1` の silent PASS リスク説明が空文字返却前提のまま。本ドキュメントは #308 で test-strategy 集約の起点として位置づけられており、新規 contract test 追加時に旧パターンがコピーされる導線リスクあり。

PR #312 PR-1 (#323) はスコープ内で対応せず follow-up Issue として #324 起票、本 PR で解消。

## Acceptance Criteria

- [x] `grep -n 'to.not.equal' docs/context/test-strategy.md` は API 履歴記述の 1 件のみ (旧パターンを意図的に残記録)
- [x] 新しい contract test を書く開発者が参照して正しい null-based パターンを採用できる
- [x] `extractBraceBlock.ts` JSDoc の caller 規約 (`expect(block).to.not.be.null`) と整合

## Test plan

- [x] ドキュメントのみの変更 → コード動作影響なし
- [x] Markdown 表示確認 (GitHub 上の PR diff view)
- [ ] CI green 確認 (markdown 構文チェックがあれば)

## 関連

- Closes #324
- PR #312 PR-1: #323 (merged)
- PR #312 PR-2: #325 (in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)