### PR TITLE
refactor(gmail): Gmail 重複判定を pure helper に抽出して logic-drift を防止 (#375)

### DIFF
--- a/functions/src/gmail/checkGmailAttachments.ts
+++ b/functions/src/gmail/checkGmailAttachments.ts
@@ -19,6 +19,7 @@ import { getGmailClient } from '../utils/gmailAuth';
 import { withRetry, RETRY_CONFIGS } from '../utils/retry';
 import { logError } from '../utils/errorLogger';
 import { sanitizeFilenameForStorage } from '../utils/fileNaming';
+import { evaluateReimportDecision, resolveExistingLogData } from './reimportPolicy';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -282,6 +283,7 @@ async function processAttachment(
   }
 
   // MD5ハッシュで重複チェック（gmailLogs + uploadLogs両方）
+  // 判定ロジックは src/gmail/reimportPolicy.ts の evaluateReimportDecision に集約 (Issue #375)。
   const hash = crypto.createHash('md5').update(buffer).digest('hex');
 
   const [existingGmailLog, existingUploadLog] = await Promise.all([
@@ -289,41 +291,44 @@ async function processAttachment(
     db.collection('uploadLogs').where('hash', '==', hash).limit(1).get(),
   ]);
 
-  if (!existingGmailLog.empty || !existingUploadLog.empty) {
-    // 該当するファイルURLを取得
-    const existingLog = !existingGmailLog.empty
-      ? existingGmailLog.docs[0]
-      : existingUploadLog.docs[0];
-    const existingFileUrl = existingLog?.data().fileUrl as string | undefined;
+  const existingGmailLogData = existingGmailLog.empty
+    ? null
+    : (existingGmailLog.docs[0].data() as { fileUrl?: string });
+  const existingUploadLogData = existingUploadLog.empty
+    ? null
+    : (existingUploadLog.docs[0].data() as { fileUrl?: string });
 
-    if (existingFileUrl) {
-      // 関連するドキュメントを確認
-      const relatedDocs = await db
-        .collection('documents')
-        .where('fileUrl', '==', existingFileUrl)
-        .get();
+  const existingFileUrl =
+    resolveExistingLogData(existingGmailLogData, existingUploadLogData)?.fileUrl ?? null;
 
-      // 全てのドキュメントが分割元（isSplitSource=true）かどうかを確認
-      const hasActiveDocs = relatedDocs.docs.some(
-        (doc) => !doc.data().isSplitSource
-      );
-
-      // アクティブなドキュメントがある場合のみ重複スキップ
-      if (hasActiveDocs) {
-        console.log(`Skipping duplicate file: ${filename}`);
-        return 'skipped';
-      }
-
-      // 全て分割元の場合は再取り込みを許可
-      console.log(
-        `Re-import allowed: all existing documents are split sources (fileUrl: ${existingFileUrl})`
-      );
-    } else {
-      // fileUrlがない場合は従来通りスキップ
-      console.log(`Skipping duplicate file: ${filename}`);
-      return 'skipped';
-    }
+  let relatedDocsData: Array<{ isSplitSource?: boolean }> = [];
+  if (existingFileUrl) {
+    const relatedDocs = await db
+      .collection('documents')
+      .where('fileUrl', '==', existingFileUrl)
+      .get();
+    relatedDocsData = relatedDocs.docs.map(
+      (d) => d.data() as { isSplitSource?: boolean },
+    );
   }
+
+  const decision = evaluateReimportDecision({
+    existingGmailLogData,
+    existingUploadLogData,
+    relatedDocsData,
+  });
+
+  if (decision.verdict === 'skip') {
+    console.log(`Skipping duplicate file: ${filename}`);
+    return 'skipped';
+  }
+
+  if (decision.verdict === 'reimport') {
+    console.log(
+      `Re-import allowed: all existing documents are split sources (fileUrl: ${decision.fileUrl})`
+    );
+  }
+  // verdict === 'new' は以降の通常処理に合流
 
   // Cloud Storageに保存
   const bucket = storage.bucket();

--- a/functions/src/gmail/reimportPolicy.ts
+++ b/functions/src/gmail/reimportPolicy.ts
@@ -1,6 +1,11 @@
 /**
  * Gmail 添付ファイルの重複/再取り込み判定 pure helper
  *
+ * Exports:
+ *   - evaluateReimportDecision: 主判定関数 (6 分岐を決定)
+ *   - resolveExistingLogData: gmailLogs 優先順位の共有 helper
+ *   - ReimportVerdict / ReimportDecisionInput / ReimportDecision: 公開型
+ *
  * checkGmailAttachments.ts の processAttachment 内で行われていた hash 重複判定と
  * isSplitSource=true 再取り込み許可ロジックを I/O 非依存の純粋関数として抽出。
  * production (checkGmailAttachments.ts) と test (gmailAttachmentIntegration.test.ts)
@@ -40,7 +45,8 @@ export interface ReimportDecision {
 /**
  * gmailLogs / uploadLogs 両方の hash 一致 log から優先順位に従って 1 件を返す。
  *
- * gmailLogs 優先 (checkGmailAttachments.ts の source:294-296 と等価)。
+ * gmailLogs 優先 (checkGmailAttachments.ts processAttachment の旧 inline 実装で
+ * `!existingGmailLog.empty ? gmail : upload` のパターンだった判定を集約)。
  * caller は戻り値の `.fileUrl` を用いて関連 documents query の発行要否を判定できる。
  * evaluateReimportDecision 本体でも同じロジックを使うため、production / test / helper
  * 内部の 3 箇所で優先順位 drift を構造的に防ぐ (Issue #375 evaluator MEDIUM 対応)。
@@ -55,7 +61,7 @@ export function resolveExistingLogData(
 /**
  * Gmail 添付ファイルの hash 重複判定と isSplitSource=true 再取り込み許可を決定する。
  *
- * 判定フロー (checkGmailAttachments.ts:287-326 と等価):
+ * 判定フロー (PR #199 の旧 inline 実装を本 helper に集約、Issue #375):
  * 1. gmailLogs / uploadLogs 両方に hash 一致なし → new (新規処理対象)
  * 2. 片方以上に hash 一致あり:
  *    a. gmailLogs 優先で existing log を採用
@@ -76,7 +82,13 @@ export function evaluateReimportDecision(
     existingGmailLogData,
     existingUploadLogData,
   );
-  const existingFileUrl = existingLogData?.fileUrl;
+  // 型ガード: 上の早期 return で両方 null はカバー済だが、将来の refactor 耐性として
+  // 本関数内で local にも null を弾くことで「早期 return 削除 → silent に skip 返却」
+  // の regression を防ぐ (#378 silent-failure-hunter H1 対応)。
+  if (existingLogData === null) {
+    return { verdict: 'new', fileUrl: null };
+  }
+  const existingFileUrl = existingLogData.fileUrl;
 
   if (!existingFileUrl) {
     return { verdict: 'skip', fileUrl: null };

--- a/functions/src/gmail/reimportPolicy.ts
+++ b/functions/src/gmail/reimportPolicy.ts
@@ -1,0 +1,90 @@
+/**
+ * Gmail 添付ファイルの重複/再取り込み判定 pure helper
+ *
+ * checkGmailAttachments.ts の processAttachment 内で行われていた hash 重複判定と
+ * isSplitSource=true 再取り込み許可ロジックを I/O 非依存の純粋関数として抽出。
+ * production (checkGmailAttachments.ts) と test (gmailAttachmentIntegration.test.ts)
+ * で同一ロジックを共有し、source drift による silent regression を防ぐ (Issue #375)。
+ *
+ * I/O 境界の設計:
+ *   - Firestore query 実行は caller 側 (production は checkGmailAttachments.ts、
+ *     test は integration test の describe blocks)
+ *   - 本 helper は snapshot.data() 相当の plain data オブジェクトのみ受取
+ *   - gmailLogs と uploadLogs の優先順位 (gmailLogs 優先) は本 helper 内で表現
+ */
+export type ReimportVerdict = 'new' | 'skip' | 'reimport';
+
+export interface ReimportDecisionInput {
+  /**
+   * gmailLogs collection の hash 一致ドキュメント .data() 戻り値。
+   * 一致なしの場合は null (空 QuerySnapshot を caller 側で null にマッピング)。
+   */
+  existingGmailLogData: { fileUrl?: string } | null;
+  /**
+   * uploadLogs collection の hash 一致ドキュメント .data() 戻り値。
+   */
+  existingUploadLogData: { fileUrl?: string } | null;
+  /**
+   * fileUrl に紐づく documents collection 全件の .data() 配列。
+   * gmailLog/uploadLog いずれにも fileUrl が存在する場合のみ caller が populate する。
+   */
+  relatedDocsData: ReadonlyArray<{ isSplitSource?: boolean }>;
+}
+
+export interface ReimportDecision {
+  verdict: ReimportVerdict;
+  /** verdict が 'reimport' の場合の既存 fileUrl。それ以外は null */
+  fileUrl: string | null;
+}
+
+/**
+ * gmailLogs / uploadLogs 両方の hash 一致 log から優先順位に従って 1 件を返す。
+ *
+ * gmailLogs 優先 (checkGmailAttachments.ts の source:294-296 と等価)。
+ * caller は戻り値の `.fileUrl` を用いて関連 documents query の発行要否を判定できる。
+ * evaluateReimportDecision 本体でも同じロジックを使うため、production / test / helper
+ * 内部の 3 箇所で優先順位 drift を構造的に防ぐ (Issue #375 evaluator MEDIUM 対応)。
+ */
+export function resolveExistingLogData(
+  existingGmailLogData: { fileUrl?: string } | null,
+  existingUploadLogData: { fileUrl?: string } | null,
+): { fileUrl?: string } | null {
+  return existingGmailLogData ?? existingUploadLogData;
+}
+
+/**
+ * Gmail 添付ファイルの hash 重複判定と isSplitSource=true 再取り込み許可を決定する。
+ *
+ * 判定フロー (checkGmailAttachments.ts:287-326 と等価):
+ * 1. gmailLogs / uploadLogs 両方に hash 一致なし → new (新規処理対象)
+ * 2. 片方以上に hash 一致あり:
+ *    a. gmailLogs 優先で existing log を採用
+ *    b. fileUrl 欠損 → skip (legacy record 後方互換)
+ *    c. fileUrl あり + アクティブ document (isSplitSource != true) が 1 件以上 → skip
+ *    d. fileUrl あり + 関連 documents が全て isSplitSource=true または 0 件 → reimport
+ */
+export function evaluateReimportDecision(
+  input: ReimportDecisionInput,
+): ReimportDecision {
+  const { existingGmailLogData, existingUploadLogData, relatedDocsData } = input;
+
+  if (existingGmailLogData === null && existingUploadLogData === null) {
+    return { verdict: 'new', fileUrl: null };
+  }
+
+  const existingLogData = resolveExistingLogData(
+    existingGmailLogData,
+    existingUploadLogData,
+  );
+  const existingFileUrl = existingLogData?.fileUrl;
+
+  if (!existingFileUrl) {
+    return { verdict: 'skip', fileUrl: null };
+  }
+
+  const hasActiveDocs = relatedDocsData.some((doc) => !doc.isSplitSource);
+  return {
+    verdict: hasActiveDocs ? 'skip' : 'reimport',
+    fileUrl: existingFileUrl,
+  };
+}

--- a/functions/src/gmail/reimportPolicy.ts
+++ b/functions/src/gmail/reimportPolicy.ts
@@ -38,7 +38,14 @@ export interface ReimportDecisionInput {
 
 export interface ReimportDecision {
   verdict: ReimportVerdict;
-  /** verdict が 'reimport' の場合の既存 fileUrl。それ以外は null */
+  /**
+   * 既存 fileUrl。verdict 別の値:
+   *   - 'new'      : 常に null (hash 一致なし)
+   *   - 'skip'     : 既存 log に fileUrl がある場合は non-null (アクティブ doc あり等)、
+   *                  fileUrl 欠損 legacy record の場合は null
+   *   - 'reimport' : 常に non-null string (再取り込み対象ファイル)
+   * caller は `verdict === 'reimport'` の場合のみ使用想定 (production の log 出力)。
+   */
   fileUrl: string | null;
 }
 

--- a/functions/test/gmailAttachmentIntegration.test.ts
+++ b/functions/test/gmailAttachmentIntegration.test.ts
@@ -6,10 +6,11 @@
  *   - isSplitSource=true の場合の再取り込み許可ロジック (documents collection)
  * を Firestore 実クエリで検証する。
  *
- * 方式: 既存 ocrRetryIntegration.test.ts の「ロジック再現型」パターンを踏襲する。
- * checkGmailAttachments wrapper の内部 helper は非公開であり、Gmail API の mock は
- * コストが高いため、source と同一の Firestore query/write pattern を test 内で再現し、
- * 結果の分岐 (skip vs 処理対象 / duplicate vs re-import) を assert する。
+ * 方式 (Issue #375 以降): 判定ロジック本体は pure helper
+ *   `src/gmail/reimportPolicy.ts` の evaluateReimportDecision に集約され、
+ *   production (checkGmailAttachments.ts) と本 integration test で共有される。
+ *   本テストは helper を呼び出すための Firestore query パターンを検証する位置づけ。
+ *   helper 単体の分岐は `reimportPolicy.test.ts` で unit test 済み。
  *
  * 実行: firebase emulators:exec --only firestore --project gmail-attachment-integration-test \
  *         'npm run test:integration'
@@ -20,6 +21,11 @@ import './helpers/initFirestoreEmulator';
 import { expect } from 'chai';
 import * as admin from 'firebase-admin';
 import { cleanupCollections } from './helpers/cleanupEmulator';
+import {
+  evaluateReimportDecision,
+  resolveExistingLogData,
+  type ReimportVerdict,
+} from '../src/gmail/reimportPolicy';
 
 const db = admin.firestore();
 const COLLECTIONS_TO_CLEAN: readonly string[] = ['gmailLogs', 'documents', 'uploadLogs'];
@@ -34,35 +40,51 @@ async function isAlreadyProcessedByMessageId(messageId: string): Promise<boolean
   return !existing.empty;
 }
 
-// checkGmailAttachments.ts の hash 重複 + isSplitSource 再取り込み許可ロジックを再現
-// 戻り値:
-//   'new'      = hash 未登録 (新規処理対象)
-//   'skip'     = fileUrl 欠損 or 1 件以上のアクティブ doc (isSplitSource != true) 存在
-//   'reimport' = fileUrl あり + アクティブ doc ゼロ (全て split source or 関連 doc なし)
-async function shouldSkipByHashDuplicate(
-  hash: string
-): Promise<'skip' | 'reimport' | 'new'> {
+/**
+ * integration test 専用の I/O wrapper: Firestore query パターンを production と
+ * 独立に実装し、判定ロジック本体は helper `evaluateReimportDecision` に委譲する。
+ *
+ * 設計意図 (Issue #375):
+ *   - 判定分岐は production と同じ helper を経由するため、分岐ロジック drift は
+ *     helper unit test (reimportPolicy.test.ts) と本 integration test の両方で検知
+ *   - Firestore query pattern (collection 名・where 条件・gmailLogs 優先) は
+ *     production (checkGmailAttachments.ts) と本 wrapper で**独立に**実装することで、
+ *     production 側 query の structural drift を integration test で検知できる
+ *   - 優先順位ロジック自体は helper の `resolveExistingLogData` を共有するため、
+ *     「gmailLogs 優先」の 3 重管理 (production / helper 内部 / test) を回避
+ */
+async function queryAndEvaluateReimport(hash: string): Promise<ReimportVerdict> {
   const [existingGmailLog, existingUploadLog] = await Promise.all([
     db.collection('gmailLogs').where('hash', '==', hash).limit(1).get(),
     db.collection('uploadLogs').where('hash', '==', hash).limit(1).get(),
   ]);
 
-  if (existingGmailLog.empty && existingUploadLog.empty) return 'new';
+  const existingGmailLogData = existingGmailLog.empty
+    ? null
+    : (existingGmailLog.docs[0].data() as { fileUrl?: string });
+  const existingUploadLogData = existingUploadLog.empty
+    ? null
+    : (existingUploadLog.docs[0].data() as { fileUrl?: string });
 
-  const existingLog = !existingGmailLog.empty
-    ? existingGmailLog.docs[0]
-    : existingUploadLog.docs[0];
-  const existingFileUrl = existingLog?.data().fileUrl as string | undefined;
+  const existingFileUrl =
+    resolveExistingLogData(existingGmailLogData, existingUploadLogData)?.fileUrl ?? null;
 
-  if (!existingFileUrl) return 'skip';
+  let relatedDocsData: Array<{ isSplitSource?: boolean }> = [];
+  if (existingFileUrl) {
+    const relatedDocs = await db
+      .collection('documents')
+      .where('fileUrl', '==', existingFileUrl)
+      .get();
+    relatedDocsData = relatedDocs.docs.map(
+      (d) => d.data() as { isSplitSource?: boolean },
+    );
+  }
 
-  const relatedDocs = await db
-    .collection('documents')
-    .where('fileUrl', '==', existingFileUrl)
-    .get();
-
-  const hasActiveDocs = relatedDocs.docs.some((doc) => !doc.data().isSplitSource);
-  return hasActiveDocs ? 'skip' : 'reimport';
+  return evaluateReimportDecision({
+    existingGmailLogData,
+    existingUploadLogData,
+    relatedDocsData,
+  }).verdict;
 }
 
 describe('checkGmailAttachments 統合テスト (#200)', () => {
@@ -133,7 +155,7 @@ describe('checkGmailAttachments 統合テスト (#200)', () => {
         status: 'split',
       });
 
-      const verdict = await shouldSkipByHashDuplicate(hash);
+      const verdict = await queryAndEvaluateReimport(hash);
       expect(verdict).to.equal('reimport');
     });
 
@@ -159,7 +181,7 @@ describe('checkGmailAttachments 統合テスト (#200)', () => {
         status: 'split',
       });
 
-      const verdict = await shouldSkipByHashDuplicate(hash);
+      const verdict = await queryAndEvaluateReimport(hash);
       expect(verdict).to.equal('skip');
     });
 
@@ -176,7 +198,7 @@ describe('checkGmailAttachments 統合テスト (#200)', () => {
         fileUrl,
       });
 
-      const verdict = await shouldSkipByHashDuplicate(hash);
+      const verdict = await queryAndEvaluateReimport(hash);
       expect(verdict).to.equal('reimport');
     });
 
@@ -189,12 +211,12 @@ describe('checkGmailAttachments 統合テスト (#200)', () => {
         // fileUrl 未設定 (古いレコード想定)
       });
 
-      const verdict = await shouldSkipByHashDuplicate(hash);
+      const verdict = await queryAndEvaluateReimport(hash);
       expect(verdict).to.equal('skip');
     });
 
     it('hash 一致がない → new (新規処理)', async () => {
-      const verdict = await shouldSkipByHashDuplicate('hash-unknown');
+      const verdict = await queryAndEvaluateReimport('hash-unknown');
       expect(verdict).to.equal('new');
     });
 
