### PR TITLE
test: checkGmailAttachments/splitPdf の統合テスト追加 (Closes #200)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "type-check:test": "tsc --noEmit -p tsconfig.test.json",
     "test": "npm run type-check:test && mocha --require ts-node/register --timeout 10000 'test/**/*.test.ts' --ignore 'test/firestore.rules.test.ts' --ignore 'test/*Integration.test.ts'",
     "test:rules": "mocha --require ts-node/register --timeout 10000 'test/firestore.rules.test.ts'",
-    "test:integration": "mocha --require ts-node/register --timeout 10000 test/ocrRetryIntegration.test.ts test/rescueStuckProcessingIntegration.test.ts"
+    "test:integration": "mocha --require ts-node/register --timeout 10000 test/ocrRetryIntegration.test.ts test/rescueStuckProcessingIntegration.test.ts test/gmailAttachmentIntegration.test.ts test/splitPdfIntegration.test.ts"
   },
   "engines": {
     "node": "20"

--- a/functions/test/checkGmailAttachmentsEndpointContract.test.ts
+++ b/functions/test/checkGmailAttachmentsEndpointContract.test.ts
@@ -6,7 +6,8 @@
  *
  * 背景: PR #199 (Gmail 重複取得の根本対策) で maxInstances:1 を導入した。同一スケジュール
  * の複数起動は gmailLogs の messageId 重複挿入レースを招くため、設定値は regression guard
- * する必要がある。既存は grep contract すら無く、settings の静かな退行を検知できない。
+ * する必要がある。onSchedule の runtime options は設定ファイル相当でコンパイルエラーを
+ * 起こさず静かに退行しうるため、grep-based contract で固定する。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
  * source import は `admin.firestore()` top-level 評価で副作用が大きく、unit test 環境に

--- a/functions/test/checkGmailAttachmentsEndpointContract.test.ts
+++ b/functions/test/checkGmailAttachmentsEndpointContract.test.ts
@@ -1,0 +1,66 @@
+/**
+ * checkGmailAttachments endpoint 設定契約テスト (Issue #200 AC2)
+ *
+ * 目的: scheduled function の runtime options (maxInstances / schedule / region /
+ * timeoutSeconds / memory) が運用前提を満たし続けることを保証する。
+ *
+ * 背景: PR #199 (Gmail 重複取得の根本対策) で maxInstances:1 を導入した。同一スケジュール
+ * の複数起動は gmailLogs の messageId 重複挿入レースを招くため、設定値は regression guard
+ * する必要がある。既存は grep contract すら無く、settings の静かな退行を検知できない。
+ *
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
+ * source import は `admin.firestore()` top-level 評価で副作用が大きく、unit test 環境に
+ * emulator host を注入すると他テストに波及するため、ソースファイル文字列から `onSchedule`
+ * の options literal を読み取って assert する。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const SOURCE_PATH = 'src/gmail/checkGmailAttachments.ts';
+const ON_SCHEDULE_ANCHOR = /export\s+const\s+checkGmailAttachments\s*=\s*onSchedule\s*\(/;
+
+let optionsBlock: string = '';
+
+describe('checkGmailAttachments endpoint contract (#200 AC2)', () => {
+  before(() => {
+    const path = resolve(__dirname, '..', SOURCE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Source file not found: ${SOURCE_PATH}`);
+    }
+    const source = readFileSync(path, 'utf-8');
+    // onSchedule( anchor の直後から最初の `{` 〜 対応する `}` を options object として抽出
+    const block = extractBraceBlock(source, ON_SCHEDULE_ANCHOR, {
+      anchorMode: 'after-match',
+    });
+    if (block === null) {
+      throw new Error(
+        `onSchedule options block not found in ${SOURCE_PATH}. ` +
+          `Anchor: ${ON_SCHEDULE_ANCHOR.source}`,
+      );
+    }
+    optionsBlock = block;
+  });
+
+  it('maxInstances:1 (Gmail duplicate race guard / PR #199)', () => {
+    expect(optionsBlock).to.match(/maxInstances:\s*1\b/);
+  });
+
+  it('schedule: "every 5 minutes"', () => {
+    expect(optionsBlock).to.match(/schedule:\s*['"]every 5 minutes['"]/);
+  });
+
+  it('region: asia-northeast1', () => {
+    expect(optionsBlock).to.match(/region:\s*['"]asia-northeast1['"]/);
+  });
+
+  it('timeoutSeconds:300', () => {
+    expect(optionsBlock).to.match(/timeoutSeconds:\s*300\b/);
+  });
+
+  it('memory:"512MiB"', () => {
+    expect(optionsBlock).to.match(/memory:\s*['"]512MiB['"]/);
+  });
+});

--- a/functions/test/gmailAttachmentIntegration.test.ts
+++ b/functions/test/gmailAttachmentIntegration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * checkGmailAttachments 統合テスト (Firebase emulator) - Issue #200 AC1/AC4
+ *
+ * PR #199 (Gmail 重複取得の根本対策) で導入された:
+ *   - messageId based 早期 skip (gmailLogs collection)
+ *   - isSplitSource=true の場合の再取り込み許可ロジック (documents collection)
+ * を Firestore 実クエリで検証する。
+ *
+ * 方式: 既存 ocrRetryIntegration.test.ts の「ロジック再現型」パターンを踏襲する。
+ * checkGmailAttachments wrapper の内部 helper は非公開であり、Gmail API の mock は
+ * コストが高いため、source と同一の Firestore query/write pattern を test 内で再現し、
+ * 結果の分岐 (skip vs 処理対象 / duplicate vs re-import) を assert する。
+ *
+ * 実行: firebase emulators:exec --only firestore --project gmail-attachment-integration-test \
+ *         'npm run test:integration'
+ */
+
+import './helpers/initFirestoreEmulator';
+
+import { expect } from 'chai';
+import * as admin from 'firebase-admin';
+import { cleanupCollections } from './helpers/cleanupEmulator';
+
+const db = admin.firestore();
+const COLLECTIONS_TO_CLEAN: readonly string[] = ['gmailLogs', 'documents', 'uploadLogs'];
+
+// checkGmailAttachments.ts の messageId skip ロジックを再現
+async function isAlreadyProcessedByMessageId(messageId: string): Promise<boolean> {
+  const existing = await db
+    .collection('gmailLogs')
+    .where('messageId', '==', messageId)
+    .limit(1)
+    .get();
+  return !existing.empty;
+}
+
+// checkGmailAttachments.ts の hash 重複 + isSplitSource 再取り込み許可ロジックを再現
+// 戻り値: 'skip' = 全件アクティブ or fileUrl 欠損 / 'reimport' = 全件 split source
+async function shouldSkipByHashDuplicate(
+  hash: string
+): Promise<'skip' | 'reimport' | 'new'> {
+  const [existingGmailLog, existingUploadLog] = await Promise.all([
+    db.collection('gmailLogs').where('hash', '==', hash).limit(1).get(),
+    db.collection('uploadLogs').where('hash', '==', hash).limit(1).get(),
+  ]);
+
+  if (existingGmailLog.empty && existingUploadLog.empty) return 'new';
+
+  const existingLog = !existingGmailLog.empty
+    ? existingGmailLog.docs[0]
+    : existingUploadLog.docs[0];
+  const existingFileUrl = existingLog?.data().fileUrl as string | undefined;
+
+  if (!existingFileUrl) return 'skip';
+
+  const relatedDocs = await db
+    .collection('documents')
+    .where('fileUrl', '==', existingFileUrl)
+    .get();
+
+  const hasActiveDocs = relatedDocs.docs.some((doc) => !doc.data().isSplitSource);
+  return hasActiveDocs ? 'skip' : 'reimport';
+}
+
+describe('checkGmailAttachments 統合テスト (#200)', () => {
+  beforeEach(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  describe('AC1: messageId based 早期 skip', () => {
+    it('既存 gmailLog あり (同一 messageId) → skip=true', async () => {
+      const messageId = 'msg-duplicate-001';
+      await db.collection('gmailLogs').add({
+        messageId,
+        fileName: 'existing.pdf',
+        hash: 'hash-abc',
+        processedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      const skip = await isAlreadyProcessedByMessageId(messageId);
+      expect(skip).to.equal(true);
+    });
+
+    it('既存 gmailLog なし (新規 messageId) → skip=false', async () => {
+      const skip = await isAlreadyProcessedByMessageId('msg-new-001');
+      expect(skip).to.equal(false);
+    });
+
+    it('異なる messageId が混在 → 対象の messageId のみ skip', async () => {
+      await db.collection('gmailLogs').add({
+        messageId: 'msg-existing-A',
+        fileName: 'a.pdf',
+        hash: 'hash-a',
+      });
+      await db.collection('gmailLogs').add({
+        messageId: 'msg-existing-B',
+        fileName: 'b.pdf',
+        hash: 'hash-b',
+      });
+
+      const skipA = await isAlreadyProcessedByMessageId('msg-existing-A');
+      const skipB = await isAlreadyProcessedByMessageId('msg-existing-B');
+      const skipC = await isAlreadyProcessedByMessageId('msg-new-C');
+
+      expect(skipA).to.equal(true);
+      expect(skipB).to.equal(true);
+      expect(skipC).to.equal(false);
+    });
+  });
+
+  describe('AC4: isSplitSource=true 再取り込み許可', () => {
+    it('関連 documents が全て isSplitSource=true → 再取り込み許可 (reimport)', async () => {
+      const hash = 'hash-split-all';
+      const fileUrl = 'gs://bucket/original/1700000000_all-split.pdf';
+
+      await db.collection('gmailLogs').add({
+        messageId: 'msg-A',
+        fileName: 'all-split.pdf',
+        hash,
+        fileUrl,
+      });
+      await db.collection('documents').add({
+        fileUrl,
+        isSplitSource: true,
+        status: 'split',
+      });
+      await db.collection('documents').add({
+        fileUrl,
+        isSplitSource: true,
+        status: 'split',
+      });
+
+      const verdict = await shouldSkipByHashDuplicate(hash);
+      expect(verdict).to.equal('reimport');
+    });
+
+    it('関連 documents にアクティブ (isSplitSource=false or 未設定) あり → skip', async () => {
+      const hash = 'hash-mixed';
+      const fileUrl = 'gs://bucket/original/1700000000_mixed.pdf';
+
+      await db.collection('gmailLogs').add({
+        messageId: 'msg-B',
+        fileName: 'mixed.pdf',
+        hash,
+        fileUrl,
+      });
+      // 1件はアクティブ (isSplitSource 未設定)
+      await db.collection('documents').add({
+        fileUrl,
+        status: 'processed',
+      });
+      // もう1件は分割元
+      await db.collection('documents').add({
+        fileUrl,
+        isSplitSource: true,
+        status: 'split',
+      });
+
+      const verdict = await shouldSkipByHashDuplicate(hash);
+      expect(verdict).to.equal('skip');
+    });
+
+    it('関連 documents が 1 件も存在しない + fileUrl あり → 再取り込み許可', async () => {
+      // hasActiveDocs は some() なので、空配列では false を返す。
+      // 既存 fileUrl に紐づくドキュメントが 1 件もない状態 = 全削除後などは reimport。
+      const hash = 'hash-no-docs';
+      const fileUrl = 'gs://bucket/original/1700000000_no-docs.pdf';
+
+      await db.collection('gmailLogs').add({
+        messageId: 'msg-C',
+        fileName: 'no-docs.pdf',
+        hash,
+        fileUrl,
+      });
+
+      const verdict = await shouldSkipByHashDuplicate(hash);
+      expect(verdict).to.equal('reimport');
+    });
+
+    it('既存 log に fileUrl が欠損 → 従来通り skip (後方互換性)', async () => {
+      const hash = 'hash-no-fileurl';
+      await db.collection('gmailLogs').add({
+        messageId: 'msg-D',
+        fileName: 'legacy.pdf',
+        hash,
+        // fileUrl 未設定 (古いレコード想定)
+      });
+
+      const verdict = await shouldSkipByHashDuplicate(hash);
+      expect(verdict).to.equal('skip');
+    });
+
+    it('hash 一致がない → new (新規処理)', async () => {
+      const verdict = await shouldSkipByHashDuplicate('hash-unknown');
+      expect(verdict).to.equal('new');
+    });
+
+    it('uploadLogs 側の hash 一致でも同じ判定', async () => {
+      const hash = 'hash-uploadlogs';
+      const fileUrl = 'gs://bucket/uploaded/file.pdf';
+
+      await db.collection('uploadLogs').add({
+        fileName: 'uploaded.pdf',
+        hash,
+        fileUrl,
+      });
+      await db.collection('documents').add({
+        fileUrl,
+        status: 'processed',
+      });
+
+      const verdict = await shouldSkipByHashDuplicate(hash);
+      expect(verdict).to.equal('skip');
+    });
+  });
+});

--- a/functions/test/gmailAttachmentIntegration.test.ts
+++ b/functions/test/gmailAttachmentIntegration.test.ts
@@ -35,7 +35,10 @@ async function isAlreadyProcessedByMessageId(messageId: string): Promise<boolean
 }
 
 // checkGmailAttachments.ts の hash 重複 + isSplitSource 再取り込み許可ロジックを再現
-// 戻り値: 'skip' = 全件アクティブ or fileUrl 欠損 / 'reimport' = 全件 split source
+// 戻り値:
+//   'new'      = hash 未登録 (新規処理対象)
+//   'skip'     = fileUrl 欠損 or 1 件以上のアクティブ doc (isSplitSource != true) 存在
+//   'reimport' = fileUrl あり + アクティブ doc ゼロ (全て split source or 関連 doc なし)
 async function shouldSkipByHashDuplicate(
   hash: string
 ): Promise<'skip' | 'reimport' | 'new'> {

--- a/functions/test/splitPdfIntegration.test.ts
+++ b/functions/test/splitPdfIntegration.test.ts
@@ -24,7 +24,9 @@ import { cleanupCollections } from './helpers/cleanupEmulator';
 const db = admin.firestore();
 const COLLECTIONS_TO_CLEAN: readonly string[] = ['documents'];
 
-// splitPdf 末尾の元ドキュメント update (src/pdf/pdfOperations.ts) と同等の書き込み
+// src/pdf/pdfOperations.ts の splitPdf 内、
+//   docRef.update({ splitInto, status: 'split', isSplitSource: true })
+// と同等の書き込み (3 フィールド、これ以外を触らない Partial Update 契約)
 async function markParentAsSplitSource(
   docRef: admin.firestore.DocumentReference,
   createdDocIds: string[]

--- a/functions/test/splitPdfIntegration.test.ts
+++ b/functions/test/splitPdfIntegration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * splitPdf 統合テスト (Firebase emulator) - Issue #200 AC3
+ *
+ * PR #199 で splitPdf が元ドキュメントに付与するようになった `isSplitSource: true` フラグと、
+ * AC4 側 (checkGmailAttachments の再取り込み許可判定) のハンドシェイクを保証する。
+ *
+ * 方式: Gmail/Storage/pdf-lib の副作用は本テスト scope 外。splitPdf 末尾の元ドキュメント
+ * update (`splitInto` / `status:'split'` / `isSplitSource:true`) を trx で再現し、
+ *   - 指定されたキー集合のみ更新されること (CLAUDE.md MUST: Partial Update 不変契約)
+ *   - AC4 のクエリ (fileUrl 一致 + isSplitSource=true) に元ドキュメントがヒットしないこと
+ *     (元ドキュメントは split source として「アクティブではない」扱いになる)
+ * を assert する。
+ *
+ * 実行: firebase emulators:exec --only firestore --project split-pdf-integration-test \
+ *         'npm run test:integration'
+ */
+
+import './helpers/initFirestoreEmulator';
+
+import { expect } from 'chai';
+import * as admin from 'firebase-admin';
+import { cleanupCollections } from './helpers/cleanupEmulator';
+
+const db = admin.firestore();
+const COLLECTIONS_TO_CLEAN: readonly string[] = ['documents'];
+
+// splitPdf 末尾の元ドキュメント update (src/pdf/pdfOperations.ts) と同等の書き込み
+async function markParentAsSplitSource(
+  docRef: admin.firestore.DocumentReference,
+  createdDocIds: string[]
+): Promise<void> {
+  await docRef.update({
+    splitInto: createdDocIds,
+    status: 'split',
+    isSplitSource: true,
+  });
+}
+
+describe('splitPdf 統合テスト (#200 AC3)', () => {
+  beforeEach(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  it('元ドキュメントに splitInto / status:split / isSplitSource:true のみが追加される', async () => {
+    const docId = 'split-parent-001';
+    const originalData = {
+      fileName: 'original.pdf',
+      fileUrl: 'gs://bucket/original/1700000000_parent.pdf',
+      mimeType: 'application/pdf',
+      totalPages: 10,
+      status: 'processed',
+      customerName: '山田太郎',
+      officeName: '事業所A',
+      documentType: '請求書',
+    };
+    await db.doc(`documents/${docId}`).set(originalData);
+
+    const createdIds = ['child-A', 'child-B'];
+    await markParentAsSplitSource(db.doc(`documents/${docId}`), createdIds);
+
+    const snap = await db.doc(`documents/${docId}`).get();
+    const data = snap.data()!;
+
+    // 追加された 3 フィールドが期待値
+    expect(data.splitInto).to.deep.equal(createdIds);
+    expect(data.status).to.equal('split');
+    expect(data.isSplitSource).to.equal(true);
+
+    // 更新対象外フィールドが不変 (CLAUDE.md MUST: Partial Update の不変契約)
+    expect(data.fileName).to.equal('original.pdf');
+    expect(data.fileUrl).to.equal('gs://bucket/original/1700000000_parent.pdf');
+    expect(data.mimeType).to.equal('application/pdf');
+    expect(data.totalPages).to.equal(10);
+    expect(data.customerName).to.equal('山田太郎');
+    expect(data.officeName).to.equal('事業所A');
+    expect(data.documentType).to.equal('請求書');
+  });
+
+  it('AC4 ハンドシェイク: 元ドキュメントは isSplitSource=true で「アクティブ」扱いされない', async () => {
+    // splitPdf 後に checkGmailAttachments が同一 fileUrl に対して再取り込み可否を判定する想定。
+    // 子ドキュメントがないケース (= 元のみ存在) でも、isSplitSource=true が付いているため
+    // AC4 のクエリ上は hasActiveDocs=false と評価されるべき。
+    const fileUrl = 'gs://bucket/original/1700000001_handshake.pdf';
+    const parentRef = db.collection('documents').doc();
+    await parentRef.set({
+      fileName: 'original.pdf',
+      fileUrl,
+      status: 'processed',
+    });
+    await markParentAsSplitSource(parentRef, ['child-X']);
+
+    // AC4 の hasActiveDocs 判定を再現
+    const related = await db
+      .collection('documents')
+      .where('fileUrl', '==', fileUrl)
+      .get();
+    const hasActiveDocs = related.docs.some((doc) => !doc.data().isSplitSource);
+
+    expect(related.size).to.equal(1);
+    expect(hasActiveDocs).to.equal(false);
+  });
+
+  it('子ドキュメント (アクティブ) が同 fileUrl を共有すると hasActiveDocs=true になる (negative guard)', async () => {
+    // 子ドキュメントは通常別 fileUrl (processed/ prefix) を持つため本来発生しないが、
+    // クエリ契約を明示するために negative case を lock-in しておく。
+    const fileUrl = 'gs://bucket/original/1700000002_negative.pdf';
+    const parentRef = db.collection('documents').doc();
+    await parentRef.set({
+      fileName: 'original.pdf',
+      fileUrl,
+      status: 'processed',
+    });
+    await markParentAsSplitSource(parentRef, ['child-Y']);
+
+    // 稀だが同一 fileUrl でアクティブな子が居ると、AC4 は skip 側に倒れるべき
+    await db.collection('documents').add({
+      fileUrl,
+      isSplitSource: false,
+      status: 'processed',
+    });
+
+    const related = await db
+      .collection('documents')
+      .where('fileUrl', '==', fileUrl)
+      .get();
+    const hasActiveDocs = related.docs.some((doc) => !doc.data().isSplitSource);
+
+    expect(related.size).to.equal(2);
+    expect(hasActiveDocs).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary

- PR #199 (Gmail 重複取得の根本対策) のテスト不足を解消
- 新規 17 cases (5 contract + 12 integration)、既存 682+36 に回帰なし

## Acceptance Criteria (#200) 対応

| AC | 内容 | 方式 | cases |
|----|------|------|-------|
| AC1 | `checkGmailAttachments`: messageId based 重複チェック | integration (emulator) | 3 |
| AC2 | `checkGmailAttachments`: maxInstances:1 の設定値契約 | grep-based contract | 5 |
| AC3 | `splitPdf`: isSplitSource フラグ設定 + Partial Update 不変契約 | integration (emulator) | 3 |
| AC4 | `checkGmailAttachments`: isSplitSource=true 再取り込み許可ロジック | integration (emulator) | 6 |

## 方式の判断

- **既存 `ocrRetryIntegration.test.ts` のロジック再現型パターン**を踏襲
- Gmail API / pdf-lib / Storage の mock は scope 外、Firestore query/write 動作に限定
- AC2 は source import が `admin.firestore()` を top-level で評価する副作用を持ち、`initFirestoreEmulator` 経由で `FIRESTORE_EMULATOR_HOST` を設定すると他 unit test に波及するため **grep-based contract** (`aggregateCapLogErrorContract.test.ts` 形式) を採用

## 追加ファイル

- `functions/test/checkGmailAttachmentsEndpointContract.test.ts` (AC2)
- `functions/test/gmailAttachmentIntegration.test.ts` (AC1/AC4)
- `functions/test/splitPdfIntegration.test.ts` (AC3)
- `functions/package.json`: `test:integration` に新規 2 ファイル追加

## Test plan

- [x] `npm test`: 682 passing / 6 pending (回帰なし)
- [x] `npm run lint`: 新規ファイルの warning 0 件、error 0 件
- [x] `npm run type-check:test`: PASS
- [x] `firebase emulators:exec --only firestore --project <id> 'npm run test:integration'`: 36 passing
- [x] `npx mocha ... test/checkGmailAttachmentsEndpointContract.test.ts`: 5 PASS (emulator 不要)

## Scope 外 (意図的)

- Gmail API / pdf-lib / Cloud Storage の mock 化による wrapper 直接 invoke (コスト見合いで見送り、Issue #299 の ts-node/esm 環境整備と同時期に再検討可)

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)