### PR TITLE
refactor: timestampToDateString を timestampHelpers に抽出 (#332)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -20,7 +20,7 @@ import {
 } from '../utils/pdfAnalyzer';
 import { buildSplitDocumentData } from './splitDocumentBuilder';
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
-import { timestampToDateString } from '../utils/backfillDisplayFileName';
+import { timestampToDateString } from '../utils/timestampHelpers';
 import { loadMasterData } from '../utils/loadMasterData';
 
 const db = admin.firestore();

--- a/functions/src/utils/backfillDisplayFileName.ts
+++ b/functions/src/utils/backfillDisplayFileName.ts
@@ -1,32 +1,15 @@
 /**
  * displayFileName バックフィル用ヘルパー
  *
- * 既存ドキュメントの Firestore Timestamp を文字列に変換し、
- * generateDisplayFileName に渡すための変換ロジック。
+ * Firestore ドキュメントから displayFileName を生成する backfill 固有ロジック。
+ * Timestamp → string 変換は utils/timestampHelpers に抽出済み (本番 pdfOperations 共用)。
  */
 
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
-
-interface TimestampLike {
-  seconds: number;
-  nanoseconds: number;
-  toDate?: () => Date;
-}
-
-/**
- * Firestore Timestamp（またはプレーンオブジェクト）を YYYY/MM/DD 文字列に変換
- */
-export function timestampToDateString(
-  ts: TimestampLike | null | undefined
-): string | undefined {
-  if (!ts || !ts.seconds) return undefined;
-
-  const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}/${m}/${d}`;
-}
+import {
+  type TimestampLike,
+  timestampToDateString,
+} from './timestampHelpers';
 
 interface DocData {
   documentType?: string;

--- a/functions/src/utils/timestampHelpers.ts
+++ b/functions/src/utils/timestampHelpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Firestore Timestamp 変換ヘルパー。
+ *
+ * backfill と本番 (pdfOperations) の両系列で使う。
+ */
+
+export interface TimestampLike {
+  seconds: number;
+  nanoseconds: number;
+  toDate?: () => Date;
+}
+
+/**
+ * Firestore Timestamp（またはプレーンオブジェクト）を YYYY/MM/DD 文字列に変換
+ */
+export function timestampToDateString(
+  ts: TimestampLike | null | undefined
+): string | undefined {
+  if (!ts || !ts.seconds) return undefined;
+
+  const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}/${m}/${d}`;
+}

--- a/functions/test/backfillDisplayFileName.test.ts
+++ b/functions/test/backfillDisplayFileName.test.ts
@@ -1,50 +1,14 @@
 /**
  * displayFileName バックフィル テスト
  *
- * 既存ドキュメントに displayFileName を一括設定するマイグレーション用
- * バックフィル固有のロジック（Timestamp→文字列変換、ドキュメントデータからの生成）をテスト
+ * buildDisplayFileNameFromDoc (backfill 固有のドキュメントデータ組立) をテスト。
+ * timestampToDateString の単体 test は timestampHelpers.test.ts に移動済み。
  */
 
 import { expect } from 'chai';
