### PR TITLE
test: backfill-display-filename の差分検出ロジック抽出 + OS 禁止文字 backfill 経路 lock-in (Closes #358)

### DIFF
--- a/functions/src/utils/backfillDisplayFileName.ts
+++ b/functions/src/utils/backfillDisplayFileName.ts
@@ -29,3 +29,10 @@ export function buildDisplayFileNameFromDoc(doc: DocData): string | null {
     fileDate: timestampToDateString(doc.fileDate),
   });
 }
+
+// #358: 純粋関数は shared/ に配置 (scripts / functions 両方から直接 import するため)。
+// functions/ 側からはこの re-export 経由でも利用可能。
+export {
+  detectDisplayFileNameChange,
+  type DisplayFileNameChange,
+} from '../../../shared/detectDisplayFileNameChange';

--- a/functions/test/backfillDisplayFileName.test.ts
+++ b/functions/test/backfillDisplayFileName.test.ts
@@ -3,10 +3,14 @@
  *
  * buildDisplayFileNameFromDoc (backfill 固有のドキュメントデータ組立) をテスト。
  * timestampToDateString の単体 test は timestampHelpers.test.ts に移動済み。
+ * detectDisplayFileNameChange の差分判定と OS 禁止文字 backfill 経路は #358 で追加。
  */
 
 import { expect } from 'chai';
-import { buildDisplayFileNameFromDoc } from '../src/utils/backfillDisplayFileName';
+import {
+  buildDisplayFileNameFromDoc,
+  detectDisplayFileNameChange,
+} from '../src/utils/backfillDisplayFileName';
 
 describe('displayFileName バックフィル', () => {
   describe('buildDisplayFileNameFromDoc', () => {
@@ -63,6 +67,75 @@ describe('displayFileName バックフィル', () => {
       };
       const result = buildDisplayFileNameFromDoc(doc);
       expect(result).to.match(/^診断書_\d{8}_佐藤花子\.pdf$/);
+    });
+
+    // #358 I2 (rating 6): shared 版サニタイズが backfill 経路でも適用されることを lock-in。
+    // backfill で OS 禁止文字を含む customerName/officeName を生成した時、shared 側の
+    // `_` 置換が効くことを確認 (#183 半角 + #335 全角 + #334 shared 統合の回帰防止)。
+    it('OS禁止文字を含む customerName がサニタイズされる (#358)', () => {
+      const doc = {
+        documentType: '介護保険証',
+        customerName: '山田/太郎', // 半角スラッシュ
+        officeName: '',
+        fileDate: null,
+      };
+      expect(buildDisplayFileNameFromDoc(doc)).to.equal('介護保険証_山田_太郎.pdf');
+    });
+
+    it('OS禁止文字を含む officeName がサニタイズされる (#358)', () => {
+      const doc = {
+        documentType: '介護保険証',
+        customerName: '田中太郎',
+        officeName: 'A事業所\\B支店', // 半角バックスラッシュ
+        fileDate: null,
+      };
+      expect(buildDisplayFileNameFromDoc(doc)).to.equal(
+        '介護保険証_A事業所_B支店_田中太郎.pdf'
+      );
+    });
+
+    it('全角コロンを含む officeName もサニタイズされる (#335 regression)', () => {
+      const doc = {
+        documentType: '診断書',
+        customerName: '鈴木',
+        officeName: 'テスト:事業所', // 全角コロン
+        fileDate: null,
+      };
+      expect(buildDisplayFileNameFromDoc(doc)).to.equal('診断書_テスト_事業所_鈴木.pdf');
+    });
+  });
+
+  // #358 I1 (rating 7): inline 判定 (Boolean(old) && old !== new) をカウンタ漏れ・
+  // 状態分岐誤りから保護するための 3 状態 lock-in。scripts 側で CHANGE/SET/noop の分岐と
+  // totalChanged カウンタ増分の基準として使う。
+  describe('detectDisplayFileNameChange', () => {
+    it('旧値が未設定 → "set" (新規 SET、--force なしでも実施)', () => {
+      expect(detectDisplayFileNameChange(undefined, '介護保険証.pdf')).to.equal('set');
+      expect(detectDisplayFileNameChange(null, '介護保険証.pdf')).to.equal('set');
+      expect(detectDisplayFileNameChange('', '介護保険証.pdf')).to.equal('set');
+    });
+
+    it('旧値が新値と一致 → "noop" (書き込み不要)', () => {
+      expect(
+        detectDisplayFileNameChange('介護保険証_田中太郎.pdf', '介護保険証_田中太郎.pdf')
+      ).to.equal('noop');
+    });
+
+    it('旧値が新値と不一致 → "change" (--force で書き換え、CHANGE ログ対象)', () => {
+      // shared 版サニタイズで "山田/太郎" → "山田_太郎" に書き換わるケース
+      expect(
+        detectDisplayFileNameChange('介護保険証_山田/太郎.pdf', '介護保険証_山田_太郎.pdf')
+      ).to.equal('change');
+      // epoch/NaN drop で日付が消えるケース
+      expect(
+        detectDisplayFileNameChange('介護保険証_19700101_田中.pdf', '介護保険証_田中.pdf')
+      ).to.equal('change');
+    });
+
+    it('未設定 → 空文字 new の組み合わせも "set" (backfill 上は到達不能だが防御)', () => {
+      // 実際には buildDisplayFileNameFromDoc が null を返すケースは scripts 側で先に
+      // スキップされるが、関数としての全域性を保証するため
+      expect(detectDisplayFileNameChange(undefined, '')).to.equal('set');
     });
   });
 });

