### PR TITLE
refactor: MasterData 型を pdfAnalyzer→extractors に移動 (Closes #343)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -16,8 +16,8 @@ import {
   analyzePdf,
   generateSplitSummary,
   PageOcrData,
-  MasterData,
 } from '../utils/pdfAnalyzer';
+import type { MasterData } from '../utils/extractors';
 import { buildSplitDocumentData } from './splitDocumentBuilder';
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
 import { timestampToDateString } from '../utils/timestampHelpers';

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -158,6 +158,16 @@ export interface DocumentMaster {
 }
 
 /**
+ * マスターデータ envelope (OCR + PDF split 両系列で共用)。
+ * #343: pdfAnalyzer.ts は analyzer concern に閉じ、型は *Master element と同居させる。
+ */
+export interface MasterData {
+  customers: CustomerMaster[];
+  documents: DocumentMaster[];
+  offices: OfficeMaster[];
+}
+
+/**
  * ファイル名から情報を抽出
  *
  * ファイル名パターン例:

--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -6,9 +6,8 @@
  */
 
 import type * as admin from 'firebase-admin';
-import type { CustomerMaster, DocumentMaster, OfficeMaster } from './extractors';
+import type { CustomerMaster, DocumentMaster, MasterData, OfficeMaster } from './extractors';
 import { MASTER_PATHS } from './masterPaths';
-import type { MasterData } from './pdfAnalyzer';
 import {
   sanitizeCustomerMasters,
   sanitizeDocumentMasters,

--- a/functions/src/utils/pdfAnalyzer.ts
+++ b/functions/src/utils/pdfAnalyzer.ts
@@ -18,9 +18,7 @@ import {
   extractDateEnhanced,
   aggregateCustomerCandidates,
   aggregateOfficeCandidates,
-  CustomerMaster,
-  DocumentMaster,
-  OfficeMaster,
+  MasterData,
   CustomerCandidate,
   OfficeCandidate,
   CustomerExtractionResult,
@@ -140,13 +138,6 @@ export interface PdfAnalysisResult {
   shouldSplit: boolean;
   /** 分割推奨理由 */
   splitReason?: string;
-}
-
-/** マスターデータ */
-export interface MasterData {
-  customers: CustomerMaster[];
-  documents: DocumentMaster[];
-  offices: OfficeMaster[];
 }
 
 /**

--- a/functions/test/pdfAnalyzer.test.ts
+++ b/functions/test/pdfAnalyzer.test.ts
@@ -12,8 +12,8 @@ import {
   generateSplitSummary,
   PageOcrData,
   PageAnalysisResult,
-  MasterData,
 } from '../src/utils/pdfAnalyzer';
+import type { MasterData } from '../src/utils/extractors';
 
 // テスト用マスターデータ
 const masterData: MasterData = {


### PR DESCRIPTION
## Summary
- PR #342 type-design-analyzer 指摘対応 (#343)
- `MasterData` envelope 型を analyzer concern から data-shape concern に移動
- natural dependency direction 違反を解消 (loadMasterData → extractors の一方向に)

## 変更ファイル (5 ファイル、+14/-14 lines、純粋な型移動)
1. `functions/src/utils/extractors.ts` — `MasterData` 定義を追加
2. `functions/src/utils/pdfAnalyzer.ts` — 定義削除 + 未使用 import 整理
3. `functions/src/utils/loadMasterData.ts` — import path 変更
4. `functions/src/pdf/pdfOperations.ts` — import path 変更 (type-only)
5. `functions/test/pdfAnalyzer.test.ts` — import path 変更 (type-only)

## Test plan
- [x] `npm test` — 648 passing (型移動のみなのでテスト数は同一、追加不要)
- [x] `npx tsc --noEmit` — PASS
- [x] `npm run lint` — 既存 warnings のみ、新規 error なし

## Backward Compatibility
全 caller (3 source + 1 test) を本 PR で同時更新。re-export shim は残さない (CLAUDE.md "Don't design for hypothetical future requirements"、全 caller 掌握済み)。

## Scope 外
- #338 (DocumentMaster optionality 統合) — 別 issue、frontend 10+ 影響の大物
- 循環参照の回避は structural な改善。本 PR では検知されていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)