### PR TITLE
test: fatal 分岐 safeLogError 二重呼出防止 integration test (Closes #370)

### DIFF
--- a/functions/test/rescueStuckProcessingIntegration.test.ts
+++ b/functions/test/rescueStuckProcessingIntegration.test.ts
@@ -22,6 +22,7 @@ import './helpers/initFirestoreEmulator';
 import { expect } from 'chai';
 import * as admin from 'firebase-admin';
 import { rescueStuckProcessingDocs } from '../src/ocr/processOCR';
+import type { LogErrorParams } from '../src/utils/errorLogger';
 import {
   MAX_RETRY_COUNT,
   STUCK_RESCUE_RETRY_AFTER_MS,
@@ -307,45 +308,35 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
   });
 
   describe('fatal 分岐 safeLogError 失敗時の二重呼出防止 (#370)', () => {
-    // #370: processOCR.ts:222-232 の inner try/catch lock-in (PR #369 silent-failure-hunter I2)。
-    //
-    // 正常実装 (inner try/catch あり):
-    //   safeLogError 失敗 → inner catch で console.error に swallow → outer catch 未到達
-    //   → rescue ループ内で safeLogError が呼ばれるのは 1 回のみ
-    //
-    // regression シナリオ (将来の「cleanup」で inner try/catch 削除):
-    //   safeLogError 失敗 → outer catch に伝播 → outer catch 内の safeLogError が再度呼ばれ、
-    //   同一 docId に対して errors/ が 2 件書き込まれる silent regression
-    //
-    // safeLogError は現実装で logError 失敗を swallow するため throw しない契約だが、将来の
-    // errorLogger 側 cleanup (safeLogError 内部 try/catch 削除) でも二重書込を防ぐ保険として
-    // processOCR.ts 側の inner try/catch 単体で regression を防ぐことを call count で lock-in する。
+    // #370: rescueStuckProcessingDocs の fatal 分岐 inner try/catch の regression lock-in。
+    // 実装元: #360 silent-failure-hunter I1 (inner try/catch 新設)、
+    // 本 test: PR #369 silent-failure-hunter I2 の follow-up として inner try/catch 削除を検知する。
+    // 詳細は Issue #370 / PR #372 参照。
 
     /**
-     * errorLogger.safeLogError を一時的に差し替えて throw を強制する。
-     * CommonJS (tsconfig "module": "NodeNext" + package.json "type": "commonjs") 配下では
-     * processOCR.ts の `await errorLogger_1.safeLogError(...)` が namespace object の dynamic
-     * lookup になるため、namespace property 書き換えが production code 側の呼出に反映される
-     * (#369 の withFailingRunTransaction と同方針、sinon 依存なし)。
+     * errorLogger.safeLogError を一時的に「常に throw する stub」に差し替える。
      *
-     * call count で fatal 分岐 (1 回目) と outer catch (2 回目、regression 時のみ) を区別する。
-     * try/finally で原値復元を保証し、後続 test への stub leak を防ぐ。
+     * CommonJS (tsconfig "module": "NodeNext" + package.json "type": "commonjs") 配下では
+     * processOCR.ts の `await (0, errorLogger_1.safeLogError)(...)` が namespace object の
+     * dynamic lookup になるため、namespace property の書き換えが production code 側の呼出に
+     * 反映される (#369 の withFailingRunTransaction と同方針、sinon 依存なし)。
+     *
+     * 「常に throw」設計で以下の 2 通りを区別する:
+     *   - 正常実装: fatal 分岐 inner try/catch が swallow → rescue 正常完了、callCount === 1
+     *   - regression (inner try/catch 削除): outer catch に伝播 → outer 内 safeLogError も throw
+     *     → rescueStuckProcessingDocs が reject → test 側 catch で拾って FAIL
      */
     async function withFailingSafeLogError(
       fn: () => Promise<void>
     ): Promise<{ callCount: number }> {
       const errorLoggerModule = require('../src/utils/errorLogger') as {
-        safeLogError: (params: unknown) => Promise<void>;
+        safeLogError: (params: LogErrorParams) => Promise<void>;
       };
       const original = errorLoggerModule.safeLogError;
       let callCount = 0;
-      errorLoggerModule.safeLogError = async (_params: unknown) => {
+      errorLoggerModule.safeLogError = async (_params: LogErrorParams) => {
         callCount++;
-        // 1 回目 (fatal 分岐 inner try) → reject: 正常実装では inner catch で swallow される
-        // 2 回目以降 (outer catch、regression 時のみ到達) → no-op resolve で callCount のみ加算
-        if (callCount === 1) {
-          throw new Error('Simulated safeLogError failure for #370 test');
-        }
+        throw new Error('Simulated safeLogError failure for #370 test');
       };
       try {
         await fn();
@@ -365,20 +356,28 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
         customerName: '顧客X',
       });
 
-      const { callCount } = await withFailingSafeLogError(async () => {
-        await rescueStuckProcessingDocs();
-      });
+      // 正常実装では rescue が reject しないことを第一 invariant として確認する。
+      // regression で outer catch に伝播した場合、outer catch 内の safeLogError (try/catch なし)
+      // が再 throw して rescueStuckProcessingDocs 全体が reject する。
+      let rescueError: Error | undefined;
+      let callCount = 0;
+      try {
+        ({ callCount } = await withFailingSafeLogError(async () => {
+          await rescueStuckProcessingDocs();
+        }));
+      } catch (err) {
+        rescueError = err as Error;
+      }
 
-      // 二重呼出防止 invariant (#370 の本体):
-      //   callCount === 1: 正常実装 (inner catch で swallow、outer 未到達)
-      //   callCount === 2: regression (inner try/catch 削除で outer catch に伝播し再呼出)
-      // この厳密等号が将来 inner try/catch を誤削除する cleanup を test で検知する。
+      expect(
+        rescueError,
+        'rescueStuckProcessingDocs must complete without throwing (inner catch must swallow safeLogError failure)'
+      ).to.be.undefined;
       expect(
         callCount,
         'safeLogError must be invoked exactly once (inner catch swallows, outer catch unreachable)'
       ).to.equal(1);
 
-      // tx は成功しているため document 本体は status='error' に更新済み
       const docAfter = (await db.doc(`documents/${docId}`).get()).data() as StuckDocFixture;
       expect(docAfter.status).to.equal('error');
       expect(docAfter.retryCount).to.equal(MAX_RETRY_COUNT);
@@ -388,12 +387,6 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
       // 更新対象外フィールド不変 (CLAUDE.md MUST: Partial Update は更新対象外の不変性)
       expect(docAfter.fileName).to.equal('fatal-log-fail.pdf');
       expect(docAfter.customerName).to.equal('顧客X');
-
-      // safeLogError を stub している間は errors/ への実書込みが発生しない。
-      // callCount による invariant 検証が regression 検知の本体であり、errors/ 件数は
-      // 副次的な safety: stub 自身が実 Firestore write を呼ばないことの裏確認。
-      const errs = await db.collection('errors').where('documentId', '==', docId).get();
-      expect(errs.size, 'errors/ must remain empty while safeLogError is stubbed').to.equal(0);
     });
   });
 

