### PR TITLE
docs: 2026-04-21 session25 handoff (WBS Phase 3 完遂)

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,8 +1,110 @@
 # ハンドオフメモ
 
-**更新日**: 2026-04-20 session24 (WBS Phase 1 + Phase 2 完遂、3 PR merged、5 Issue closed、5 follow-up Issue 起票)
-**ブランチ**: main (PR #330 マージ済、clean)
-**フェーズ**: Phase 8 + 運用監視基盤全環境展開完了 + Phase A-1 (#312) + A-2/A-3 (#313/#315) + Phase 2 (#181/#182/#183) 完遂
+**更新日**: 2026-04-21 session25 (WBS Phase 3 完遂、PR #337 merged、3 Issue closed、3 follow-up Issue 起票)
+**ブランチ**: main (PR #337 マージ済、clean)
+**フェーズ**: Phase 8 + 運用監視基盤全環境展開完了 + Phase A-1 (#312) + A-2/A-3 (#313/#315) + Phase 2 (#181/#182/#183) + Phase 3 (#188/#189/#190) 完遂
+
+<a id="session25"></a>
+## ✅ session25 完了サマリー (WBS Phase 3 完遂)
+
+PM/PL 視点で WBS を引き、Phase 3 (#188 loadMasterData 共通化 + #189 dateMarker サニタイズ境界 + #190 check-master-data.js chunk) を **1 PR バッチ化で完遂**。Quality Gate フル 4 段発動 (simplify 3 並列 → safe-refactor → Evaluator 分離 → review-pr 6 並列)、合計 **13 エージェントレビュー**。
+
+### PR 一覧
+
+| PR | Phase | 内容 | closed Issues | merged commit |
+|----|-------|------|--------------|--------------|
+| **#337** | 3 | loadMasterData 共通化 + dateMarker サニタイズ + check-master-data chunk 対応 | #188 / #189 / #190 | `cd2ceca` |
+
+### 主要成果
+
+| 項目 | 内容 |
+|------|------|
+| **merged PR** | 1 本 (#337、2 commit: 初版 + review-pr 指摘対応) |
+| **closed Issue** | #188 / #189 / #190 (3 件すべて auto-close 成功) |
+| **新規 follow-up Issue** | #338-#340 (3 件、P2 enhancement、PR #337 の Evaluator + review-pr 指摘由来) |
+| **BE テスト** | 622 → **632 passing** (+10: dateMarker 5 + 空文字 1 + loadMasterData 4) |
+| **FE テスト** | 127 passing (変化なし) |
+| **コード量** | +277 / -84 行 (33 行重複ブロック × 2 箇所を共通関数化、純増は新規テスト + JSDoc 追加分) |
+| **品質改善** | loadMasterData() 共通関数 / MASTER_PATHS 定数抽出 / sanitizeDocumentMasters に dateMarker 取り込み / 空文字正規化 / check-master-data.js 400 件 chunk + partial-write 可視化 |
+
+### Quality Gate 実施記録 (13 エージェントレビュー)
+
+| Stage | 結果 |
+|-------|------|
+| `/impl-plan` | Phase 2.7 AC1-6 定義、TDD サイクル策定 |
+| `/simplify` 3 並列 | Critical 0, **Important 5 対応** (MASTER_PATHS 抽出 / task-ref コメント削除 / destructuring rename 削除 / unsafe cast 二層防御化 / awkward rename 解消) |
+| `/safe-refactor` | LOW 1 対応 (matchedDocMaster → matchedDoc rename) |
+| **Evaluator 分離** | **REQUEST_CHANGES** → Important 2 対応 (check-master-data.js schema に dateMarker 追加 / 空文字テスト追加)、shared/types.ts 乖離は follow-up #338 化 |
+| `/review-pr` 6 並列 | Critical 0 (silent-failure の partial-write 指摘は実質 Important として対応)、**Important 5 対応** (空文字→undefined 正規化 / chunk 失敗可視化 / JSDoc 3 ヘルパー / Readonly 強制 / masterOperations 整理) |
+
+### 設計判断 / Lessons Learned (本セッション重要知見)
+
+1. **chunk 分割で atomicity が失われる regression (silent-failure-hunter Critical)**: 単一 `batch.commit()` → 400 件 chunk ループに変更した時点で、途中失敗で部分書き込みが発生する。operator 可視化 (`committedCount` + 未処理 docId ログ) を追加しないと silent に `totalFixed` が嘘になる。**chunk 化 = atomic 破壊**を設計判断時点で認識すべき
+
+2. **sanitize 境界での空文字正規化**: dateMarker 空文字 `""` を sanitize で通過させると、下流 `extractDateEnhanced` が `similarity.ts` の truthy チェックで弾く実装詳細に依存する。**契約を runtime で明示**するため sanitize 層で `""` → `undefined` に正規化 (`toOptionalNonEmptyString` helper 新設)。silent-failure + code-reviewer が一致指摘
+
+3. **squash merge の複数 Closes auto-close**: session24 で `#181 のみ auto-close、#182/#183 手動 close` の事例あり。今回 #337 では `Closes #188 / Closes #189 / Closes #190` 3 件とも auto-close 成功 → **PR body で別行 + `Closes #XX` 形式を厳守すれば機能する**ことが再検証
+
+4. **Evaluator も見落とす既存設計差異 (再検証)**: Evaluator が `shared/types.ts` vs `extractors.ts` の DocumentMaster 乖離を AC6 FAIL と指摘したが、実際は元々 id/category が既存乖離しており、dateMarker 追加は後方互換的変更。**既存契約を複数ファイル確認してから Evaluator 指摘の採否判断**の教訓 (session24 Lessons 4) を再踏襲、follow-up Issue 化で scope クリープ回避
+
+5. **3 Issue バッチ化 + Quality Gate コスト効率 (踏襲)**: session24 の #181/#182/#183 パターンを #188/#189/#190 で再適用、1 PR で 3 Issue 同時処理 + Evaluator / review-pr 発動 1 回で完結。**類似 Issue の意図的な束ね込み**は標準プラクティス化可
+
+6. **二層防御 (型キャスト + sanitizer)**: loadMasterData.ts の `as string` / `as T | undefined` キャストは unsafe だが、直後に `sanitize*Masters` が `unknown` 想定で防御するため runtime 安全。型システム上の「嘘」を sanitize が runtime で補正する **書き捨て境界キャスト** パターンは code-simplifier 却下判定でも容認（Zod 等の段階型化は過剰コスト）
+
+### 次セッション着手候補 (WBS 進捗)
+
+**Phase 4: 独立軽微バグ (#196 + #152)** (次セッション最優先):
+- **#196** rescueStuckProcessingDocs MAX_RETRY_COUNT + retryAfter 追加 (bug, 1-2 ファイル、tdd → simplify のみ、軽量)
+- **#152** dev 環境 setup-tenant.sh 実行 (手順実行のみ、switch-client.sh プロトコル厳守)
+- 想定規模: 合わせて 0.5-1 セッション相当
+
+**Phase 5: sanitize / displayFileName follow-up 群 (#331-#335)** (Phase 4 後):
+- 5 Issue バッチ候補、4-6 ファイル、Quality Gate フル発動
+- sanitize helper 3 本の shared/ 統合 (#331) / timestampToDateString 抽出 (#332) / pdfOperations.ts legacy sanitize 整理 (#333) / scripts/backfill-display-filename.js 共通化 (#334) / 全角禁止文字対応 (#335)
+
+**Phase 6: Phase 3 follow-up 統合 (#338 + #339 + #340)** (優先度中):
+- **#338** DocumentMaster 型を shared/types.ts と extractors.ts で統合 (optionality 方向性決定、Raw* 型化検討も含む)
+- **#339** LoadedMasterData と pdfAnalyzer.MasterData 型の統合
+- **#340** loadMasterData カバレッジ拡張 (部分失敗 / 全除外 / silent drop 安全化)
+- バッチ化で効率的処理可
+
+**その他 WBS 順序**:
+- Phase 7 #262 diagnostics 強化 (0.5 セッション)
+- Phase 8 #220 OOM/truncated log-based metric + alert (1 セッション、マルチクライアント 3 環境展開)
+- Phase 9 #237 search tokenizer FE/BE/script 共通化 (2 セッション、横断変更、Evaluator 必須)
+- Phase 10 #251 summaryGenerator unit test + #200 Firestore emulator test (2 セッション)
+- Phase 11 #299 ts-node/esm 環境整備 (1.5-2 セッション、過去 PR #298 失敗実績、3 回失敗 → /codex 委譲条項)
+- Phase 12 #238 / #239 force-reindex audit log + 孤児検出 (1-2 セッション、低優先)
+
+### 見送り (本セッション scope 外、follow-up Issue 起票済)
+
+| # | 内容 | 由来 |
+|---|------|------|
+| **#338** | DocumentMaster 型を shared/types.ts と extractors.ts で統合 (optionality 方向性決定) | PR #337 Evaluator + type-design-analyzer + code-reviewer 一致指摘 |
+| **#339** | LoadedMasterData と pdfAnalyzer.MasterData 型の統合 (drift risk) | PR #337 code-simplifier + type-design-analyzer |
+| **#340** | loadMasterData カバレッジ拡張 (部分失敗・全除外・name 欠落 silent drop) | PR #337 pr-test-analyzer + silent-failure-hunter |
+
+### Test plan 実行結果
+
+- [x] BE `npx tsc --noEmit` EXIT 0
+- [x] BE `npm test` **632 passing** (dateMarker 5 + 空文字 1 + loadMasterData 4 = +10)
+- [x] FE `npx tsc --noEmit` EXIT 0
+- [x] FE `npm test` (vitest) **127 passing** (変化なし)
+- [x] `scripts/check-master-data.js` syntax check (`node -c`) OK
+- [x] main CI 3/3 green (lint-build-test 5m49s / CodeRabbit / GitGuardian 全 pass)
+- [x] `gh issue view 188 / 189 / 190` で CLOSED 確認 (squash merge で 3 件とも auto-close 成功)
+- [x] follow-up Issue #338-#340 起票確認
+
+---
+
+**過去セッション (session15〜22) は `docs/handoff/archive/2026-04-history.md` に移管済み。** 本 session25 完了時点で session23/24 を archive へ追加移管予定 (次セッション冒頭で実施可)。
+
+直近前セッション:
+- **session24** (2026-04-20): WBS Phase 1 + Phase 2 完遂 (3 PR #328/#329/#330)、5 Issue closed、15+ エージェントレビュー
+- **session23** (2026-04-20): Phase A-1 #312 helper API 改善セット 完遂 (3 PR #323/#325/#326)、Issue 2 件 closed、13 エージェントレビュー
+- 以前は下記 `session24` 詳細 + `docs/handoff/archive/2026-04-history.md` 参照
+
+---
 
 <a id="session24"></a>
 ## ✅ session24 完了サマリー (WBS Phase 1 + Phase 2 完遂)


### PR DESCRIPTION
## Summary
- Phase 3 (#188 + #189 + #190) 完遂を handoff に記録
- next session 向けに Phase 4/5/6 候補を整理
- Lessons Learned 6 項目を文書化

## 次セッション着手候補
- **Phase 4**: #196 (rescueStuckProcessingDocs MAX_RETRY_COUNT) + #152 (dev 環境 setup-tenant)
- **Phase 5**: #331-#335 sanitize/displayFileName follow-up 群
- **Phase 6**: #338-#340 Phase 3 follow-up (型統合・カバレッジ拡張)

## Test plan
- [x] LATEST.md 213 行 (500 行以下)
- [x] session25 エントリ追加、session24 は既存維持
- [ ] マージ後 `archive` への session23/24 移管 (次セッション冒頭実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project documentation to reflect current session phase and tracking information, including completed deliverables, outstanding issues, and quality assurance metrics.

**Note:** This release contains no user-facing changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->