### PR TITLE
test: rescueStuckProcessingDocs の per-doc catch 経路 integration test (Closes #364)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -21,28 +21,30 @@
     "node": "20"
   },
   "dependencies": {
+    "@google-cloud/secret-manager": "^5.6.0",
+    "@google-cloud/vertexai": "^1.9.0",
+    "date-fns": "^4.1.0",
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^6.1.0",
-    "@google-cloud/vertexai": "^1.9.0",
     "googleapis": "^144.0.0",
-    "pdf-lib": "^1.17.1",
-    "date-fns": "^4.1.0",
-    "@google-cloud/secret-manager": "^5.6.0"
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@firebase/rules-unit-testing": "^3.0.4",
+    "@types/chai": "^4.3.20",
+    "@types/mocha": "^10.0.10",
+    "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
-    "eslint": "^9.15.0",
-    "globals": "^15.12.0",
-    "typescript-eslint": "^8.15.0",
-    "typescript": "~5.6.2",
-    "firebase-functions-test": "^3.3.0",
-    "@firebase/rules-unit-testing": "^3.0.4",
-    "mocha": "^10.8.2",
-    "@types/mocha": "^10.0.10",
-    "ts-node": "^10.9.2",
     "chai": "^4.5.0",
-    "@types/chai": "^4.3.20"
+    "eslint": "^9.15.0",
+    "firebase-functions-test": "^3.3.0",
+    "globals": "^15.12.0",
+    "mocha": "^10.8.2",
+    "sinon": "^17.0.1",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.6.2",
+    "typescript-eslint": "^8.15.0"
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -34,7 +34,6 @@
     "@firebase/rules-unit-testing": "^3.0.4",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
-    "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
     "chai": "^4.5.0",
@@ -42,7 +41,6 @@
     "firebase-functions-test": "^3.3.0",
     "globals": "^15.12.0",
     "mocha": "^10.8.2",
-    "sinon": "^17.0.1",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0"

--- a/functions/test/rescueStuckProcessingIntegration.test.ts
+++ b/functions/test/rescueStuckProcessingIntegration.test.ts
@@ -21,6 +21,7 @@ import './helpers/initFirestoreEmulator';
 
 import { expect } from 'chai';
 import * as admin from 'firebase-admin';
+import * as sinon from 'sinon';
 import { rescueStuckProcessingDocs } from '../src/ocr/processOCR';
 import {
   MAX_RETRY_COUNT,
@@ -207,6 +208,77 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
       const errDoc = errs.docs[0].data();
       expect(errDoc.source).to.equal('ocr');
       expect(errDoc.functionName).to.equal('processOCR');
+    });
+  });
+
+  describe('per-doc catch 経路 (runTransaction 失敗時) #364', () => {
+    // #364: sinon で db.runTransaction を stub し、tx 失敗時に per-doc catch の
+    // safeLogError が呼ばれることを lock-in する。#360 silent-failure-hunter I1 で
+    // 実装されたが、integration test は fatalReached=true 経路のみ検証していた。
+    // 将来 outer try/catch を誤削除すると partial failure で silent 未処理復活するリスクを防ぐ。
+
+    const TX_FAILURE_MESSAGE = 'Simulated runTransaction failure for #364 test';
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('runTransaction 失敗 → errors/ に記録、lastErrorMessage は fatal prefix と異なる', async () => {
+      const docId = 'stuck-tx-fail';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        updatedAt: admin.firestore.Timestamp.fromMillis(Date.now() - STUCK_UPDATED_AT_OFFSET_MS),
+        retryCount: 1,
+        fileName: 'tx-fail.pdf',
+      });
+
+      sinon.stub(db, 'runTransaction').rejects(new Error(TX_FAILURE_MESSAGE));
+
+      await rescueStuckProcessingDocs();
+
+      // per-doc catch 経路の errors/ 記録 (silent-failure-hunter I1 の完全 lock-in)
+      const errs = await db.collection('errors').where('documentId', '==', docId).get();
+      expect(errs.size).to.equal(1);
+      const errDoc = errs.docs[0].data();
+      expect(errDoc.source).to.equal('ocr');
+      expect(errDoc.functionName).to.equal('processOCR');
+      // per-doc catch 由来のメッセージは fatal 分岐 (STUCK_RESCUE_FATAL_MESSAGE_PREFIX) とは異なる。
+      // errors/ の errorMessage は safeLogError が params.error.message をそのまま記録するため、
+      // 送信元の TX_FAILURE_MESSAGE が含まれる。fatal 分岐は別の Error.message を投入するので区別可能。
+      const errorMessage = errDoc.errorMessage as string | undefined;
+      expect(errorMessage).to.be.a('string');
+      expect(errorMessage).to.include(TX_FAILURE_MESSAGE);
+      expect(errorMessage).to.not.include(STUCK_RESCUE_FATAL_MESSAGE_PREFIX);
+
+      // tx 失敗のため document 本体の status/retryCount は更新されない (processing のまま)。
+      // これも silent failure でなく「状態復旧に失敗した事実」を保存する観測可能性の lock-in。
+      const docAfter = (await db.doc(`documents/${docId}`).get()).data() as StuckDocFixture;
+      expect(docAfter.status).to.equal('processing');
+      expect(docAfter.retryCount).to.equal(1);
+    });
+
+    it('partial failure: 複数 doc の tx が全て失敗しても per-doc catch がループを継続する', async () => {
+      // 2 doc を配置、全 tx を失敗させる。ループ継続性 (outer try/catch 誤削除の検知) を lock-in。
+      const docIds = ['stuck-partial-1', 'stuck-partial-2'];
+      for (const docId of docIds) {
+        await db.doc(`documents/${docId}`).set({
+          status: 'processing',
+          updatedAt: admin.firestore.Timestamp.fromMillis(Date.now() - STUCK_UPDATED_AT_OFFSET_MS),
+          retryCount: 1,
+          fileName: `${docId}.pdf`,
+        });
+      }
+
+      sinon.stub(db, 'runTransaction').rejects(new Error(TX_FAILURE_MESSAGE));
+
+      await rescueStuckProcessingDocs();
+
+      // 両 doc について errors/ に記録されていること (ループが途中で止まっていない証左)
+      for (const docId of docIds) {
+        const errs = await db.collection('errors').where('documentId', '==', docId).get();
+        expect(errs.size, `errors/ for ${docId}`).to.equal(1);
+        expect(errs.docs[0].data().functionName).to.equal('processOCR');
+      }
     });
   });
 