--- a/functions/test/rescueStuckProcessingIntegration.test.ts
+++ b/functions/test/rescueStuckProcessingIntegration.test.ts
@@ -306,6 +306,97 @@ describe('rescueStuckProcessingDocs 統合テスト (#360)', () => {
     });
   });
 
+  describe('fatal 分岐 safeLogError 失敗時の二重呼出防止 (#370)', () => {
+    // #370: processOCR.ts:222-232 の inner try/catch lock-in (PR #369 silent-failure-hunter I2)。
+    //
+    // 正常実装 (inner try/catch あり):
+    //   safeLogError 失敗 → inner catch で console.error に swallow → outer catch 未到達
+    //   → rescue ループ内で safeLogError が呼ばれるのは 1 回のみ
+    //
+    // regression シナリオ (将来の「cleanup」で inner try/catch 削除):
+    //   safeLogError 失敗 → outer catch に伝播 → outer catch 内の safeLogError が再度呼ばれ、
+    //   同一 docId に対して errors/ が 2 件書き込まれる silent regression
+    //
+    // safeLogError は現実装で logError 失敗を swallow するため throw しない契約だが、将来の
+    // errorLogger 側 cleanup (safeLogError 内部 try/catch 削除) でも二重書込を防ぐ保険として
+    // processOCR.ts 側の inner try/catch 単体で regression を防ぐことを call count で lock-in する。
+
+    /**
+     * errorLogger.safeLogError を一時的に差し替えて throw を強制する。
+     * CommonJS (tsconfig "module": "NodeNext" + package.json "type": "commonjs") 配下では
+     * processOCR.ts の `await errorLogger_1.safeLogError(...)` が namespace object の dynamic
+     * lookup になるため、namespace property 書き換えが production code 側の呼出に反映される
+     * (#369 の withFailingRunTransaction と同方針、sinon 依存なし)。
+     *
+     * call count で fatal 分岐 (1 回目) と outer catch (2 回目、regression 時のみ) を区別する。
+     * try/finally で原値復元を保証し、後続 test への stub leak を防ぐ。
+     */
+    async function withFailingSafeLogError(
+      fn: () => Promise<void>
+    ): Promise<{ callCount: number }> {
+      const errorLoggerModule = require('../src/utils/errorLogger') as {
+        safeLogError: (params: unknown) => Promise<void>;
+      };
+      const original = errorLoggerModule.safeLogError;
+      let callCount = 0;
+      errorLoggerModule.safeLogError = async (_params: unknown) => {
+        callCount++;
+        // 1 回目 (fatal 分岐 inner try) → reject: 正常実装では inner catch で swallow される
+        // 2 回目以降 (outer catch、regression 時のみ到達) → no-op resolve で callCount のみ加算
+        if (callCount === 1) {
+          throw new Error('Simulated safeLogError failure for #370 test');
+        }
+      };
+      try {
+        await fn();
+      } finally {
+        errorLoggerModule.safeLogError = original;
+      }
+      return { callCount };
+    }
+
+    it('fatal 分岐で safeLogError 失敗が inner catch で swallow され outer catch に伝播しない', async () => {
+      const docId = 'stuck-fatal-log-fail';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        updatedAt: admin.firestore.Timestamp.fromMillis(Date.now() - STUCK_UPDATED_AT_OFFSET_MS),
+        retryCount: MAX_RETRY_COUNT - 1, // tx 内 +1 で MAX 到達 → fatal 分岐
+        fileName: 'fatal-log-fail.pdf',
+        customerName: '顧客X',
+      });
+
+      const { callCount } = await withFailingSafeLogError(async () => {
+        await rescueStuckProcessingDocs();
+      });
+
+      // 二重呼出防止 invariant (#370 の本体):
+      //   callCount === 1: 正常実装 (inner catch で swallow、outer 未到達)
+      //   callCount === 2: regression (inner try/catch 削除で outer catch に伝播し再呼出)
+      // この厳密等号が将来 inner try/catch を誤削除する cleanup を test で検知する。
+      expect(
+        callCount,
+        'safeLogError must be invoked exactly once (inner catch swallows, outer catch unreachable)'
+      ).to.equal(1);
+
+      // tx は成功しているため document 本体は status='error' に更新済み
+      const docAfter = (await db.doc(`documents/${docId}`).get()).data() as StuckDocFixture;
+      expect(docAfter.status).to.equal('error');
+      expect(docAfter.retryCount).to.equal(MAX_RETRY_COUNT);
+      expect(docAfter.retryAfter).to.be.undefined;
+      expect(docAfter.lastErrorMessage).to.include(STUCK_RESCUE_FATAL_MESSAGE_PREFIX);
+
+      // 更新対象外フィールド不変 (CLAUDE.md MUST: Partial Update は更新対象外の不変性)
+      expect(docAfter.fileName).to.equal('fatal-log-fail.pdf');
+      expect(docAfter.customerName).to.equal('顧客X');
+
+      // safeLogError を stub している間は errors/ への実書込みが発生しない。
+      // callCount による invariant 検証が regression 検知の本体であり、errors/ 件数は
+      // 副次的な safety: stub 自身が実 Firestore write を呼ばないことの裏確認。
+      const errs = await db.collection('errors').where('documentId', '==', docId).get();
+      expect(errs.size, 'errors/ must remain empty while safeLogError is stubbed').to.equal(0);
+    });
+  });
+
   describe('既存動作の維持 (境界値)', () => {
     it('閾値未満の processing は対象外 (不変)', async () => {
       // 閾値未満の fixture は THRESHOLD 自体に依存させる (定数変更で test が意味不明化しないよう)


### PR DESCRIPTION
## Summary

- PR #369 (Closes #364) の /review-pr で silent-failure-hunter I2 (HIGH) が指摘した
  `processOCR.ts:222-232` 「fatal 分岐 inner try/catch の regression 検知」を integration test で lock-in
- 既存 convention「sinon 依存を新規追加しない polyfill」に従い、PR #369 の `withFailingRunTransaction` と同方針で `errorLogger.safeLogError` を書き換えて throw を強制
- call count ベースの assertion で、将来 inner try/catch を誤削除する cleanup を検知

## 背景

正常実装 (inner try/catch あり):
  `safeLogError` 失敗 → inner catch で `console.error` に swallow → outer catch 未到達
  → rescue ループ内で `safeLogError` は **1 回のみ** 呼ばれる

regression シナリオ (将来の「cleanup」で inner try/catch 削除):
  `safeLogError` 失敗 → outer catch に伝播 → outer catch 内で `safeLogError` 再呼出
  → 同一 `docId` に対して `errors/` が **2 件** 書き込まれる silent regression

## 変更内容

### 追加テスト (1 件)

`functions/test/rescueStuckProcessingIntegration.test.ts` に新 describe
`fatal 分岐 safeLogError 失敗時の二重呼出防止 (#370)` を追加:

- fixture: `retryCount = MAX_RETRY_COUNT - 1` で fatal 分岐到達
- polyfill (`withFailingSafeLogError`): `errorLogger.safeLogError` を一時差替え、
  1 回目 reject / 2 回目以降 no-op resolve で call count 計測
- 正常実装 → `callCount === 1` (outer 未到達)
- regression 時 → `callCount === 2` → test FAIL で検知

## 設計判断

### sinon 不採用 (既存 convention 準拠)

PR #369 レビューで確立された convention「sinon 依存を新規追加しない polyfill」
(`buildPageResult.test.ts:74` の `withWarnSpy` と同方針) に従い、`withFailingRunTransaction`
(#369) と同じ inline try/finally polyfill で実装。

CommonJS compile 出力 (`await (0, errorLogger_1.safeLogError)(...)`) の namespace
dynamic lookup を利用し、test 側で `errorLoggerModule.safeLogError` を直接書き換え
(try/finally で原値復元を保証、後続 test への stub leak なし)。

### safeLogError の契約と本 test の位置づけ

現実装の `safeLogError` (`errorLogger.ts:140-152`) は `logError` 失敗を内部 try/catch で
swallow するため throw しない契約。したがって本 test の polyfill は現実装では発火
しない仮想 regression シナリオを検証する保険:

- 誰が壊しうるか: **(A)** `errorLogger.ts` 側の `safeLogError` 内部 try/catch 削除 +
  **(B)** `processOCR.ts` 側の inner try/catch 削除 が**同時発生**すると二重書込
- 本 test は (B) 単体で regression を検知 → (A) の変更に依らず lock-in する

## Acceptance Criteria

- [x] AC1: fatal 分岐到達 fixture で `safeLogError` call count === 1 (outer 未到達)
- [x] AC2: tx 成功後の document 本体が `status='error'` / `retryCount=MAX_RETRY_COUNT`
        / `retryAfter` undefined / `lastErrorMessage` に fatal prefix を含む
- [x] AC3: 更新対象外フィールド (`fileName`, `customerName`) 不変 (CLAUDE.md MUST: Partial Update 不変性)
- [x] AC4: polyfill 原値復元で後続 test (既存 23 テスト) へ stub leak なし

## Test plan

- [x] `npm --prefix functions run type-check:test` EXIT 0
- [x] `npm --prefix functions test` (BE unit) **677 passing + 6 pending** (変化なし)
- [x] `firebase emulators:exec --only firestore --project rescue-stuck-integration-test 'npm --prefix functions run test:integration'` **24 passing** (23 → +1 from #370)
- [x] `npm run lint` (root workspaces) 0 errors, **25 warnings** (本 PR 新規 warning ゼロ)

動作確認ログ (integration test 実行時):
```
fatal 分岐 safeLogError 失敗時の二重呼出防止 (#370)
Found 1 stuck processing documents, resetting to pending
Marked stuck document stuck-fatal-log-fail as error (>= 5 retries)
safeLogError failed for stuck-fatal-log-fail (fatal branch): Error: Simulated safeLogError failure for #370 test
  ✔ fatal 分岐で safeLogError 失敗が inner catch で swallow され outer catch に伝播しない
```
→ `processOCR.ts:224` の inner try/catch が期待通り `console.error` で swallow、outer 未到達を確認。

## Issue Triage 不対応

なし (AC 全てカバー、単一 test file の追加)。

## 関連

- Closes #370
- 派生元: PR #369 (Closes #364) silent-failure-hunter I2 (HIGH) の follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify error handling and document status management during system recovery processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->