### PR TITLE
refactor: backfill-display-filename を shared/ 統合 + silent bug 解消 (Closes #334)

### DIFF
--- a/.claude/hooks/ops-script-redirect.sh
+++ b/.claude/hooks/ops-script-redirect.sh
@@ -14,9 +14,10 @@ if echo "$COMMAND" | grep -qE '^git (commit|log|diff|show|blame)'; then
   exit 0
 fi
 
-# FIREBASE_PROJECT_ID=xxx node scripts/ パターンを検出
-if echo "$COMMAND" | grep -qE 'FIREBASE_PROJECT_ID=\S+\s+node\s+scripts/'; then
-  SCRIPT_NAME=$(echo "$COMMAND" | grep -oE 'scripts/[a-zA-Z0-9_-]+\.js' | sed 's/scripts\///' | sed 's/\.js//')
+# FIREBASE_PROJECT_ID=xxx ... scripts/X.(js|ts) パターンを検出 (#334 で .ts 化対応)
+# interpreter (node / npx ts-node / ts-node 直接 / yarn ts-node 等) を問わず広く検知
+if echo "$COMMAND" | grep -qE 'FIREBASE_PROJECT_ID=\S+\s+.*scripts/[a-zA-Z0-9_-]+\.(js|ts)'; then
+  SCRIPT_NAME=$(echo "$COMMAND" | grep -oE 'scripts/[a-zA-Z0-9_-]+\.(js|ts)' | sed 's/scripts\///' | sed -E 's/\.(js|ts)//')
   echo "⚠️ 運用スクリプトはGitHub Actions経由で実行してください（ADC不要）。" >&2
   echo "" >&2
   echo "実行方法:" >&2

--- a/.claude/hooks/ops-script-redirect.sh
+++ b/.claude/hooks/ops-script-redirect.sh
@@ -16,6 +16,8 @@ fi
 
 # FIREBASE_PROJECT_ID=xxx ... scripts/X.(js|ts) パターンを検出 (#334 で .ts 化対応)
 # interpreter (node / npx ts-node / ts-node 直接 / yarn ts-node 等) を問わず広く検知
+# 注: .* の貪欲マッチで interpreter 検出を不要にしたため、誤検知許容方針
+# (hook は ADC 依存の運用コマンドを GitHub Actions に誘導する目的なので、多少の過剰検知は許容)。
 if echo "$COMMAND" | grep -qE 'FIREBASE_PROJECT_ID=\S+\s+.*scripts/[a-zA-Z0-9_-]+\.(js|ts)'; then
   SCRIPT_NAME=$(echo "$COMMAND" | grep -oE 'scripts/[a-zA-Z0-9_-]+\.(js|ts)' | sed 's/scripts\///' | sed -E 's/\.(js|ts)//')
   echo "⚠️ 運用スクリプトはGitHub Actions経由で実行してください（ADC不要）。" >&2

--- a/.github/workflows/backfill-display-filename.yml
+++ b/.github/workflows/backfill-display-filename.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: ./functions
         run: npm ci
 
+      - name: Install scripts devDependencies (ts-node for .ts scripts)
+        working-directory: ./scripts
+        run: npm install --no-audit --no-fund
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -75,6 +79,7 @@ jobs:
           echo "Force: ${{ github.event.inputs.force }}"
           echo "================================"
 
-          NODE_PATH=./functions/node_modules \
+          cd scripts
+          NODE_PATH=../functions/node_modules \
             FIREBASE_PROJECT_ID=${{ steps.resolve.outputs.project_id }} \
-            node scripts/backfill-display-filename.js $ARGS
+            npx ts-node backfill-display-filename.ts $ARGS

--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -67,6 +67,10 @@ jobs:
         working-directory: ./functions
         run: npm run build
 
+      - name: Install scripts devDependencies (ts-node for .ts scripts)
+        working-directory: ./scripts
+        run: npm install --no-audit --no-fund
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -127,6 +131,13 @@ jobs:
           echo "Args: $SCRIPT_ARGS"
           echo "========================="
 
-          NODE_PATH=./functions/node_modules \
-            FIREBASE_PROJECT_ID="$PROJECT_ID" \
-            node "scripts/${SCRIPT_NAME}.js" $SCRIPT_ARGS
+          if [ "$SCRIPT_NAME" = "backfill-display-filename" ]; then
+            cd scripts
+            NODE_PATH=../functions/node_modules \
+              FIREBASE_PROJECT_ID="$PROJECT_ID" \
+              npx ts-node "${SCRIPT_NAME}.ts" $SCRIPT_ARGS
+          else
+            NODE_PATH=./functions/node_modules \
+              FIREBASE_PROJECT_ID="$PROJECT_ID" \
+              node "scripts/${SCRIPT_NAME}.js" $SCRIPT_ARGS
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,10 @@ FIREBASE_PROJECT_ID=<project-id> node scripts/fix-stuck-documents.js
 FIREBASE_PROJECT_ID=<project-id> node scripts/check-master-data.js            # dry-run
 FIREBASE_PROJECT_ID=<project-id> node scripts/check-master-data.js --fix      # 修正実行
 
-# displayFileName一括設定
-FIREBASE_PROJECT_ID=<project-id> node scripts/backfill-display-filename.js --dry-run  # プレビュー
-FIREBASE_PROJECT_ID=<project-id> node scripts/backfill-display-filename.js             # 実行
-FIREBASE_PROJECT_ID=<project-id> node scripts/backfill-display-filename.js --force     # 既存値も上書き
+# displayFileName一括設定 (#334 で .ts 化、ts-node 経由で shared/ import)
+FIREBASE_PROJECT_ID=<project-id> npx ts-node scripts/backfill-display-filename.ts --dry-run  # プレビュー
+FIREBASE_PROJECT_ID=<project-id> npx ts-node scripts/backfill-display-filename.ts             # 実行
+FIREBASE_PROJECT_ID=<project-id> npx ts-node scripts/backfill-display-filename.ts --force     # 既存値も上書き
 
 # 重複ドキュメント検出・削除（同一fileNameのGmail添付ファイル重複を整理）
 FIREBASE_PROJECT_ID=<project-id> node scripts/cleanup-duplicates.js                # dry-run（デフォルト）

--- a/functions/src/utils/timestampHelpers.ts
+++ b/functions/src/utils/timestampHelpers.ts
@@ -4,6 +4,9 @@
  * #334 で実装を shared/ に昇格。BE 既存 import path (`../utils/timestampHelpers`) を
  * 維持するためこのモジュールは re-export のみに留める。
  * star export で shared 側に新エクスポート追加時も自動追従する (re-export drift 防止)。
+ *
+ * 注: `../../../shared/` 前提 (functions/src/utils/ から 3 hops up)。functions/ の
+ * ディレクトリ構造変更時は shared 側のパス解決もあわせて再検証すること。
  */
 
 export * from '../../../shared/timestampHelpers';

--- a/functions/src/utils/timestampHelpers.ts
+++ b/functions/src/utils/timestampHelpers.ts
@@ -1,28 +1,9 @@
 /**
- * Firestore Timestamp 変換ヘルパー。
+ * Firestore Timestamp 変換ヘルパー (shared/timestampHelpers.ts への re-export)。
  *
- * backfill と本番 (pdfOperations) の両系列で使う。
+ * #334 で実装を shared/ に昇格。BE 既存 import path (`../utils/timestampHelpers`) を
+ * 維持するためこのモジュールは re-export のみに留める。
+ * star export で shared 側に新エクスポート追加時も自動追従する (re-export drift 防止)。
  */
 
-export interface TimestampLike {
-  seconds: number;
-  nanoseconds: number;
-  toDate?: () => Date;
-}
-
-/**
- * Firestore Timestamp（またはプレーンオブジェクト）を YYYY/MM/DD 文字列に変換
- */
-export function timestampToDateString(
-  ts: TimestampLike | null | undefined
-): string | undefined {
-  // seconds=0 (epoch 1970-01-01) を silent に missing 扱いしないため typeof で判定する (#346)。
-  // NaN / Infinity は typeof 'number' を通るが Date(NaN) → "NaN/NaN/NaN" silent 誤出力になるため isFinite で排除する。
-  if (!ts || typeof ts.seconds !== 'number' || !Number.isFinite(ts.seconds)) return undefined;
-
-  const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}/${m}/${d}`;
-}
+export * from '../../../shared/timestampHelpers';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17976,6 +17976,10 @@
       "version": "0.1.0",
       "dependencies": {
         "firebase-admin": "^12.7.0"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
       }
     },
     "shared": {

--- a/scripts/backfill-display-filename.ts
+++ b/scripts/backfill-display-filename.ts
@@ -7,8 +7,9 @@
  * Storage上の実ファイルは変更しない（表示用ラベルのみ）。
  *
  * #334 で shared/generateDisplayFileName + shared/timestampHelpers 統合済み。
- * 旧 inline 実装に欠落していた OS 禁止文字サニタイズ (#181/#183/#335) と
- * epoch (seconds=0) / NaN / Infinity の silent drop 排除 (#346) を取り込む。
+ * 旧 inline は shared 化 (#181) の取りこぼしで、以下の silent bug を抱えていた:
+ * - OS 禁止文字サニタイズ欠落 (#183 半角 + #335 全角) → shared 版で `_` 置換
+ * - epoch (seconds=0) / NaN / Infinity の silent drop (#346) → shared 版で isFinite guard
  *
  * 使用方法:
  *   FIREBASE_PROJECT_ID=doc-split-dev npx ts-node scripts/backfill-display-filename.ts --dry-run
@@ -42,11 +43,10 @@ async function main(): Promise<void> {
   console.log(`モード: ${dryRun ? 'DRY RUN（変更なし）' : '実行'}`);
   console.log(`上書き: ${force ? 'あり（既存displayFileNameも再生成）' : 'なし（未設定のみ対象）'}`);
   if (force) {
-    // #334: shared 版は OS 禁止文字 (\ / : * ? " < > |) + 全角相当 + 制御文字を `_` に置換する。
-    // 旧 inline 実装には欠落していたサニタイズなので、--force 実行時は既存 displayFileName が
-    // 書き換わる可能性がある。operator が変化を把握できるよう old → new の差分ログを出す。
+    // #334: shared 版サニタイズ (半角 \ / : * ? " < > | + 全角相当 + 制御文字 → "_") を適用。
+    // 詳細は shared/generateDisplayFileName.ts 参照。operator が変化を把握できるよう old → new 差分を CHANGE ログで出す。
     console.log('⚠️  --force: 既存 displayFileName を shared 版サニタイズで再生成します。');
-    console.log('    禁止文字 (\\ / : * ? " < > |) や全角相当・制御文字を含む既存値は変換されます (#334)。');
+    console.log('    禁止文字 (\\ / : * ? " < > |) や全角相当・制御文字を含む既存値は変換されます（shared 版サニタイズ適用のため）。');
   }
   console.log('---');
 
@@ -105,22 +105,18 @@ async function main(): Promise<void> {
           continue;
         }
 
-        // #334: --force 時に old → new が変化するかを追跡。operator が silent 書き換えを検知できるようにする。
+        // #334: --force 時の silent 書き換え検知用。"未設定 → 新規 SET" は CHANGE 扱いしないため
+        // oldDisplayFileName の存在チェックを先に置く。
         const oldDisplayFileName: string | undefined = data.displayFileName;
         const isChange = Boolean(oldDisplayFileName) && oldDisplayFileName !== displayFileName;
 
-        if (dryRun) {
-          if (isChange) {
-            console.log(`  CHANGE: ${docSnap.id}`);
-            console.log(`          "${oldDisplayFileName}" → "${displayFileName}"`);
-          } else {
-            console.log(`  SET: ${docSnap.id}`);
-            console.log(`       ${data.fileName || '(no name)'} → ${displayFileName}`);
-          }
+        if (isChange) {
+          console.log(`  CHANGE: ${docSnap.id} "${oldDisplayFileName}" → "${displayFileName}"`);
         } else {
-          if (isChange) {
-            console.log(`  CHANGE: ${docSnap.id} "${oldDisplayFileName}" → "${displayFileName}"`);
-          }
+          console.log(`  SET: ${docSnap.id} ${data.fileName || '(no name)'} → ${displayFileName}`);
+        }
+
+        if (!dryRun) {
           batch.update(docSnap.ref, {
             displayFileName,
             updatedAt: admin.firestore.FieldValue.serverTimestamp(),

--- a/scripts/backfill-display-filename.ts
+++ b/scripts/backfill-display-filename.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node
 /**
  * displayFileName バックフィルスクリプト
  *
@@ -6,16 +6,22 @@
  * メタ情報（書類名・事業所・日付・顧客名）から自動生成。
  * Storage上の実ファイルは変更しない（表示用ラベルのみ）。
  *
+ * #334 で shared/generateDisplayFileName + shared/timestampHelpers 統合済み。
+ * 旧 inline 実装に欠落していた OS 禁止文字サニタイズ (#181/#183/#335) と
+ * epoch (seconds=0) / NaN / Infinity の silent drop 排除 (#346) を取り込む。
+ *
  * 使用方法:
- *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/backfill-display-filename.js --dry-run
- *   FIREBASE_PROJECT_ID=doc-split-dev node scripts/backfill-display-filename.js
+ *   FIREBASE_PROJECT_ID=doc-split-dev npx ts-node scripts/backfill-display-filename.ts --dry-run
+ *   FIREBASE_PROJECT_ID=doc-split-dev npx ts-node scripts/backfill-display-filename.ts
  *
  * オプション:
  *   --dry-run    変更を行わず対象と生成結果をプレビュー
  *   --force      既に displayFileName が設定済みのドキュメントも上書き
  */
 
-const admin = require('firebase-admin');
+import * as admin from 'firebase-admin';
+import { generateDisplayFileName } from '../shared/generateDisplayFileName';
+import { timestampToDateString, type TimestampLike } from '../shared/timestampHelpers';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 if (!projectId) {
@@ -29,66 +35,30 @@ const force = process.argv.includes('--force');
 admin.initializeApp({ projectId });
 const db = admin.firestore();
 
-// --- generateDisplayFileName ロジック（functions/src/utils/displayFileNameGenerator.ts と同一） ---
-
-const DEFAULT_VALUES = new Set(['未判定', '不明顧客']);
-
-function generateDisplayFileName(input) {
-  const ext = input.extension || '.pdf';
-  const parts = [];
-
-  if (input.documentType && !DEFAULT_VALUES.has(input.documentType)) {
-    parts.push(input.documentType);
-  }
-  if (input.officeName && !DEFAULT_VALUES.has(input.officeName)) {
-    parts.push(input.officeName);
-  }
-  if (input.fileDate) {
-    const dateStr = input.fileDate.replace(/[/-]/g, '');
-    if (dateStr.length >= 8) {
-      parts.push(dateStr.slice(0, 8));
-    }
-  }
-  if (input.customerName && !DEFAULT_VALUES.has(input.customerName)) {
-    parts.push(input.customerName);
-  }
-
-  if (parts.length === 0) return null;
-
-  const hasNonDatePart = parts.some((p) => !/^\d{8}$/.test(p));
-  if (!hasNonDatePart) return null;
-
-  return parts.join('_') + ext;
-}
-
-function timestampToDateString(ts) {
-  if (!ts || !ts.seconds) return undefined;
-  const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}/${m}/${d}`;
-}
-
-// --- メイン処理 ---
-
 const BATCH_SIZE = 500;
 
