### PR TITLE
refactor(test): withNodeEnv helper 強化 3 件 (Closes #315)

### DIFF
--- a/functions/eslint.config.mjs
+++ b/functions/eslint.config.mjs
@@ -42,22 +42,43 @@ export default tseslint.config(
       'no-useless-escape': 'warn',
       'no-irregular-whitespace': 'warn',
       'no-control-regex': 'warn',
-      // Issue #315 #1 (silent-failure-hunter I1): 素の process.env.NODE_ENV 代入を禁止し
+      // Issue #315 #1 (silent-failure-hunter I1 + C1): 素の process.env.NODE_ENV 代入を禁止し
       // withNodeEnv/withNodeEnvAsync helper 経由に強制する。helper 自身 (test/helpers/**) は
       // 次の override block で rule を無効化する。
+      //
+      // C1 対応: dot-access / computed property (bracket literal) / Object.assign による
+      // process.env 変更の 3 経路を封じる。dynamic key (`process.env[key] = ...`) は selector で
+      // 原理的に拾えないが、現実的な bypass path は本 rule で覆う。
       'no-restricted-syntax': [
         'error',
         {
+          // 1. process.env.NODE_ENV = ... (dot access)
           selector:
             "AssignmentExpression[left.object.object.name='process'][left.object.property.name='env'][left.property.name='NODE_ENV']",
           message:
             "process.env.NODE_ENV への直接代入は禁止。undefined 文字列化 leak を防ぐため withNodeEnv / withNodeEnvAsync helper を使用してください (test/helpers/withNodeEnv.ts)。",
+        },
+        {
+          // 2. process.env['NODE_ENV'] = ... (computed property with string literal)
+          selector:
+            "AssignmentExpression[left.computed=true][left.object.object.name='process'][left.object.property.name='env'][left.property.value='NODE_ENV']",
+          message:
+            "process.env['NODE_ENV'] への bracket 代入も禁止 (dot access と同じ silent failure リスク)。withNodeEnv / withNodeEnvAsync helper を使用してください。",
+        },
+        {
+          // 3. Object.assign(process.env, { ... }) — bulk mutation
+          selector:
+            "CallExpression[callee.object.name='Object'][callee.property.name='assign'][arguments.0.type='MemberExpression'][arguments.0.object.name='process'][arguments.0.property.name='env']",
+          message:
+            "Object.assign(process.env, ...) による process.env 変更も禁止。withNodeEnv / withNodeEnvAsync helper を使用してください。",
         },
       ],
     },
   },
   {
     // helper 自身は rule 対象外 (helper 実装が process.env.NODE_ENV を直接代入する必要がある)。
+    // glob が `test/helpers/**/*.ts` と広いため、将来 env-mutation helper を追加する際は
+    // 明示レビューで本 rule の無効化妥当性を確認すること (review-pr comment-analyzer Important)。
     files: ['test/helpers/**/*.ts'],
     rules: {
       'no-restricted-syntax': 'off',

--- a/functions/eslint.config.mjs
+++ b/functions/eslint.config.mjs
@@ -42,6 +42,25 @@ export default tseslint.config(
       'no-useless-escape': 'warn',
       'no-irregular-whitespace': 'warn',
       'no-control-regex': 'warn',
+      // Issue #315 #1 (silent-failure-hunter I1): 素の process.env.NODE_ENV 代入を禁止し
+      // withNodeEnv/withNodeEnvAsync helper 経由に強制する。helper 自身 (test/helpers/**) は
+      // 次の override block で rule を無効化する。
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "AssignmentExpression[left.object.object.name='process'][left.object.property.name='env'][left.property.name='NODE_ENV']",
+          message:
+            "process.env.NODE_ENV への直接代入は禁止。undefined 文字列化 leak を防ぐため withNodeEnv / withNodeEnvAsync helper を使用してください (test/helpers/withNodeEnv.ts)。",
+        },
+      ],
+    },
+  },
+  {
+    // helper 自身は rule 対象外 (helper 実装が process.env.NODE_ENV を直接代入する必要がある)。
+    files: ['test/helpers/**/*.ts'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
 )

--- a/functions/test/helpers/withNodeEnv.test.ts
+++ b/functions/test/helpers/withNodeEnv.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from 'chai';
-import { withNodeEnv, withNodeEnvAsync } from './withNodeEnv';
+import { withNodeEnv, withNodeEnvAsync, type NodeEnvValue } from './withNodeEnv';
 
 describe('withNodeEnv helper', () => {
   let saved: string | undefined;
@@ -125,6 +125,38 @@ describe('withNodeEnv helper', () => {
     it('async fn の戻り値を透過する', async () => {
       const result = await withNodeEnvAsync('production', async () => 99);
       expect(result).to.equal(99);
+    });
+  });
+
+  // Issue #315 #3 (type-design-analyzer): signature が NodeEnvValue literal union で typo を
+  // 完全拒否することを compile-time で lock-in (docs/context/test-strategy.md §2.2 型契約 test)。
+  // (string & {}) escape hatch は採用せず strict union、実行時挙動は既存 sync/async describe
+  // で網羅済のため、本 describe は型構造のみを検証する。
+  describe('NodeEnvValue literal union narrow (#315)', () => {
+    it('NodeEnvValue 型は production / test / development の 3 値 union である (構造 lock-in)', () => {
+      // NodeEnvValue[] 宣言時点で tsc が union 構造を検証。値が 4 個になる / number に変わる
+      // 等の破壊的変更は compile エラーで検知される。
+      const members: readonly NodeEnvValue[] = ['production', 'test', 'development'];
+      expect(members).to.have.lengthOf(3);
+      expect(members).to.include.members(['production', 'test', 'development']);
+    });
+
+    it('typo (`prdouction` / `PROD` 等) は NodeEnvValue に含まれず @ts-expect-error で弾かれる', () => {
+      // 未消費の @ts-expect-error は tsc エラーになるため、行末に typo literal を代入する形で
+      // compile-time 検知を直接確認できる。runtime assert は不要 (expect().to.throw は getter
+      // アクセスで no-op になるため採用しない — simplify review Critical 指摘対応)。
+      // @ts-expect-error: 'prdouction' は NodeEnvValue に含まれない typo。
+      const _typo1: NodeEnvValue = 'prdouction';
+      // @ts-expect-error: 'PROD' 等の case 違いも別 literal として弾かれる。
+      const _typo2: NodeEnvValue = 'PROD';
+      void _typo1;
+      void _typo2;
+    });
+
+    it('async 版 withNodeEnvAsync も NodeEnvValue を継承し typo を弾く', () => {
+      // @ts-expect-error: async 版 signature にも同じ union が適用されることを型レベルで確認。
+      const _asyncTypo: Parameters<typeof withNodeEnvAsync>[0] = 'stagings';
+      void _asyncTypo;
     });
   });
 });

--- a/functions/test/helpers/withNodeEnv.test.ts
+++ b/functions/test/helpers/withNodeEnv.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from 'chai';
-import { withNodeEnv, withNodeEnvAsync, type NodeEnvValue } from './withNodeEnv';
+import { withNodeEnv, withNodeEnvAsync } from './withNodeEnv';
 
 describe('withNodeEnv helper', () => {
   let saved: string | undefined;
@@ -128,35 +128,7 @@ describe('withNodeEnv helper', () => {
     });
   });
 
-  // Issue #315 #3 (type-design-analyzer): signature が NodeEnvValue literal union で typo を
-  // 完全拒否することを compile-time で lock-in (docs/context/test-strategy.md §2.2 型契約 test)。
-  // (string & {}) escape hatch は採用せず strict union、実行時挙動は既存 sync/async describe
-  // で網羅済のため、本 describe は型構造のみを検証する。
-  describe('NodeEnvValue literal union narrow (#315)', () => {
-    it('NodeEnvValue 型は production / test / development の 3 値 union である (構造 lock-in)', () => {
-      // NodeEnvValue[] 宣言時点で tsc が union 構造を検証。値が 4 個になる / number に変わる
-      // 等の破壊的変更は compile エラーで検知される。
-      const members: readonly NodeEnvValue[] = ['production', 'test', 'development'];
-      expect(members).to.have.lengthOf(3);
-      expect(members).to.include.members(['production', 'test', 'development']);
-    });
-
-    it('typo (`prdouction` / `PROD` 等) は NodeEnvValue に含まれず @ts-expect-error で弾かれる', () => {
-      // 未消費の @ts-expect-error は tsc エラーになるため、行末に typo literal を代入する形で
-      // compile-time 検知を直接確認できる。runtime assert は不要 (expect().to.throw は getter
-      // アクセスで no-op になるため採用しない — simplify review Critical 指摘対応)。
-      // @ts-expect-error: 'prdouction' は NodeEnvValue に含まれない typo。
-      const _typo1: NodeEnvValue = 'prdouction';
-      // @ts-expect-error: 'PROD' 等の case 違いも別 literal として弾かれる。
-      const _typo2: NodeEnvValue = 'PROD';
-      void _typo1;
-      void _typo2;
-    });
-
-    it('async 版 withNodeEnvAsync も NodeEnvValue を継承し typo を弾く', () => {
-      // @ts-expect-error: async 版 signature にも同じ union が適用されることを型レベルで確認。
-      const _asyncTypo: Parameters<typeof withNodeEnvAsync>[0] = 'stagings';
-      void _asyncTypo;
-    });
-  });
+  // 型契約 test (NodeEnvValue literal union narrow) は test/types/withNodeEnv.types.test.ts に分離。
+  // tsconfig.test.json の include が test/types/ のため、type-check:test で strict 検査される
+  // (silent-failure-hunter C2 指摘対応)。
 });