--- a/scripts/backfill-display-filename.ts
+++ b/scripts/backfill-display-filename.ts
@@ -23,6 +23,7 @@
 import * as admin from 'firebase-admin';
 import { generateDisplayFileName } from '../shared/generateDisplayFileName';
 import { timestampToDateString, type TimestampLike } from '../shared/timestampHelpers';
+import { detectDisplayFileNameChange } from '../shared/detectDisplayFileNameChange';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 if (!projectId) {
@@ -105,15 +106,25 @@ async function main(): Promise<void> {
           continue;
         }
 
-        // #334: --force 時の silent 書き換え検知用。"未設定 → 新規 SET" は CHANGE 扱いしないため
-        // oldDisplayFileName の存在チェックを先に置く。
+        // #334: --force 時の silent 書き換え検知用。判定は純粋関数 detectDisplayFileNameChange
+        // に委譲 (#358 I1 でテスト lock-in 済み)。
         const oldDisplayFileName: string | undefined = data.displayFileName;
-        const isChange = Boolean(oldDisplayFileName) && oldDisplayFileName !== displayFileName;
+        const action = detectDisplayFileNameChange(oldDisplayFileName, displayFileName);
 
-        if (isChange) {
+        if (action === 'noop') {
+          // 既存 displayFileName が新生成値と一致 → 書き込み不要
+          totalSkipped++;
+          continue;
+        }
+        // noop 以降は 'change' | 'set' のみ。将来の enum 拡張で silent に SET に落ちるのを
+        // 防ぐため exhaustive 判定で assertNever する (#358 code-simplifier S2)。
+        if (action === 'change') {
           console.log(`  CHANGE: ${docSnap.id} "${oldDisplayFileName}" → "${displayFileName}"`);
-        } else {
+        } else if (action === 'set') {
           console.log(`  SET: ${docSnap.id} ${data.fileName || '(no name)'} → ${displayFileName}`);
+        } else {
+          const _exhaustive: never = action;
+          throw new Error(`Unexpected DisplayFileNameChange: ${String(_exhaustive)}`);
         }
 
         if (!dryRun) {
@@ -123,7 +134,8 @@ async function main(): Promise<void> {
           });
           batchCount++;
         }
-        if (isChange) totalChanged++;
+        // totalChanged は totalUpdated の subset (change + set の合計 = totalUpdated)。
+        if (action === 'change') totalChanged++;
         totalUpdated++;
       }
 

--- a/scripts/backfill-display-filename.ts
+++ b/scripts/backfill-display-filename.ts
@@ -117,12 +117,20 @@ async function main(): Promise<void> {
           continue;
         }
         // noop 以降は 'change' | 'set' のみ。将来の enum 拡張で silent に SET に落ちるのを
