### PR TITLE
fix: timestampToDateString epoch (seconds=0) 扱いを修正 (Closes #346)

### DIFF
--- a/functions/src/utils/timestampHelpers.ts
+++ b/functions/src/utils/timestampHelpers.ts
@@ -16,8 +16,9 @@ export interface TimestampLike {
 export function timestampToDateString(
   ts: TimestampLike | null | undefined
 ): string | undefined {
-  // seconds=0 (epoch 1970-01-01) を silent に missing 扱いしないため typeof で判定する (#346)
-  if (!ts || typeof ts.seconds !== 'number') return undefined;
+  // seconds=0 (epoch 1970-01-01) を silent に missing 扱いしないため typeof で判定する (#346)。
+  // NaN / Infinity は typeof 'number' を通るが Date(NaN) → "NaN/NaN/NaN" silent 誤出力になるため isFinite で排除する。
+  if (!ts || typeof ts.seconds !== 'number' || !Number.isFinite(ts.seconds)) return undefined;
 
   const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
   const y = date.getFullYear();

--- a/functions/src/utils/timestampHelpers.ts
+++ b/functions/src/utils/timestampHelpers.ts
@@ -16,7 +16,8 @@ export interface TimestampLike {
 export function timestampToDateString(
   ts: TimestampLike | null | undefined
 ): string | undefined {
-  if (!ts || !ts.seconds) return undefined;
+  // seconds=0 (epoch 1970-01-01) を silent に missing 扱いしないため typeof で判定する (#346)
+  if (!ts || typeof ts.seconds !== 'number') return undefined;
 
   const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
   const y = date.getFullYear();

--- a/functions/test/timestampHelpers.test.ts
+++ b/functions/test/timestampHelpers.test.ts
@@ -42,6 +42,17 @@ describe('timestampToDateString', () => {
     expect(timestampToDateString(ts)).to.be.undefined;
   });
 
+  it('seconds が NaN の場合は undefined を返す (#346 silent-failure-hunter)', () => {
+    // typeof NaN === 'number' で guard を素通りしてしまうため、Number.isFinite で排除する。
+    const ts = { seconds: NaN, nanoseconds: 0 };
+    expect(timestampToDateString(ts)).to.be.undefined;
+  });
+
+  it('seconds が Infinity の場合は undefined を返す (#346 silent-failure-hunter)', () => {
+    const ts = { seconds: Infinity, nanoseconds: 0 };
+    expect(timestampToDateString(ts)).to.be.undefined;
+  });
+
   it('toDate メソッドを持つ Timestamp インスタンスも変換可能', () => {
     // 2026-01-15 00:00:00 UTC（TZずれなし確認用に15日を使用）
     const ts = {

--- a/functions/test/timestampHelpers.test.ts
+++ b/functions/test/timestampHelpers.test.ts
@@ -23,8 +23,22 @@ describe('timestampToDateString', () => {
     expect(timestampToDateString(undefined)).to.be.undefined;
   });
 
-  it('seconds が 0 の場合は undefined を返す（無効な日付）', () => {
+  it('seconds=0 (epoch 1970-01-01) を有効な日付として扱う (#346)', () => {
+    // 旧仕様では `!ts.seconds` で silent null だったが、0 は有効な Timestamp 値。
+    // UTC epoch をローカル TZ 解釈するため、正規表現でフォーマットのみ検証する。
     const ts = { seconds: 0, nanoseconds: 0 };
+    const result = timestampToDateString(ts);
+    expect(result).to.match(/^\d{4}\/\d{2}\/\d{2}$/);
+  });
+
+  it('seconds が undefined の場合は undefined を返す (#346)', () => {
+    // `typeof ts.seconds !== 'number'` guard の lock-in。
+    const ts = { nanoseconds: 0 } as unknown as { seconds: number; nanoseconds: number };
+    expect(timestampToDateString(ts)).to.be.undefined;
+  });
+
+  it('seconds が string の場合は undefined を返す (#346)', () => {
+    const ts = { seconds: '1773619200', nanoseconds: 0 } as unknown as { seconds: number; nanoseconds: number };
     expect(timestampToDateString(ts)).to.be.undefined;
   });
 


### PR DESCRIPTION
## Summary
- PR #345 type-design-analyzer 指摘 (#346) の bug fix
- `!ts.seconds` の truthy/falsy 判定を `typeof ts.seconds !== 'number'` に変更
- `seconds=0` (epoch 1970-01-01) が silent null になる latent bug を解消

## 変更ファイル
- `functions/src/utils/timestampHelpers.ts` — guard 修正 + コメント追加
- `functions/test/timestampHelpers.test.ts` — 既存テスト仕様変更 + lock-in テスト 2 件追加

## Test plan
- [x] `npm test` — functions 全650テスト PASS
- [x] `npm run lint` — 既存 warnings のみ、新規 error なし
- [x] `npx tsc --noEmit` — PASS
- [x] `timestampHelpers.test.ts` 7 ケース PASS (既存 4 + 新規 3)

## 呼び出し元影響
- `backfillDisplayFileName.ts:29` — Firestore `doc.fileDate` 由来、seconds=0 実運用ケース想定外
- `pdfOperations.ts:377` — 同上
- `scripts/backfill-display-filename.js:64` — inline 版 (#334 スコープで別途対応)

## Scope 外
- `scripts/backfill-display-filename.js` の inline 同コード: #334 (shared 統合) で一括修正予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)