### PR TITLE
refactor: DocumentMaster / CustomerMaster / OfficeMaster 型統合 (Closes #338)

### DIFF
--- a/frontend/src/components/RegisterNewMasterModal.tsx
+++ b/frontend/src/components/RegisterNewMasterModal.tsx
@@ -101,9 +101,13 @@ export function RegisterNewMasterModal({
 
   const isLoading = addCustomer.isPending || addOffice.isPending || addDocumentType.isPending;
 
-  // 既存カテゴリの一覧を抽出
+  // 既存カテゴリの一覧を抽出 (#338: DocumentMaster.category は optional、型述語で string に絞る)
   const existingCategories = Array.from(
-    new Set((existingDocTypes || []).map((d) => d.category).filter(Boolean))
+    new Set(
+      (existingDocTypes || [])
+        .map((d) => d.category)
+        .filter((c): c is string => !!c)
+    )
   );
 
   // モーダル開閉時に初期化

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -472,8 +472,9 @@ async function fetchDocumentMasters(): Promise<DocumentMaster[]> {
   return snapshot.docs.map((doc) => ({
     id: doc.id,
     name: doc.data().name as string,
-    dateMarker: doc.data().dateMarker as string,
-    category: doc.data().category as string,
+    // #338: shared 側 optional と整合させる honesty cast (silent-failure-hunter I2/I3 対応)
+    dateMarker: doc.data().dateMarker as string | undefined,
+    category: doc.data().category as string | undefined,
   }))
 }
 
@@ -490,8 +491,9 @@ async function fetchCustomerMasters(): Promise<CustomerMaster[]> {
   return snapshot.docs.map((doc) => ({
     id: doc.id,
     name: doc.data().name as string,
-    isDuplicate: doc.data().isDuplicate as boolean,
-    furigana: doc.data().furigana as string,
+    // #338: shared 側 optional と整合させる honesty cast。fetchCustomers (useMasters.ts) と同パターンに統一。
+    isDuplicate: doc.data().isDuplicate as boolean | undefined,
+    furigana: doc.data().furigana as string | undefined,
     careManagerName: doc.data().careManagerName as string | undefined,
   }))
 }
@@ -509,7 +511,8 @@ async function fetchOfficeMasters(): Promise<OfficeMaster[]> {
   return snapshot.docs.map((doc) => ({
     id: doc.id,
     name: doc.data().name as string,
-    isDuplicate: (doc.data().isDuplicate as boolean) ?? false,
+    // #338: shared 側 optional と整合。旧 `?? false` は caller 側で行う方が optional 契約を隠蔽せず明瞭。
+    isDuplicate: doc.data().isDuplicate as boolean | undefined,
     shortName: doc.data().shortName as string | undefined,
   }))
 }

--- a/frontend/src/hooks/useMasters.ts
+++ b/frontend/src/hooks/useMasters.ts
@@ -48,8 +48,11 @@ async function fetchCustomers(): Promise<CustomerMaster[]> {
   return snapshot.docs.map((doc) => ({
     id: doc.id,
     name: doc.data().name as string,
-    isDuplicate: doc.data().isDuplicate as boolean,
-    furigana: doc.data().furigana as string,
+    // #338: shared/types.ts 側を optional に統一したため、reader では `as ... | undefined` で honesty cast する。
+    // 旧 `as string` / `as boolean` だと shared の optional 化が type system 上で骨抜きになり、
+    // `.includes`/`.trim` 等の downstream 呼出で runtime crash する silent failure 経路が残る。
+    isDuplicate: doc.data().isDuplicate as boolean | undefined,
+    furigana: doc.data().furigana as string | undefined,
     careManagerName: doc.data().careManagerName as string | undefined,
     notes: doc.data().notes as string | undefined,
     aliases: doc.data().aliases as string[] | undefined,
@@ -274,8 +277,9 @@ async function fetchDocumentTypes(): Promise<DocumentMaster[]> {
   const snapshot = await getDocs(collection(db, COLLECTION_PATHS.documents))
   return snapshot.docs.map((doc) => ({
     name: doc.data().name as string,
-    dateMarker: doc.data().dateMarker as string,
-    category: doc.data().category as string,
+    // #338: shared 側の optional と整合させる honesty cast。silent force cast 禁止。
+    dateMarker: doc.data().dateMarker as string | undefined,
+    category: doc.data().category as string | undefined,
     keywords: normalizeKeywords(doc.data().keywords),
     aliases: doc.data().aliases as string[] | undefined,
   }))

--- a/frontend/src/lib/__tests__/kanaUtils.test.ts
+++ b/frontend/src/lib/__tests__/kanaUtils.test.ts
@@ -187,6 +187,16 @@ describe('buildFuriganaMap', () => {
     const map = buildFuriganaMap(customersWithEmpty);
     expect(map.get('不明者')).toBe('');
   });
+
+  // #338: CustomerMaster.furigana が optional 化されたため、runtime で欠落した場合に
+  // Map 構築が落ちず、空文字 fallback で格納される契約をロックインする。
+  it('furigana が undefined でも空文字で Map に格納される (#338)', () => {
+    const customersWithMissing: CustomerMaster[] = [
+      { id: '1', name: '新規顧客', isDuplicate: false },
+    ];
+    const map = buildFuriganaMap(customersWithMissing);
+    expect(map.get('新規顧客')).toBe('');
+  });
 });
 
 // ============================================

--- a/frontend/src/lib/kanaUtils.ts
+++ b/frontend/src/lib/kanaUtils.ts
@@ -103,7 +103,9 @@ export function getKanaRow(text: string): KanaRow | null {
 export function buildFuriganaMap(customers: CustomerMaster[]): Map<string, string> {
   const map = new Map<string, string>();
   for (const customer of customers) {
-    map.set(customer.name, customer.furigana);
+    // #338: CustomerMaster.furigana は optional (Firestore 実態で欠損ケースあり)。
+    // ソート時に空文字を末尾扱いとする既存挙動 (sortGroupsByFurigana 内) と整合させる。
+    map.set(customer.name, customer.furigana ?? '');
   }
   return map;
 }

--- a/frontend/src/pages/MastersPage.tsx
+++ b/frontend/src/pages/MastersPage.tsx
@@ -173,7 +173,7 @@ function CustomersMaster() {
   const filteredCustomers = customers?.filter(
     (c) =>
       c.name.includes(searchText) ||
-      c.furigana.includes(searchText)
+      (c.furigana ?? '').includes(searchText)
   )
 
   // 同名チェック → 確認ダイアログ or 直接追加
@@ -251,9 +251,9 @@ function CustomersMaster() {
 
   const openEdit = (customer: CustomerMaster) => {
     setFormName(customer.name)
-    setFormFurigana(customer.furigana)
+    setFormFurigana(customer.furigana ?? '')
     setFormCareManagerName(customer.careManagerName || '')
-    setFormIsDuplicate(customer.isDuplicate)
+    setFormIsDuplicate(customer.isDuplicate ?? false)
     setFormNotes(customer.notes || '')
     setFormAliases(customer.aliases?.join(', ') || '')
     setEditingCustomer(customer)
@@ -329,7 +329,7 @@ function CustomersMaster() {
                 filteredCustomers?.map((customer) => (
                   <TableRow key={customer.id}>
                     <TableCell className="font-medium">{customer.name}</TableCell>
-                    <TableCell>{customer.furigana}</TableCell>
+                    <TableCell>{customer.furigana ?? '-'}</TableCell>
                     <TableCell>{customer.careManagerName || '-'}</TableCell>
                     <TableCell className="max-w-[200px]">
                       {customer.aliases && customer.aliases.length > 0
@@ -610,7 +610,7 @@ function DocumentTypesMaster() {
   const filteredDocs = documentTypes?.filter(
     (d) =>
       d.name.includes(searchText) ||
-      d.category.includes(searchText)
+      (d.category ?? '').includes(searchText)
   )
 
   const handleAdd = async () => {
@@ -659,8 +659,8 @@ function DocumentTypesMaster() {
 
   const openEdit = (doc: DocumentMaster) => {
     setFormName(doc.name)
-    setFormDateMarker(doc.dateMarker)
-    setFormCategory(doc.category)
+    setFormDateMarker(doc.dateMarker ?? '')
+    setFormCategory(doc.category ?? '')
     setFormKeywords(doc.keywords?.join(';') || '')
     setFormAliases(doc.aliases?.join(', ') || '')
     setEditingDoc(doc)
@@ -739,7 +739,7 @@ function DocumentTypesMaster() {
                     <TableCell className="font-medium">{doc.name}</TableCell>
                     <TableCell>{doc.dateMarker || '-'}</TableCell>
                     <TableCell>
-                      <Badge variant="outline">{doc.category}</Badge>
+                      <Badge variant="outline">{doc.category ?? '-'}</Badge>
                     </TableCell>
                     <TableCell className="max-w-[200px]">
                       {doc.keywords && doc.keywords.length > 0 ? (

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -129,33 +129,19 @@ export interface FilenameInfo {
 }
 
 /**
- * マスターデータ型定義
+ * マスターデータ型定義 (#338 統合)
+ *
+ * 元々は本 extractors.ts で独自定義していたが、shared/types.ts の同名型と optionality が
+ * 乖離し (shared 側 required / 本 module optional)、FE/BE で型互換が破綻していた。
+ * Firestore 実態は optional 側なので、shared/types.ts を optional に寄せた上で本 module
+ * は re-export のみ担う (型の単一ソース化)。BE 既存 import パスは維持される。
  */
-export interface CustomerMaster {
-  id: string;
-  name: string;
-  furigana?: string;
-  isDuplicate?: boolean;
-  careManagerName?: string;
-  aliases?: string[];  // 許容される別表記
-}
-
-export interface OfficeMaster {
-  id: string;
-  name: string;
-  shortName?: string;
-  isDuplicate?: boolean;
-  aliases?: string[];  // 許容される別表記
-}
-
-export interface DocumentMaster {
-  id: string;
-  name: string;
-  category?: string;
-  keywords?: string[];
-  aliases?: string[];  // 許容される別表記
-  dateMarker?: string;
-}
+import type {
+  CustomerMaster,
+  DocumentMaster,
+  OfficeMaster,
+} from '../../../shared/types';
+export type { CustomerMaster, DocumentMaster, OfficeMaster };
 
 /**
  * マスターデータ envelope (OCR + PDF split 両系列で共用)。

--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -21,7 +21,15 @@ import {
 
 type RawDoc = FirebaseFirestore.DocumentData;
 
-/** Firestore Raw → 型付き中間表現。型崩れは後段の sanitize*Masters で除去される */
+/**
+ * Firestore Raw → 型付き中間表現。
+ *
+ * 型崩れは後段の sanitize*Masters で除去される。
+ * #338: shared/types.ts で `id?: string` に optional 化した後も、本関数経由で構築された
+ * DocumentMaster は必ず `id` を持つ (引数 `id: string` required)。loadMasterData の
+ * 下流で `id` 前提アクセスがあっても runtime 保証される (signature 起点の invariant)。
+ * 将来 id 無しで構築する caller が現れた場合は、shared 側 optional が型チェックで検知する。
+ */
 function toDocumentMaster(id: string, raw: RawDoc): DocumentMaster {
   return {
     id,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -178,11 +178,21 @@ export interface DocumentGroup {
 // マスターデータ
 // ============================================
 
+/**
+ * マスターデータ共通型 (#338 統合)
+ *
+ * Firestore 実態に合わせて optionality を統一。書き込み時に欠落するケース (CSV import 前の
+ * partial / 旧スキーマ移行中) や sanitize*Masters (functions/src/utils/sanitizeMasterData.ts)
+ * で undefined 正規化されるケースがあるため、reader 側は optional 前提でアクセスする。
+ *
+ * 履歴: #337 で BE/FE で optionality 乖離 (BE extractors.ts は既に optional) が判明、#338 で shared 側を
+ * optional に寄せて一本化。FE で required 前提アクセスがあった箇所は `?? fallback` で防御 (MastersPage.tsx)。
+ */
 export interface DocumentMaster {
   id?: string;        // FirestoreドキュメントID（フロントエンド取得時に設定）
   name: string;
-  dateMarker: string; // 日付抽出の目印（例: "発行日"）
-  category: string;
+  dateMarker?: string; // 日付抽出の目印（例: "発行日"）。Firestore 実態で欠損するケースあり (#338)
+  category?: string;   // 分類（例: "医療"）。Firestore 実態で欠損するケースあり (#338)
   keywords?: string[]; // 照合用キーワード（例: ["被保険者証", "介護保険"]）
   aliases?: string[];  // 許容される別表記（例: ["介護保険被保険者証", "被保険者証明書"]）
 }
@@ -190,8 +200,8 @@ export interface DocumentMaster {
 export interface CustomerMaster {
   id: string;
   name: string;
-  isDuplicate: boolean; // 同姓同名フラグ
-  furigana: string;
+  isDuplicate?: boolean; // 同姓同名フラグ。sanitize で欠損ケースあり (#338)
+  furigana?: string;     // Firestore 実態で欠損ケースあり、sanitize で undefined 正規化 (#338)
   careManagerName?: string; // 担当ケアマネジャー名
   aliases?: string[];  // 許容される別表記（例: ["田中　太郎", "たなか太郎"]）
   notes?: string;      // 区別用補足情報（例: "北名古屋在住"）
@@ -202,7 +212,7 @@ export interface OfficeMaster {
   name: string;
   nameKey?: string;        // 正規化キー（検索用）
   shortName?: string;
-  isDuplicate: boolean;    // 同名フラグ
+  isDuplicate?: boolean;   // 同名フラグ。sanitize で欠損ケースあり (#338)
   aliases?: string[];      // 許容される別表記（例: ["北名古屋市東部地域包括支援センター"]）
   notes?: string;          // 区別用補足情報（例: "東部"）
 }


### PR DESCRIPTION
## Summary
- shared/types.ts と functions/src/utils/extractors.ts で同名型が optionality 乖離していた問題を修正
- Firestore 実態に合わせて shared/types.ts を optional 化、extractors.ts は re-export 化、FE ガード + fetch layer honesty cast で runtime 安全を確保
- Closes #338

## 背景
- `shared/types.ts:181-215` (required) vs `functions/src/utils/extractors.ts:134-158` (optional) で DocumentMaster / CustomerMaster / OfficeMaster の 6 フィールドが乖離
- Firestore 実態は optional 側 (dateMarker / category / furigana / isDuplicate 欠損レコード存在)
- FE/BE で型互換が型レベルで破綻、runtime 時 `.includes()` 等で crash リスク

## 変更内容

| # | ファイル | 変更 |
|---|---------|------|
| 1 | `shared/types.ts` | DocumentMaster.dateMarker/category, CustomerMaster.furigana/isDuplicate, OfficeMaster.isDuplicate を required → optional、WHY コメント追加 |
| 2 | `functions/src/utils/extractors.ts` | 3 型重複定義削除 → shared から `import type` + `export type` で re-export (BE 既存 import path 維持) |
| 3 | `functions/src/utils/loadMasterData.ts` | toDocumentMaster の id invariant コメント追加 (signature 起点の runtime 保証明記) |
| 4 | `frontend/src/pages/MastersPage.tsx` | 8 箇所 optional chain + fallback (`?? ''` / `?? false` / `?? '-'`) で防御 — L176/254/256/332/613/662/663/742 |
| 5 | `frontend/src/components/RegisterNewMasterModal.tsx` | `.filter(Boolean)` → `.filter((c): c is string => !!c)` type predicate 化 |
| 6 | `frontend/src/hooks/useMasters.ts` | **fetch layer の force cast `as string`/`as boolean` → `as ... \| undefined` に矯正** (silent-failure-hunter I2 対応) |
| 7 | `frontend/src/hooks/useDocuments.ts` | 同上 (3 fetcher、I3 対応、fetchOfficeMasters の既存 `?? false` も統一) |
| 8 | `frontend/src/lib/kanaUtils.ts` | `buildFuriganaMap` で `customer.furigana ?? ''` fallback |
| 9 | `frontend/src/lib/__tests__/kanaUtils.test.ts` | undefined furigana lock-in テスト追加 (+1 = 128 passing) |

## Quality Gate 実施記録 (3 エージェント並列)

| エージェント | 判定 | 対応 |
|------------|------|------|
| **evaluator** | APPROVE_WITH_SUGGESTIONS | MEDIUM 1 (L332 TableCell fallback) + LOW 1 (L742 Badge fallback) → **本 PR で修正** |
| **silent-failure-hunter** | HIGH 4 + MEDIUM 5 | I2/I3 (FE fetch layer force cast) / I4 (DocumentMaster.id invariant) → **本 PR で対応**。I1 (updateCustomer silent overwrite) は caller 側 `?? ''` で保証済 / S2 (UI subText UX) は follow-up 化予定 |
| **code-reviewer** | No Critical/Important, Suggestion 3 | S2 (FE fetch layer) は silent-failure-hunter と整合、**本 PR で対応済**。S3 (test comment 齟齬) → **本 PR で修正**。S1 (diff stat under-count) → 本 PR body で反映済 |

## 設計判断

1. **shared/types.ts を optional に寄せる (Option A)**: Firestore 実態と BE sanitize 層 (既に optional) と一致、Breaking 最小。代替案 B (Write/Read 型分離) は管理コスト過大、C (extractors 削除のみ) は shared 側 required 残存で解決にならない
2. **extractors.ts の re-export 方式**: BE の 7 import 箇所 (pdfOperations/ocrProcessor/loadMasterData/sanitizeMasterData/pdfAnalyzer + test 2) を breaking なしで統一、@shared alias 導入 (PR #330 教訓) を回避
3. **FE fetch layer honesty cast の必要性**: shared を optional 化しても reader で `as string` force cast すると型システムが undefined を検知できず、downstream で silent crash する。`as ... | undefined` に矯正することで shared 側 optional 化の効果を型レベルで保持

## Test plan

- [x] BE `npx tsc --noEmit` EXIT 0
- [x] BE `npm test` **662 passing + 6 pending** (変化なし、既存契約維持確認)
- [x] FE `npx tsc --noEmit` EXIT 0 (全 fetcher honesty cast 後も regression なし)
- [x] FE `npm test` **128 passing** (+1: undefined furigana lock-in)
- [ ] main CI 3/3 green (lint-build-test / CodeRabbit / GitGuardian) — マージ前確認
- [ ] dev デプロイ後 MastersPage で顧客検索 / 書類カテゴリ検索 / 編集 form 初期化を手動確認 (undefined を含む既存データ存在時の UI 挙動)

## Follow-up (別 Issue 化候補、本 PR scope 外)

- **UI UX**: PdfSplitModal.tsx:95 / DocumentDetailModal.tsx:416 の subText で undefined 時 '(ふりがな未設定)' 等の明示表示 (silent-failure-hunter S2)
- **CSV 入力契約**: scripts/samples/README.md の required 表記 (○) を optional と整合させる運用整理 (本型変更との乖離)
- **updateCustomer invariant**: BulkCustomerParams / checkCustomerDuplicatesInBulk の型 furigana を optional に合わせる (silent-failure-hunter S3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data handling for optional master record fields. The application now consistently displays missing data with placeholders and applies proper defaults during filtering operations, ensuring reliable behavior when records contain incomplete information.

* **Tests**
  * Added test coverage for handling missing customer data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->