@@ -212,7 +234,7 @@ describe('checkGmailAttachments 統合テスト (#200)', () => {
         status: 'processed',
       });
 
-      const verdict = await shouldSkipByHashDuplicate(hash);
+      const verdict = await queryAndEvaluateReimport(hash);
       expect(verdict).to.equal('skip');
     });
   });

--- a/functions/test/reimportPolicy.test.ts
+++ b/functions/test/reimportPolicy.test.ts
@@ -1,0 +1,182 @@
+/**
+ * evaluateReimportDecision unit test (Issue #375)
+ *
+ * Gmail 添付ファイルの hash 重複 + isSplitSource=true 再取り込み判定 pure helper のテスト。
+ * production (checkGmailAttachments.ts) と integration test
+ * (gmailAttachmentIntegration.test.ts) が共有する helper の全分岐を lock-in する。
+ *
+ * 方針: helper は純粋関数なので Firestore emulator 不要 (unit test)。
+ * 既存の integration test は I/O を含む契約として別途保持 (#200 AC4)。
+ */
+
+import { expect } from 'chai';
+import {
+  evaluateReimportDecision,
+  resolveExistingLogData,
+} from '../src/gmail/reimportPolicy';
+
+describe('evaluateReimportDecision (#375 pure helper)', () => {
+  describe('verdict="new" (hash 未登録)', () => {
+    it('両方 empty → new / fileUrl=null', () => {
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: null,
+        existingUploadLogData: null,
+        relatedDocsData: [],
+      });
+      expect(decision).to.deep.equal({ verdict: 'new', fileUrl: null });
+    });
+
+    it('両方 empty + relatedDocsData 非空 (理論上起こらない) → new で lock-in (防御)', () => {
+      // 両方 empty なら caller は relatedDocs query をしないが、helper 単体としては
+      // log 両方 null のとき relatedDocsData を読まず new を返す契約を lock-in する。
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: null,
+        existingUploadLogData: null,
+        relatedDocsData: [{ isSplitSource: false }],
+      });
+      expect(decision.verdict).to.equal('new');
+      expect(decision.fileUrl).to.equal(null);
+    });
+  });
+
+  describe('verdict="skip" (重複 + アクティブ doc あり / fileUrl 欠損)', () => {
+    it('gmailLog あり + fileUrl 欠損 → skip / fileUrl=null (legacy record 後方互換)', () => {
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: {},
+        existingUploadLogData: null,
+        relatedDocsData: [],
+      });
+      expect(decision).to.deep.equal({ verdict: 'skip', fileUrl: null });
+    });
+
+    it('uploadLog あり + fileUrl 欠損 → skip / fileUrl=null', () => {
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: null,
+        existingUploadLogData: {},
+        relatedDocsData: [],
+      });
+      expect(decision).to.deep.equal({ verdict: 'skip', fileUrl: null });
+    });
+
+    it('gmailLog + fileUrl あり + アクティブ doc (isSplitSource 未設定) あり → skip', () => {
+      const fileUrl = 'gs://bucket/original/1700_a.pdf';
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: { fileUrl },
+        existingUploadLogData: null,
+        relatedDocsData: [{}, { isSplitSource: true }],
+      });
+      expect(decision).to.deep.equal({ verdict: 'skip', fileUrl });
+    });
+
+    it('gmailLog + fileUrl あり + アクティブ doc (isSplitSource=false 明示) あり → skip', () => {
+      const fileUrl = 'gs://bucket/original/1700_b.pdf';
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: { fileUrl },
+        existingUploadLogData: null,
+        relatedDocsData: [{ isSplitSource: false }],
+      });
+      expect(decision).to.deep.equal({ verdict: 'skip', fileUrl });
+    });
+  });
+
+  describe('verdict="reimport" (全て split source または関連 doc ゼロ)', () => {
+    it('gmailLog + fileUrl あり + 全 doc isSplitSource=true → reimport', () => {
+      const fileUrl = 'gs://bucket/original/1700_all_split.pdf';
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: { fileUrl },
+        existingUploadLogData: null,
+        relatedDocsData: [
+          { isSplitSource: true },
+          { isSplitSource: true },
+        ],
+      });
+      expect(decision).to.deep.equal({ verdict: 'reimport', fileUrl });
+    });
+
+    it('gmailLog + fileUrl あり + 関連 doc 0 件 (全削除後) → reimport', () => {
+      const fileUrl = 'gs://bucket/original/1700_no_docs.pdf';
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: { fileUrl },
+        existingUploadLogData: null,
+        relatedDocsData: [],
+      });
+      expect(decision).to.deep.equal({ verdict: 'reimport', fileUrl });
+    });
+
+    it('uploadLog + fileUrl あり + 全 doc isSplitSource=true → reimport', () => {
+      const fileUrl = 'gs://bucket/uploaded/uploaded.pdf';
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: null,
+        existingUploadLogData: { fileUrl },
+        relatedDocsData: [{ isSplitSource: true }],
+      });
+      expect(decision).to.deep.equal({ verdict: 'reimport', fileUrl });
+    });
+  });
+
+  describe('resolveExistingLogData (優先順位 helper、production/test/内部の 3 重管理防止)', () => {
+    it('両方 null → null', () => {
+      expect(resolveExistingLogData(null, null)).to.equal(null);
+    });
+
+    it('gmailLog のみ → gmailLog', () => {
+      const gmail = { fileUrl: 'gs://bucket/a.pdf' };
+      expect(resolveExistingLogData(gmail, null)).to.equal(gmail);
+    });
+
+    it('uploadLog のみ → uploadLog', () => {
+      const upload = { fileUrl: 'gs://bucket/b.pdf' };
+      expect(resolveExistingLogData(null, upload)).to.equal(upload);
+    });
+
+    it('両方あり → gmailLog 優先 (uploadLog は返さない、同一参照)', () => {
+      const gmail = { fileUrl: 'gs://bucket/gmail.pdf' };
+      const upload = { fileUrl: 'gs://bucket/upload.pdf' };
+      const resolved = resolveExistingLogData(gmail, upload);
+      expect(resolved).to.equal(gmail);
+      expect(resolved).to.not.equal(upload);
+    });
+  });
+
+  describe('AC4 bundle: gmailLogs 優先 (source:294-296 lock-in)', () => {
+    it('gmailLog と uploadLog 両方に hash 一致 + 別 fileUrl → gmailLog 側 fileUrl を返す', () => {
+      // PR #374 pr-test-analyzer rating 7 指摘: source は !existingGmailLog.empty 判定で
+      // gmailLog を優先採用する。両方ヒットしたときに uploadLog 側 fileUrl が silent に
+      // 使われる regression を防ぐ契約。
+      const gmailUrl = 'gs://bucket/original/from-gmail.pdf';
+      const uploadUrl = 'gs://bucket/uploaded/from-upload.pdf';
+
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: { fileUrl: gmailUrl },
+        existingUploadLogData: { fileUrl: uploadUrl },
+        relatedDocsData: [{ isSplitSource: true }],
+      });
+
+      // reimport 時は gmailLog 側 fileUrl
+      expect(decision.verdict).to.equal('reimport');
+      expect(decision.fileUrl).to.equal(gmailUrl);
+      expect(decision.fileUrl).to.not.equal(uploadUrl);
+    });
+
+    it('gmailLog fileUrl 欠損 + uploadLog fileUrl あり + 両方 hash 一致 → skip (gmailLog 優先 / fileUrl 欠損)', () => {
+      // gmailLog 優先は fileUrl 有無に関わらず適用される。gmailLog を優先した結果
+      // fileUrl 欠損なら skip (legacy 互換)。uploadLog 側 fileUrl に「降格」しない。
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: {},
+        existingUploadLogData: { fileUrl: 'gs://bucket/uploaded/fallback.pdf' },
+        relatedDocsData: [],
+      });
+      expect(decision).to.deep.equal({ verdict: 'skip', fileUrl: null });
+    });
+
+    it('gmailLog と uploadLog 両方に hash 一致 + 同 fileUrl + アクティブ doc あり → skip', () => {
+      const fileUrl = 'gs://bucket/original/same-url.pdf';
+      const decision = evaluateReimportDecision({
+        existingGmailLogData: { fileUrl },
+        existingUploadLogData: { fileUrl },
+        relatedDocsData: [{}],
+      });
+      expect(decision).to.deep.equal({ verdict: 'skip', fileUrl });
+    });
+  });
+});

