### PR TITLE
fix(scripts): force-reindex audit log の Cloud Logging 反映問題を修正 (#384)

### DIFF
--- a/functions/test/auditLogger.test.ts
+++ b/functions/test/auditLogger.test.ts
@@ -71,6 +71,8 @@ interface EventsMap {
   readonly BATCH_SUMMARY: 'force_reindex_batch_summary';
   readonly AUDIT_LOG_FAILED: 'force_reindex_audit_log_failed';
   readonly STARTUP_FAILED: 'force_reindex_startup_failed';
+  readonly LOGGING_CLOSE_FAILED: 'force_reindex_logging_close_failed';
+  readonly LOGGING_CLOSE_UNAVAILABLE: 'force_reindex_logging_close_unavailable';
 }
 
 interface SeveritiesMap {
@@ -530,20 +532,53 @@ describe('scripts/lib/auditLogger (#239)', () => {
         },
       });
 
-      // throw しないこと。catch ブロックを書かずに await できれば成功。
-      await flushAndCloseLogging();
+      // #386 review C1: 本体 throw しないことに加え、診断情報を stderr に出力する
+      const { stderr } = await captureStderr(async () => {
+        await flushAndCloseLogging();
+      });
+
+      expect(stderr).to.contain(EVENTS.LOGGING_CLOSE_FAILED);
+      expect(stderr).to.contain('project-a');
+      expect(stderr).to.contain('grpc channel already closed');
     });
 
-    it('loggingService が undefined でも throw しない (defensive)', async () => {
+    it('loggingService が undefined でも throw せず、unavailable 診断を出力する', async () => {
       _setLoggingForTest('project-a', {});
 
-      await flushAndCloseLogging();
+      // #386 review C2: silent skip ではなく LOGGING_CLOSE_UNAVAILABLE を必ず stderr に残す
+      const { stderr } = await captureStderr(async () => {
+        await flushAndCloseLogging();
+      });
+
+      expect(stderr).to.contain(EVENTS.LOGGING_CLOSE_UNAVAILABLE);
+      expect(stderr).to.contain('project-a');
     });
 
-    it('loggingService.close が undefined でも throw しない (defensive)', async () => {
+    it('loggingService.close が undefined でも throw せず、unavailable 診断を出力する', async () => {
       _setLoggingForTest('project-a', { loggingService: {} });
 
-      await flushAndCloseLogging();
+      const { stderr } = await captureStderr(async () => {
+        await flushAndCloseLogging();
+      });
+
+      expect(stderr).to.contain(EVENTS.LOGGING_CLOSE_UNAVAILABLE);
+    });
+
+    it('close() が同期 throw しても本体は throw せず診断を出力する (#386 review C1 補強)', async () => {
+      _setLoggingForTest('project-a', {
+        loggingService: {
+          close: () => {
+            throw new Error('synchronous throw');
+          },
+        },
+      });
+
+      const { stderr } = await captureStderr(async () => {
+        await flushAndCloseLogging();
+      });
+
+      expect(stderr).to.contain(EVENTS.LOGGING_CLOSE_FAILED);
+      expect(stderr).to.contain('synchronous throw');
     });
 
     it('cache が空でも throw しない', async () => {
@@ -567,10 +602,15 @@ describe('scripts/lib/auditLogger (#239)', () => {
         },
       });
 
-      await flushAndCloseLogging();
+      // project-a が失敗しても project-b は close される (fail-isolation invariant)
+      const { stderr } = await captureStderr(async () => {
+        await flushAndCloseLogging();
+      });
 
-      // project-a が失敗しても project-b は close される (Promise.all + per-promise catch)
       expect(closeCalls).to.deep.equal(['project-b']);
+      // project-a の失敗は LOGGING_CLOSE_FAILED として stderr に残る
+      expect(stderr).to.contain(EVENTS.LOGGING_CLOSE_FAILED);
+      expect(stderr).to.contain('a failed');
     });
   });
 });

--- a/functions/test/auditLogger.test.ts
+++ b/functions/test/auditLogger.test.ts
@@ -81,17 +81,23 @@ interface SeveritiesMap {
   readonly CRITICAL: 'CRITICAL';
 }
 
