### PR TITLE
refactor: LoadedMasterData 型統合 + loadMasterData テスト拡張 (#339 #340)

### DIFF
--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -8,17 +8,12 @@
 import type * as admin from 'firebase-admin';
 import type { CustomerMaster, DocumentMaster, OfficeMaster } from './extractors';
 import { MASTER_PATHS } from './masterPaths';
+import type { MasterData } from './pdfAnalyzer';
 import {
   sanitizeCustomerMasters,
   sanitizeDocumentMasters,
   sanitizeOfficeMasters,
 } from './sanitizeMasterData';
-
-export interface LoadedMasterData {
-  documents: DocumentMaster[];
-  customers: CustomerMaster[];
-  offices: OfficeMaster[];
-}
 
 type RawDoc = FirebaseFirestore.DocumentData;
 
@@ -59,7 +54,7 @@ function toOfficeMaster(id: string, raw: RawDoc): OfficeMaster {
 
 export async function loadMasterData(
   db: admin.firestore.Firestore
-): Promise<LoadedMasterData> {
+): Promise<MasterData> {
   const [documentSnap, customerSnap, officeSnap] = await Promise.all([
     db.collection(MASTER_PATHS.documents).get(),
     db.collection(MASTER_PATHS.customers).get(),

--- a/functions/test/loadMasterData.test.ts
+++ b/functions/test/loadMasterData.test.ts
@@ -143,20 +143,32 @@ describe('loadMasterData', () => {
     expect(result.offices).to.deep.equal([]);
   });
 
-  it('name欠落レコードはsilent dropされ、有効レコードのみ残る（現状契約）', async () => {
+  it('name欠落レコードはsilent dropされ、有効レコードのみ残る（3 sanitizer 全てで同契約）', async () => {
     const stub = createFirestoreStub({
       'masters/documents/items': [
         { id: 'd1', data: { name: '保険証', category: '保険' } },
         { id: 'd2', data: { category: '届出' } }, // name 欠落 → drop
         { id: 'd3', data: { name: '請求書' } },
       ],
-      'masters/customers/items': [],
-      'masters/offices/items': [],
+      'masters/customers/items': [
+        { id: 'c1', data: { name: '田中太郎' } },
+        { id: 'c2', data: { furigana: 'すずき' } }, // name 欠落 → drop
+        { id: 'c3', data: { name: '鈴木花子' } },
+      ],
+      'masters/offices/items': [
+        { id: 'o1', data: { name: '事業所A' } },
+        { id: 'o2', data: { shortName: 'B' } }, // name 欠落 → drop
+        { id: 'o3', data: { name: '事業所C' } },
+      ],
     });
 
     const result = await loadMasterData(stub);
 
     expect(result.documents).to.have.length(2);
     expect(result.documents.map((d) => d.id)).to.deep.equal(['d1', 'd3']);
+    expect(result.customers).to.have.length(2);
+    expect(result.customers.map((c) => c.id)).to.deep.equal(['c1', 'c3']);
+    expect(result.offices).to.have.length(2);
+    expect(result.offices.map((o) => o.id)).to.deep.equal(['o1', 'o3']);
   });
 });

--- a/functions/test/loadMasterData.test.ts
+++ b/functions/test/loadMasterData.test.ts
@@ -94,4 +94,69 @@ describe('loadMasterData', () => {
       expect((err as Error).message).to.equal('Firestore unavailable');
     }
   });
+
+  it('3コレクションのうち1つだけrejectしても呼び出し元に伝播する（Promise.all 先着reject）', async () => {
+    const partialFailingStub = {
+      collection(path: string) {
+        return {
+          get: async () => {
+            if (path === 'masters/customers/items') {
+              throw new Error('customers fetch failed');
+            }
+            return {
+              docs:
+                path === 'masters/documents/items'
+                  ? [{ id: 'd1', data: () => ({ name: '保険証' }) }]
+                  : [{ id: 'o1', data: () => ({ name: '事業所A' }) }],
+            };
+          },
+        };
+      },
+    } as unknown as admin.firestore.Firestore;
+
+    try {
+      await loadMasterData(partialFailingStub);
+      expect.fail('should throw');
+    } catch (err) {
+      expect((err as Error).message).to.equal('customers fetch failed');
+    }
+  });
+
+  it('全レコードがサニタイズで除外されるケース（name欠落のみ）では空配列を返す', async () => {
+    const stub = createFirestoreStub({
+      'masters/documents/items': [
+        { id: 'd1', data: { category: '保険' } }, // name 欠落
+        { id: 'd2', data: { name: '', category: '届出' } }, // name 空文字
+      ],
+      'masters/customers/items': [
+        { id: 'c1', data: { furigana: 'たろう' } }, // name 欠落
+      ],
+      'masters/offices/items': [
+        { id: 'o1', data: { name: 123 } }, // name が数値（型崩れ）
+      ],
+    });
+
+    const result = await loadMasterData(stub);
+
+    expect(result.documents).to.deep.equal([]);
+    expect(result.customers).to.deep.equal([]);
+    expect(result.offices).to.deep.equal([]);
+  });
+
+  it('name欠落レコードはsilent dropされ、有効レコードのみ残る（現状契約）', async () => {
+    const stub = createFirestoreStub({
+      'masters/documents/items': [
+        { id: 'd1', data: { name: '保険証', category: '保険' } },
+        { id: 'd2', data: { category: '届出' } }, // name 欠落 → drop
+        { id: 'd3', data: { name: '請求書' } },
+      ],
+      'masters/customers/items': [],
+      'masters/offices/items': [],
+    });
+
+    const result = await loadMasterData(stub);
+
+    expect(result.documents).to.have.length(2);
+    expect(result.documents.map((d) => d.id)).to.deep.equal(['d1', 'd3']);
+  });
 });


### PR DESCRIPTION
## Summary
- **#339**: `LoadedMasterData` を削除し `pdfAnalyzer.ts` の `MasterData` に統一。同一構造の型が 2 箇所で管理される drift リスクを解消
- **#340**: pr-test-analyzer / silent-failure-hunter 指摘の 3 エッジケース (部分 reject / 全 sanitize 除外 / name 欠落 silent drop) をテスト追加で lock-in
- Phase 3 の follow-up。WBS Phase A (loadMasterData 周辺)

## Design decisions
- **どちらの型に寄せるか**: `MasterData` 側の consumer が 2 箇所 (pdfOperations.ts / pdfAnalyzer.ts 内部)、`LoadedMasterData` は内部のみ → `MasterData` に集約
- **循環参照**: pdfAnalyzer.ts は loadMasterData を import していないため問題なし
- **#340 (3) silent drop の扱い**: 設計拡張 (drop カウント返却) は scope 外、現状 behavior の契約テストのみ追加

## Test plan
- [x] `npm test` (functions) → 635 passing (loadMasterData.test.ts 7 cases 含む)
- [x] `npm run lint` → 0 errors (既存 warnings 21 件は本 PR 無関係)
- [x] `npx tsc --noEmit` (functions) → PASS
- [x] `npx tsc --noEmit` (frontend) → PASS
- [x] 回帰なし確認

## 関連
- Closes #339
- Closes #340
- Phase 3 follow-up: PR #337 (loadMasterData 新設)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type consistency across data management utilities.

* **Tests**
  * Expanded test coverage for data loading functionality, including error handling, data sanitization, and edge case validation to ensure robust operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->