### PR TITLE
refactor(ocr): buildSummaryPrompt を別モジュールに分離 + pure unit test 追加 (#251 Scope 2)

### DIFF
--- a/functions/src/ocr/summaryGenerator.ts
+++ b/functions/src/ocr/summaryGenerator.ts
@@ -20,43 +20,15 @@ import { withRetry, RETRY_CONFIGS } from '../utils/retry';
 import { capPageText, MAX_SUMMARY_LENGTH } from '../utils/textCap';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryGenerationRequest } from './summaryRequestBuilder';
+import { buildSummaryPrompt } from './summaryPromptBuilder';
 
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
 const MODEL_ID = GEMINI_CONFIG.modelId;
 
-const MAX_SUMMARY_INPUT_LENGTH = 8000;
-
 // 要約生成を行う最小 OCR 文字数。caller 側 (ocrProcessor / regenerateSummary) で
 // 閾値同期漏れが起きないよう単一定数化。
 export const MIN_OCR_LENGTH_FOR_SUMMARY = 100;
-
-// documentType が空の場合のフォールバック表示名 (prompt 文言に差し込まれる)。
-// 非 export: fallback の single source of truth を core 内に閉じ込め、caller 側での
-// 二重 fallback (type-design-analyzer 指摘) を構造的に防止する。
-const DEFAULT_DOCUMENT_TYPE_LABEL = '書類';
-
-function buildSummaryPrompt(ocrResult: string, documentType: string): string {
-  const truncatedText =
-    ocrResult.length > MAX_SUMMARY_INPUT_LENGTH
-      ? ocrResult.slice(0, MAX_SUMMARY_INPUT_LENGTH) + '...(以下省略)'
-      : ocrResult;
-
-  return `
-以下は「${documentType || DEFAULT_DOCUMENT_TYPE_LABEL}」のOCR結果です。この書類の内容を3〜5行で要約してください。
-
-【要約のポイント】
-- 書類の主な目的・内容
-- 重要な日付や金額があれば含める
-- 関係者（顧客名、事業所名など）の記載があれば含める
-- 専門用語は平易に言い換える
-
-【OCR結果】
-${truncatedText}
-
-【要約】
-`;
-}
 
 /**
  * OCR結果から AI 要約を生成する共通コア関数。

--- a/functions/src/ocr/summaryPromptBuilder.ts
+++ b/functions/src/ocr/summaryPromptBuilder.ts
@@ -1,0 +1,52 @@
+/**
+ * 要約生成用プロンプト構築 (Issue #251 Scope 2)
+ *
+ * summaryGenerator.ts から `buildSummaryPrompt` と関連定数を分離した pure module。
+ * Vertex AI / firebase-admin / rateLimiter への依存を持たず、unit test が admin 初期化
+ * なしで実行可能。
+ *
+ * 分離の理由 (PR #250 review 指摘):
+ * - summaryGenerator.ts の依存チェーン (rateLimiter.ts → firebase-admin) により
+ *   pure function 部分を unit test しようとすると `app/no-app` エラーで失敗する
+ * - prompt 文言は最も退行しやすい箇所 (truncation 閾値、fallback 文言、セクション配置)
+ *   だが、既存は grep 契約も無く境界値テストも欠落していた
+ */
+
+/** OCR 結果がこの長さを超えたら「...(以下省略)」で切り詰める */
+export const MAX_SUMMARY_INPUT_LENGTH = 8000;
+
+/**
+ * documentType が空文字列のときに prompt 文言に差し込む fallback ラベル。
+ * caller 側での二重 fallback (type-design-analyzer 指摘) を構造的に防止するため、
+ * 本モジュール内に single source of truth として閉じ込める (export しない)。
+ */
+const DEFAULT_DOCUMENT_TYPE_LABEL = '書類';
+
+/**
+ * OCR 結果と書類タイプから Gemini 要約生成用プロンプトを組み立てる。
+ *
+ * - `ocrResult.length > MAX_SUMMARY_INPUT_LENGTH` の場合、先頭 MAX_SUMMARY_INPUT_LENGTH
+ *   文字のみを使用し末尾に「...(以下省略)」を付ける
+ * - `documentType` が空文字列なら DEFAULT_DOCUMENT_TYPE_LABEL をタイトルに差し込む
+ */
+export function buildSummaryPrompt(ocrResult: string, documentType: string): string {
+  const truncatedText =
+    ocrResult.length > MAX_SUMMARY_INPUT_LENGTH
+      ? ocrResult.slice(0, MAX_SUMMARY_INPUT_LENGTH) + '...(以下省略)'
+      : ocrResult;
+
+  return `
+以下は「${documentType || DEFAULT_DOCUMENT_TYPE_LABEL}」のOCR結果です。この書類の内容を3〜5行で要約してください。
+
+【要約のポイント】
+- 書類の主な目的・内容
+- 重要な日付や金額があれば含める
+- 関係者（顧客名、事業所名など）の記載があれば含める
+- 専門用語は平易に言い換える
+
+【OCR結果】
+${truncatedText}
+
+【要約】
+`;
+}