+interface FakeLoggingWithClose {
+  loggingService?: { close?: () => Promise<void> | void };
+}
+
 interface AuditLoggerModule {
   writeForceReindexAuditLog: (
     payload: AuditPayloadInput,
     ctx: AuditCtx,
     options?: AuditOptions,
   ) => Promise<{ ok: boolean; error?: Error }>;
+  flushAndCloseLogging: () => Promise<void>;
   EVENTS: EventsMap;
   SEVERITIES: SeveritiesMap;
   LOG_NAME: 'force_reindex_audit';
   VALID_SEVERITIES: Set<AuditSeverity>;
   _resetCacheForTest: () => void;
+  _setLoggingForTest: (projectId: string, logging: FakeLoggingWithClose) => void;
 }
 
 const requireCjs = createRequire(`${process.cwd()}/package.json`);
@@ -101,11 +107,13 @@ const auditLoggerMod = requireCjs(
 
 const {
   writeForceReindexAuditLog,
+  flushAndCloseLogging,
   EVENTS,
   SEVERITIES,
   LOG_NAME,
   VALID_SEVERITIES,
   _resetCacheForTest,
+  _setLoggingForTest,
 } = auditLoggerMod;
 
 /** Fake Logging factory: 呼び出された entry/metadata を捕捉 */
@@ -468,6 +476,101 @@ describe('scripts/lib/auditLogger (#239)', () => {
 
       // 各 projectId で factory 呼出 (cache key 化されている、silent bug 防止)
       expect(factoryCalls).to.deep.equal(['project-a', 'project-b']);
+    });
+  });
+
+  // #384: process.exit() で in-flight gRPC writes が drop される問題への対策。
+  // flushAndCloseLogging() が cached Logging instance の loggingService.close() を
+  // gracefully 呼ぶことで、event loop natural drain と組み合わせて書き込み完全性を保証する。
+  describe('flushAndCloseLogging (#384)', () => {
+    it('cached Logging instances の loggingService.close() を全て呼ぶ', async () => {
+      const closeCalls: string[] = [];
+      _setLoggingForTest('project-a', {
+        loggingService: {
+          close: async () => {
+            closeCalls.push('project-a');
+          },
+        },
+      });
+      _setLoggingForTest('project-b', {
+        loggingService: {
+          close: async () => {
+            closeCalls.push('project-b');
+          },
+        },
+      });
+
+      await flushAndCloseLogging();
+
+      expect(closeCalls).to.have.members(['project-a', 'project-b']);
+    });
+
+    it('flush 後に cache が clear され、二重 close されない', async () => {
+      let closeCount = 0;
+      _setLoggingForTest('project-a', {
+        loggingService: {
+          close: async () => {
+            closeCount += 1;
+          },
+        },
+      });
+
+      await flushAndCloseLogging();
+      await flushAndCloseLogging();
+
+      expect(closeCount).to.equal(1);
+    });
+
+    it('close() が throw しても本体は throw しない (fail-open invariant)', async () => {
+      _setLoggingForTest('project-a', {
+        loggingService: {
+          close: async () => {
+            throw new Error('grpc channel already closed');
+          },
+        },
+      });
+
+      // throw しないこと。catch ブロックを書かずに await できれば成功。
+      await flushAndCloseLogging();
+    });
+
+    it('loggingService が undefined でも throw しない (defensive)', async () => {
+      _setLoggingForTest('project-a', {});
+
+      await flushAndCloseLogging();
+    });
+
+    it('loggingService.close が undefined でも throw しない (defensive)', async () => {
+      _setLoggingForTest('project-a', { loggingService: {} });
+
+      await flushAndCloseLogging();
+    });
+
+    it('cache が空でも throw しない', async () => {
+      await flushAndCloseLogging();
+    });
+
+    it('複数 instance のうち 1 つが throw しても他の close は実行される', async () => {
+      const closeCalls: string[] = [];
+      _setLoggingForTest('project-a', {
+        loggingService: {
+          close: async () => {
+            throw new Error('a failed');
+          },
+        },
+      });
+      _setLoggingForTest('project-b', {
+        loggingService: {
+          close: async () => {
+            closeCalls.push('project-b');
+          },
+        },
+      });
+
+      await flushAndCloseLogging();
+
+      // project-a が失敗しても project-b は close される (Promise.all + per-promise catch)
+      expect(closeCalls).to.deep.equal(['project-b']);
     });
   });
 });

