### PR TITLE
refactor(test): SAFE_LOG_ERROR_CALL 集約 + before() キャッシュ化 (Closes #313)

### DIFF
--- a/functions/test/aggregateCapLogErrorContract.test.ts
+++ b/functions/test/aggregateCapLogErrorContract.test.ts
@@ -20,6 +20,7 @@ import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { extractBraceBlock, extractParenBlock } from './helpers/extractBraceBlock';
+import { SAFE_LOG_ERROR_CALL } from './helpers/patterns';
 
 const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
 const AGGREGATE_CAP_ANCHOR =
@@ -38,7 +39,7 @@ describe('aggregate cap safeLogError contract (#283)', () => {
   const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
   const source = readFileSync(absPath, 'utf-8');
   const capBlock = extractBraceBlock(source, AGGREGATE_CAP_ANCHOR);
-  const safeLogErrorArgs = extractParenBlock(capBlock, /\bsafeLogError\s*\(/);
+  const safeLogErrorArgs = extractParenBlock(capBlock, SAFE_LOG_ERROR_CALL);
 
   it('aggregate cap block が抽出できる', () => {
     expect(
@@ -49,7 +50,6 @@ describe('aggregate cap safeLogError contract (#283)', () => {
   });
 
   it('aggregate cap block 内に safeLogError 呼出がある', () => {
-    const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
     expect(capBlock, 'capBlock 抽出失敗 (上位 it を確認)').to.not.be.null;
     expect(SAFE_LOG_ERROR_CALL.test(capBlock!)).to.equal(
       true,
@@ -166,7 +166,7 @@ if (afterAggregateChars < beforeAggregateChars) {
 `;
       const block = extractBraceBlock(fixture, AGGREGATE_CAP_ANCHOR);
       expect(block, 'block 抽出失敗').to.not.be.null;
-      expect(/\bsafeLogError\s*\(/.test(block!)).to.equal(
+      expect(SAFE_LOG_ERROR_CALL.test(block!)).to.equal(
         false,
         'block 外の safeLogError 呼出が block 抽出結果に含まれてはならない'
       );

--- a/functions/test/handleProcessingErrorContract.test.ts
+++ b/functions/test/handleProcessingErrorContract.test.ts
@@ -27,9 +27,9 @@ import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { extractBraceBlock, extractParenBlock } from './helpers/extractBraceBlock';
+import { SAFE_LOG_ERROR_CALL } from './helpers/patterns';
 
 const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
-const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 
 // brace/paren 抽出は共通 helper (extractBraceBlock / extractParenBlock) を使用 (#302)。
 // 関数本体の抽出 = brace-nesting、safeLogError 引数の抽出 = paren-nesting で scope を絞ることで

--- a/functions/test/helpers/patterns.test.ts
+++ b/functions/test/helpers/patterns.test.ts
@@ -1,0 +1,89 @@
+/**
+ * helpers/patterns.ts の regex 定数挙動 lock-in テスト (Issue #313 Q4)
+ *
+ * 目的: SAFE_LOG_ERROR_CALL 等の anchor 正規表現が意図通りに match/non-match することを
+ * 単体で保証する。集約により caller の安全性が regex 定義に集中依存するため、
+ * 定数自体の挙動回帰を静的に防ぐ。
+ *
+ * 方針: positive / negative / boundary の 3 軸で網羅。`\b` word boundary の
+ * 偽陽性防御挙動 (`xxxSafeLogError(` / `SafeLogErrorWrapper(` を除外) を明示 lock-in。
+ */
+
+import { expect } from 'chai';
+import { SAFE_LOG_ERROR_CALL } from './patterns';
+
+describe('helpers/patterns SAFE_LOG_ERROR_CALL', () => {
+  describe('positive: 正当な safeLogError 呼出を match', () => {
+    it('単純呼出 `safeLogError(` を match', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('safeLogError(')).to.equal(true);
+    });
+
+    it('await 付き `await safeLogError(` を match', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('await safeLogError(')).to.equal(true);
+    });
+
+    it('スペース入り `safeLogError (` を match (\\s* 許容)', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('safeLogError (')).to.equal(true);
+    });
+
+    it('行頭 indent 後の呼出を match', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('    safeLogError(')).to.equal(true);
+    });
+
+    it('オブジェクトリテラル引数付きの呼出を match', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('safeLogError({ error, source: "ocr" })')).to.equal(true);
+    });
+  });
+
+  describe('negative: 類似名 / 無関係文字列を非 match (\\b 偽陽性防御)', () => {
+    it('prefix 付き `xxxSafeLogError(` を非 match (word boundary)', () => {
+      // `\b` の直前が word char (x) の場合、`\b` は非境界で match しない。
+      expect(SAFE_LOG_ERROR_CALL.test('xxxSafeLogError(')).to.equal(false);
+    });
+
+    it('類似名 `SafeLogErrorWrapper(` を非 match', () => {
+      // 大文字始まりは `safeLogError` と literal が一致しないため non-match。
+      // `s` と `S` で大小文字が食い違う検知も lock-in。
+      expect(SAFE_LOG_ERROR_CALL.test('SafeLogErrorWrapper(')).to.equal(false);
+    });
+
+    it('中間含有名 `isSafeLogError(` を非 match (word 中間の `\\b` 偽陽性防御)', () => {
+      // `isSafeLogError` は `is` + `SafeLogError` のキャメル結合。literal `safeLogError` (s 小文字)
+      // が文字列中に現れず non-match。大文字 `SafeLogError` への match を許すと、helper 名と
+      // 判定関数名 (`isSafeLogError` 等) が混同される silent 誤検知リスクがある。
+      expect(SAFE_LOG_ERROR_CALL.test('isSafeLogError(')).to.equal(false);
+    });
+
+    it('`logError(` (safe なし) を非 match', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('logError(')).to.equal(false);
+    });
+
+    it('文字列リテラル内のみで `(` が欠落している場合は非 match', () => {
+      // `\s*\(` で `(` 必須のため、呼出 syntax を持たない参照は非 match。
+      expect(SAFE_LOG_ERROR_CALL.test("const fn = 'safeLogError';")).to.equal(false);
+    });
+
+    it('空文字列を非 match', () => {
+      expect(SAFE_LOG_ERROR_CALL.test('')).to.equal(false);
+    });
+  });
+
+  describe('boundary: 挙動契約 lock-in', () => {
+    it('global flag (/g) を持たない (exec 状態保持による silent drift 防止)', () => {
+      // `match(/foo/g)` は match.index を undefined にする silent PASS 経路を持つ
+      // (session23 CodeRabbit 指摘)。SAFE_LOG_ERROR_CALL は /g を持たない契約。
+      expect(SAFE_LOG_ERROR_CALL.global).to.equal(false);
+    });
+
+    it('case sensitive (/i flag を持たない)', () => {
+      // `safelogerror` 等の大小文字違いは別 identifier として non-match であるべき。
+      expect(SAFE_LOG_ERROR_CALL.ignoreCase).to.equal(false);
+      expect(SAFE_LOG_ERROR_CALL.test('safelogerror(')).to.equal(false);
+      expect(SAFE_LOG_ERROR_CALL.test('SAFELOGERROR(')).to.equal(false);
+    });
+
+    it('multiline flag (/m) を持たない (単一行検知前提)', () => {
+      expect(SAFE_LOG_ERROR_CALL.multiline).to.equal(false);
+    });
+  });
+});

--- a/functions/test/helpers/patterns.test.ts
+++ b/functions/test/helpers/patterns.test.ts
@@ -41,17 +41,25 @@ describe('helpers/patterns SAFE_LOG_ERROR_CALL', () => {
       expect(SAFE_LOG_ERROR_CALL.test('xxxSafeLogError(')).to.equal(false);
     });
 
-    it('類似名 `SafeLogErrorWrapper(` を非 match', () => {
-      // 大文字始まりは `safeLogError` と literal が一致しないため non-match。
-      // `s` と `S` で大小文字が食い違う検知も lock-in。
+    it('類似名 `SafeLogErrorWrapper(` を非 match (literal 不一致)', () => {
+      // 大文字始まりは literal `safeLogError` (s 小文字) と一致しないため non-match。
+      // 本ケースは literal 差による非 match 軸で、`/i` flag 不保持の挙動契約は boundary
+      // セクションで別途 lock-in する (axis 分離)。
       expect(SAFE_LOG_ERROR_CALL.test('SafeLogErrorWrapper(')).to.equal(false);
     });
 
-    it('中間含有名 `isSafeLogError(` を非 match (word 中間の `\\b` 偽陽性防御)', () => {
+    it('中間含有名 `isSafeLogError(` を非 match (literal 不一致)', () => {
       // `isSafeLogError` は `is` + `SafeLogError` のキャメル結合。literal `safeLogError` (s 小文字)
       // が文字列中に現れず non-match。大文字 `SafeLogError` への match を許すと、helper 名と
       // 判定関数名 (`isSafeLogError` 等) が混同される silent 誤検知リスクがある。
       expect(SAFE_LOG_ERROR_CALL.test('isSafeLogError(')).to.equal(false);
+    });
+
+    it('suffix 付き `safeLogErrorAsync(` を非 match (`\\s*\\(` 境界防御)', () => {
+      // `\b` は `safeLogError` の `r` と `A` の間で境界成立 (word char 連続中でも大小境界は非境界、
+      // ただし後続の `\s*\(` が `A` に到達できず失敗) → non-match。suffix 差分による類似名の
+      // 検知漏れ/誤検知を lock-in する (pr-test-analyzer S1 対応)。
+      expect(SAFE_LOG_ERROR_CALL.test('safeLogErrorAsync(')).to.equal(false);
     });
 
     it('`logError(` (safe なし) を非 match', () => {
@@ -84,6 +92,21 @@ describe('helpers/patterns SAFE_LOG_ERROR_CALL', () => {
 
     it('multiline flag (/m) を持たない (単一行検知前提)', () => {
       expect(SAFE_LOG_ERROR_CALL.multiline).to.equal(false);
+    });
+
+    it('sticky flag (/y) を持たない (lastIndex 進行による silent PASS 防止)', () => {
+      // `/y` は `/g` と同様に `lastIndex` を進行させる。`test()` 連続呼出で位置が進み、
+      // 2 回目以降の呼出が silent に non-match になる経路を作る。
+      expect(SAFE_LOG_ERROR_CALL.sticky).to.equal(false);
+    });
+
+    it('idempotency: 同一インスタンスを連続 test() 実行しても結果が変わらない', () => {
+      // `/g` や `/y` が誤付与されると、`lastIndex` 進行で 2 回目の test() が silent に false を
+      // 返す drift 経路が発生する。現契約 (flag 不保持) では同一入力に対して test() は冪等。
+      const input = 'await safeLogError({ error });';
+      expect(SAFE_LOG_ERROR_CALL.test(input)).to.equal(true);
+      expect(SAFE_LOG_ERROR_CALL.test(input)).to.equal(true);
+      expect(SAFE_LOG_ERROR_CALL.test(input)).to.equal(true);
     });
   });
 });

--- a/functions/test/helpers/patterns.ts
+++ b/functions/test/helpers/patterns.ts
@@ -18,8 +18,11 @@
 /**
  * safeLogError 呼出の anchor。
  *
- * - `\b` で word boundary を取り、`functionName: 'xxxSafeLogError'` 等の偽陽性を避ける。
+ * - `\b` で word boundary を取り、識別子 prefix を持つ `xxxSafeLogError(` 等の偽陽性を避ける。
  * - `\s*` で `safeLogError (` / `safeLogError(` の両方を許容。
+ * - flag 不保持 (`/g` / `/i` / `/m` / `/y` なし) は `patterns.test.ts` で契約化済。
+ *   `/g` や `/y` が誤って付与されると `test()` / `match()` の `lastIndex` 進行で silent PASS
+ *   経路を作るため、必ず flag 追加前にテストを更新すること。
  * - 引数側は `extractParenBlock(..., SAFE_LOG_ERROR_CALL)` のような paren-nesting helper と
  *   組み合わせて scope を絞ること。
  */

--- a/functions/test/helpers/patterns.ts
+++ b/functions/test/helpers/patterns.ts
@@ -1,0 +1,26 @@
+/**
+ * 契約テスト共通 regex パターン定数 (Issue #313 Q4)
+ *
+ * 目的: 複数の契約テストで重複していた `/\bsafeLogError\s*\(/` 等の inline 定義を
+ * 一元化し、anchor 表記の食い違いによる silent drift を防ぐ。
+ *
+ * 依存方針: 他の helper (extractBraceBlock 等) に依存させず、純粋な RegExp 定数のみを
+ * export する。循環依存リスクを避け、他 helper 側がパターン定数を取り込むのが自然になる。
+ *
+ * 関連:
+ * - Issue #313 Q4 + E2 (PR #311 follow-up)
+ * - session23 PR #325 (PR-2): `SAFE_LOG_ERROR_CALL` を handleProcessingErrorContract L32 /
+ *   textCapProdInvariantContract L29 の top-level に昇格する先行対応を実施済。
+ *   本 helper は 4 caller (上記 2 + summaryCatchLogErrorContract + aggregateCapLogErrorContract)
+ *   の import 先を一本化する。
+ */
+
+/**
+ * safeLogError 呼出の anchor。
+ *
+ * - `\b` で word boundary を取り、`functionName: 'xxxSafeLogError'` 等の偽陽性を避ける。
+ * - `\s*` で `safeLogError (` / `safeLogError(` の両方を許容。
+ * - 引数側は `extractParenBlock(..., SAFE_LOG_ERROR_CALL)` のような paren-nesting helper と
+ *   組み合わせて scope を絞ること。
+ */
+export const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -19,6 +19,7 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { SAFE_LOG_ERROR_CALL } from './helpers/patterns';
 
 /**
  * summary 生成失敗 catch 句のアンカー定義。
@@ -147,7 +148,6 @@ describe('summary catch logError contract (#266)', () => {
     it('ocrProcessor.ts の safeLogError 呼出に source: \'ocr\' が含まれる', () => {
       // safeLogError( ... source: 'ocr' ... ) の近接パターン検証
       // ANCHOR_WINDOW_LINES=8 内で両要素が共存することを確認
-      const SAFE_LOG_ERROR_CALL = /safeLogError\s*\(/;
       const SOURCE_OCR = /source:\s*['"]ocr['"]/;
       const lines = ocrProcessorSource.split('\n');
       const safeLogLines = lines
@@ -171,7 +171,6 @@ describe('summary catch logError contract (#266)', () => {
     });
 
     it('regenerateSummary.ts の safeLogError 呼出に functionName: \'regenerateSummary\' が含まれる', () => {
-      const SAFE_LOG_ERROR_CALL = /safeLogError\s*\(/;
       const FUNCTION_NAME_REGENERATE = /functionName:\s*['"]regenerateSummary['"]/;
       const lines = regenerateSummarySource.split('\n');
       const safeLogLines = lines
@@ -195,7 +194,6 @@ describe('summary catch logError contract (#266)', () => {
     });
 
     it('ocrProcessor.ts の safeLogError 呼出で documentId が渡されている', () => {
-      const SAFE_LOG_ERROR_CALL = /safeLogError\s*\(/;
       const DOCUMENT_ID_PARAM = /documentId:/;
       const lines = ocrProcessorSource.split('\n');
       const safeLogLines = lines

--- a/functions/test/textCapProdInvariantContract.test.ts
+++ b/functions/test/textCapProdInvariantContract.test.ts
@@ -11,12 +11,19 @@
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。prod 分岐内の safeLogError 呼出と
  * params (source: 'ocr', functionName: 'capPageResultsAggregate') の存在を静的検証する。
  * 将来委譲: Phase 3 (#288 item 1) で動的 safeLogError invocation test と二段で lock-in 予定。
+ *
+ * キャッシュ方針:
+ * before() で assertBody / helperBody / prodBranch / safeLogErrorArgs を 1 回ずつ抽出し、
+ * 各 it は cached 値を参照する。null passthrough は extractBraceBlock / extractParenBlock が
+ * `null` 入力を素通しするため、各 it では必要に応じて `expect(cached).to.not.be.null` を
+ * 先行し silent PASS を構造防御する (caller 規約 JSDoc 準拠)。
  */
 
 import { expect } from 'chai';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { extractBraceBlock, extractParenBlock } from './helpers/extractBraceBlock';
+import { SAFE_LOG_ERROR_CALL } from './helpers/patterns';
 
 const TEXT_CAP_PATH = 'src/utils/textCap.ts';
 
@@ -26,95 +33,78 @@ const HELPER_BODY_ANCHOR =
   /function\s+handleAggregateInvariantViolation\s*\([^)]*\)\s*:\s*void\s*\{/;
 const PROD_BRANCH_ANCHOR =
   /if\s*\(\s*process\.env\.NODE_ENV\s*===\s*['"]production['"]\s*\)\s*\{/;
-const SAFE_LOG_ERROR_CALL = /\bsafeLogError\s*\(/;
 
 describe('textCap prod invariant observability contract (#288 item 6)', () => {
-  let source = '';
+  let cachedAssertBody: string | null = null;
+  let cachedHelperBody: string | null = null;
+  let cachedProdBranch: string | null = null;
+  let cachedSafeLogErrorArgs: string | null = null;
 
   before(() => {
     const absPath = resolve(process.cwd(), TEXT_CAP_PATH);
     expect(existsSync(absPath), `${TEXT_CAP_PATH} が見つからない`).to.be.true;
-    source = readFileSync(absPath, 'utf-8');
+    const source = readFileSync(absPath, 'utf-8');
+
+    // 抽出キャッシュ。helper 分離の場合は helper 本体、未分離なら assert 本体を探索。
+    cachedAssertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
+    cachedHelperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
+    const searchScope = cachedHelperBody || cachedAssertBody;
+    cachedProdBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
+    cachedSafeLogErrorArgs = extractParenBlock(cachedProdBranch, SAFE_LOG_ERROR_CALL);
   });
 
   it('assertAggregatePageInvariant 関数定義が存在する (anchor 保護)', () => {
-    const body = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    expect(body, 'assertAggregatePageInvariant 関数の anchor が消失 — リネームなら本契約更新').to
-      .not.be.null;
+    expect(
+      cachedAssertBody,
+      'assertAggregatePageInvariant 関数の anchor が消失 — リネームなら本契約更新',
+    ).to.not.be.null;
   });
 
   it('prod 分岐 (process.env.NODE_ENV === "production") が存在する', () => {
-    // helper 分離の場合は helper 本体、未分離なら assert 本体を探索。
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
-    const searchScope = helperBody || assertBody;
-    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
     expect(
-      prodBranch,
+      cachedProdBranch,
       'prod 分岐が検出されない — silent return に回帰している可能性',
     ).to.not.be.null;
   });
 
   it('prod 分岐内に safeLogError 呼出が存在する', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
-    const searchScope = helperBody || assertBody;
-    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    expect(prodBranch!).to.match(
-      /\bsafeLogError\s*\(/,
+    expect(cachedProdBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
+    expect(cachedProdBranch!).to.match(
+      SAFE_LOG_ERROR_CALL,
       'prod 分岐内に safeLogError 呼出が見つからない — silent 回帰',
     );
   });
 
   it('prod 分岐の safeLogError 引数に source: "ocr" が含まれる', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
-    const searchScope = helperBody || assertBody;
-    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    const args = extractParenBlock(prodBranch, SAFE_LOG_ERROR_CALL);
-    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
-    expect(args!).to.match(/source\s*:\s*['"]ocr['"]/);
+    expect(cachedSafeLogErrorArgs, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
+    expect(cachedSafeLogErrorArgs!).to.match(/source\s*:\s*['"]ocr['"]/);
   });
 
   it('prod 分岐の safeLogError 引数に functionName: "capPageResultsAggregate" が含まれる', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
-    const searchScope = helperBody || assertBody;
-    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    const args = extractParenBlock(prodBranch, SAFE_LOG_ERROR_CALL);
-    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
-    expect(args!).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
+    expect(cachedSafeLogErrorArgs, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
+    expect(cachedSafeLogErrorArgs!).to.match(/functionName\s*:\s*['"]capPageResultsAggregate['"]/);
   });
 
   it('prod 分岐内で throw が発生しない (throw 文がない)', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
-    const searchScope = helperBody || assertBody;
-    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
-    // anchor 消失で prodBranch が null のまま to.not.match(...) が silent PASS する経路を防ぐ。
+    // anchor 消失で cachedProdBranch が null のまま to.not.match(...) が silent PASS する経路を防ぐ。
     expect(
-      prodBranch,
+      cachedProdBranch,
       'prod 分岐が抽出できない — anchor 消失 (#311 review C1 対応)',
     ).to.not.be.null;
-    expect(prodBranch!).to.not.match(
+    expect(cachedProdBranch!).to.not.match(
       /\bthrow\s+(?:new\s+)?Error\b/,
       'prod 分岐に throw が残存 — fire-and-forget 方針に違反',
     );
   });
 
   it('dev 経路では throw が維持されている (assert 本体 or helper 本体に throw が存在)', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
     // 両方 null (anchor 消失) の場合は assertion を silent に通過させないため、少なくとも一方は
     // 抽出できていることを先に担保する。null 連結で `"null"` 文字列が混入する false PASS 経路を防ぐ。
     expect(
-      assertBody !== null || helperBody !== null,
+      cachedAssertBody !== null || cachedHelperBody !== null,
       'assert/helper の両方が抽出できない — anchor 両方消失で throw 検証が silent PASS する',
     ).to.equal(true);
-    const combined = `${assertBody ?? ''}\n${helperBody ?? ''}`;
+    const combined = `${cachedAssertBody ?? ''}\n${cachedHelperBody ?? ''}`;
     expect(combined).to.match(
       /\bthrow\s+new\s+Error\b/,
       'dev throw が消滅 — 既存 #284 契約が壊れている',
@@ -124,9 +114,8 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   // Codex second opinion (MED): helper が残ったまま assert が silent return に回帰する
   // パターンを検知するため、assert 本体からの helper 呼出を grep で lock-in。
   it('assertAggregatePageInvariant 本体から handleAggregateInvariantViolation が呼ばれる', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    expect(assertBody, 'assert 本体が抽出できない — anchor 消失').to.not.be.null;
-    expect(assertBody!).to.match(
+    expect(cachedAssertBody, 'assert 本体が抽出できない — anchor 消失').to.not.be.null;
+    expect(cachedAssertBody!).to.match(
       /\bhandleAggregateInvariantViolation\s*\(/,
       'assert 本体から helper 呼出が消失 — silent return 回帰の可能性',
     );
@@ -135,14 +124,8 @@ describe('textCap prod invariant observability contract (#288 item 6)', () => {
   // silent-failure-hunter S2 + Codex MED: errors collection triage のため documentId 伝搬を
   // lock-in。context?.documentId または documentId キー自体の存在を検証する。
   it('prod 分岐の safeLogError 引数に documentId が含まれる (triage 伝搬)', () => {
-    const assertBody = extractBraceBlock(source, ASSERT_BODY_ANCHOR);
-    const helperBody = extractBraceBlock(source, HELPER_BODY_ANCHOR);
-    const searchScope = helperBody || assertBody;
-    const prodBranch = extractBraceBlock(searchScope, PROD_BRANCH_ANCHOR);
-    expect(prodBranch, 'prod 分岐が抽出できない — anchor 消失').to.not.be.null;
-    const args = extractParenBlock(prodBranch, SAFE_LOG_ERROR_CALL);
-    expect(args, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
-    expect(args!).to.match(
+    expect(cachedSafeLogErrorArgs, 'safeLogError 引数ブロックが抽出できない').to.not.be.null;
+    expect(cachedSafeLogErrorArgs!).to.match(
       /\bdocumentId\b/,
       'safeLogError 引数に documentId が含まれない — 違反 document の特定不可',
     );


### PR DESCRIPTION
## Summary

Issue #313 Q4 + E2 対応:

- **Q4**: 4 contract test ファイル (textCapProdInvariantContract / handleProcessingErrorContract / aggregateCapLogErrorContract / summaryCatchLogErrorContract) で inline 宣言されていた `/\bsafeLogError\s*\(/` を `functions/test/helpers/patterns.ts` に集約し `SAFE_LOG_ERROR_CALL` として export。anchor 表記の drift を構造的に防止。
- **E2**: `textCapProdInvariantContract` の 6 テストで合計 17 回繰返していた `extractBraceBlock` / `extractParenBlock` 呼出を `before()` で 4 回に集約（~76% 削減、元目標 ~40% を上回る）。null passthrough は caller 規約 (`expect(cached).to.not.be.null`) で silent PASS を構造防御。
- **lock-in**: `helpers/patterns.test.ts` で 14 ケース (positive/negative/boundary/flag contract) を追加し、将来の定数改変に対する回帰を防止。

## Acceptance Criteria

- [x] **AC1**: `functions/test/helpers/patterns.ts` が存在し `SAFE_LOG_ERROR_CALL: RegExp` を export
- [x] **AC2**: 4 ファイルから `const SAFE_LOG_ERROR_CALL =` inline 定義消失（helpers/ 外 0 件、grep 確認済）
- [x] **AC3**: `textCapProdInvariantContract` の全 it が `before()` の cached 値を参照（各 it 内 `extractBraceBlock`/`extractParenBlock` 直接呼出ゼロ）
- [x] **AC4**: 590 → **604 passing** (+14、目標 595+ 達成)
- [x] **AC5**: `npx tsc --noEmit` EXIT 0
- [x] **AC6**: anchor 文脈が異なる inline regex (B2 describe の anchor 挙動 lock-in 目的) は無理に統一せず silent PASS 防御精神を維持

## Quality Gate 実施記録

| Stage | 結果 |
|-------|------|
| `/simplify` 3 並列 (reuse/quality/efficiency) | Critical 0, Important 2 + Suggestion 1 全対応（`cachedSearchScope` / `source` を local const 降格、narrating コメント削除） |
| `/safe-refactor` | scope 内追加修正なし、3 件は別 Issue 推奨 |
| Evaluator 分離 (別コンテキスト AC 判定) | **APPROVE**、LOW 1 件 (isSafeLogError 中間マッチ lock-in 不足) → 対応済 |

## Test plan

- [x] `npx tsc --noEmit` EXIT 0
- [x] `npm test` 604 passing (元 590 + 新規 patterns.test.ts 14 ケース)
- [x] grep で helpers/ 外の `const SAFE_LOG_ERROR_CALL =` が 0 件
- [ ] `/review-pr` 4-6 並列レビュー実施（次ステップ）
- [ ] CI 3/3 green (lint-build-test / CodeRabbit / GitGuardian) 確認
- [ ] main マージ後、Issue #313 自動 close 確認

## Scope 外 (別 Issue 化候補)

Evaluator / simplify 指摘のうち本 PR scope 外と判断したもの:

1. aggregateCap / handleProcessing の `before()` existsSync guard が top-level readFileSync 先行により unreachable (structural 修正必要)
2. summaryCatch の `ocrProcessor.ts` / `regenerateSummary.ts` 重複 read (3回/2回)
3. summaryCatch 3 it 内の scanning loop 重複 (`assertNearSafeLog` helper 抽出で ~60% 削減余地)

## 関連

- Closes #313
- session23 PR #325 (SAFE_LOG_ERROR_CALL top-level 昇格の先行対応) の延長

🤖 Generated with [Claude Code](https://claude.com/claude-code)