### PR TITLE
refactor: loadMasterData 共通化 + dateMarker サニタイズ + check-master-data chunk (Phase 3)

### DIFF
--- a/functions/src/admin/masterOperations.ts
+++ b/functions/src/admin/masterOperations.ts
@@ -10,7 +10,7 @@ import { MASTER_PATHS } from '../utils/masterPaths';
 
 type MasterType = 'office' | 'customer' | 'document';
 
-const MASTER_COLLECTIONS: Record<MasterType, string> = {
+const MASTER_COLLECTIONS: Readonly<Record<MasterType, string>> = {
   office: MASTER_PATHS.offices,
   customer: MASTER_PATHS.customers,
   document: MASTER_PATHS.documents,

--- a/functions/src/admin/masterOperations.ts
+++ b/functions/src/admin/masterOperations.ts
@@ -6,15 +6,14 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { MASTER_PATHS } from '../utils/masterPaths';
 
-/** マスタータイプ */
 type MasterType = 'office' | 'customer' | 'document';
 
-/** マスターコレクションパス */
 const MASTER_COLLECTIONS: Record<MasterType, string> = {
-  office: 'masters/offices/items',
-  customer: 'masters/customers/items',
-  document: 'masters/documents/items',
+  office: MASTER_PATHS.offices,
+  customer: MASTER_PATHS.customers,
+  document: MASTER_PATHS.documents,
 };
 
 /**

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -20,7 +20,7 @@ import {
   normalizeForMatching,
 } from '../utils/extractors';
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
-import { sanitizeCustomerMasters, sanitizeOfficeMasters, sanitizeDocumentMasters } from '../utils/sanitizeMasterData';
+import { loadMasterData } from '../utils/loadMasterData';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
 import {
@@ -237,42 +237,11 @@ export async function processDocument(
     }
   );
 
-  // マスターデータ取得
-  const [documentMasters, customerMasters, officeMasters] = await Promise.all([
-    db.collection('masters/documents/items').get(),
-    db.collection('masters/customers/items').get(),
-    db.collection('masters/offices/items').get(),
-  ]);
-
-  // マスターデータを型付きで変換
-  const docMasterData = sanitizeDocumentMasters(documentMasters.docs.map((d) => ({
-    id: d.id,
-    name: d.data().name as string,
-    category: d.data().category as string | undefined,
-    keywords: d.data().keywords as string[] | undefined,
-    aliases: d.data().aliases as string[] | undefined,
-  })));
-
-  const custMasterData = sanitizeCustomerMasters(customerMasters.docs.map((d) => ({
-    id: d.id,
-    name: d.data().name as string,
-    furigana: d.data().furigana as string | undefined,
-    isDuplicate: d.data().isDuplicate as boolean | undefined,
-    careManagerName: d.data().careManagerName as string | undefined,
-    aliases: d.data().aliases as string[] | undefined,
-  })));
-
-  const officeMasterData = sanitizeOfficeMasters(officeMasters.docs.map((d) => ({
-    id: d.id,
-    name: d.data().name as string,
-    shortName: d.data().shortName as string | undefined,
-    isDuplicate: d.data().isDuplicate as boolean | undefined,
-    aliases: d.data().aliases as string[] | undefined,
-  })));
+  const { documents, customers, offices } = await loadMasterData(db);
 
   // 情報抽出（強化版エクストラクター使用）
-  const documentTypeResult = extractDocumentTypeEnhanced(ocrResult, docMasterData);
-  const customerResult = extractCustomerCandidates(ocrResult, custMasterData);
+  const documentTypeResult = extractDocumentTypeEnhanced(ocrResult, documents);
+  const customerResult = extractCustomerCandidates(ocrResult, customers);
 
   // ファイル名から事業所情報を抽出
   const fileName = docData.fileName as string | undefined;
@@ -280,7 +249,7 @@ export async function processDocument(
   console.log(`Filename info: ${JSON.stringify(filenameInfo)}`);
 
   // 事業所候補抽出
-  const officeResult = extractOfficeCandidates(ocrResult, officeMasterData, { filenameInfo });
+  const officeResult = extractOfficeCandidates(ocrResult, offices, { filenameInfo });
 
   // ファイル名からの事業所登録提案
   let suggestedNewOffice: string | null = null;
@@ -295,9 +264,9 @@ export async function processDocument(
     }
   }
 
-  // 日付抽出（1ページ目を優先）
-  const matchedDocMaster = documentMasters.docs.find((d) => d.data().name === documentTypeResult.documentType);
-  const dateMarker = matchedDocMaster?.data().dateMarker as string | undefined;
+  // dateMarker は型崩れしていても undefined に正規化済み (sanitizeDocumentMasters)
+  const matchedDoc = documents.find((d) => d.name === documentTypeResult.documentType);
+  const dateMarker = matchedDoc?.dateMarker;
   const firstPageText = pageResults.length > 0 ? pageResults[0]?.text : undefined;
   const dateResult = extractDateEnhanced(ocrResult, dateMarker, firstPageText);
 

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -21,7 +21,7 @@ import {
 import { buildSplitDocumentData } from './splitDocumentBuilder';
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
 import { timestampToDateString } from '../utils/backfillDisplayFileName';
-import { sanitizeCustomerMasters, sanitizeOfficeMasters, sanitizeDocumentMasters } from '../utils/sanitizeMasterData';
+import { loadMasterData } from '../utils/loadMasterData';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -92,37 +92,7 @@ export const detectSplitPoints = onCall(
 
     // 強化版分析を使用
     if (useEnhanced) {
-      // マスターデータ取得
-      const [documentMasters, customerMasters, officeMasters] = await Promise.all([
-        db.collection('masters/documents/items').get(),
-        db.collection('masters/customers/items').get(),
-        db.collection('masters/offices/items').get(),
-      ]);
-
-      const masters: MasterData = {
-        documents: sanitizeDocumentMasters(documentMasters.docs.map((d) => ({
-          id: d.id,
-          name: d.data().name as string,
-          category: d.data().category as string | undefined,
-          keywords: d.data().keywords as string[] | undefined,
-          aliases: d.data().aliases as string[] | undefined,
-        }))),
-        customers: sanitizeCustomerMasters(customerMasters.docs.map((d) => ({
-          id: d.id,
-          name: d.data().name as string,
-          furigana: d.data().furigana as string | undefined,
-          isDuplicate: d.data().isDuplicate as boolean | undefined,
-          aliases: d.data().aliases as string[] | undefined,
-          careManagerName: d.data().careManagerName as string | undefined,
-        }))),
-        offices: sanitizeOfficeMasters(officeMasters.docs.map((d) => ({
-          id: d.id,
-          name: d.data().name as string,
-          shortName: d.data().shortName as string | undefined,
-          isDuplicate: d.data().isDuplicate as boolean | undefined,
-          aliases: d.data().aliases as string[] | undefined,
-        }))),
-      };
+      const masters: MasterData = await loadMasterData(db);
 
       // ページデータを変換
       const pages: PageOcrData[] = pageResults.map((p) => ({

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -154,6 +154,7 @@ export interface DocumentMaster {
   category?: string;
   keywords?: string[];
   aliases?: string[];  // 許容される別表記
+  dateMarker?: string;
 }
 
 /**

--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -1,0 +1,78 @@
+/**
+ * マスターデータ読み込み共通関数。
+ *
+ * 3 コレクション（documents/customers/offices）を並列取得し、各サニタイザで型崩れを
+ * 除去したマスターデータを返す。OCR 処理と PDF 分割提案の両系列で使う。
+ */
+
+import type * as admin from 'firebase-admin';
+import type { CustomerMaster, DocumentMaster, OfficeMaster } from './extractors';
+import { MASTER_PATHS } from './masterPaths';
+import {
+  sanitizeCustomerMasters,
+  sanitizeDocumentMasters,
+  sanitizeOfficeMasters,
+} from './sanitizeMasterData';
+
+export interface LoadedMasterData {
+  documents: DocumentMaster[];
+  customers: CustomerMaster[];
+  offices: OfficeMaster[];
+}
+
+/** Firestore から読み出した生ドキュメントデータ (unknown 型のフィールド集合) */
+type RawDoc = FirebaseFirestore.DocumentData;
+
+function toDocumentMaster(id: string, raw: RawDoc): DocumentMaster {
+  return {
+    id,
+    name: raw.name as string,
+    category: raw.category as string | undefined,
+    keywords: raw.keywords as string[] | undefined,
+    aliases: raw.aliases as string[] | undefined,
+    dateMarker: raw.dateMarker as string | undefined,
+  };
+}
+
+function toCustomerMaster(id: string, raw: RawDoc): CustomerMaster {
+  return {
+    id,
+    name: raw.name as string,
+    furigana: raw.furigana as string | undefined,
+    isDuplicate: raw.isDuplicate as boolean | undefined,
+    careManagerName: raw.careManagerName as string | undefined,
+    aliases: raw.aliases as string[] | undefined,
+  };
+}
+
+function toOfficeMaster(id: string, raw: RawDoc): OfficeMaster {
+  return {
+    id,
+    name: raw.name as string,
+    shortName: raw.shortName as string | undefined,
+    isDuplicate: raw.isDuplicate as boolean | undefined,
+    aliases: raw.aliases as string[] | undefined,
+  };
+}
+
+export async function loadMasterData(
+  db: admin.firestore.Firestore
+): Promise<LoadedMasterData> {
+  const [documentSnap, customerSnap, officeSnap] = await Promise.all([
+    db.collection(MASTER_PATHS.documents).get(),
+    db.collection(MASTER_PATHS.customers).get(),
+    db.collection(MASTER_PATHS.offices).get(),
+  ]);
+
+  return {
+    documents: sanitizeDocumentMasters(
+      documentSnap.docs.map((d) => toDocumentMaster(d.id, d.data()))
+    ),
+    customers: sanitizeCustomerMasters(
+      customerSnap.docs.map((d) => toCustomerMaster(d.id, d.data()))
+    ),
+    offices: sanitizeOfficeMasters(
+      officeSnap.docs.map((d) => toOfficeMaster(d.id, d.data()))
+    ),
+  };
+}

--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -20,9 +20,9 @@ export interface LoadedMasterData {
   offices: OfficeMaster[];
 }
 
-/** Firestore から読み出した生ドキュメントデータ (unknown 型のフィールド集合) */
 type RawDoc = FirebaseFirestore.DocumentData;
 
+/** Firestore Raw → 型付き中間表現。型崩れは後段の sanitize*Masters で除去される */
 function toDocumentMaster(id: string, raw: RawDoc): DocumentMaster {
   return {
     id,
@@ -34,6 +34,7 @@ function toDocumentMaster(id: string, raw: RawDoc): DocumentMaster {
   };
 }
 
+/** Firestore Raw → 型付き中間表現。型崩れは後段の sanitize*Masters で除去される */
 function toCustomerMaster(id: string, raw: RawDoc): CustomerMaster {
   return {
     id,
@@ -45,6 +46,7 @@ function toCustomerMaster(id: string, raw: RawDoc): CustomerMaster {
   };
 }
 
+/** Firestore Raw → 型付き中間表現。型崩れは後段の sanitize*Masters で除去される */
 function toOfficeMaster(id: string, raw: RawDoc): OfficeMaster {
   return {
     id,

--- a/functions/src/utils/masterPaths.ts
+++ b/functions/src/utils/masterPaths.ts
@@ -1,0 +1,7 @@
+export const MASTER_PATHS = {
+  documents: 'masters/documents/items',
+  customers: 'masters/customers/items',
+  offices: 'masters/offices/items',
+} as const;
+
+export type MasterType = keyof typeof MASTER_PATHS;

--- a/functions/src/utils/sanitizeMasterData.ts
+++ b/functions/src/utils/sanitizeMasterData.ts
@@ -16,6 +16,12 @@ function toOptionalString(value: unknown): string | undefined {
   return undefined;
 }
 
+/** 空文字もundefinedとして扱う。dateMarkerのように「空=指定なし」と解釈したい用途専用 */
+function toOptionalNonEmptyString(value: unknown): string | undefined {
+  const s = toOptionalString(value);
+  return s === '' ? undefined : s;
+}
+
 /** 値がbooleanであればそのまま、それ以外はundefined */
 function toOptionalBoolean(value: unknown): boolean | undefined {
   if (typeof value === 'boolean') return value;
@@ -71,6 +77,6 @@ export function sanitizeDocumentMasters(
       category: toOptionalString(d.category),
       keywords: toOptionalStringArray(d.keywords),
       aliases: toOptionalStringArray(d.aliases),
-      dateMarker: toOptionalString(d.dateMarker),
+      dateMarker: toOptionalNonEmptyString(d.dateMarker),
     }));
 }

--- a/functions/src/utils/sanitizeMasterData.ts
+++ b/functions/src/utils/sanitizeMasterData.ts
@@ -71,5 +71,6 @@ export function sanitizeDocumentMasters(
       category: toOptionalString(d.category),
       keywords: toOptionalStringArray(d.keywords),
       aliases: toOptionalStringArray(d.aliases),
+      dateMarker: toOptionalString(d.dateMarker),
     }));
 }

--- a/functions/test/loadMasterData.test.ts
+++ b/functions/test/loadMasterData.test.ts
@@ -1,0 +1,97 @@
+/**
+ * loadMasterData の単体テスト。3 コレクション並列取得 + サニタイズ委譲 + Firestore エラー伝播を検証する。
+ */
+
+import { expect } from 'chai';
+import type * as admin from 'firebase-admin';
+import { loadMasterData } from '../src/utils/loadMasterData';
+
+/** Firestore の collection().get() を最小限スタブする */
+function createFirestoreStub(
+  collectionData: Record<string, Array<{ id: string; data: Record<string, unknown> }>>
+): admin.firestore.Firestore {
+  return {
+    collection(path: string) {
+      return {
+        get: async () => ({
+          docs: (collectionData[path] || []).map((d) => ({
+            id: d.id,
+            data: () => d.data,
+          })),
+        }),
+      };
+    },
+  } as unknown as admin.firestore.Firestore;
+}
+
+describe('loadMasterData', () => {
+  it('3コレクションを並列取得し、サニタイズ済みで返す', async () => {
+    const stub = createFirestoreStub({
+      'masters/documents/items': [
+        { id: 'd1', data: { name: '介護保険証', category: '保険', dateMarker: '発行日' } },
+      ],
+      'masters/customers/items': [
+        { id: 'c1', data: { name: '田中太郎', furigana: 'たなかたろう' } },
+      ],
+      'masters/offices/items': [
+        { id: 'o1', data: { name: 'デイサービスさくら', shortName: 'さくら' } },
+      ],
+    });
+
+    const result = await loadMasterData(stub);
+
+    expect(result.documents).to.have.length(1);
+    expect(result.documents[0]).to.include({ id: 'd1', name: '介護保険証', dateMarker: '発行日' });
+    expect(result.customers).to.have.length(1);
+    expect(result.customers[0]).to.include({ id: 'c1', name: '田中太郎' });
+    expect(result.offices).to.have.length(1);
+    expect(result.offices[0]).to.include({ id: 'o1', name: 'デイサービスさくら' });
+  });
+
+  it('空コレクションの場合、空配列を返す', async () => {
+    const stub = createFirestoreStub({
+      'masters/documents/items': [],
+      'masters/customers/items': [],
+      'masters/offices/items': [],
+    });
+
+    const result = await loadMasterData(stub);
+
+    expect(result.documents).to.deep.equal([]);
+    expect(result.customers).to.deep.equal([]);
+    expect(result.offices).to.deep.equal([]);
+  });
+
+  it('サニタイズが適用される（dateMarkerが型崩れしている場合、undefinedに正規化）', async () => {
+    const stub = createFirestoreStub({
+      'masters/documents/items': [
+        { id: 'd1', data: { name: '介護保険証', dateMarker: { text: '発行日' } } },
+      ],
+      'masters/customers/items': [],
+      'masters/offices/items': [],
+    });
+
+    const result = await loadMasterData(stub);
+
+    expect(result.documents[0]?.dateMarker).to.be.undefined;
+  });
+
+  it('Firestoreエラーは呼び出し元に伝播する', async () => {
+    const failingStub = {
+      collection() {
+        return {
+          get: async () => {
+            throw new Error('Firestore unavailable');
+          },
+        };
+      },
+    } as unknown as admin.firestore.Firestore;
+
+    try {
+      await loadMasterData(failingStub);
+      expect.fail('should throw');
+    } catch (err) {
+      expect((err as Error).message).to.equal('Firestore unavailable');
+    }
+  });
+});

--- a/functions/test/sanitizeMasterData.test.ts
+++ b/functions/test/sanitizeMasterData.test.ts
@@ -122,6 +122,7 @@ describe('sanitizeMasterData', () => {
         category: '保険',
         keywords: ['被保険者証', '介護保険'],
         aliases: ['保険証'],
+        dateMarker: '発行日',
       }];
       const result = sanitizeDocumentMasters(input);
       expect(result).to.deep.equal(input);
@@ -145,6 +146,66 @@ describe('sanitizeMasterData', () => {
       }];
       const result = sanitizeDocumentMasters(input);
       expect(result[0].keywords).to.deep.equal(['被保険者証']);
+    });
+
+    it('dateMarkerが正常なstringの場合、そのまま通過する', () => {
+      const input = [{
+        id: 'd1',
+        name: '介護保険証',
+        dateMarker: '発行日',
+      }];
+      const result = sanitizeDocumentMasters(input);
+      expect(result[0].dateMarker).to.equal('発行日');
+    });
+
+    it('dateMarkerがundefinedの場合、undefinedのまま', () => {
+      const input = [{
+        id: 'd1',
+        name: '介護保険証',
+        dateMarker: undefined,
+      }];
+      const result = sanitizeDocumentMasters(input);
+      expect(result[0].dateMarker).to.be.undefined;
+    });
+
+    it('dateMarkerがnumberの場合、undefinedにする', () => {
+      const input = [{
+        id: 'd1',
+        name: '介護保険証',
+        dateMarker: 20260101 as unknown as string,
+      }];
+      const result = sanitizeDocumentMasters(input);
+      expect(result[0].dateMarker).to.be.undefined;
+    });
+
+    it('dateMarkerがobjectの場合、undefinedにする', () => {
+      const input = [{
+        id: 'd1',
+        name: '介護保険証',
+        dateMarker: { text: '発行日' } as unknown as string,
+      }];
+      const result = sanitizeDocumentMasters(input);
+      expect(result[0].dateMarker).to.be.undefined;
+    });
+
+    it('dateMarkerが配列の場合、先頭要素を文字列化する', () => {
+      const input = [{
+        id: 'd1',
+        name: '介護保険証',
+        dateMarker: ['発行日', '作成日'] as unknown as string,
+      }];
+      const result = sanitizeDocumentMasters(input);
+      expect(result[0].dateMarker).to.equal('発行日');
+    });
+
+    it('dateMarkerが空文字の場合、空文字のまま通過する（extractDateEnhanced で undefined 同等に扱われる契約）', () => {
+      const input = [{
+        id: 'd1',
+        name: '介護保険証',
+        dateMarker: '',
+      }];
+      const result = sanitizeDocumentMasters(input);
+      expect(result[0].dateMarker).to.equal('');
     });
   });
 });