--- a/scripts/force-reindex.js
+++ b/scripts/force-reindex.js
@@ -531,36 +531,58 @@ if (require.main === module) {
   // process.exit() は in-flight gRPC を切断するため使用しない (#384)。
   // process.exitCode を設定し、Logging client を gracefully close することで
   // event loop が natural drain し audit 書き込みの完全性を保証する。
-  // try/finally で flush を統合し、then 内の throw でも flush 漏れを防ぐ。
+  // #386 review I1: process.exitCode は flush より先に設定し、flush throw でも反映を保証。
+  // #386 review I2: emitFailureEvent も try/catch で包み FATAL audit log の silent loss を防止。
+  // #386 review I3: 初期値は意味的定数 EXIT_PRECONDITION (main() 同期 throw 時の事前検証エラー扱い)。
   (async () => {
-    let exitCode = 1;
+    let exitCode = EXIT_PRECONDITION;
     try {
       exitCode = await main();
       console.log(exitCode === EXIT_OK ? '完了' : `部分失敗で終了 (exit code=${exitCode})`);
     } catch (error) {
-      // projectId 未設定時は main() 内で先に return するため、ここに到達するのは
-      // admin.initializeApp 以降の async エラーに限られる
+      // main() 内のエラー (projectId 未設定 / parseArgs 失敗 / args.help) は
+      // EXIT_PRECONDITION/EXIT_OK で return するため、ここに到達するのは
+      // admin.initializeApp 以降に発生した未捕捉 async エラーに限られる
+      exitCode = EXIT_PARTIAL_FAILURE;
       const projectId = process.env.FIREBASE_PROJECT_ID;
       if (projectId) {
-        await emitFailureEvent({
-          event: EVENTS.FATAL,
-          severity: SEVERITIES.CRITICAL,
-          error,
-          auditCtx: buildAuditCtx(projectId),
-        });
+        try {
+          await emitFailureEvent({
+            event: EVENTS.FATAL,
+            severity: SEVERITIES.CRITICAL,
+            error,
+            auditCtx: buildAuditCtx(projectId),
+          });
+        } catch (emitErr) {
+          // emitFailureEvent 自体の throw (JSON circular 等) を最低限 stderr に残す
+          console.error(`fatal: emitFailureEvent failed: ${emitErr?.message ?? emitErr}`);
+          console.error(`original error: ${error?.message ?? error}`);
+        }
       } else {
-        console.error(JSON.stringify({
-          severity: SEVERITIES.CRITICAL,
-          event: EVENTS.FATAL,
-          errorCode: error.code ?? null,
-          errorMessage: error.message,
-          stack: error.stack,
-        }));
+        try {
+          console.error(JSON.stringify({
+            severity: SEVERITIES.CRITICAL,
+            event: EVENTS.FATAL,
+            errorCode: error?.code ?? null,
+            errorMessage: error?.message ?? String(error),
+            stack: error?.stack,
+          }));
+        } catch (stringifyErr) {
+          console.error(`fatal: error stringify failed: ${stringifyErr?.message}`);
+        }
       }
-      exitCode = 1;
     } finally {
-      await flushAndCloseLogging();
+      // exit code を flush より先に設定 (flush throw でも反映を保証)
       process.exitCode = exitCode;
+      try {
+        await flushAndCloseLogging();
+      } catch (flushErr) {
+        // flush 自体の throw は audit drop の強い示唆。exit code を強制的に失敗扱いに
+        console.error(`fatal: flushAndCloseLogging failed: ${flushErr?.message ?? flushErr}`);
+        if (process.exitCode === EXIT_OK) {
+          process.exitCode = EXIT_PARTIAL_FAILURE;
+        }
+      }
     }
   })();
 }

--- a/scripts/force-reindex.js
+++ b/scripts/force-reindex.js
@@ -27,7 +27,12 @@
 // BE tokenizer.ts の compiled lib/ を参照することで drift を防止する。
 const { loadTokenizer, ensureTokenizerBuilt } = require('./lib/loadTokenizer');
 const { aggregateTokensByTokenId } = require('./lib/aggregateTokens');