--- a/functions/test/splitPdfPayloadContract.test.ts
+++ b/functions/test/splitPdfPayloadContract.test.ts
@@ -1,0 +1,120 @@
+/**
+ * splitPdf 元ドキュメント update payload 契約テスト (Issue #375 AC3 bundle)
+ *
+ * 目的: pdfOperations.ts の splitPdf 末尾 `docRef.update({...})` が
+ *   - splitInto
+ *   - status: 'split'
+ *   - isSplitSource: true
+ * の 3 フィールドのみであることを lock-in。4 番目のフィールドが追加された場合、
+ * 既存の Gmail 再取り込み判定 (isSplitSource 依存) と Firestore クエリが
+ * silent に drift する可能性がある。
+ *
+ * 背景: PR #374 pr-test-analyzer rating 6 指摘 → Issue #375 bundle として対応。
+ * 選定理由: 3 フィールドの薄い update に対し payload builder 抽出は over-engineering。
+ * #200 AC2 の endpoint contract と同じ grep-based + extractBraceBlock で統一する。
+ *
+ * 方式: #200 AC2 (checkGmailAttachmentsEndpointContract.test.ts) と同形式の
+ * grep-based contract。source import は避けてソースファイル文字列を直接解析する。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const SOURCE_PATH = 'src/pdf/pdfOperations.ts';
+// 元ドキュメントを `isSplitSource: true` に更新する箇所の anchor。
+// 先行する `// 元ドキュメントのステータスを更新` コメントを起点にし、
+// forEach 内 split doc 書き込みの `newDocRef` 箇所と混同しないようにする。
+const UPDATE_ANCHOR =
+  /元ドキュメントのステータスを更新[\s\S]*?await\s+docRef\.update\s*\(/;
+
+let payloadBlock: string | null = null;
+
+describe('splitPdf docRef.update payload contract (#375 AC3)', () => {
+  before(() => {
+    const path = resolve(__dirname, '..', SOURCE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Source file not found: ${SOURCE_PATH}`);
+    }
+    const source = readFileSync(path, 'utf-8');
+    payloadBlock = extractBraceBlock(source, UPDATE_ANCHOR, {
+      anchorMode: 'after-match',
+    });
+  });
+
+  it('payload ブロックが抽出できる (anchor 不在時 silent PASS 防御)', () => {
+    expect(
+      payloadBlock,
+      `splitPdf docRef.update payload block not found in ${SOURCE_PATH}. ` +
+        `Anchor: ${UPDATE_ANCHOR.source}`,
+    ).to.not.be.null;
+  });
+
+  it('splitInto フィールドが含まれる', () => {
+    expect(payloadBlock).to.match(/\bsplitInto\s*:/);
+  });
+
+  it('status: "split"', () => {
+    expect(payloadBlock).to.match(/\bstatus\s*:\s*['"]split['"]/);
+  });
+
+  it('isSplitSource: true (Gmail 再取り込み判定の前提)', () => {
+    expect(payloadBlock).to.match(/\bisSplitSource\s*:\s*true\b/);
+  });
+
+  it('payload フィールド数は 3 のみ (4 番目追加で decisive fail)', () => {
+    // trailing comma を除去した上でトップレベルのキーをカウント。
+    // ネストした object (現状なし) を含む場合は depth tracking が必要だが、
+    // 4 番目が原始値でも object でも確実に検知できるよう、
+    // payload 内のトップレベル `key:` の出現数で判定する。
+    expect(payloadBlock, 'payloadBlock must be non-null').to.not.be.null;
+    const topLevelKeyCount = countTopLevelKeys(payloadBlock as string);
+    expect(topLevelKeyCount).to.equal(
+      3,
+      `splitPdf docRef.update payload has ${topLevelKeyCount} top-level keys ` +
+        `(expected 3: splitInto / status / isSplitSource). ` +
+        `Adding a 4th field risks drifting the Gmail re-import decision ` +
+        `(evaluateReimportDecision, src/gmail/reimportPolicy.ts) and other ` +
+        `isSplitSource-dependent logic. Update this contract deliberately ` +
+        `when extending the split source metadata.`,
+    );
+  });
+});
+
+/**
+ * `{ key1: v1, key2: { nested }, key3: v3 }` の top-level key 数を数える。
+ * ネスト object 内の key はカウント対象外。
+ */
+function countTopLevelKeys(block: string): number {
+  // 先頭 `{` と末尾 `}` を剥がして中身だけを対象にする
+  const inner = block.slice(1, -1);
+  let depth = 0;
+  let count = 0;
+  let tokenStart = 0;
+  // 簡易 parser: `,` で区切られるエントリを列挙し、
+  // 各エントリの最初の `:` が depth 0 なら key とみなす。
+  for (let i = 0; i <= inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '{' || ch === '[' || ch === '(') depth++;
+    else if (ch === '}' || ch === ']' || ch === ')') depth--;
+    else if ((ch === ',' || i === inner.length) && depth === 0) {
+      const entry = inner.slice(tokenStart, i);
+      if (hasTopLevelColon(entry)) count++;
+      tokenStart = i + 1;
+    }
+  }
+  return count;
+}
+
+/** entry の中で depth 0 の `:` が 1 個以上あるか (key:value エントリか判定) */
+function hasTopLevelColon(entry: string): boolean {
+  let depth = 0;
+  for (let i = 0; i < entry.length; i++) {
+    const ch = entry[i];
+    if (ch === '{' || ch === '[' || ch === '(') depth++;
+    else if (ch === '}' || ch === ']' || ch === ')') depth--;
+    else if (ch === ':' && depth === 0) return true;
+  }
+  return false;
+}