--- a/functions/test/sanitizeMasterData.test.ts
+++ b/functions/test/sanitizeMasterData.test.ts
@@ -198,14 +198,14 @@ describe('sanitizeMasterData', () => {
       expect(result[0].dateMarker).to.equal('発行日');
     });
 
-    it('dateMarkerが空文字の場合、空文字のまま通過する（extractDateEnhanced で undefined 同等に扱われる契約）', () => {
+    it('dateMarkerが空文字の場合、undefinedに正規化する（下流の truthy チェック依存を排除）', () => {
       const input = [{
         id: 'd1',
         name: '介護保険証',
         dateMarker: '',
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.equal('');
+      expect(result[0].dateMarker).to.be.undefined;
     });
   });
 });

--- a/scripts/check-master-data.js
+++ b/scripts/check-master-data.js
@@ -22,6 +22,9 @@ if (!projectId) {
 
 const fix = process.argv.includes('--fix');
 
+/** Firestore バッチ上限は 500 writes。余裕を持って 400 件で chunk 分割する */
+const BATCH_CHUNK_SIZE = 400;
+
 admin.initializeApp({ projectId });
 const db = admin.firestore();
 
@@ -89,6 +92,7 @@ const COLLECTIONS = {
     category: 'string',
     keywords: 'string[]',
     aliases: 'string[]',
+    dateMarker: 'string',
   },
 };
 
