### PR TITLE
feat: sanitize*Masters の silent drop を observable 化 (Closes #344)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -237,7 +237,10 @@ export async function processDocument(
     }
   );
 
-  const { documents, customers, offices } = await loadMasterData(db);
+  const { documents, customers, offices } = await loadMasterData(db, {
+    source: 'ocr',
+    functionName: 'ocrProcessor',
+  });
 
   // 情報抽出（強化版エクストラクター使用）
   const documentTypeResult = extractDocumentTypeEnhanced(ocrResult, documents);

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -92,7 +92,10 @@ export const detectSplitPoints = onCall(
 
     // 強化版分析を使用
     if (useEnhanced) {
-      const masters: MasterData = await loadMasterData(db);
+      const masters: MasterData = await loadMasterData(db, {
+        source: 'pdf',
+        functionName: 'detectSplitPoints',
+      });
 
       // ページデータを変換
       const pages: PageOcrData[] = pageResults.map((p) => ({

--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -11,6 +11,7 @@
 
 import type * as admin from 'firebase-admin';
 import type { CustomerMaster, DocumentMaster, MasterData, OfficeMaster } from './extractors';
+import type { ErrorSource } from './errorLogger';
 import { MASTER_PATHS } from './masterPaths';
 import {
   sanitizeCustomerMasters,
@@ -93,6 +94,7 @@ function isFirebaseFunctionsRuntime(): boolean {
  */
 async function reportSanitizeDrops(
   reports: Array<{ kind: 'documents' | 'customers' | 'offices'; rawCount: number; droppedIds: string[] }>,
+  context: { source: ErrorSource; functionName: string },
 ): Promise<void> {
   const dropped = reports.filter((r) => r.droppedIds.length > 0);
   if (dropped.length === 0) return;
@@ -117,8 +119,8 @@ async function reportSanitizeDrops(
     const { safeLogError } = require('./errorLogger') as typeof import('./errorLogger');
     await safeLogError({
       error: new Error(message),
-      source: 'ocr',
-      functionName: 'loadMasterData',
+      source: context.source,
+      functionName: context.functionName,
     });
   } catch (loadErr) {
     // 全 droppedIds を fallback に含める (safeLogError 不達時のデバッグ可能性担保)
@@ -131,9 +133,21 @@ async function reportSanitizeDrops(
   }
 }
 
+/**
+ * マスターデータを取得する。
+ *
+ * @param db Firestore インスタンス
+ * @param options.source 呼び出し元の functional area (drop 発生時 safeLogError の source として記録)。
+ *   省略時 'ocr' を default とする (歴史的な主 caller、既存動作の後方互換)。
+ *   PDF 分割候補検出から呼ぶ場合は 'pdf' を明示 (#344 codex-review 指摘対応)。
+ * @param options.functionName 呼び出し元関数名 (observability の trace 用、省略時 'loadMasterData')
+ */
 export async function loadMasterData(
-  db: admin.firestore.Firestore
+  db: admin.firestore.Firestore,
+  options: { source?: ErrorSource; functionName?: string } = {},
 ): Promise<MasterData> {
+  const source: ErrorSource = options.source ?? 'ocr';
+  const functionName = options.functionName ?? 'loadMasterData';
   const [documentSnap, customerSnap, officeSnap] = await Promise.all([
     db.collection(MASTER_PATHS.documents).get(),
     db.collection(MASTER_PATHS.customers).get(),
@@ -148,11 +162,14 @@ export async function loadMasterData(
   const customerResult = sanitizeCustomerMasters(customerRaw);
   const officeResult = sanitizeOfficeMasters(officeRaw);
 
-  await reportSanitizeDrops([
-    { kind: 'documents', rawCount: documentRaw.length, droppedIds: documentResult.droppedIds },
-    { kind: 'customers', rawCount: customerRaw.length, droppedIds: customerResult.droppedIds },
-    { kind: 'offices', rawCount: officeRaw.length, droppedIds: officeResult.droppedIds },
-  ]);
+  await reportSanitizeDrops(
+    [
+      { kind: 'documents', rawCount: documentRaw.length, droppedIds: documentResult.droppedIds },
+      { kind: 'customers', rawCount: customerRaw.length, droppedIds: customerResult.droppedIds },
+      { kind: 'offices', rawCount: officeRaw.length, droppedIds: officeResult.droppedIds },
+    ],
+    { source, functionName },
+  );
 
   return {
     documents: documentResult.items,

--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -3,6 +3,10 @@
  *
  * 3 コレクション（documents/customers/offices）を並列取得し、各サニタイザで型崩れを
  * 除去したマスターデータを返す。OCR 処理と PDF 分割提案の両系列で使う。
+ *
+ * #344: sanitize で drop が発生した場合、errorLogger.safeLogError で observability を確保する
+ *       (silent failure 解消)。errorLogger は top-level で admin.firestore() を呼ぶため lazy
+ *       import で遅延初期化する (テスト環境で未初期化の場合も主パスが壊れない)。
  */
 
 import type * as admin from 'firebase-admin';
@@ -51,6 +55,82 @@ function toOfficeMaster(id: string, raw: RawDoc): OfficeMaster {
   };
 }
 
+/**
+ * Firebase Functions runtime 判定 (positive signal)。
+ *
+ * `NODE_ENV === 'production'` 単独判定は Functions Gen2 (Cloud Run ベース) で
+ * 未設定のケースがあり、production drop を safeLogError に送れない silent risk がある
+ * (silent-failure-hunter Important #1 対応)。Firebase runtime は `K_SERVICE` (Cloud Run SA
+ * 由来) または `FUNCTION_TARGET` (Functions framework) を常時セットするため、いずれか
+ * 検出で production path を確定させる。ローカル dev / test 環境では両方 unset で skip される。
+ */
+function isFirebaseFunctionsRuntime(): boolean {
+  return (
+    !!process.env.K_SERVICE ||
+    !!process.env.FUNCTION_TARGET ||
+    process.env.NODE_ENV === 'production'
+  );
+}
+
+/**
+ * sanitize 各層の drop 結果を集約し observability を確保する (#344)。
+ *
+ * 挙動:
+ * - drop ゼロ → no-op (return early)
+ * - drop あり → console.warn 1 発 (常時、本番/テスト共通) + Firebase runtime のみ safeLogError 発火
+ * - 「raw 非ゼロ だが items ゼロ」の kind があれば Error message prefix を 'ALL RECORDS DROPPED'
+ *   にする (運用で閾値検知を容易にする)
+ *
+ * Why lazy require:
+ * errorLogger は top-level で `admin.firestore()` を呼ぶため、admin 未初期化のテスト環境で
+ * import するとエラーになる。Firebase runtime gate + lazy require は textCap.ts の既存パターン
+ * (rules/error-handling.md §1 の独立 try-catch 推奨に準拠)。テスト環境では console.warn
+ * を stub して drop 検出を検証する。
+ *
+ * Why always async:
+ * 戻り値を `Promise<void>` 統一 (evaluator/silent-failure-hunter 指摘)。caller は常に await
+ * で待機する契約で、将来 safeLogError が sync になっても型安全が崩れない。
+ */
+async function reportSanitizeDrops(
+  reports: Array<{ kind: 'documents' | 'customers' | 'offices'; rawCount: number; droppedIds: string[] }>,
+): Promise<void> {
+  const dropped = reports.filter((r) => r.droppedIds.length > 0);
+  if (dropped.length === 0) return;
+
+  const hasAllDroppedKind = dropped.some((r) => r.rawCount > 0 && r.rawCount === r.droppedIds.length);
+  // ログの可読性のため先頭 5 件のみ列挙、超過分は '...' で省略する (droppedIds.length > 5 の時のみ付与)。
+  // 全 droppedIds は fallback 時のデバッグ用に別途保持 (L87 allDroppedIds)。
+  const summary = dropped
+    .map((r) => `${r.kind}: ${r.droppedIds.length}/${r.rawCount} (ids: ${r.droppedIds.slice(0, 5).join(', ')}${r.droppedIds.length > 5 ? ', ...' : ''})`)
+    .join('; ');
+  const prefix = hasAllDroppedKind ? 'ALL RECORDS DROPPED' : 'Records dropped during sanitize';
+  const message = `${prefix}: ${summary}`;
+  const allDroppedIds = dropped.flatMap((r) => r.droppedIds);
+
+  console.warn(`[loadMasterData] ${message}`);
+
+  if (!isFirebaseFunctionsRuntime()) return;
+
+  // Firebase runtime のみ: errorLogger は top-level で admin.firestore() を呼ぶため lazy require
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { safeLogError } = require('./errorLogger') as typeof import('./errorLogger');
+    await safeLogError({
+      error: new Error(message),
+      source: 'ocr',
+      functionName: 'loadMasterData',
+    });
+  } catch (loadErr) {
+    // 全 droppedIds を fallback に含める (safeLogError 不達時のデバッグ可能性担保)
+    console.error(
+      '[loadMasterData] failed to load errorLogger for drop report:',
+      loadErr,
+      message,
+      { fullDroppedIds: allDroppedIds },
+    );
+  }
+}
+
 export async function loadMasterData(
   db: admin.firestore.Firestore
 ): Promise<MasterData> {
@@ -60,15 +140,23 @@ export async function loadMasterData(
     db.collection(MASTER_PATHS.offices).get(),
   ]);
 
+  const documentRaw = documentSnap.docs.map((d) => toDocumentMaster(d.id, d.data()));
+  const customerRaw = customerSnap.docs.map((d) => toCustomerMaster(d.id, d.data()));
+  const officeRaw = officeSnap.docs.map((d) => toOfficeMaster(d.id, d.data()));
+
+  const documentResult = sanitizeDocumentMasters(documentRaw);
+  const customerResult = sanitizeCustomerMasters(customerRaw);
+  const officeResult = sanitizeOfficeMasters(officeRaw);
+
+  await reportSanitizeDrops([
+    { kind: 'documents', rawCount: documentRaw.length, droppedIds: documentResult.droppedIds },
+    { kind: 'customers', rawCount: customerRaw.length, droppedIds: customerResult.droppedIds },
+    { kind: 'offices', rawCount: officeRaw.length, droppedIds: officeResult.droppedIds },
+  ]);
+
   return {
-    documents: sanitizeDocumentMasters(
-      documentSnap.docs.map((d) => toDocumentMaster(d.id, d.data()))
-    ),
-    customers: sanitizeCustomerMasters(
-      customerSnap.docs.map((d) => toCustomerMaster(d.id, d.data()))
-    ),
-    offices: sanitizeOfficeMasters(
-      officeSnap.docs.map((d) => toOfficeMaster(d.id, d.data()))
-    ),
+    documents: documentResult.items,
+    customers: customerResult.items,
+    offices: officeResult.items,
   };
 }

--- a/functions/src/utils/sanitizeMasterData.ts
+++ b/functions/src/utils/sanitizeMasterData.ts
@@ -5,9 +5,18 @@
  * 背景: INVALID_ARGUMENT: Property array contains an invalid nested entity
  *       マスターデータに配列やオブジェクトが混入していると、
  *       candidates配列経由でFirestore書き込み時にエラーとなる。
+ *
+ * #344: silent drop を observable にするため、戻り値に droppedIds を含める。
+ *       caller 側 (loadMasterData) が drop 件数に応じて safeLogError を発火する契約。
  */
 
 import type { CustomerMaster, OfficeMaster, DocumentMaster } from './extractors';
+
+/** サニタイズ結果 envelope (items + drop された id 一覧) */
+export interface SanitizeResult<T> {
+  items: T[];
+  droppedIds: string[];
+}
 
 /** 値が文字列であればそのまま、配列なら先頭要素、それ以外はundefined */
 function toOptionalString(value: unknown): string | undefined {
@@ -37,46 +46,72 @@ function toOptionalStringArray(value: unknown): string[] | undefined {
   return undefined;
 }
 
+/** id 欠落レコードでも drop trace に含めるための plug (id が string でない場合 '(unknown)' を採用) */
+function safeId(raw: { id?: unknown }): string {
+  return typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : '(unknown)';
+}
+
 export function sanitizeCustomerMasters(
   raw: CustomerMaster[]
-): CustomerMaster[] {
-  return raw
-    .filter((c) => typeof c.name === 'string' && c.name.length > 0)
-    .map((c) => ({
-      id: c.id,
-      name: c.name,
-      furigana: toOptionalString(c.furigana),
-      isDuplicate: toOptionalBoolean(c.isDuplicate),
-      careManagerName: toOptionalString(c.careManagerName),
-      aliases: toOptionalStringArray(c.aliases),
-    }));
+): SanitizeResult<CustomerMaster> {
+  const items: CustomerMaster[] = [];
+  const droppedIds: string[] = [];
+  for (const c of raw) {
+    if (typeof c.name === 'string' && c.name.length > 0) {
+      items.push({
+        id: c.id,
+        name: c.name,
+        furigana: toOptionalString(c.furigana),
+        isDuplicate: toOptionalBoolean(c.isDuplicate),
+        careManagerName: toOptionalString(c.careManagerName),
+        aliases: toOptionalStringArray(c.aliases),
+      });
+    } else {
+      droppedIds.push(safeId(c));
+    }
+  }
+  return { items, droppedIds };
 }
 
 export function sanitizeOfficeMasters(
   raw: OfficeMaster[]
-): OfficeMaster[] {
-  return raw
-    .filter((o) => typeof o.name === 'string' && o.name.length > 0)
-    .map((o) => ({
-      id: o.id,
-      name: o.name,
-      shortName: toOptionalString(o.shortName),
-      isDuplicate: toOptionalBoolean(o.isDuplicate),
-      aliases: toOptionalStringArray(o.aliases),
-    }));
+): SanitizeResult<OfficeMaster> {
+  const items: OfficeMaster[] = [];
+  const droppedIds: string[] = [];
+  for (const o of raw) {
+    if (typeof o.name === 'string' && o.name.length > 0) {
+      items.push({
+        id: o.id,
+        name: o.name,
+        shortName: toOptionalString(o.shortName),
+        isDuplicate: toOptionalBoolean(o.isDuplicate),
+        aliases: toOptionalStringArray(o.aliases),
+      });
+    } else {
+      droppedIds.push(safeId(o));
+    }
+  }
+  return { items, droppedIds };
 }
 
 export function sanitizeDocumentMasters(
   raw: DocumentMaster[]
-): DocumentMaster[] {
-  return raw
-    .filter((d) => typeof d.name === 'string' && d.name.length > 0)
-    .map((d) => ({
-      id: d.id,
-      name: d.name,
-      category: toOptionalString(d.category),
-      keywords: toOptionalStringArray(d.keywords),
-      aliases: toOptionalStringArray(d.aliases),
-      dateMarker: toOptionalNonEmptyString(d.dateMarker),
-    }));
+): SanitizeResult<DocumentMaster> {
+  const items: DocumentMaster[] = [];
+  const droppedIds: string[] = [];
+  for (const d of raw) {
+    if (typeof d.name === 'string' && d.name.length > 0) {
+      items.push({
+        id: d.id,
+        name: d.name,
+        category: toOptionalString(d.category),
+        keywords: toOptionalStringArray(d.keywords),
+        aliases: toOptionalStringArray(d.aliases),
+        dateMarker: toOptionalNonEmptyString(d.dateMarker),
+      });
+    } else {
+      droppedIds.push(safeId(d));
+    }
+  }
+  return { items, droppedIds };
 }

--- a/functions/test/loadMasterData.test.ts
+++ b/functions/test/loadMasterData.test.ts
@@ -143,6 +143,108 @@ describe('loadMasterData', () => {
     expect(result.offices).to.deep.equal([]);
   });
 
+  it('drop が発生すると console.warn で observable 化される (#344)', async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      const stub = createFirestoreStub({
+        'masters/documents/items': [
+          { id: 'd1', data: { name: '保険証' } },
+          { id: 'd2', data: {} }, // name 欠落 → drop
+        ],
+        'masters/customers/items': [],
+        'masters/offices/items': [],
+      });
+      await loadMasterData(stub);
+      expect(warnings).to.have.length(1);
+      expect(warnings[0]).to.include('[loadMasterData]');
+      expect(warnings[0]).to.include('Records dropped during sanitize');
+      expect(warnings[0]).to.include('documents: 1/2');
+      expect(warnings[0]).to.include('d2');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('全レコード drop のケースでは ALL RECORDS DROPPED prefix になる (#344)', async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      const stub = createFirestoreStub({
+        'masters/documents/items': [{ id: 'd1', data: {} }], // name 欠落
+        'masters/customers/items': [],
+        'masters/offices/items': [],
+      });
+      await loadMasterData(stub);
+      expect(warnings).to.have.length(1);
+      expect(warnings[0]).to.include('ALL RECORDS DROPPED');
+      expect(warnings[0]).to.include('documents: 1/1');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('drop ゼロのケースでは console.warn が呼ばれない (no-op path) (#344)', async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      const stub = createFirestoreStub({
+        'masters/documents/items': [{ id: 'd1', data: { name: '保険証' } }],
+        'masters/customers/items': [],
+        'masters/offices/items': [],
+      });
+      await loadMasterData(stub);
+      expect(warnings).to.deep.equal([]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('rawCount=0 の kind が混在しても ALL RECORDS DROPPED は誤発動しない (#344 silent-failure-hunter)', async () => {
+    // customers / offices が空 (rawCount=0) で documents のみ全件 drop した時、
+    // hasAllDroppedKind は documents の rawCount>0 判定で ALL RECORDS DROPPED 発動。
+    // rawCount=0 コレクションが偽陽性トリガーにならないことを lock-in。
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      const stub = createFirestoreStub({
+        'masters/documents/items': [{ id: 'd1', data: {} }], // 全件 drop
+        'masters/customers/items': [], // rawCount=0
+        'masters/offices/items': [], // rawCount=0
+      });
+      await loadMasterData(stub);
+      expect(warnings[0]).to.include('ALL RECORDS DROPPED');
+      // customers/offices は warn の summary に含まれない (dropped.filter で除外)
+      expect(warnings[0]).not.to.include('customers');
+      expect(warnings[0]).not.to.include('offices');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('id 欠落レコードが drop された場合、droppedIds には "(unknown)" が入る (#344)', async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      const stub = createFirestoreStub({
+        'masters/documents/items': [{ id: '', data: {} }], // id も name も欠落 (doc.id='' は createFirestoreStub で保持)
+        'masters/customers/items': [],
+        'masters/offices/items': [],
+      });
+      await loadMasterData(stub);
+      // id は空文字のまま toDocumentMaster に渡り、sanitize で name 欠落 → drop。
+      // safeId は string && length>0 なので '' は '(unknown)' に fallback する契約 lock-in
+      expect(warnings[0]).to.include('(unknown)');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('name欠落レコードはsilent dropされ、有効レコードのみ残る（3 sanitizer 全てで同契約）', async () => {
     const stub = createFirestoreStub({
       'masters/documents/items': [

--- a/functions/test/sanitizeMasterData.test.ts
+++ b/functions/test/sanitizeMasterData.test.ts
@@ -25,7 +25,8 @@ describe('sanitizeMasterData', () => {
         aliases: ['田中', 'タナカ'],
       }];
       const result = sanitizeCustomerMasters(input);
-      expect(result).to.deep.equal(input);
+      expect(result.items).to.deep.equal(input);
+      expect(result.droppedIds).to.deep.equal([]);
     });
 
     it('careManagerNameが配列の場合、先頭要素を文字列化する', () => {
@@ -35,7 +36,7 @@ describe('sanitizeMasterData', () => {
         careManagerName: ['山田', '佐藤'] as unknown as string,
       }];
       const result = sanitizeCustomerMasters(input);
-      expect(result[0].careManagerName).to.equal('山田');
+      expect(result.items[0].careManagerName).to.equal('山田');
     });
 
     it('careManagerNameがオブジェクトの場合、undefinedにする', () => {
@@ -45,7 +46,7 @@ describe('sanitizeMasterData', () => {
         careManagerName: { text: '山田' } as unknown as string,
       }];
       const result = sanitizeCustomerMasters(input);
-      expect(result[0].careManagerName).to.be.undefined;
+      expect(result.items[0].careManagerName).to.be.undefined;
     });
 
     it('nameが空文字やundefinedの場合、そのレコードを除外する', () => {
@@ -55,8 +56,9 @@ describe('sanitizeMasterData', () => {
         { id: 'c3', name: '鈴木一郎' },
       ];
       const result = sanitizeCustomerMasters(input);
-      expect(result).to.have.length(1);
-      expect(result[0].name).to.equal('鈴木一郎');
+      expect(result.items).to.have.length(1);
+      expect(result.items[0].name).to.equal('鈴木一郎');
+      expect(result.droppedIds).to.deep.equal(['c1', 'c2']);
     });
 
     it('aliasesが文字列の場合、配列に変換する', () => {
@@ -66,7 +68,7 @@ describe('sanitizeMasterData', () => {
         aliases: '田中' as unknown as string[],
       }];
       const result = sanitizeCustomerMasters(input);
-      expect(result[0].aliases).to.deep.equal(['田中']);
+      expect(result.items[0].aliases).to.deep.equal(['田中']);
     });
 
     it('aliasesがネストした配列の場合、フラット化してstring以外を除外する', () => {
@@ -76,7 +78,7 @@ describe('sanitizeMasterData', () => {
         aliases: ['田中', ['タナカ', '太郎']] as unknown as string[],
       }];
       const result = sanitizeCustomerMasters(input);
-      expect(result[0].aliases).to.deep.equal(['田中']);
+      expect(result.items[0].aliases).to.deep.equal(['田中']);
     });
   });
 
@@ -90,7 +92,8 @@ describe('sanitizeMasterData', () => {
         aliases: ['サクラ'],
       }];
       const result = sanitizeOfficeMasters(input);
-      expect(result).to.deep.equal(input);
+      expect(result.items).to.deep.equal(input);
+      expect(result.droppedIds).to.deep.equal([]);
     });
 
     it('shortNameがオブジェクトの場合、undefinedにする', () => {
@@ -100,7 +103,7 @@ describe('sanitizeMasterData', () => {
         shortName: { text: 'さくら' } as unknown as string,
       }];
       const result = sanitizeOfficeMasters(input);
-      expect(result[0].shortName).to.be.undefined;
+      expect(result.items[0].shortName).to.be.undefined;
     });
 
     it('shortNameが配列の場合、先頭要素を文字列化する', () => {
@@ -110,7 +113,7 @@ describe('sanitizeMasterData', () => {
         shortName: ['さくら', 'サクラ'] as unknown as string,
       }];
       const result = sanitizeOfficeMasters(input);
-      expect(result[0].shortName).to.equal('さくら');
+      expect(result.items[0].shortName).to.equal('さくら');
     });
   });
 
@@ -125,7 +128,8 @@ describe('sanitizeMasterData', () => {
         dateMarker: '発行日',
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result).to.deep.equal(input);
+      expect(result.items).to.deep.equal(input);
+      expect(result.droppedIds).to.deep.equal([]);
     });
 
     it('keywordsにネストした配列が含まれる場合、string要素のみ残す', () => {
@@ -135,7 +139,7 @@ describe('sanitizeMasterData', () => {
         keywords: ['被保険者証', ['介護保険']] as unknown as string[],
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].keywords).to.deep.equal(['被保険者証']);
+      expect(result.items[0].keywords).to.deep.equal(['被保険者証']);
     });
 
     it('keywordsが文字列の場合、配列に変換する', () => {
@@ -145,7 +149,7 @@ describe('sanitizeMasterData', () => {
         keywords: '被保険者証' as unknown as string[],
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].keywords).to.deep.equal(['被保険者証']);
+      expect(result.items[0].keywords).to.deep.equal(['被保険者証']);
     });
 
     it('dateMarkerが正常なstringの場合、そのまま通過する', () => {
@@ -155,7 +159,7 @@ describe('sanitizeMasterData', () => {
         dateMarker: '発行日',
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.equal('発行日');
+      expect(result.items[0].dateMarker).to.equal('発行日');
     });
 
     it('dateMarkerがundefinedの場合、undefinedのまま', () => {
@@ -165,7 +169,7 @@ describe('sanitizeMasterData', () => {
         dateMarker: undefined,
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.be.undefined;
+      expect(result.items[0].dateMarker).to.be.undefined;
     });
 
     it('dateMarkerがnumberの場合、undefinedにする', () => {
@@ -175,7 +179,7 @@ describe('sanitizeMasterData', () => {
         dateMarker: 20260101 as unknown as string,
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.be.undefined;
+      expect(result.items[0].dateMarker).to.be.undefined;
     });
 
     it('dateMarkerがobjectの場合、undefinedにする', () => {
@@ -185,7 +189,7 @@ describe('sanitizeMasterData', () => {
         dateMarker: { text: '発行日' } as unknown as string,
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.be.undefined;
+      expect(result.items[0].dateMarker).to.be.undefined;
     });
 
     it('dateMarkerが配列の場合、先頭要素を文字列化する', () => {
@@ -195,7 +199,7 @@ describe('sanitizeMasterData', () => {
         dateMarker: ['発行日', '作成日'] as unknown as string,
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.equal('発行日');
+      expect(result.items[0].dateMarker).to.equal('発行日');
     });
 
     it('dateMarkerが空文字の場合、undefinedに正規化する（下流の truthy チェック依存を排除）', () => {
@@ -205,7 +209,7 @@ describe('sanitizeMasterData', () => {
         dateMarker: '',
       }];
       const result = sanitizeDocumentMasters(input);
-      expect(result[0].dateMarker).to.be.undefined;
+      expect(result.items[0].dateMarker).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
## Summary
- PR #342 silent-failure-hunter Important #1/#2 対応 (#344)
- sanitize*Masters の silent drop を console.warn + safeLogError (Firebase runtime のみ) で observable 化
- 全 caller (loadMasterData + tests) を本 PR で同時更新し breaking change を scope 内に閉じる

## 変更ファイル (4 ファイル、+289/-60 lines)
1. `functions/src/utils/sanitizeMasterData.ts` — 戻り値 `{ items, droppedIds }` に変更 + safeId helper
2. `functions/src/utils/loadMasterData.ts` — reportSanitizeDrops 追加、Firebase runtime positive signal gate + lazy require
3. `functions/test/sanitizeMasterData.test.ts` — 18 ケース `result.items` 形式に追従
4. `functions/test/loadMasterData.test.ts` — 5 ケース追加

## 設計判断 (Evaluator + silent-failure-hunter レビュー反映)
- **Promise<void> 統一** (evaluator MEDIUM + silent-failure-hunter Important #3): `reportSanitizeDrops` を async function に統一、`Promise<void> | void` union を回避
- **Positive signal gate** (silent-failure-hunter Important #1): Firebase Functions Gen2 で NODE_ENV が 'production' にならないリスク対策。`K_SERVICE` / `FUNCTION_TARGET` / `NODE_ENV === 'production'` のいずれかで Firebase runtime を検出
- **Fallback 情報量**: lazy require 失敗時、`fullDroppedIds` を console.error に含め trace 保持 (silent-failure-hunter Important #2)
- **ALL RECORDS DROPPED prefix**: raw 非ゼロ かつ items ゼロ の kind を閾値で検知可能に

## Test plan
- [x] `npm test` — 657 passing (既存 +7 = 新規 lock-in 7 ケース)
- [x] `npx tsc --noEmit` — PASS
- [x] `npm run lint` — 既存 warnings のみ、新規 error なし
- [x] drop 検出 console.warn 出力確認 (test output で実見)

## Scope 外 (follow-up)
- `MasterData` への `_meta: { droppedCounts }` 付与 (caller が degraded mode 検出可能にする拡張) → silent-failure-hunter Suggestion #5、別 Issue 候補
- sanitize helper 3 本の共通化 (#331) は独立 Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error logging and observability for data processing operations, now tracking records dropped during data sanitization with detailed per-category drop counts.
  * Added context-aware error tracking across OCR and PDF processing pipelines for improved diagnostics.

* **Bug Fixes**
  * Improved runtime environment detection to ensure proper error reporting in cloud execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->