--- a/functions/test/helpers/withNodeEnv.ts
+++ b/functions/test/helpers/withNodeEnv.ts
@@ -13,14 +13,22 @@
  */
 
 /**
+ * NODE_ENV として受け入れる literal 値 (Issue #315 提案 #3)。
+ *
+ * `(string & {})` escape hatch は敢えて採用せず strict union に留め、typo (`'prdouction'` 等) を
+ * 型レベルで完全拒否する。新しい値が必要になった場合のみ本 union を拡張する。
+ */
+export type NodeEnvValue = 'production' | 'test' | 'development';
+
+/**
  * NODE_ENV を value に切替えて fn を同期実行し、finally で元値に復元する。
  *
  * `try/finally` で throw 経路も保護する。original が undefined の場合は `delete` で復元する。
  *
- * @param value - 一時的に設定する NODE_ENV 値 (`'production'` / `'test'` 等)
+ * @param value - 一時的に設定する NODE_ENV 値 (`NodeEnvValue`)
  * @param fn - 切替中に実行する処理 (戻り値はそのまま返す)
  */
-export function withNodeEnv<T>(value: string, fn: () => T): T {
+export function withNodeEnv<T>(value: NodeEnvValue, fn: () => T): T {
   const original = process.env.NODE_ENV;
   process.env.NODE_ENV = value;
   try {
@@ -35,7 +43,7 @@ export function withNodeEnv<T>(value: string, fn: () => T): T {
  * `withNodeEnv` の async 版。await 対応。
  */
 export async function withNodeEnvAsync<T>(
-  value: string,
+  value: NodeEnvValue,
   fn: () => Promise<T>,
 ): Promise<T> {
   const original = process.env.NODE_ENV;

--- a/functions/test/textCap.test.ts
+++ b/functions/test/textCap.test.ts
@@ -453,6 +453,10 @@ describe('textCap', () => {
       // textCapProdInvariantContract.test.ts (grep) + Phase 3 (動的) で二段 lock-in。
       it('production では invalid 入力でも throw しない (safeLogError 経由で emit)', () => {
         withNodeEnv('production', () => {
+          // Issue #315 #2 (silent-failure-hunter I2): helper 経由で prod 分岐に到達したことを
+          // callsite で明示。helper 実装が value.toLowerCase() 等に誤改変されても silent に
+          // 素通りしない二段 lock-in (helper 単体 test + 本 positive assert)。
+          expect(process.env.NODE_ENV, 'helper 経由で prod 分岐到達を明示').to.equal('production');
           const invalidPage = makeInvalidPage(999_999, 'short');
           expect(() => capPageResultsAggregate([invalidPage])).to.not.throw();
         });

--- a/functions/test/types/withNodeEnv.types.test.ts
+++ b/functions/test/types/withNodeEnv.types.test.ts
@@ -1,0 +1,54 @@
+/**
+ * withNodeEnv NodeEnvValue literal union narrow の型契約 test (Issue #315 #3)
+ *
+ * 目的: `withNodeEnv` / `withNodeEnvAsync` signature の `value: NodeEnvValue` narrow を
+ * @ts-expect-error で lock-in し、typo ('prdouction' 等) が型レベルで拒否されることを保証する。
+ *
+ * 背景: Issue #315 提案 #3 (type-design-analyzer) で literal union narrow を導入。
+ * (string & {}) escape hatch は敢えて採用せず strict union に留め、真の typo 検知を実現。
+ *
+ * 方式: `@ts-expect-error` 型契約 test (docs/context/test-strategy.md §2.2 参照)。
+ * tsconfig.test.json の include に test/types/ が含まれるため、npm run type-check:test で
+ * strict 検査される (test/helpers/ は include 外で silent PASS する silent-failure-hunter C2
+ * 指摘を回避するため本ファイルに分離)。
+ * runtime 挙動 (prod 分岐到達、finally 復元等) は test/helpers/withNodeEnv.test.ts
+ * (既存 8+4 ケース) で網羅。
+ *
+ * 将来委譲: NodeEnvValue に新しい値を追加する場合、本ファイルの @ts-expect-error directive が
+ *          unused になるため tsc が fail → 意図的変更を明示させる安全弁。
+ */
+
+import { expect } from 'chai';
+import { withNodeEnv, withNodeEnvAsync, type NodeEnvValue } from '../helpers/withNodeEnv';
+
+describe('withNodeEnv NodeEnvValue 型契約 (#315)', () => {
+  it('NodeEnvValue 型は production / test / development の 3 値 union である (構造 lock-in)', () => {
+    // 配列リテラル宣言時点で tsc が union 構造を検証。値が 4 個になる / number に変わる等の
+    // 破壊的変更は compile エラーで検知される。
+    const members: readonly NodeEnvValue[] = ['production', 'test', 'development'];
+    expect(members).to.have.lengthOf(3);
+    expect(members).to.include.members(['production', 'test', 'development']);
+  });
+
+  it('typo (`prdouction` / `PROD` 等) は NodeEnvValue に含まれず @ts-expect-error で弾かれる', () => {
+    // @ts-expect-error: 'prdouction' は NodeEnvValue に含まれない typo。
+    const _typo1: NodeEnvValue = 'prdouction';
+    // @ts-expect-error: 'PROD' 等の case 違いも別 literal として弾かれる。
+    const _typo2: NodeEnvValue = 'PROD';
+    void _typo1;
+    void _typo2;
+    expect(true).to.equal(true);
+  });
+
+  it('sync/async 両 helper が同じ NodeEnvValue を継承する (signature lock-in)', () => {
+    // Parameters<typeof fn>[0] で signature 由来の型を参照し、sync/async 片側改変の silent drift を
+    // 防止する (type-design-analyzer Important 対応)。
+    // @ts-expect-error: sync 版 signature も同 union。
+    const _syncTypo: Parameters<typeof withNodeEnv>[0] = 'debug';
+    // @ts-expect-error: async 版 signature も同 union。
+    const _asyncTypo: Parameters<typeof withNodeEnvAsync>[0] = 'stagings';
+    void _syncTypo;
+    void _asyncTypo;
+    expect(true).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #315 (PR #314 #306 withNodeEnv helper follow-up) の 3 項目を 1 PR で実装:

1. **ESLint no-restricted-syntax** (silent-failure-hunter I1): test/ 配下で `process.env.NODE_ENV = ...` 直接代入を禁止し、`withNodeEnv` / `withNodeEnvAsync` helper 経由に強制。`test/helpers/**` は override で除外。
2. **callsite positive assert** (silent-failure-hunter I2): `textCap.test.ts` の prod 分岐 test で `expect(process.env.NODE_ENV).to.equal('production')` を追加。helper 実装が誤改変されても silent 素通りしない二段 lock-in。
3. **NodeEnvValue literal union narrow** (type-design-analyzer): `value: NodeEnvValue = 'production' | 'test' | 'development'` strict union で typo (`'prdouction'` 等) を型レベル完全拒否。

## 設計変更 (Issue 本文から)

Issue 本文の提案 #3 は `(string & {})` escape hatch 付きだったが、全 caller が 3 値のみ使用のため **strict union** に変更 (YAGNI、真の typo 検知)。escape hatch は必要時に拡張する方針。

## Acceptance Criteria

- [x] **AC1**: `withNodeEnv` / `withNodeEnvAsync` signature が `NodeEnvValue` literal union に narrow、既存 caller が壊れない (tsc EXIT 0)
- [x] **AC2**: typo caller (`'prdouction'` / `'PROD'` / `'stagings'`) が `@ts-expect-error` で弾かれる (型契約 test 3 ケース追加)
- [x] **AC3**: ESLint rule が test/ 配下の `process.env.NODE_ENV =` 代入で fail、`test/helpers/**` は除外 (dummy violation で EXIT 1 + 日本語 error message、helpers/ dummy で EXIT 0 確認済み)
- [x] **AC4**: `textCap.test.ts` の 1 callsite に positive assert 追加 (`L456-460`)
- [x] **AC5**: 607 → **610 passing** (+3 型契約 test、目標 +1-3 達成)
- [x] **AC6**: エラーメッセージに helper 導線を含む (「withNodeEnv / withNodeEnvAsync helper を使用してください (test/helpers/withNodeEnv.ts)。」)

## Quality Gate 実施記録

| Stage | 結果 |
|-------|------|
| `/simplify` 3 並列 (reuse/quality/efficiency) | Critical 2 + Important 1 全対応 (`expect(...).to.throw` getter noop → `@ts-expect-error` only、runtime loop 削除、test-strategy §2.2 参照追加) |
| `/safe-refactor` | 追加修正なし、4 ファイル全て clean |

## Test plan

- [x] `npx tsc --noEmit` EXIT 0
- [x] `npm test` 610 passing
- [x] `npx eslint test/` 本 PR 由来のエラー/警告 0 件
- [x] ESLint rule dummy violation で EXIT 1 + helper 導線メッセージ表示
- [x] ESLint rule helpers/ dummy で EXIT 0 (除外確認)
- [ ] `/review-pr` 4-6 並列レビュー実施（次ステップ）
- [ ] CI 3/3 green (lint-build-test / CodeRabbit / GitGuardian) 確認
- [ ] main マージ後、Issue #315 自動 close 確認

## 関連

- Closes #315
- PR #314 (#306 withNodeEnv helper 本体、follow-up の出典)
- session23 AnchorMode literal union narrow との設計思想整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)