@@ -123,15 +127,21 @@ async function main() {
       }
 
       if (fix) {
-        const batch = db.batch();
-        for (const issue of issues) {
-          const docRef = db.doc(`${collPath}/${issue.docId}`);
-          const data = docDataMap.get(issue.docId);
-          const sanitized = sanitizeValue(data[issue.field], schema[issue.field]);
-          batch.update(docRef, { [issue.field]: sanitized });
+        const totalChunks = Math.ceil(issues.length / BATCH_CHUNK_SIZE);
+        for (let i = 0; i < issues.length; i += BATCH_CHUNK_SIZE) {
+          const chunk = issues.slice(i, i + BATCH_CHUNK_SIZE);
+          const chunkNum = Math.floor(i / BATCH_CHUNK_SIZE) + 1;
+          const batch = db.batch();
+          for (const issue of chunk) {
+            const docRef = db.doc(`${collPath}/${issue.docId}`);
+            const data = docDataMap.get(issue.docId);
+            const sanitized = sanitizeValue(data[issue.field], schema[issue.field]);
+            batch.update(docRef, { [issue.field]: sanitized });
+          }
+          await batch.commit();
+          console.log(`    → batch ${chunkNum}/${totalChunks}: ${chunk.length}件コミット`);
         }
-        await batch.commit();
-        console.log(`    → ${issues.length}件を修正しました`);
+        console.log(`    → 合計 ${issues.length}件を修正しました`);
         totalFixed += issues.length;
       }
     }