-const { writeForceReindexAuditLog, EVENTS, SEVERITIES } = require('./lib/auditLogger');
+const {
+  writeForceReindexAuditLog,
+  flushAndCloseLogging,
+  EVENTS,
+  SEVERITIES,
+} = require('./lib/auditLogger');
 
 /**
  * 失敗イベントを stdout JSON (GitHub Actions 調査用) と
@@ -483,7 +488,7 @@ async function main() {
   const projectId = process.env.FIREBASE_PROJECT_ID;
   if (!projectId) {
     console.error('[ERROR] FIREBASE_PROJECT_ID 環境変数が未設定です');
-    process.exit(1);
+    return EXIT_PRECONDITION;
   }
   const auditCtx = buildAuditCtx(projectId);
 
@@ -498,12 +503,12 @@ async function main() {
       auditCtx,
     });
     printHelp();
-    process.exit(1);
+    return EXIT_PRECONDITION;
   }
 
   if (args.help) {
     printHelp();
-    process.exit(0);
+    return EXIT_OK;
   }
 
   admin.initializeApp({ projectId });
@@ -523,14 +528,17 @@ async function main() {
 
 // テスト時は main 呼び出しをスキップ
 if (require.main === module) {
-  main()
-    .then((exitCode) => {
+  // process.exit() は in-flight gRPC を切断するため使用しない (#384)。
+  // process.exitCode を設定し、Logging client を gracefully close することで
+  // event loop が natural drain し audit 書き込みの完全性を保証する。
+  // try/finally で flush を統合し、then 内の throw でも flush 漏れを防ぐ。
+  (async () => {
+    let exitCode = 1;
+    try {
+      exitCode = await main();
       console.log(exitCode === EXIT_OK ? '完了' : `部分失敗で終了 (exit code=${exitCode})`);
-      process.exit(exitCode);
-    })
-    .catch(async (error) => {
-      // process.exit は in-flight gRPC を切断するため、await で audit 完了を待つ
-      // projectId 未設定時は main() 内で先に exit 1 するため、ここに到達するのは
+    } catch (error) {
+      // projectId 未設定時は main() 内で先に return するため、ここに到達するのは
       // admin.initializeApp 以降の async エラーに限られる
       const projectId = process.env.FIREBASE_PROJECT_ID;
       if (projectId) {
@@ -549,8 +557,12 @@ if (require.main === module) {
           stack: error.stack,
         }));
       }
-      process.exit(1);
-    });
+      exitCode = 1;
+    } finally {
+      await flushAndCloseLogging();
+      process.exitCode = exitCode;
+    }
+  })();
 }
 
 module.exports = {

--- a/scripts/lib/auditLogger.js
+++ b/scripts/lib/auditLogger.js
@@ -74,6 +74,41 @@ function _resetCacheForTest() {
   cachedRequireError = null;
 }
 
+/** test 用: cachedLogging に直接 instance を注入 (flushAndCloseLogging の検証用 @internal) */
+function _setLoggingForTest(projectId, logging) {
+  cachedLogging.set(projectId, logging);
+}
+
+/**
+ * Cached Logging instance の gRPC channel を gracefully close する。
+ *
+ * 必要性 (#384):
+ *   `Log.write()` の await が resolve しても内部 gRPC stream の post-processing が
+ *   未完了の場合があり、`process.exit()` で event loop を即時停止すると in-flight
+ *   write が drop される。`LoggingServiceV2Client.close()` を呼んで channel を
+ *   gracefully close することで全 in-flight write の完了を保証する。
+ *
+ * 呼び出しタイミング: script 終了直前 (main の then/catch 内)。
+ * Fail-open: close 失敗は無視 (script 終了処理を止めない invariant)。
+ *
+ * @returns {Promise<void>}
+ */
+async function flushAndCloseLogging() {
+  const closes = [];
+  for (const logging of cachedLogging.values()) {
+    // loggingService は @google-cloud/logging v11 の internal property だが、
+    // public な Logging.close() が存在しないため唯一の graceful shutdown 経路。
+    // close は test injection で undefined のケースを許容するため optional chain を残す。
+    closes.push(
+      Promise.resolve(logging.loggingService?.close?.()).catch(() => {
+        // close 失敗は audit invariant の対象外。本体の終了処理を止めないため握り潰す。
+      }),
+    );
+  }
+  await Promise.all(closes);
+  cachedLogging.clear();
+}
+
 /**
  * force-reindex 実行結果を Cloud Logging に書き込む。
  *
@@ -190,9 +225,11 @@ function _normalizeError(err) {
 
 module.exports = {
   writeForceReindexAuditLog,
+  flushAndCloseLogging,
   EVENTS,
   SEVERITIES,
   LOG_NAME,
   VALID_SEVERITIES,
   _resetCacheForTest,
+  _setLoggingForTest,
 };

--- a/scripts/lib/auditLogger.js
+++ b/scripts/lib/auditLogger.js
@@ -27,6 +27,10 @@ const EVENTS = Object.freeze({
   BATCH_SUMMARY: 'force_reindex_batch_summary',
   AUDIT_LOG_FAILED: 'force_reindex_audit_log_failed',
   STARTUP_FAILED: 'force_reindex_startup_failed',
+  // #386 review C1: close 失敗 = in-flight write drop 可能性。silent にしない
+  LOGGING_CLOSE_FAILED: 'force_reindex_logging_close_failed',
+  // #386 review C2: loggingService が undefined = library API 変更検知。#384 再発予兆
+  LOGGING_CLOSE_UNAVAILABLE: 'force_reindex_logging_close_unavailable',
 });
 
 /** Severity SSoT (typo 防止)。Cloud Logging string severity と一致させる */
