### PR TITLE
feat(ops): backfill-display-filename の totalSkipped を existing/noop に分割 (Closes #365)

### DIFF
--- a/scripts/backfill-display-filename.ts
+++ b/scripts/backfill-display-filename.ts
@@ -54,7 +54,12 @@ async function main(): Promise<void> {
   const targetStatuses = ['processed', 'split'];
   let totalProcessed = 0;
   let totalUpdated = 0;
-  let totalSkipped = 0;
+  // #365: totalSkipped を 2 カウンタに分割。
+  // - totalSkippedExisting: --force なしで既存 displayFileName があるためスキップ
+  // - totalSkippedNoop: --force ありで既存値 === 新生成値のため書き込み不要でスキップ
+  // 合計値 (totalSkippedExisting + totalSkippedNoop) は _migrations.skippedCount で後方互換維持。
+  let totalSkippedExisting = 0;
+  let totalSkippedNoop = 0;
   let totalNoMeta = 0;
   let totalChanged = 0;
 
@@ -87,7 +92,7 @@ async function main(): Promise<void> {
         const data = docSnap.data();
 
         if (data.displayFileName && !force) {
-          totalSkipped++;
+          totalSkippedExisting++;
           continue;
         }
 
@@ -113,7 +118,7 @@ async function main(): Promise<void> {
 
         if (action === 'noop') {
           // 既存 displayFileName が新生成値と一致 → 書き込み不要
-          totalSkipped++;
+          totalSkippedNoop++;
           continue;
         }
         // noop 以降は 'change' | 'set' のみ。将来の enum 拡張で silent に SET に落ちるのを
@@ -128,7 +133,7 @@ async function main(): Promise<void> {
           console.error(
             `[FATAL] Unexpected DisplayFileNameChange: ${String(action)}. ` +
             `Progress (before abort): processed=${totalProcessed}, updated=${totalUpdated}, ` +
-            `skipped=${totalSkipped}, changed=${totalChanged}. ` +
+            `skippedExisting=${totalSkippedExisting}, skippedNoop=${totalSkippedNoop}, changed=${totalChanged}. ` +
             `Uncommitted batch (size=${batchCount}) will be LOST.`
           );
           const _exhaustive: never = action;
@@ -162,7 +167,10 @@ async function main(): Promise<void> {
       status: 'completed',
       processedCount: totalProcessed,
       updatedCount: totalUpdated,
-      skippedCount: totalSkipped,
+      // #365: 後方互換で skippedCount = 合計値を維持。新 field は分割カウンタ。
+      skippedCount: totalSkippedExisting + totalSkippedNoop,
+      skippedExistingCount: totalSkippedExisting,
+      skippedNoopCount: totalSkippedNoop,
       noMetaCount: totalNoMeta,
       changedCount: totalChanged,
       force,
@@ -176,7 +184,11 @@ async function main(): Promise<void> {
   if (force) {
     console.log(`  うち既存値からの変更: ${totalChanged}件`);
   }
-  console.log(`スキップ（設定済み）: ${totalSkipped}件`);
+  console.log(`スキップ（設定済み・--forceなし）: ${totalSkippedExisting}件`);
+  if (force) {
+    // --force 時のみ意味がある (noop は --force 経路でのみ発生)
+    console.log(`スキップ（既存値 === 新生成値・noop）: ${totalSkippedNoop}件`);
+  }
   console.log(`スキップ（メタ不足）: ${totalNoMeta}件`);
 
   if (dryRun) {

--- a/scripts/backfill-display-filename.ts
+++ b/scripts/backfill-display-filename.ts
@@ -54,7 +54,7 @@ async function main(): Promise<void> {
   const targetStatuses = ['processed', 'split'];
   let totalProcessed = 0;
   let totalUpdated = 0;
-  // #365: totalSkipped を 2 カウンタに分割。
+  // #365: totalSkipped を 2 カウンタに分割 (--force 時の冗長 write 削減量を運用で個別可視化するため)。
   // - totalSkippedExisting: --force なしで既存 displayFileName があるためスキップ
   // - totalSkippedNoop: --force ありで既存値 === 新生成値のため書き込み不要でスキップ
   // 合計値 (totalSkippedExisting + totalSkippedNoop) は _migrations.skippedCount で後方互換維持。
@@ -162,6 +162,17 @@ async function main(): Promise<void> {
     }
   }
 
+  // #365 silent-failure-hunter I4: --force=false 経路で noop は到達不能 (L94 early return で
+  // 既存値あり doc は既に totalSkippedExisting に集約されるため)。invariant が破れた場合は
+  // _migrations への silent 汚染を防ぎ、operator の audit 証跡を保つために abort する。
+  if (!force && totalSkippedNoop > 0) {
+    console.error(
+      `[FATAL] invariant violation: totalSkippedNoop=${totalSkippedNoop} with force=false. ` +
+      'noop path must be reachable only via --force. Aborting before _migrations write to preserve audit trail.'
+    );
+    process.exit(1);
+  }
+
   if (!dryRun && totalUpdated > 0) {
     await db.collection('_migrations').doc('display_filename_backfill').set({
       status: 'completed',
@@ -186,7 +197,7 @@ async function main(): Promise<void> {
   }
   console.log(`スキップ（設定済み・--forceなし）: ${totalSkippedExisting}件`);
   if (force) {
-    // --force 時のみ意味がある (noop は --force 経路でのみ発生)
+    // --force 時のみ意味がある (noop は --force 経路でのみ発生、L94 の early return が保証)
     console.log(`スキップ（既存値 === 新生成値・noop）: ${totalSkippedNoop}件`);
   }
   console.log(`スキップ（メタ不足）: ${totalNoMeta}件`);


### PR DESCRIPTION
## Summary

- PR #366 (Closes #358) で追加された noop スキップロジックにより、`totalSkipped` が 2 ケース (既存値ありで `--force` なし / 既存値 === 新生成値の noop) を統合計上していた
- 運用で `--force` 実行時の「冗長 write 削減量 = noop スキップ件数」を個別可視化するため counter を分割
- `_migrations.skippedCount` は合計値で後方互換維持し、`skippedExistingCount` / `skippedNoopCount` を純増

## 変更内容

### counter 分割

```ts
let totalSkippedExisting = 0;  // --force なしで既存 displayFileName あり
let totalSkippedNoop = 0;      // 既存値 === 新生成値で書き込み不要
```

### _migrations record 拡張

```ts
skippedCount: totalSkippedExisting + totalSkippedNoop,  // 後方互換
skippedExistingCount: totalSkippedExisting,             // 新規
skippedNoopCount: totalSkippedNoop,                     // 新規
```

### 結果サマリー

- `スキップ（設定済み・--forceなし）: N件` を常時出力
- `スキップ（既存値 === 新生成値・noop）: N件` を `--force` 時のみ出力 (noop は `--force` 経路でのみ発生)

### fatal progress log

未知 enum 到達時の error log で `skippedExisting` / `skippedNoop` を個別表示、operator の partial-apply 把握を改善

## Acceptance Criteria

- [x] AC1: `--force` なしで既存 displayFileName あり → `totalSkippedExisting` のみ+1
- [x] AC2: `--force` で既存値 === 新生成値 → `totalSkippedNoop` のみ+1
- [x] AC3: `_migrations.skippedCount = skippedExistingCount + skippedNoopCount` (後方互換)
- [x] AC4: fatal progress log で両カウンタ個別表示
- [x] AC5: `npx tsc --noEmit -p scripts/tsconfig.json` EXIT 0

## Test plan

- [x] `npx tsc --noEmit -p scripts/tsconfig.json` EXIT 0
- [ ] GitHub Actions "Run Operations Script" で dev 環境 `backfill-display-filename --dry-run` 実行、結果サマリーに existing 分離出力確認 (dev 環境は実運用データなしのため counter は全 0 予定。crash なし + 新サマリー文字列が出力されれば OK)

## 関連

- Closes #365
- 派生元: PR #366 (Closes #358) の /simplify efficiency Agent 推奨
- 同セッション follow-up: #364 (per-doc catch integration test、次 PR で対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal tracking and reporting for data migration processes to provide clearer differentiation between operation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->