--- a/functions/test/splitPdfPayloadContract.test.ts
+++ b/functions/test/splitPdfPayloadContract.test.ts
@@ -31,24 +31,36 @@ const UPDATE_ANCHOR =
 
 let payloadBlock: string | null = null;
 
+let sourceText: string = '';
+
 describe('splitPdf docRef.update payload contract (#375 AC3)', () => {
   before(() => {
     const path = resolve(__dirname, '..', SOURCE_PATH);
     if (!existsSync(path)) {
       throw new Error(`Source file not found: ${SOURCE_PATH}`);
     }
-    const source = readFileSync(path, 'utf-8');
-    payloadBlock = extractBraceBlock(source, UPDATE_ANCHOR, {
+    sourceText = readFileSync(path, 'utf-8');
+    payloadBlock = extractBraceBlock(sourceText, UPDATE_ANCHOR, {
       anchorMode: 'after-match',
     });
+    // 以降の it で payloadBlock null 前提で assert するため、ここで早期 throw する
+    // (#378 silent-failure-hunter M1 対応: `.to.match(null)` は Chai で TypeError
+    // になる点は既に loud failure だが、診断情報を 1 箇所に集約して原因特定を高速化)。
+    if (payloadBlock === null) {
+      throw new Error(
+        `splitPdf docRef.update payload block not found in ${SOURCE_PATH}. ` +
+          `Anchor: ${UPDATE_ANCHOR.source}`,
+      );
+    }
   });
 
-  it('payload ブロックが抽出できる (anchor 不在時 silent PASS 防御)', () => {
-    expect(
-      payloadBlock,
-      `splitPdf docRef.update payload block not found in ${SOURCE_PATH}. ` +
-        `Anchor: ${UPDATE_ANCHOR.source}`,
-    ).to.not.be.null;
+  it('anchor コメント "元ドキュメントのステータスを更新" がソース内に 1 箇所のみ存在する', () => {
+    // UPDATE_ANCHOR の先頭コメント部分がソース内で複製されると、non-greedy 検索が
+    // 別 `docRef.update` にマッチする silent regression が発生しうる
+    // (#378 pr-test-analyzer I1 対応)。コメントの一意性そのものを lock-in する。
+    const matches = sourceText.match(/元ドキュメントのステータスを更新/g);
+    expect(matches, 'anchor comment must match exactly once').to.not.be.null;
+    expect(matches).to.have.lengthOf(1);
   });
 
   it('splitInto フィールドが含まれる', () => {


### PR DESCRIPTION
## Summary

PR #374 pr-test-analyzer rating 7 / confidence 85% の指摘 (Issue #375) を受け、
`checkGmailAttachments.ts:287-326` の hash 重複判定分岐を pure helper
`evaluateReimportDecision` に抽出し、production と integration test で
同一ロジックを共有する構造に変更。source drift 時に test が silent PASS し続ける
構造的リスクを解消する。bundle で PR #374 指摘の 2 項目 (AC4 gmailLogs 優先 negative
test + splitPdf contract) も同時対応。

## 変更ファイル (5)

| ファイル | 変更内容 |
|---------|---------|
| `functions/src/gmail/reimportPolicy.ts` (新規) | `evaluateReimportDecision` (純粋関数) + `resolveExistingLogData` (優先順位 helper) |
| `functions/src/gmail/checkGmailAttachments.ts` | 手書き分岐を helper 呼出しに置換 |
| `functions/test/gmailAttachmentIntegration.test.ts` | wrapper を `queryAndEvaluateReimport` に改名、内部は helper 委譲 |
| `functions/test/reimportPolicy.test.ts` (新規) | helper unit test 16 ケース |
| `functions/test/splitPdfPayloadContract.test.ts` (新規) | splitPdf docRef.update grep-based contract 5 ケース |

## Acceptance Criteria (impl-plan Phase 2.7)

- [x] AC1 機能 (helper): `evaluateReimportDecision` が 6 分岐を正しく返す → unit test 16 ケース全 pass
- [x] AC2 置換: `checkGmailAttachments.ts` の手書き分岐が消え helper 呼出し 1 箇所に集約 → grep で `evaluateReimportDecision` import 確認済み
- [x] AC3 test 切替: 旧 `shouldSkipByHashDuplicate` wrapper を helper 委譲版に差替 (I/O 境界を明示する `queryAndEvaluateReimport` に改名)
- [x] AC4 bundle (PR #374 指摘): gmailLogs + uploadLogs 両方に同一 hash + **別 fileUrl** → gmailLogs 優先 fileUrl が返る test が helper unit test に追加 (source:294-296 lock-in)
- [x] AC5 bundle (PR #374 指摘): `pdfOperations.ts:429-433` の `docRef.update` が `splitInto`/`status:'split'`/`isSplitSource:true` の 3 フィールドのみ、4 番目追加で fail する grep-based contract 新設
- [x] AC6 regression: BE 699 → **720 unit** passing (+21) + **36 integration** passing (変化なし、verdict 不変)
- [x] AC7 品質: Lint 0 error / tsc pass / 新規 warning ゼロ

## 設計判断

| 論点 | 採用案 | 理由 |
|-----|-------|------|
| helper signature | 純粋関数 (plain data 受取) | DocumentSnapshot 受取は test mock コスト高。data-only で I/O 境界を caller に一元化 |
| splitPdf contract | grep-based + `extractBraceBlock` | 3 フィールド薄い update に対し payload builder は over-engineering。#200 AC2 と統一 |
| 優先順位ロジック | `resolveExistingLogData` helper 共有 | production / helper 内部 / integration test wrapper の 3 箇所を 1 source に集約 (evaluator MEDIUM 対応) |
| wrapper 保持 | `queryAndEvaluateReimport` に改名 | Firestore query pattern 自体の drift を integration test で検知する役割を明示 (evaluator HIGH 対応) |

## Quality Gate 実施記録

PR 作成前に以下を実施 (rules/quality-gate.md Evaluator 分離プロトコル発動、5 ファイル変更):
- **/simplify (reuse)**: 全 rating 5-6、起票基準未達、現状維持で OK
- **code-reviewer (quality)**: confidence ≥ 80 の issue ゼロ、"Ready to commit"
- **evaluator (第三者)**: HIGH (AC3 文言乖離) + MEDIUM (existingFileUrl 二重計算) 指摘を **PR 内修正で両方解消**

## Test plan

- [x] BE `npm run type-check:test` EXIT 0
- [x] BE `npm test` **720 passing + 6 pending**
- [x] BE `firebase emulators:exec --only firestore --project gmail-attachment-integration-test 'npm run test:integration'` **36 passing**
- [x] `npm run lint` 0 errors, 25 warnings (既存と同水準)
- [ ] main マージ時 CI 3/3 green (lint-build-test / CodeRabbit / GitGuardian)
- [ ] `gh issue view 375` で CLOSED 確認 (squash merge 予定)

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)