-import {
-  timestampToDateString,
-  buildDisplayFileNameFromDoc,
-} from '../src/utils/backfillDisplayFileName';
+import { buildDisplayFileNameFromDoc } from '../src/utils/backfillDisplayFileName';
 
 describe('displayFileName バックフィル', () => {
-  describe('timestampToDateString', () => {
-    it('Timestampオブジェクト（seconds/nanoseconds）を YYYY/MM/DD 文字列に変換', () => {
-      // 2026-03-16 00:00:00 UTC → ローカルTZで解釈
-      const ts = { seconds: 1773619200, nanoseconds: 0 };
-      const result = timestampToDateString(ts);
-      // UTCで2026-03-16。ローカルTZにより日付が変わりうるため、フォーマットのみ検証
-      expect(result).to.match(/^\d{4}\/\d{2}\/\d{2}$/);
-    });
-
-    it('null の場合は undefined を返す', () => {
-      expect(timestampToDateString(null)).to.be.undefined;
-    });
-
-    it('undefined の場合は undefined を返す', () => {
-      expect(timestampToDateString(undefined)).to.be.undefined;
-    });
-
-    it('seconds が 0 の場合は undefined を返す（無効な日付）', () => {
-      const ts = { seconds: 0, nanoseconds: 0 };
-      expect(timestampToDateString(ts)).to.be.undefined;
-    });
-
-    it('toDate メソッドを持つ Timestamp インスタンスも変換可能', () => {
-      // 2026-01-15 00:00:00 UTC（TZずれなし確認用に15日を使用）
-      const ts = {
-        seconds: 1768435200,
-        nanoseconds: 0,
-        toDate: () => new Date(1768435200 * 1000),
-      };
-      expect(timestampToDateString(ts)).to.equal('2026/01/15');
-    });
-  });
-
   describe('buildDisplayFileNameFromDoc', () => {
     it('全メタ情報が揃ったドキュメントから displayFileName を生成', () => {
       const doc = {

--- a/functions/test/displayFileName.test.ts
+++ b/functions/test/displayFileName.test.ts
@@ -179,7 +179,7 @@ describe('displayFileName 自動生成 (#178 Stage 1)', () => {
 
   describe('generateDisplayFileName - 日付 fallback 経路 (#182)', () => {
     // pdfOperations.ts 内の `fileDateFormatted ?? timestampToDateString(fileDate)` chain を
-    // 単体で lock-in。timestampToDateString 自体の単体 test は backfillDisplayFileName.test.ts
+    // 単体で lock-in。timestampToDateString 自体の単体 test は timestampHelpers.test.ts
     // に存在するため、本 describe は fallback 優先順位と null passthrough のみ検証する。
     it('fileDateFormatted 未設定 + Timestamp 由来文字列 (YYYY/MM/DD) 設定時、YYYYMMDD として採用', () => {
       const fileDateFormatted: string | null = null;

--- a/functions/test/timestampHelpers.test.ts
+++ b/functions/test/timestampHelpers.test.ts
@@ -1,0 +1,40 @@
+/**
+ * timestampHelpers (Firestore Timestamp 変換) の単体テスト。
+ * backfill / 本番 pdfOperations 両系列で使うため backfillDisplayFileName から独立。
+ */
+
+import { expect } from 'chai';
+import { timestampToDateString } from '../src/utils/timestampHelpers';
+
+describe('timestampToDateString', () => {
+  it('Timestampオブジェクト（seconds/nanoseconds）を YYYY/MM/DD 文字列に変換', () => {
+    // 2026-03-16 00:00:00 UTC → ローカルTZで解釈
+    const ts = { seconds: 1773619200, nanoseconds: 0 };
+    const result = timestampToDateString(ts);
+    // UTCで2026-03-16。ローカルTZにより日付が変わりうるため、フォーマットのみ検証
+    expect(result).to.match(/^\d{4}\/\d{2}\/\d{2}$/);
+  });
+
+  it('null の場合は undefined を返す', () => {
+    expect(timestampToDateString(null)).to.be.undefined;
+  });
+
+  it('undefined の場合は undefined を返す', () => {
+    expect(timestampToDateString(undefined)).to.be.undefined;
+  });
+
+  it('seconds が 0 の場合は undefined を返す（無効な日付）', () => {
+    const ts = { seconds: 0, nanoseconds: 0 };
+    expect(timestampToDateString(ts)).to.be.undefined;
+  });
+
+  it('toDate メソッドを持つ Timestamp インスタンスも変換可能', () => {
+    // 2026-01-15 00:00:00 UTC（TZずれなし確認用に15日を使用）
+    const ts = {
+      seconds: 1768435200,
+      nanoseconds: 0,
+      toDate: () => new Date(1768435200 * 1000),
+    };
+    expect(timestampToDateString(ts)).to.equal('2026/01/15');
+  });
+});


### PR DESCRIPTION
## Summary
- **#332**: \`timestampToDateString\` (と \`TimestampLike\` interface) を \`backfillDisplayFileName.ts\` から \`utils/timestampHelpers.ts\` に抽出
- PR #330 review-pr code-reuse Important #2 指摘対応
- Phase 3 WBS Phase B (Phase A #339/#340 に続く)

## 変更理由
本番パス (\`pdfOperations.ts\`) が \`backfillDisplayFileName\` 経由で \`timestampToDateString\` を import していたが、「backfill 専用」を示唆する name と実態 (本番 PDF 分割でも使用) が不一致。将来の reader が backfill-only と誤読するリスクを解消。

## 変更内容
| File | 変更 |
|------|------|
| \`functions/src/utils/timestampHelpers.ts\` | 新設 (TimestampLike + timestampToDateString) |
| \`functions/src/utils/backfillDisplayFileName.ts\` | timestampHelpers から import、自前定義削除 |
| \`functions/src/pdf/pdfOperations.ts\` | import path 変更 |
| \`functions/test/timestampHelpers.test.ts\` | 新設 (5 cases 移動) |
| \`functions/test/backfillDisplayFileName.test.ts\` | timestampToDateString セクション削除 (buildDisplayFileNameFromDoc のみ残) |

## Test plan
- [x] \`npm test\` (functions) → 635 passing
- [x] \`npm run lint\` → 0 errors (既存 warnings 21 件は本 PR 無関係)
- [x] \`npx tsc --noEmit\` (functions/frontend) → PASS
- [x] 回帰なし確認

## 関連
- Closes #332
- Phase A: #342 (merged) — #339 #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)