@@ -95,18 +99,48 @@ function _setLoggingForTest(projectId, logging) {
  */
 async function flushAndCloseLogging() {
   const closes = [];
-  for (const logging of cachedLogging.values()) {
+  for (const [projectId, logging] of cachedLogging.entries()) {
     // loggingService は @google-cloud/logging v11 の internal property だが、
     // public な Logging.close() が存在しないため唯一の graceful shutdown 経路。
-    // close は test injection で undefined のケースを許容するため optional chain を残す。
+    if (!logging.loggingService?.close) {
+      // #386 review C2: API 変更検知。#384 と同じ silent drop の予兆として stderr に必ず残す
+      _emitLoggingDiagnostic(EVENTS.LOGGING_CLOSE_UNAVAILABLE, projectId);
+      continue;
+    }
     closes.push(
-      Promise.resolve(logging.loggingService?.close?.()).catch(() => {
-        // close 失敗は audit invariant の対象外。本体の終了処理を止めないため握り潰す。
-      }),
+      // 同期 throw も catch するため try で wrap (Promise.resolve は sync throw を変換しない)
+      Promise.resolve()
+        .then(() => logging.loggingService.close())
+        .catch((closeErr) => {
+          // #386 review C1: close 失敗 = in-flight write drop の可能性。
+          // 本体終了は止めない (fail-open invariant) が診断情報は必ず残す
+          _emitLoggingDiagnostic(EVENTS.LOGGING_CLOSE_FAILED, projectId, closeErr);
+        }),
     );
   }
   await Promise.all(closes);
   cachedLogging.clear();
+}
+
+/** flushAndCloseLogging 内の診断情報出力 (silent failure 防止)。@internal */
+function _emitLoggingDiagnostic(event, projectId, err) {
+  try {
+    const payload = {
+      severity: SEVERITIES.WARNING,
+      event,
+      projectId,
+      timestamp: new Date().toISOString(),
+    };
+    if (err !== undefined) {
+      payload.errorMessage = err?.message ?? String(err);
+      payload.errorCode = err?.code ?? null;
+    }
+    _safeWriteStderr(JSON.stringify(payload) + '\n');
+  } catch (stringifyErr) {
+    _safeWriteStderr(
+      `${event}: projectId=${projectId} (stringify error: ${stringifyErr?.message})\n`,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- `@google-cloud/logging` の `Log.write()` は内部 gRPC stream で async batch dispatch するため、`await` 完了後も in-flight writes が event loop に残る。`process.exit()` で event loop を即時停止すると drop されていた根本原因を修正
- `process.exitCode` + `flushAndCloseLogging()` (gRPC channel graceful close) + `try/finally` で event loop natural drain を保証し、書き込み完全性を担保
- `/review-pr` (6 エージェント並列) と `/codex review` セカンドオピニオンを実施。silent-failure-hunter の Critical 2 + Important 3 を反映、Codex は Approve (追加指摘なし)

## 根本原因と修正方針

| 仮説 | 検証結果 | 採否 |
|---|---|---|
| 1. gRPC async batch write の drop | 公式は serverless 環境で `LogSync` または明示的な channel close を推奨。`process.exit` で event loop 即時停止 = in-flight gRPC drop | ✅ 確定 |
| 2. SA `roles/logging.logWriter` 権限不足 | `docsplit-cloud-build@doc-split-dev` に付与済 (IAM policy 確認) | ❌ 否定 |
| 3. `resource: { type: 'global' }` silent reject | `global` は valid な monitored resource type、known issue なし | ❌ 否定 |

**修正パターン (Plan A)**:
1. `auditLogger.js` に `flushAndCloseLogging()` 追加 (cached `Logging` instance の `loggingService.close()` を Promise.all で並列 close、fail-open invariant 維持)
2. `force-reindex.js` の `process.exit(N)` を `process.exitCode = N` + return に置換 (5箇所)
3. main 終了時に `try/finally` で `flushAndCloseLogging()` を保証 (then 内 throw でも flush 漏れなし)

**`/review-pr` 反映 (commit 9db9069)**:
- C1: close 失敗を `LOGGING_CLOSE_FAILED` event で stderr 構造化 JSON 出力 (silent failure 排除)
- C2: `loggingService` / `close` undefined を `LOGGING_CLOSE_UNAVAILABLE` event で stderr 出力 (library API drift 検知)
- C1 補強: `Promise.resolve().then(close).catch()` で同期 throw も catch
- I1: `process.exitCode` を flush より先に設定、flush は別 try/catch、flush 失敗時 exit code 強制失敗扱い
- I2: `emitFailureEvent` と `JSON.stringify` を try/catch で防御 (FATAL audit log silent loss 防止)
- I3: マジックナンバー `1` → `EXIT_PRECONDITION` (初期値) / `EXIT_PARTIAL_FAILURE` (catch) の意味的定数

## 受け入れ基準達成状況

| # | 基準 | 状態 |
|---|------|------|
| AC-1 | dev 環境で `force-reindex --all-drift` 実行後、`gcloud logging read 'logName="projects/doc-split-dev/logs/force_reindex_audit"'` で `force_reindex_batch_summary` が 1 件以上取得 | ✅ **2回確認済** (run_id 24815729133: 03:54:19、再検証 run_id 24816478814: 04:20:53、いずれも NOTICE / dryRun=True / counts=processed:3) |
| AC-2 | kanameone 環境で同様確認 | ⏳ post-merge で実施 |
| AC-3 | cocoro 環境で同様確認 | ⏳ post-merge で実施 |
| AC-4 | unit test で `Log.write` 完了 = 実書き込み完了 invariant を lock-in | ✅ 8 cases 追加 (close 呼び出し / 二重 flush 防止 / fail-open / defensive / 同期 throw / stderr 診断出力 lock-in) |
| AC-5 | 既存 27 cases (auditLogger + forceReindexAudit) 100% pass 維持 | ✅ 805 passing (新規 8 + 既存 797) |
| AC-6 | fail-open invariant 維持 (close 失敗で本体停止しない) | ✅ test 検証済 + stderr 診断追加で silent failure 排除 |

## Test plan

- [x] `cd functions && npm test` → 805 passing (新規 8 + 既存 797、既存影響なし)
- [x] `cd functions && npm run lint` → 0 errors (既存 25 warnings は今回の変更外)
- [x] `cd functions && npm run type-check:test` → PASS
- [x] **dev 環境で実証 (1 回目)**: GitHub Actions "Run Operations Script" run_id 24815729133 → exit 0、`gcloud logging read` で `force_reindex_batch_summary` 受信
- [x] **dev 環境で実証 (review 反映後)**: run_id 24816478814 → exit 0、`gcloud logging read` で `force_reindex_batch_summary` 受信 (04:20:53)
- [x] CI 全 pass (lint-build-test / GitGuardian / CodeRabbit)
- [ ] **post-merge**: kanameone/cocoro 環境で同様確認

## Quality Gate

- `/impl-plan`: Plan A 承認 (process.exitCode + gRPC close + try/finally 統合)
- `/simplify` 3並列レビュー (reuse/quality/efficiency):
  - Quality High 反映: `then`/`catch` 重複 → `try/finally` 統合
  - Quality Medium 反映: `logging?.` 過剰防御除去
- `/safe-refactor`: DRY/未使用/複雑度/命名/型安全性/エラー処理 全項目クリア
- `/review-pr` (6 エージェント並列): silent-failure-hunter Critical 2 + Important 3 反映 (commit 9db9069)
- `/codex review` セカンドオピニオン: **Approve** (High/Medium 追加指摘なし)、follow-up に entrypoint refactor + library 互換性チェック推奨

## Follow-up (post-merge Issue 化予定)

- pr-test-analyzer Important I-1 + Codex follow-up #1: `force-reindex.js` の `require.main === module` の try/finally entrypoint を export 化し unit test でカバー (entrypoint refactor が必要なため別 Issue)
- Codex follow-up #2: `@google-cloud/logging` 更新時の `loggingService.close()` 互換性チェック (運用ドキュメントへの追記 or smoke test)

## 関連

- Issue #384 (本修正)
- PR #383 (元実装)
- ADR-0008 (データ保護)
- ADR-0015 (search_index silent failure policy)

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)