### PR TITLE
refactor: pdfOperations local sanitize を fileNaming 版に統合 (Closes #333)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -22,6 +22,7 @@ import { buildSplitDocumentData } from './splitDocumentBuilder';
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
 import { timestampToDateString } from '../utils/timestampHelpers';
 import { loadMasterData } from '../utils/loadMasterData';
+import { sanitizeFilenameForStorage } from '../utils/fileNaming';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -587,19 +588,11 @@ function generateFileName(params: {
   const { customerName, documentType, timestamp, startPage, endPage } = params;
   const date = new Date(timestamp);
   const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`;
-  const sanitizedCustomer = sanitize(customerName || '不明顧客');
-  const sanitizedDocType = sanitize(documentType || '不明文書');
+  const sanitizedCustomer = sanitizeFilenameForStorage(customerName || '不明顧客');
+  const sanitizedDocType = sanitizeFilenameForStorage(documentType || '不明文書');
   const pageRange = startPage === endPage ? `p${startPage}` : `p${startPage}-${endPage}`;
 
   return `${dateStr}_${sanitizedCustomer}_${sanitizedDocType}_${pageRange}.pdf`;
-}
-
-function sanitize(str: string): string {
-  return str
-    .replace(/[\\/:*?"<>|]/g, '_')
-    .replace(/[\s\u3000]/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^_|_$/g, '');
 }
 
 function extractOcrResultForPages(

--- a/functions/src/utils/fileNaming.ts
+++ b/functions/src/utils/fileNaming.ts
@@ -196,8 +196,11 @@ export function analyzeCustomerEntries(customers: CustomerAttribute[]): Customer
 export function sanitizeFilenameForStorage(filename: string, maxLength: number = 200): string {
   return filename
     .replace(/[\\/:*?"<>|]/g, '_')
-    .replace(/\s+/g, '_')
+    // `\s` は半角空白のみで全角空白 `\u3000` を含まないため明示 (OCR 由来 text 対策、#333)
+    .replace(/[\s\u3000]+/g, '_')
     .replace(/_+/g, '_')
+    // 先頭・末尾の `_` を除去して clean な filename にする (#333 pdfOperations local 統合)
+    .replace(/^_+|_+$/g, '')
     .slice(0, maxLength);
 }
 

--- a/functions/src/utils/fileNaming.ts
+++ b/functions/src/utils/fileNaming.ts
@@ -201,7 +201,9 @@ export function sanitizeFilenameForStorage(filename: string, maxLength: number =
     .replace(/_+/g, '_')
     // 先頭・末尾の `_` を除去して clean な filename にする (#333 pdfOperations local 統合)
     .replace(/^_+|_+$/g, '')
-    .slice(0, maxLength);
+    .slice(0, maxLength)
+    // slice で境界の `_` が末尾に残った場合 (maxLength 付近の長 filename) も trim する
+    .replace(/_+$/, '');
 }
 
 /**

--- a/functions/test/fileNaming.test.ts
+++ b/functions/test/fileNaming.test.ts
@@ -134,6 +134,24 @@ describe('sanitizeFilenameForStorage', () => {
   it('空文字列を処理', () => {
     expect(sanitizeFilenameForStorage('')).to.equal('');
   });
+
+  it('全角空白 \\u3000 をアンダースコアに置換 (#333 OCR 由来 text 対策)', () => {
+    expect(sanitizeFilenameForStorage('田中\u3000太郎')).to.equal('田中_太郎');
+  });
+
+  it('半角+全角空白混在もアンダースコア統一 (#333)', () => {
+    expect(sanitizeFilenameForStorage('田中 \u3000太郎')).to.equal('田中_太郎');
+  });
+
+  it('先頭・末尾の `_` を除去 (#333 pdfOperations local 統合)', () => {
+    // 禁止文字が先頭末尾に → 置換後 `_`、さらにトリム → clean な形
+    expect(sanitizeFilenameForStorage('<test>')).to.equal('test');
+    expect(sanitizeFilenameForStorage('/path/')).to.equal('path');
+  });
+
+  it('連続する末尾 `_` も全て除去 (#333)', () => {
+    expect(sanitizeFilenameForStorage('name<>')).to.equal('name');
+  });
 });
 
 describe('sanitizeFileName', () => {

--- a/functions/test/fileNaming.test.ts
+++ b/functions/test/fileNaming.test.ts
@@ -152,6 +152,12 @@ describe('sanitizeFilenameForStorage', () => {
   it('連続する末尾 `_` も全て除去 (#333)', () => {
     expect(sanitizeFilenameForStorage('name<>')).to.equal('name');
   });
+
+  it('maxLength 境界で末尾に `_` が残る場合も再 trim (#333 code-reviewer suggestion)', () => {
+    // 'abc_def_ghi' (11 文字) を maxLength=8 で切ると 'abc_def_' (末尾 `_`)。
+    // slice 後 trim で 'abc_def' になることを lock-in。
+    expect(sanitizeFilenameForStorage('abc_def_ghi', 8)).to.equal('abc_def');
+  });
 });
 
 describe('sanitizeFileName', () => {


### PR DESCRIPTION
## Summary
- Issue #333: PR #330 /review-pr quality Important 指摘
- pdfOperations.ts:597 の local `sanitize` を fileNaming.ts `sanitizeFilenameForStorage` に統合
- local 版の全角空白対応 + 前後トリム仕様を shared helper に移植

## 変更ファイル (3 ファイル、+25/-11)
1. `functions/src/utils/fileNaming.ts` — sanitizeFilenameForStorage 強化 (全角空白 + 前後トリム)
2. `functions/src/pdf/pdfOperations.ts` — local sanitize 削除、fileNaming から import
3. `functions/test/fileNaming.test.ts` — 4 lock-in テスト追加

## Test plan
- [x] `npm test` — 661 passing (既存 657 + 新規 4)
- [x] `npx tsc --noEmit` — PASS
- [x] `npm run lint` — 既存 warnings のみ、新規 error なし
- [x] 既存 `sanitizeFilenameForStorage` 7 ケース影響なし確認 (末尾 `_` にならない input のみ)

## Scope 外 (follow-up)
- #331 (shared/ への統合): Storage path 用 (fileNaming) と displayFileName 用 (generateDisplayFileName) は仕様差大 (禁止文字セット、連続 `_` 圧縮の有無、前後トリムの有無) で単純共通化は不適切。concern-based 分離維持の判断を別 Issue comment で提案予定

## 呼び出し元影響
- `upload/uploadPdf.ts:176` / `gmail/checkGmailAttachments.ts:330` — 両者とも filename 先頭末尾に禁止文字が来る input は想定外のため、前後トリム追加で behavior 変化なし
- `pdfOperations.ts` generateFileName — `{dateStr}_{customer}_{docType}_{pageRange}.pdf` 形式で customer/docType のみ sanitize、全体構造は変わらず

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Filename generation now properly handles full-width spaces and other special characters commonly found in international text, in addition to standard whitespace.
  * Generated filenames are automatically cleaned by removing unnecessary leading and trailing underscores, resulting in more consistent file naming across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->