--- a/functions/test/rescueStuckProcessingIntegration.test.ts
+++ b/functions/test/rescueStuckProcessingIntegration.test.ts
@@ -21,7 +21,6 @@ import './helpers/initFirestoreEmulator';
 
 import { expect } from 'chai';
 import * as admin from 'firebase-admin';
-import * as sinon from 'sinon';
 import { rescueStuckProcessingDocs } from '../src/ocr/processOCR';
 import {
   MAX_RETRY_COUNT,
@@ -212,18 +211,32 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
   });
 
   describe('per-doc catch 経路 (runTransaction 失敗時) #364', () => {
-    // #364: sinon で db.runTransaction を stub し、tx 失敗時に per-doc catch の
-    // safeLogError が呼ばれることを lock-in する。#360 silent-failure-hunter I1 で
-    // 実装されたが、integration test は fatalReached=true 経路のみ検証していた。
-    // 将来 outer try/catch を誤削除すると partial failure で silent 未処理復活するリスクを防ぐ。
+    // #364: db.runTransaction を一時的に差し替えて tx 失敗を誘発し、per-doc catch の safeLogError
+    // 呼出を lock-in する。#360 silent-failure-hunter I1 で実装された outer try/catch を誤削除すると
+    // partial failure で silent 未処理が復活するリスクを防ぐ。
+    //
+    // buildPageResult.test.ts の withWarnSpy と同方針で sinon 依存を新規追加しない polyfill で差し替える。
 
     const TX_FAILURE_MESSAGE = 'Simulated runTransaction failure for #364 test';
 
-    afterEach(() => {
-      sinon.restore();
-    });
+    /**
+     * db.runTransaction を一時差し替えして rescue 本体が per-doc catch を通るよう強制する。
+     * try/finally で原値復元を保証するため、assertion 内で失敗しても stub がリークしない。
+     */
+    async function withFailingRunTransaction(fn: () => Promise<void>): Promise<void> {
+      const original = db.runTransaction.bind(db);
+      // rejects() で tx body を一切呼ばず即 reject する。rescue 本体の per-doc try/catch が発火する。
+      (db as unknown as { runTransaction: unknown }).runTransaction = async () => {
+        throw new Error(TX_FAILURE_MESSAGE);
+      };
+      try {
+        await fn();
+      } finally {
+        (db as unknown as { runTransaction: typeof original }).runTransaction = original;
+      }
+    }
 
-    it('runTransaction 失敗 → errors/ に記録、lastErrorMessage は fatal prefix と異なる', async () => {
+    it('runTransaction 失敗 → errors/ に記録、errorMessage は fatal prefix と異なる', async () => {
       const docId = 'stuck-tx-fail';
       await db.doc(`documents/${docId}`).set({
         status: 'processing',
@@ -232,33 +245,42 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
         fileName: 'tx-fail.pdf',
       });
 
-      sinon.stub(db, 'runTransaction').rejects(new Error(TX_FAILURE_MESSAGE));
+      await withFailingRunTransaction(async () => {
+        await rescueStuckProcessingDocs();
+      });
 
-      await rescueStuckProcessingDocs();
-
-      // per-doc catch 経路の errors/ 記録 (silent-failure-hunter I1 の完全 lock-in)
+      // per-doc catch 経路の errors/ 記録 (#360 silent-failure-hunter I1 の完全 lock-in)。
+      // silent-failure-hunter I1 (#369 レビュー): 全件 forEach で検証することで、rescue が
+      // 同一 docId に対し safeLogError を二重呼出する regression を検知できる。
       const errs = await db.collection('errors').where('documentId', '==', docId).get();
-      expect(errs.size).to.equal(1);
-      const errDoc = errs.docs[0].data();
-      expect(errDoc.source).to.equal('ocr');
-      expect(errDoc.functionName).to.equal('processOCR');
-      // per-doc catch 由来のメッセージは fatal 分岐 (STUCK_RESCUE_FATAL_MESSAGE_PREFIX) とは異なる。
-      // errors/ の errorMessage は safeLogError が params.error.message をそのまま記録するため、
-      // 送信元の TX_FAILURE_MESSAGE が含まれる。fatal 分岐は別の Error.message を投入するので区別可能。
-      const errorMessage = errDoc.errorMessage as string | undefined;
-      expect(errorMessage).to.be.a('string');
-      expect(errorMessage).to.include(TX_FAILURE_MESSAGE);
-      expect(errorMessage).to.not.include(STUCK_RESCUE_FATAL_MESSAGE_PREFIX);
+      expect(errs.size, 'errors/ should be written exactly once per doc').to.equal(1);
+      errs.docs.forEach((d) => {
+        const data = d.data();
+        expect(data.source).to.equal('ocr');
+        expect(data.functionName).to.equal('processOCR');
+        // per-doc catch 由来のメッセージは fatal 分岐 (STUCK_RESCUE_FATAL_MESSAGE_PREFIX) とは異なる。
+        // errors/ の errorMessage は safeLogError が params.error.message をそのまま記録するため
+        // (errorLogger.ts:175)、TX_FAILURE_MESSAGE を含む。fatal 分岐とは別 Error.message で区別可能。
+        const errorMessage = data.errorMessage as string | undefined;
+        expect(errorMessage).to.be.a('string');
+        expect(errorMessage).to.include(TX_FAILURE_MESSAGE);
+        expect(errorMessage).to.not.include(STUCK_RESCUE_FATAL_MESSAGE_PREFIX);
+      });
 
-      // tx 失敗のため document 本体の status/retryCount は更新されない (processing のまま)。
-      // これも silent failure でなく「状態復旧に失敗した事実」を保存する観測可能性の lock-in。
+      // tx 失敗のため document 本体には一切の書込みが発生しない invariant。catch 句が fallback で
+      // db.update を呼ぶような silent 救済が入った場合、このテストが壊れて検知できる。
+      // silent-failure-hunter I4 (#369 レビュー): retryAfter / lastErrorMessage の undefined まで
+      // 検証することで tx 外の silent partial write を全て検知する。
       const docAfter = (await db.doc(`documents/${docId}`).get()).data() as StuckDocFixture;
       expect(docAfter.status).to.equal('processing');
       expect(docAfter.retryCount).to.equal(1);
+      expect(docAfter.retryAfter).to.be.undefined;
+      expect(docAfter.lastErrorMessage).to.be.undefined;
     });
 
     it('partial failure: 複数 doc の tx が全て失敗しても per-doc catch がループを継続する', async () => {
-      // 2 doc を配置、全 tx を失敗させる。ループ継続性 (outer try/catch 誤削除の検知) を lock-in。
+      // ループ継続性の lock-in (outer try/catch 誤削除で 2 doc 目が silent skip される回帰を検知)。
+      // 単一 doc では継続 vs 停止を区別不能なため 2 doc 必須。
       const docIds = ['stuck-partial-1', 'stuck-partial-2'];
       for (const docId of docIds) {
         await db.doc(`documents/${docId}`).set({
@@ -269,11 +291,13 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
         });
       }
 
-      sinon.stub(db, 'runTransaction').rejects(new Error(TX_FAILURE_MESSAGE));
+      await withFailingRunTransaction(async () => {
+        await rescueStuckProcessingDocs();
+      });
 
-      await rescueStuckProcessingDocs();
-
-      // 両 doc について errors/ に記録されていること (ループが途中で止まっていない証左)
+      // 両 doc について errors/ に記録されていること (ループが途中で止まっていない証左)。
+      // 差し替えた runTransaction は全 doc に対して throw するため、片方のみ記録されていれば
+      // ループが early-return している silent regression を検知できる。
       for (const docId of docIds) {
         const errs = await db.collection('errors').where('documentId', '==', docId).get();
         expect(errs.size, `errors/ for ${docId}`).to.equal(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "@firebase/rules-unit-testing": "^3.0.4",
         "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.10",
+        "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
         "@typescript-eslint/parser": "^8.15.0",
         "chai": "^4.5.0",
@@ -99,6 +100,7 @@
         "firebase-functions-test": "^3.3.0",
         "globals": "^15.12.0",
         "mocha": "^10.8.2",
+        "sinon": "^17.0.1",
         "ts-node": "^10.9.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.15.0"
@@ -6046,7 +6048,6 @@
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -6061,6 +6062,35 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "deprecated": "Deprecated: no longer maintained and no longer used by Sinon packages. See\n  https://github.com/sinonjs/nise/issues/243 for replacement details.",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -6589,6 +6619,23 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -12356,6 +12403,13 @@
         "npm": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -13168,6 +13222,37 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/nise": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
+      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "3.86.0",
@@ -15118,6 +15203,35 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.5",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/slash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
         "@firebase/rules-unit-testing": "^3.0.4",
         "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.10",
-        "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
         "@typescript-eslint/parser": "^8.15.0",
         "chai": "^4.5.0",
@@ -100,7 +99,6 @@
         "firebase-functions-test": "^3.3.0",
         "globals": "^15.12.0",
         "mocha": "^10.8.2",
-        "sinon": "^17.0.1",
         "ts-node": "^10.9.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.15.0"
@@ -6048,6 +6046,7 @@
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -6062,35 +6061,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
-      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
-      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
-      "deprecated": "Deprecated: no longer maintained and no longer used by Sinon packages. See\n  https://github.com/sinonjs/nise/issues/243 for replacement details.",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -6619,23 +6589,6 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/sinon": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
-      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
-      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -12403,13 +12356,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/just-extend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -13222,37 +13168,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/nise": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
-      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "@sinonjs/text-encoding": "^0.7.2",
-        "just-extend": "^6.2.0",
-        "path-to-regexp": "^6.2.1"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
-      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "3.86.0",
@@ -15203,35 +15118,6 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/sinon": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
-      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "@sinonjs/samsam": "^8.0.0",
-        "diff": "^5.1.0",
-        "nise": "^5.1.5",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
-      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/slash": {


### PR DESCRIPTION
## Summary

- PR #363 (Closes #360) の /review-pr で evaluator と pr-test-analyzer が共通指摘していた「per-doc catch 経路 (runTransaction 失敗時) の safeLogError 呼出が integration test 未カバー」を解消
- sinon で \`db.runTransaction\` を stub し、tx 失敗時の per-doc catch を直接検証
- 将来 outer try/catch を誤削除した場合の silent failure 復活リスクを lock-in

## 変更内容

### sinon 導入

\`functions/package.json\` に sinon@^17.0.1 / @types/sinon@^17.0.4 を devDependencies 追加。\`npm install\` に伴い既存 dep 順序が自動 sort されたが機能差異なし。

### 追加テスト (2 件)

**1. runTransaction 失敗 → errors/ に記録、lastErrorMessage は fatal prefix と異なる**
- 1 doc 配置、tx reject
- errors/ に 1 件記録、\`source='ocr'\` / \`functionName='processOCR'\`
- \`errorMessage\` に TX_FAILURE_MESSAGE を含み、\`STUCK_RESCUE_FATAL_MESSAGE_PREFIX\` は含まない (分岐の区別)
- document 本体の status/retryCount は不変 (tx 失敗の観測可能性)

**2. partial failure: 複数 doc の tx が全て失敗してもループが継続する**
- 2 doc 配置、全 tx reject
- 両 doc について errors/ に 1 件ずつ記録 (ループ継続性 lock-in)

## 設計判断

Issue 本文の 3 選択肢のうち **sinon 導入を採用**:

| 案 | 採否 | 理由 |
|---|---|---|
| emulator rules で書き込み拒否 | ❌ | admin SDK は emulator でも rules を bypass する仕様のため不可 |
| tx.update invalid data 誘発 | ❌ | emulator 実装依存で fragile |
| **sinon で runTransaction stub** | ✅ | 新規テストのみで使用、既存テストへの影響なし |

## Acceptance Criteria

- [x] AC1: runTransaction reject 時、errors/ に 1 件記録 (\`source='ocr'\` / \`functionName='processOCR'\`)
- [x] AC2: errors/ の errorMessage は per-doc catch 由来で fatal prefix と異なる
- [x] AC3: tx 失敗時に document 本体は status='processing' のまま (tx atomicity 保証 + 観測可能性)
- [x] AC4: 複数 doc の tx 失敗でループ継続、全 doc が errors/ に記録される
- [x] AC5: sinon.restore() で既存テストへの影響ゼロ (BE unit 677 passing 維持)

## Test plan

- [x] \`npm run type-check:test\` EXIT 0
- [x] \`npm test\` (BE unit) **677 passing + 6 pending** (変化なし、sinon 既存影響なし)
- [x] \`npm run test:integration\` (emulator) **23 passing** (21 → +2 from #364)
- [x] \`npm run lint\` 0 errors, 25 warnings (本 PR 新規 warning ゼロ、既存 warning 2 件削減)

## Issue Triage 不対応

なし (AC 全てカバー)。rating 5-6 の suggestion は発生しなかった。

## 関連

- Closes #364
- 派生元: PR #363 (Closes #360) evaluator + pr-test-analyzer 共通指摘
- 同セッション先行 PR: #368 (Closes #365)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test coverage for error handling and failure scenarios.

* **Chores**
  * Updated development dependencies and project tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->