--- a/scripts/check-master-data.js
+++ b/scripts/check-master-data.js
@@ -127,22 +127,34 @@ async function main() {
       }
 
       if (fix) {
+        // 500 件上限対策で chunk 分割した結果 atomicity が失われる。失敗時は
+        // 成功済み chunk と未処理 docId を明示して運用者が再実行できるようにする。
         const totalChunks = Math.ceil(issues.length / BATCH_CHUNK_SIZE);
-        for (let i = 0; i < issues.length; i += BATCH_CHUNK_SIZE) {
-          const chunk = issues.slice(i, i + BATCH_CHUNK_SIZE);
-          const chunkNum = Math.floor(i / BATCH_CHUNK_SIZE) + 1;
-          const batch = db.batch();
-          for (const issue of chunk) {
-            const docRef = db.doc(`${collPath}/${issue.docId}`);
-            const data = docDataMap.get(issue.docId);
-            const sanitized = sanitizeValue(data[issue.field], schema[issue.field]);
-            batch.update(docRef, { [issue.field]: sanitized });
+        let committedCount = 0;
+        try {
+          for (let i = 0; i < issues.length; i += BATCH_CHUNK_SIZE) {
+            const chunk = issues.slice(i, i + BATCH_CHUNK_SIZE);
+            const chunkNum = Math.floor(i / BATCH_CHUNK_SIZE) + 1;
+            const batch = db.batch();
+            for (const issue of chunk) {
+              const docRef = db.doc(`${collPath}/${issue.docId}`);
+              const data = docDataMap.get(issue.docId);
+              const sanitized = sanitizeValue(data[issue.field], schema[issue.field]);
+              batch.update(docRef, { [issue.field]: sanitized });
+            }
+            await batch.commit();
+            committedCount += chunk.length;
+            console.log(`    → batch ${chunkNum}/${totalChunks}: ${chunk.length}件コミット (累計 ${committedCount}/${issues.length})`);
           }
-          await batch.commit();
-          console.log(`    → batch ${chunkNum}/${totalChunks}: ${chunk.length}件コミット`);
+          console.log(`    → 合計 ${issues.length}件を修正しました`);
+          totalFixed += issues.length;
+        } catch (commitErr) {
+          const skipped = issues.slice(committedCount).map((it) => `${it.docId}.${it.field}`);
+          console.error(`    → コミット失敗: ${committedCount}件は書き込み済、${skipped.length}件は未処理`);
+          console.error(`    → 未処理docId一覧: ${skipped.slice(0, 20).join(', ')}${skipped.length > 20 ? ` ...(他${skipped.length - 20}件)` : ''}`);
+          totalFixed += committedCount;
+          throw commitErr;
         }
-        console.log(`    → 合計 ${issues.length}件を修正しました`);
-        totalFixed += issues.length;
       }
     }
 


### PR DESCRIPTION
## Summary
- **#188** ocrProcessor/pdfOperations で重複していたマスターデータ取得+サニタイズの 33 行ブロックを `loadMasterData()` 共通関数に集約。MASTER_PATHS 定数も同時に抽出して masterOperations.ts と統合
- **#189** `DocumentMaster.dateMarker` を `sanitizeDocumentMasters` の境界内に取り込み、ocrProcessor.ts の `matchedDocMaster?.data().dateMarker` 直接参照をサニタイズ済み map 経由に変更（型崩れ防御）
- **#190** `check-master-data.js` の `--fix` バッチを 400 件 chunk に分割（Firestore 500 件上限対策）+ schema に `dateMarker: 'string'` を追加

Closes #188
Closes #189
Closes #190

## 変更内容

### 新規
- `functions/src/utils/loadMasterData.ts` (共通関数、Raw→sanitize の二段階変換)
- `functions/src/utils/masterPaths.ts` (MASTER_PATHS 定数)
- `functions/test/loadMasterData.test.ts` (4 ケース: 正常/空/型崩れサニタイズ/エラー伝播)

### 修正
- `functions/src/utils/extractors.ts` - DocumentMaster に `dateMarker?: string` 追加
- `functions/src/utils/sanitizeMasterData.ts` - sanitizeDocumentMasters で dateMarker 対応
- `functions/src/ocr/ocrProcessor.ts` - loadMasterData 呼び出しに置換、dateMarker をサニタイズ済み map 経由に
- `functions/src/pdf/pdfOperations.ts` - loadMasterData 呼び出しに置換
- `functions/src/admin/masterOperations.ts` - MASTER_PATHS 共通利用
- `functions/test/sanitizeMasterData.test.ts` - dateMarker 5 + 空文字 1 ケース追加
- `scripts/check-master-data.js` - 400 件 chunk + dateMarker schema 追加

## Quality Gate 実施記録

| Stage | 結果 |
|-------|------|
| `/impl-plan` | Phase 2.7 AC1-6 定義、TDD サイクル策定 |
| `/simplify` 3 並列 | Critical 0、Important 5 対応（MASTER_PATHS 抽出 / task-ref コメント削除 / destructuring rename 削除 / etc.） |
| `/safe-refactor` | LOW 1 対応（matchedDocMaster → matchedDoc rename） |
| **Evaluator 分離** | REQUEST_CHANGES → dateMarker schema 追加 + 空文字テスト対応、`shared/types.ts` 乖離は follow-up 化 |
| `/review-pr` | 本 PR で 6 並列実施 |

## Test plan

- [x] BE `npx tsc --noEmit` EXIT 0
- [x] BE `npm test` **632 passing** (622 → +10: dateMarker 5 + 空文字 1 + loadMasterData 4)
- [x] FE `npx tsc --noEmit` EXIT 0
- [x] FE `npm test` **127 passing**
- [x] ESLint 0 error (warnings のみ、既存)
- [x] `scripts/check-master-data.js` syntax check (node -c) OK
- [ ] Post-merge: `gh issue view 188 / 189 / 190` で CLOSED 確認（session24 教訓: squash merge で auto-close が 1 件のみ機能する場合あり、手動確認）
- [ ] Post-merge: follow-up Issue 起票（`shared/types.ts` vs `extractors.ts` の DocumentMaster 型統合、dateMarker/category/id の 3 フィールドで乖離）

## Acceptance Criteria（全達成）

- ✅ **AC1**: extractors.ts の DocumentMaster に `dateMarker?: string` 追加、tsc 0 error
- ✅ **AC2**: sanitizeDocumentMasters が dateMarker を正規化、5 ケーステスト PASS
- ✅ **AC3**: loadMasterData.ts 新規、ocrProcessor/pdfOperations の 33 行ブロック置換
- ✅ **AC4**: 既存 622 → 632 passing (+10)
- ✅ **AC5**: check-master-data.js 400 件 chunk + ログ出力
- ✅ **AC6**: DocumentMaster 型変更は extractors.ts のみ（read-only データパス、#178 派生フィールド教訓対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added date marker field support for document master records.

* **Refactoring**
  * Consolidated master data fetching into unified utilities for improved system consistency and maintainability.

* **Tests**
  * Expanded test coverage for master data operations, sanitization, and normalization.

* **Chores**
  * Enhanced master data validation script with improved batch processing and schema verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->