--- a/functions/src/ocr/summaryPromptBuilder.ts
+++ b/functions/src/ocr/summaryPromptBuilder.ts
@@ -6,10 +6,11 @@
  * なしで実行可能。
  *
  * 分離の理由 (PR #250 review 指摘):
- * - summaryGenerator.ts の依存チェーン (rateLimiter.ts → firebase-admin) により
- *   pure function 部分を unit test しようとすると `app/no-app` エラーで失敗する
- * - prompt 文言は最も退行しやすい箇所 (truncation 閾値、fallback 文言、セクション配置)
- *   だが、既存は grep 契約も無く境界値テストも欠落していた
+ * - summaryGenerator.ts が import する utils/rateLimiter.ts が module load 時に
+ *   `admin.firestore()` を呼ぶため、本モジュールを import するだけで
+ *   `app/no-app` エラー (default app 未初期化) で test が失敗する
+ * - prompt 文言は退行リスクが高い箇所 (truncation 閾値、fallback 文言、セクション配置)
+ *   のため、境界値 test を本モジュールに併置して lock-in する
  */
 
 /** OCR 結果がこの長さを超えたら「...(以下省略)」で切り詰める */
@@ -17,7 +18,7 @@ export const MAX_SUMMARY_INPUT_LENGTH = 8000;
 
 /**
  * documentType が空文字列のときに prompt 文言に差し込む fallback ラベル。
- * caller 側での二重 fallback (type-design-analyzer 指摘) を構造的に防止するため、
+ * caller 側で同じ fallback を二重に書くことを構造的に防止するため、
  * 本モジュール内に single source of truth として閉じ込める (export しない)。
  */
 const DEFAULT_DOCUMENT_TYPE_LABEL = '書類';

--- a/functions/test/summaryPromptBuilder.test.ts
+++ b/functions/test/summaryPromptBuilder.test.ts
@@ -1,0 +1,97 @@
+/**
+ * buildSummaryPrompt pure function unit test (Issue #251 Scope 2)
+ *
+ * 要約生成プロンプトの境界値・fallback・セクション保持を、firebase-admin /
+ * Vertex AI の初期化なしで検証する。分離の経緯は summaryPromptBuilder.ts 冒頭参照。
+ *
+ * 方式: pure unit test (mocha + chai)。外部依存ゼロ、test case は入力→出力の
+ * 期待値比較のみ。
+ */
+
+import { expect } from 'chai';
+import {
+  buildSummaryPrompt,
+  MAX_SUMMARY_INPUT_LENGTH,
+} from '../src/ocr/summaryPromptBuilder';
+
+const TRUNCATION_SUFFIX = '...(以下省略)';
+
+describe('buildSummaryPrompt (#251 Scope 2)', () => {
+  describe('ocrResult 切り詰め境界', () => {
+    it('length === MAX_SUMMARY_INPUT_LENGTH (8000) は切り詰めなし', () => {
+      const ocr = 'a'.repeat(MAX_SUMMARY_INPUT_LENGTH);
+      const prompt = buildSummaryPrompt(ocr, '請求書');
+      expect(prompt).to.include(ocr);
+      expect(prompt).to.not.include(TRUNCATION_SUFFIX);
+    });
+
+    it('length === MAX_SUMMARY_INPUT_LENGTH + 1 (8001) は切り詰めあり', () => {
+      const ocr = 'a'.repeat(MAX_SUMMARY_INPUT_LENGTH + 1);
+      const prompt = buildSummaryPrompt(ocr, '請求書');
+      // 末尾の 1 文字は欠落 → 完全一致では含まれない
+      expect(prompt).to.not.include(ocr);
+      // 先頭 8000 文字 + 省略 suffix は含まれる
+      expect(prompt).to.include('a'.repeat(MAX_SUMMARY_INPUT_LENGTH) + TRUNCATION_SUFFIX);
+    });
+
+    it('length < MAX_SUMMARY_INPUT_LENGTH はそのまま差し込まれる', () => {
+      const ocr = '短いOCR結果';
+      const prompt = buildSummaryPrompt(ocr, '請求書');
+      expect(prompt).to.include(ocr);
+      expect(prompt).to.not.include(TRUNCATION_SUFFIX);
+    });
+
+    it('空文字 OCR でも prompt は生成される (caller 責任で短文ガード済み想定)', () => {
+      const prompt = buildSummaryPrompt('', '請求書');
+      expect(prompt).to.not.include(TRUNCATION_SUFFIX);
+      expect(prompt).to.include('【OCR結果】');
+      expect(prompt).to.include('【要約】');
+    });
+  });
+
+  describe('documentType fallback', () => {
+    it('documentType が空文字列ならタイトルに "書類" が差し込まれる', () => {
+      const prompt = buildSummaryPrompt('dummy ocr', '');
+      expect(prompt).to.include('「書類」のOCR結果です');
+    });
+
+    it('documentType に値があればその値が差し込まれる', () => {
+      const prompt = buildSummaryPrompt('dummy ocr', '介護保険証');
+      expect(prompt).to.include('「介護保険証」のOCR結果です');
+      // fallback ラベルは含まれない
+      expect(prompt).to.not.include('「書類」のOCR結果です');
+    });
+  });
+
+  describe('プロンプト構造 (主要セクション保持)', () => {
+    it('OCR 結果・要約・ポイント のセクション見出しを全て含む', () => {
+      const prompt = buildSummaryPrompt('sample', '書類A');
+      expect(prompt).to.include('【要約のポイント】');
+      expect(prompt).to.include('【OCR結果】');
+      expect(prompt).to.include('【要約】');
+    });
+
+    it('要約ポイント 4 項目 (目的・日付金額・関係者・平易化) を含む', () => {
+      const prompt = buildSummaryPrompt('sample', '書類A');
+      expect(prompt).to.include('書類の主な目的・内容');
+      expect(prompt).to.include('重要な日付や金額');
+      expect(prompt).to.include('関係者（顧客名、事業所名など）');
+      expect(prompt).to.include('専門用語は平易に言い換える');
+    });
+
+    it('「3〜5行で要約してください」の指示を含む', () => {
+      const prompt = buildSummaryPrompt('sample', '書類A');
+      expect(prompt).to.include('3〜5行で要約');
+    });
+  });
+
+  describe('外部依存ゼロ (firebase-admin / Vertex 不要)', () => {
+    it('admin 初期化なし + Vertex mock なしで PASS する (本 test の存在自体が証拠)', () => {
+      // このブロックに到達していれば import 副作用で初期化エラーになっていない。
+      // summaryGenerator.ts の依存チェーン (rateLimiter.ts → firebase-admin) から
+      // 切り離されていることを assertion レベルで lock-in する。
+      expect(typeof buildSummaryPrompt).to.equal('function');
+      expect(MAX_SUMMARY_INPUT_LENGTH).to.equal(8000);
+    });
+  });
+});

--- a/functions/test/summaryPromptBuilder.test.ts
+++ b/functions/test/summaryPromptBuilder.test.ts
@@ -1,5 +1,6 @@
 /**
- * buildSummaryPrompt pure function unit test (Issue #251 Scope 2)
+ * buildSummaryPrompt pure function unit test (Issue #251 で分離された
+ * pure prompt builder の test)
  *
  * 要約生成プロンプトの境界値・fallback・セクション保持を、firebase-admin /
  * Vertex AI の初期化なしで検証する。分離の経緯は summaryPromptBuilder.ts 冒頭参照。
@@ -25,13 +26,25 @@ describe('buildSummaryPrompt (#251 Scope 2)', () => {
       expect(prompt).to.not.include(TRUNCATION_SUFFIX);
     });
 
-    it('length === MAX_SUMMARY_INPUT_LENGTH + 1 (8001) は切り詰めあり', () => {
+    it('length === MAX_SUMMARY_INPUT_LENGTH + 1 (8001) は切り詰めあり (OCR結果ブロック厳密一致)', () => {
       const ocr = 'a'.repeat(MAX_SUMMARY_INPUT_LENGTH + 1);
       const prompt = buildSummaryPrompt(ocr, '請求書');
-      // 末尾の 1 文字は欠落 → 完全一致では含まれない
-      expect(prompt).to.not.include(ocr);
-      // 先頭 8000 文字 + 省略 suffix は含まれる
-      expect(prompt).to.include('a'.repeat(MAX_SUMMARY_INPUT_LENGTH) + TRUNCATION_SUFFIX);
+
+      // 【OCR結果】〜【要約】で挟まれたブロックが「先頭 8000 文字 + 省略 suffix」と厳密一致
+      // (comment-analyzer / pr-test-analyzer I1 対応: slice(0,8000) が slice(0,8001) に
+      // 変わる / suffix 位置がずれる regression を decisive に検知)
+      const bodyStart = prompt.indexOf('【OCR結果】\n') + '【OCR結果】\n'.length;
+      const bodyEnd = prompt.indexOf('\n\n【要約】');
+      expect(prompt.slice(bodyStart, bodyEnd)).to.equal(
+        'a'.repeat(MAX_SUMMARY_INPUT_LENGTH) + TRUNCATION_SUFFIX
+      );
+    });
+
+    it('length === MAX_SUMMARY_INPUT_LENGTH - 1 (7999) は切り詰めなし (off-by-one ガード)', () => {
+      const ocr = 'a'.repeat(MAX_SUMMARY_INPUT_LENGTH - 1);
+      const prompt = buildSummaryPrompt(ocr, '請求書');
+      expect(prompt).to.include(ocr);
+      expect(prompt).to.not.include(TRUNCATION_SUFFIX);
     });
 
     it('length < MAX_SUMMARY_INPUT_LENGTH はそのまま差し込まれる', () => {
@@ -86,10 +99,11 @@ describe('buildSummaryPrompt (#251 Scope 2)', () => {
   });
 
   describe('外部依存ゼロ (firebase-admin / Vertex 不要)', () => {
-    it('admin 初期化なし + Vertex mock なしで PASS する (本 test の存在自体が証拠)', () => {
-      // このブロックに到達していれば import 副作用で初期化エラーになっていない。
-      // summaryGenerator.ts の依存チェーン (rateLimiter.ts → firebase-admin) から
-      // 切り離されていることを assertion レベルで lock-in する。
+    it('admin 初期化なしで import・実行可能 (import 副作用がない)', () => {
+      // 本 test がここまで走った時点で、buildSummaryPrompt の import で
+      // admin.initializeApp() を呼ばなくても実行可能であることが示されている。
+      // 構造的な分離契約 (utils/rateLimiter 等への再依存禁止) は
+      // summaryPromptBuilderIsolationContract.test.ts で別途 lock-in する。
       expect(typeof buildSummaryPrompt).to.equal('function');
       expect(MAX_SUMMARY_INPUT_LENGTH).to.equal(8000);
     });

--- a/functions/test/summaryPromptBuilderIsolationContract.test.ts
+++ b/functions/test/summaryPromptBuilderIsolationContract.test.ts
@@ -1,0 +1,64 @@
+/**
+ * summaryPromptBuilder の外部依存ゼロ契約テスト (Issue #251 Scope 2 補強)
+ *
+ * 目的: `summaryPromptBuilder.ts` が firebase-admin / Vertex AI / rateLimiter /
+ * summaryGenerator 等への依存を import 経路で再獲得した場合に decisive に落とす。
+ *
+ * 背景: Issue #251 Scope 2 で pure module として分離したが、将来の refactor で
+ * 軽い気持ちで import を足すと admin 未初期化エラーが unit test に波及する。
+ * 境界値 test (summaryPromptBuilder.test.ts) は「この test が走る限り pure」を
+ * 間接的に示すのみで、再依存が入った瞬間に test suite 全体が壊れる脆さがある。
+ * 本契約 test は import 文を静的に検査して「pure 性」を構造的に lock-in する。
+ *
+ * 方式: grep-based (既存 aggregateCapLogErrorContract.test.ts 形式に準拠)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+// 既存 contract test (checkGmailAttachmentsEndpointContract.test.ts 等) と同じく
+// relative path の helper import を 1 つ添えることで ts-node が本ファイルを CJS と
+// して解決し、`__dirname` が利用可能になる。fs/path だけの import では ESM 扱いと
+// なり `__dirname is not defined` で before hook が失敗する。
+import './helpers/extractBraceBlock';
+
+const SOURCE_PATH = 'src/ocr/summaryPromptBuilder.ts';
+
+describe('summaryPromptBuilder 外部依存ゼロ契約 (#251)', () => {
+  let source: string;
+
+  before(() => {
+    const path = resolve(__dirname, '..', SOURCE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Source file not found: ${SOURCE_PATH}`);
+    }
+    source = readFileSync(path, 'utf-8');
+  });
+
+  it('firebase-admin を import していない (app/no-app 回避)', () => {
+    expect(source).to.not.match(/from\s+['"]firebase-admin['"]/);
+  });
+
+  it('Vertex AI SDK を import していない (GCP 認証不要)', () => {
+    expect(source).to.not.match(/from\s+['"]@google-cloud\/vertexai['"]/);
+  });
+
+  it('utils/rateLimiter を import していない (admin.firestore() 連鎖回避)', () => {
+    expect(source).to.not.match(/from\s+['"][^'"]*\/rateLimiter['"]/);
+  });
+
+  it('summaryGenerator を import していない (双方向依存禁止)', () => {
+    expect(source).to.not.match(/from\s+['"][^'"]*\/summaryGenerator['"]/);
+  });
+
+  it('utils/errorLogger を import していない (firebase-admin 連鎖回避)', () => {
+    expect(source).to.not.match(/from\s+['"][^'"]*\/errorLogger['"]/);
+  });
+
+  it('import 文を 1 つも含まない (純粋な定数 + 関数のみ)', () => {
+    // 将来 shared/types.ts の型 import が必要になった場合は本テストを明示的に
+    // 更新して「意図的に増やした」証跡を残す。
+    const importLines = source.match(/^import\s+.+?from\s+['"][^'"]+['"];?\s*$/gm) ?? [];
+    expect(importLines).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Issue #251 の 3 scope のうち Scope 2 (`buildSummaryPrompt` 分離 + pure function test) を完遂
- 新規 10 cases (境界値 / fallback / 構造保持)、既存 682 に回帰なし → 692 passing
- Scope 1/3 は #251 を open 維持して body で明示化 (partial progress)

## 変更点

### `functions/src/ocr/summaryPromptBuilder.ts` (新規)

- `buildSummaryPrompt` 関数 + `MAX_SUMMARY_INPUT_LENGTH` export
- `DEFAULT_DOCUMENT_TYPE_LABEL` は内部定数 (type-design-analyzer 指摘の二重 fallback 防止)
- firebase-admin / Vertex AI への依存ゼロの pure module

### `functions/src/ocr/summaryGenerator.ts` (修正)

- `buildSummaryPrompt` 定義を削除し import 経由で利用
- `MAX_SUMMARY_INPUT_LENGTH` / `DEFAULT_DOCUMENT_TYPE_LABEL` も summaryPromptBuilder.ts 側に移設

### `functions/test/summaryPromptBuilder.test.ts` (新規、10 cases)

| 観点 | cases | 内容 |
|------|-------|------|
| 境界値 | 4 | length===8000 (truncation なし) / length===8001 (truncation あり) / length<8000 / 空文字 |
| fallback | 2 | documentType 空で「書類」差し込み / 値ありで差し込み、fallback なし |
| 構造保持 | 3 | セクション見出し (【要約のポイント】【OCR結果】【要約】) / 要約ポイント 4 項目 / 指示文 |
| 外部依存ゼロ | 1 | admin 初期化/Vertex mock なしで PASS する契約を lock-in |

## 動機 (Issue #251 Scope 2)

PR #250 の `/review-pr` で pr-test-analyzer が指摘: summaryGenerator.ts の依存チェーン (rateLimiter.ts → firebase-admin) により pure function 部分を unit test しようとすると `app/no-app` エラーで失敗する。本 PR で分離後は admin/Vertex mock なしで境界値・fallback・構造保持が検証可能。

## Issue #251 の残スコープ (別作業)

- [ ] **Scope 1**: `generateSummaryCore` の runtime unit test — Vertex AI mock 化 (sinon/proxyquire) が必要、#299 類似の mock 戦略選定コストが伴うため待機
- [ ] **Scope 3**: silent-failure-hunter 指摘の error handling 改善 — #220 の延長として別途起票検討

## Test plan

- [x] `npx mocha ... test/summaryPromptBuilder.test.ts`: 10 passing
- [x] `npm test`: 692 passing / 6 pending (+10 新規、回帰なし)
- [x] `npm run type-check:test`: PASS
- [x] `npm run lint`: 新規ファイル warning 0 件、error 0 件
- [x] 既存 `summaryRequestBuilder.test.ts` / `summaryBuilderCallerContract.test.ts` への影響なし

## Scope 外 (意図的)

- Vertex AI mock 化による `generateSummaryCore` の runtime test (#251 Scope 1 に留保)
- error handling の `console.error` → `logError` 置き換え (#251 Scope 3)

Refs #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Separated OCR summarization prompt building logic into a dedicated module to improve code organization.

* **Tests**
  * Added comprehensive test coverage for OCR prompt generation, including truncation handling and document type fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->