-        // 防ぐため exhaustive 判定で assertNever する (#358 code-simplifier S2)。
+        // 防ぐため exhaustive 判定で assertNever する。
         if (action === 'change') {
           console.log(`  CHANGE: ${docSnap.id} "${oldDisplayFileName}" → "${displayFileName}"`);
         } else if (action === 'set') {
           console.log(`  SET: ${docSnap.id} ${data.fileName || '(no name)'} → ${displayFileName}`);
         } else {
+          // 未知の enum 値到達時は部分 batch commit 前で止めて、operator が partial-apply を
+          // 把握できるよう進捗サマリーを error log に出す (#358 silent-failure-hunter Critical)。
+          console.error(
+            `[FATAL] Unexpected DisplayFileNameChange: ${String(action)}. ` +
+            `Progress (before abort): processed=${totalProcessed}, updated=${totalUpdated}, ` +
+            `skipped=${totalSkipped}, changed=${totalChanged}. ` +
+            `Uncommitted batch (size=${batchCount}) will be LOST.`
+          );
           const _exhaustive: never = action;
           throw new Error(`Unexpected DisplayFileNameChange: ${String(_exhaustive)}`);
         }

--- a/shared/detectDisplayFileNameChange.ts
+++ b/shared/detectDisplayFileNameChange.ts
@@ -1,0 +1,33 @@
+/**
+ * displayFileName backfill の差分判定 (#358)
+ *
+ * scripts と functions の両方から参照されるため shared/ に配置。
+ * Firestore / Admin SDK 非依存の純粋関数。
+ */
+
+/**
+ * backfill 差分判定の 3 状態:
+ *   - 'noop':   旧値と新値が一致 (書き込み不要)
+ *   - 'set':    旧値が未設定 (新規 SET、--force なしでも実施)
+ *   - 'change': 旧値あり かつ 新値と不一致 (--force で shared サニタイズ等により書き換わるケース)
+ *
+ * `'change'` は operator が書き換え前後の値を把握する必要があるため、scripts 側で
+ * CHANGE ログを出し `_migrations.changedCount` にカウントする (silent 書き換え防止)。
+ */
+export type DisplayFileNameChange = 'noop' | 'set' | 'change';
+
+/**
+ * backfill 時の oldDisplayFileName と新生成 displayFileName を比較し、
+ * 書き込みアクション種別を返す純粋関数。
+ *
+ * inline 判定 (Boolean(old) && old !== new) はカウンタ漏れ・状態分岐誤りの silent bug 温床。
+ * 純粋関数 + test lock-in で drift を防ぐ。
+ */
+export function detectDisplayFileNameChange(
+  oldDisplayFileName: string | null | undefined,
+  newDisplayFileName: string
+): DisplayFileNameChange {
+  if (!oldDisplayFileName) return 'set';
+  if (oldDisplayFileName === newDisplayFileName) return 'noop';
+  return 'change';
+}

--- a/shared/detectDisplayFileNameChange.ts
+++ b/shared/detectDisplayFileNameChange.ts
@@ -11,8 +11,9 @@
  *   - 'set':    旧値が未設定 (新規 SET、--force なしでも実施)
  *   - 'change': 旧値あり かつ 新値と不一致 (--force で shared サニタイズ等により書き換わるケース)
  *
- * `'change'` は operator が書き換え前後の値を把握する必要があるため、scripts 側で
- * CHANGE ログを出し `_migrations.changedCount` にカウントする (silent 書き換え防止)。
+ * `'change'` は operator が書き換え前後の値を把握する必要があるため、scripts/backfill-display-filename.ts
+ * で CHANGE ログを出し、ローカル `totalChanged` カウンタを経由して `_migrations.display_filename_backfill.changedCount`
+ * Firestore ドキュメントに永続化する (silent 書き換え防止)。
  */
 export type DisplayFileNameChange = 'noop' | 'set' | 'change';
 
@@ -22,6 +23,14 @@ export type DisplayFileNameChange = 'noop' | 'set' | 'change';
  *
  * inline 判定 (Boolean(old) && old !== new) はカウンタ漏れ・状態分岐誤りの silent bug 温床。
  * 純粋関数 + test lock-in で drift を防ぐ。