-async function main() {
+async function main(): Promise<void> {
   console.log(`プロジェクト: ${projectId}`);
   console.log(`モード: ${dryRun ? 'DRY RUN（変更なし）' : '実行'}`);
   console.log(`上書き: ${force ? 'あり（既存displayFileNameも再生成）' : 'なし（未設定のみ対象）'}`);
+  if (force) {
+    // #334: shared 版は OS 禁止文字 (\ / : * ? " < > |) + 全角相当 + 制御文字を `_` に置換する。
+    // 旧 inline 実装には欠落していたサニタイズなので、--force 実行時は既存 displayFileName が
+    // 書き換わる可能性がある。operator が変化を把握できるよう old → new の差分ログを出す。
+    console.log('⚠️  --force: 既存 displayFileName を shared 版サニタイズで再生成します。');
+    console.log('    禁止文字 (\\ / : * ? " < > |) や全角相当・制御文字を含む既存値は変換されます (#334)。');
+  }
   console.log('---');
 
-  // processed ドキュメントを取得（split含む：分割後のドキュメントも対象）
   const targetStatuses = ['processed', 'split'];
   let totalProcessed = 0;
   let totalUpdated = 0;
   let totalSkipped = 0;
   let totalNoMeta = 0;
+  let totalChanged = 0;
 
   for (const status of targetStatuses) {
-    let lastDoc = null;
+    let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | null = null;
     let hasMore = true;
 
     while (hasMore) {
@@ -115,7 +85,6 @@ async function main() {
         totalProcessed++;
         const data = docSnap.data();
 
-        // 既にdisplayFileNameがある場合はスキップ（--force時は上書き）
         if (data.displayFileName && !force) {
           totalSkipped++;
           continue;
@@ -125,7 +94,7 @@ async function main() {
           documentType: data.documentType || undefined,
           customerName: data.customerName || undefined,
           officeName: data.officeName || undefined,
-          fileDate: timestampToDateString(data.fileDate),
+          fileDate: timestampToDateString(data.fileDate as TimestampLike | null | undefined),
         });
 
         if (!displayFileName) {
@@ -136,16 +105,29 @@ async function main() {
           continue;
         }
 
+        // #334: --force 時に old → new が変化するかを追跡。operator が silent 書き換えを検知できるようにする。
+        const oldDisplayFileName: string | undefined = data.displayFileName;
+        const isChange = Boolean(oldDisplayFileName) && oldDisplayFileName !== displayFileName;
+
         if (dryRun) {
-          console.log(`  SET: ${docSnap.id}`);
-          console.log(`       ${data.fileName || '(no name)'} → ${displayFileName}`);
+          if (isChange) {
+            console.log(`  CHANGE: ${docSnap.id}`);
+            console.log(`          "${oldDisplayFileName}" → "${displayFileName}"`);
+          } else {
+            console.log(`  SET: ${docSnap.id}`);
+            console.log(`       ${data.fileName || '(no name)'} → ${displayFileName}`);
+          }
         } else {
+          if (isChange) {
+            console.log(`  CHANGE: ${docSnap.id} "${oldDisplayFileName}" → "${displayFileName}"`);
+          }
           batch.update(docSnap.ref, {
             displayFileName,
             updatedAt: admin.firestore.FieldValue.serverTimestamp(),
           });
           batchCount++;
         }
+        if (isChange) totalChanged++;
         totalUpdated++;
       }
 
@@ -159,7 +141,6 @@ async function main() {
     }
   }
 
-  // _migrations に記録
   if (!dryRun && totalUpdated > 0) {
     await db.collection('_migrations').doc('display_filename_backfill').set({
       status: 'completed',
@@ -167,6 +148,7 @@ async function main() {
       updatedCount: totalUpdated,
       skippedCount: totalSkipped,
       noMetaCount: totalNoMeta,
+      changedCount: totalChanged,
       force,
       completedAt: admin.firestore.FieldValue.serverTimestamp(),
     }, { merge: true });
@@ -175,6 +157,9 @@ async function main() {
   console.log('\n--- 結果 ---');
   console.log(`検査: ${totalProcessed}件`);
   console.log(`更新${dryRun ? '予定' : '済み'}: ${totalUpdated}件`);
+  if (force) {
+    console.log(`  うち既存値からの変更: ${totalChanged}件`);
+  }
   console.log(`スキップ（設定済み）: ${totalSkipped}件`);
   console.log(`スキップ（メタ不足）: ${totalNoMeta}件`);
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,9 +8,14 @@
     "import:customers": "node import-masters.js --customers",
     "import:documents": "node import-masters.js --documents",
     "import:offices": "node import-masters.js --offices",
-    "import:all": "node import-masters.js --all"
+    "import:all": "node import-masters.js --all",
+    "backfill:displayname": "ts-node backfill-display-filename.ts"
   },
   "dependencies": {
     "firebase-admin": "^12.7.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
   }
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["./**/*.ts", "../shared/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/shared/timestampHelpers.ts
+++ b/shared/timestampHelpers.ts
@@ -1,0 +1,29 @@
+/**
+ * Firestore Timestamp 変換ヘルパー。
+ *
+ * backfill (scripts) と本番 (functions/pdfOperations) で共有する純粋関数。
+ * #334 で functions/src/utils/ から shared/ に昇格。
+ */
+
+export interface TimestampLike {
+  seconds: number;
+  nanoseconds: number;
+  toDate?: () => Date;
+}
+
+/**
+ * Firestore Timestamp（またはプレーンオブジェクト）を YYYY/MM/DD 文字列に変換
+ */
+export function timestampToDateString(
+  ts: TimestampLike | null | undefined
+): string | undefined {
+  // seconds=0 (epoch 1970-01-01) を silent に missing 扱いしないため typeof で判定する (#346)。
+  // NaN / Infinity は typeof 'number' を通るが Date(NaN) → "NaN/NaN/NaN" silent 誤出力になるため isFinite で排除する。
+  if (!ts || typeof ts.seconds !== 'number' || !Number.isFinite(ts.seconds)) return undefined;
+
+  const date = ts.toDate ? ts.toDate() : new Date(ts.seconds * 1000);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}/${m}/${d}`;
+}

--- a/shared/timestampHelpers.ts
+++ b/shared/timestampHelpers.ts
@@ -2,12 +2,14 @@
  * Firestore Timestamp 変換ヘルパー。
  *
  * backfill (scripts) と本番 (functions/pdfOperations) で共有する純粋関数。
- * #334 で functions/src/utils/ から shared/ に昇格。
+ * #332 で functions/src/utils/ に抽出、#334 で shared/ に昇格 (FE/BE/scripts 三者共有)。
  */
 
 export interface TimestampLike {
   seconds: number;
-  nanoseconds: number;
+  // #334: consumer (timestampToDateString) は seconds のみ使用するため optional。
+  // Firestore Timestamp 本物の shape を documenting しつつ、plain object 経由の duck-type 互換性を持たせる。
+  nanoseconds?: number;
   toDate?: () => Date;
 }
 


### PR DESCRIPTION
## Summary

scripts/backfill-display-filename.js を .ts 化して inline 実装 (`generateDisplayFileName` + `timestampToDateString`) を shared/ 経由に統合。同時に旧 inline 実装で欠落していた **silent bug** を解消する。

## 背景

セッション26-27 で shared 集約路線が進み、functions/src と frontend/ は shared/generateDisplayFileName + shared/timestampHelpers (functions/src/utils/timestampHelpers) を利用中。しかし `scripts/backfill-display-filename.js` は JS で ts-node 未使用のため inline 重複のまま残存。

調査で判明した silent bug:
- **OS 禁止文字サニタイズ欠落**: inline には `\\ / : * ? " < > |` や全角相当の `_` 置換がない (shared 版は #181/#183/#335 で実装済み)
- **epoch/NaN/Infinity silent drop**: inline の `timestampToDateString` は `!ts.seconds` で seconds=0 を弾く + NaN/Infinity 素通りで `NaN/NaN/NaN` 誤出力リスク (shared 版は #346 で Number.isFinite guard 実装済み)

## 設計判断

**Option A' (scripts に最小 ts-node 導入)** を採用。

| 案 | 選定理由 |
|---|---|
| **A'**: scripts に ts-node を devDep 追加、対象 1 ファイルのみ .ts 化 | ✅ 最小変更、他 scripts/*.js は据え置き |
| A: 全 scripts を ts-node 化 | ❌ スコープ超過、回帰リスク多 |
| B: shared を JS 化 | ❌ 既存 FE/BE 壊れる |
| C: shared に build step + dist/ 生成 | ❌ CI pre-build 必要、実行忘れリスク |

## 主な変更

### shared/ 統合
- `shared/timestampHelpers.ts` 新設 (functions/src/utils/ から昇格)
- `functions/src/utils/timestampHelpers.ts` は `export * from '../../../shared/timestampHelpers'` の star re-export に (drift 防止)
- `scripts/backfill-display-filename.js` → `.ts` 改名、inline 削除、shared から import
- `scripts/package.json` に ts-node + typescript devDep 追加、`scripts/tsconfig.json` 新設

### CI / hook 更新
- GitHub Actions workflow 2 本 (`backfill-display-filename.yml`, `run-ops-script.yml`) に `scripts/npm install` step 追加
- `run-ops-script.yml` に backfill-display-filename 専用分岐 (ts-node 経由)
- `.claude/hooks/ops-script-redirect.sh` の regex を `.js/.ts` + interpreter 非依存の形に拡張 (silent-failure-hunter I3 対応)

### --force silent 書き換え対策 (silent-failure-hunter I2 対応)
- 起動時に `⚠️ --force: 既存 displayFileName を shared 版サニタイズで再生成` 警告バナー
- 既存 `displayFileName` → 新値が変化する場合 `CHANGE: <id> "<old>" → "<new>"` ログ
- `_migrations` に `changedCount` カウンタ追加

## Quality Gate 実施記録

| エージェント | 判定 | 対応 |
|---|---|---|
| code-reviewer | Important 1 (workflow install step 未追加) | 対応済 |
| silent-failure-hunter | Critical 1 (CI ts-node install) + Important 4 | Critical + I2/I3/S1 対応済 |
| evaluator | **APPROVE_WITH_SUGGESTIONS** | AC6 は merge 後 CI dry-run で確認 |

見送り (旧コード踏襲 + scope 外):
- silent-failure-hunter C2 (admin.initializeApp が top-level): 旧 .js と同じ挙動、scope 外
- silent-failure-hunter I1 (batch commit partial failure): 旧 .js と同じ挙動、follow-up 候補
- silent-failure-hunter I4 (strict mode discard return): 理論的リスク、scope 外

## ⚠️ 運用上の注意

**本 PR merge 後、`--force` を実行すると既存 `displayFileName` が shared 版サニタイズで書き換わる可能性があります。**

- 禁止文字 (`\\ / : * ? " < > |` や全角相当) を含む既存値は `_` に置換
- 再実行前に `--dry-run --force` で影響範囲を確認することを強く推奨
- 影響ドキュメントは `CHANGE: <id> "<old>" → "<new>"` ログで追跡可能

## Test plan

- [x] BE `npx tsc --noEmit` EXIT 0
- [x] BE `npm test` **662 passing + 6 pending** (基準値維持)
- [x] FE `npx tsc --noEmit` EXIT 0
- [x] FE `npm test` (vitest) **128 passing** (変化なし)
- [x] scripts `npx tsc --noEmit --project tsconfig.json` EXIT 0
- [x] `npx ts-node scripts/backfill-display-filename.ts` で parse + shared import 解決成功 (FIREBASE_PROJECT_ID 未設定の早期終了で確認)
- [ ] merge 後に GitHub Actions "Run Operations Script" で dev 環境に対して `backfill-display-filename --dry-run` を実行し、AC6 (OS 禁止文字を含む customerName のサニタイズ確認 or 該当データなし確認) を完了

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)