+ *
+ * @param oldDisplayFileName Firestore ドキュメントの既存 displayFileName。未設定時は
+ *                           null/undefined/空文字が渡る可能性 (すべて `'set'` に分類)。
+ * @param newDisplayFileName 新たに生成された displayFileName。**非空文字列** (callsite で
+ *                           `generateDisplayFileName` の null 返しは事前に skip 済み前提)。
+ *                           空文字が渡ると `oldDisplayFileName === ''` ケースで誤って 'noop' と
+ *                           判定されるが、実運用パスでは到達不能。
+ * @returns 'set' | 'change' | 'noop'
  */
 export function detectDisplayFileNameChange(
   oldDisplayFileName: string | null | undefined,


### PR DESCRIPTION
## Summary

PR #357 (Closes #334) の /review-pr で指摘された pr-test-analyzer I1 (rating 7) / I2 (rating 6) への follow-up。

- **差分検出ロジック抽出** (I1): inline `isChange` 判定を `shared/detectDisplayFileNameChange.ts` の純粋関数に抽出。3 状態 (`set` / `change` / `noop`) を unit test で lock-in
- **OS 禁止文字 backfill 経路テスト** (I2): `buildDisplayFileNameFromDoc` 経路で shared サニタイズが効くことを smoke test で lock-in
- **動作改善** (副作用): `--force` 時に既存値 === 新生成値 (`noop`) なら Firestore write をスキップ。元コードは無意味な `updatedAt` 書き込みが走っていた

## 変更ファイル (4 ファイル)

**新規**:
- `shared/detectDisplayFileNameChange.ts`: `DisplayFileNameChange` type + `detectDisplayFileNameChange` 純粋関数

**修正**:
- `functions/src/utils/backfillDisplayFileName.ts`: shared からの re-export に置換
- `scripts/backfill-display-filename.ts`: inline 判定を pure 関数に置換 + noop skip + exhaustive assertNever
- `functions/test/backfillDisplayFileName.test.ts`: 差分検出 5 テスト + OS 禁止文字 3 テスト追加

## 受け入れ基準 (AC)

- [x] **AC1 (I1)**: `detectDisplayFileNameChange(old, new)` が `'set' | 'change' | 'noop'` を返し、test で 3 状態 + 境界値 (null/undefined/空文字) を lock-in
- [x] **AC2 (I2)**: `buildDisplayFileNameFromDoc({ customerName: '山田/太郎', ... })` が `山田_太郎` を含む displayFileName を返す (半角スラッシュサニタイズ)
- [x] **AC3 (I2)**: officeName に半角バックスラッシュ / 全角コロンを含むケースも同様にサニタイズされる
- [x] **AC4**: scripts 側が pure 関数 + exhaustive switch (assertNever) で将来の enum 拡張 silent drift から保護される

## 動作変更の明示

従来の `--force` 実行時挙動:
- 既存 `displayFileName` === 新生成 `displayFileName` の場合でも `batch.update` が実行される
- `SET:` ログが出力される (「未設定 → 新規 SET」と同じ log、誤解しやすい)
- `updatedAt` だけが更新され、Cloud Functions trigger / Firestore listener がノイズ発火

新挙動:
- noop ケースは `totalSkipped` にカウントし Firestore write をスキップ
- ログなし (`SET:` / `CHANGE:` どちらにも該当しない明示的な skip)
- 大量ドキュメント (数万件) で実変更分のみ write → コスト削減 + trigger 抑制

## Test plan

- [x] BE `npm test`: 677 passing (670 → +7 新規) / 6 pending
- [x] BE `npx tsc --noEmit`: PASS
- [x] BE `npm run type-check:test`: PASS
- [x] scripts `tsc --noEmit -p scripts/tsconfig.json`: PASS
- [ ] CI 3/3 green (マージ前確認)
- [ ] GitHub Actions "Run Operations Script" で dev 環境 `backfill-display-filename --dry-run` 実行し noop skip が反映されることを確認 (次セッション確認)

## Quality Gate

- [x] `/simplify` 3 並列 review (reuse / quality / efficiency):
  * 必須 0 件
  * 推奨対応: shared/ 配置化 + assertNever + 包含関係コメント → 本 PR 内で対応
  * Follow-up: `totalSkipped` カウンタ分割 → Issue #365
- [ ] `/review-pr`: PR 作成後に実施
- [ ] CI 3/3 green

Closes #358
Follow-up: #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)