### PR TITLE
docs: 2026-04-23 session37 handoff (#384 完遂、PR #386 merged + 新規 #387 起票で Net 0)

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,8 +1,74 @@
 # ハンドオフメモ
 
-**更新日**: 2026-04-22 session36 (**待機時間活用で 2 Issue 着手・1 PR merged**。#152 (dev Firestore 初期設定) は調査で 16/16 合格状態と判明し作業不要 close、#239 (force-reindex audit log to Cloud Logging) は PR #383 merge。新規 #384 (Cloud Logging 反映未確認 P1) を起票したため Issue Net **-1**)
-**ブランチ**: main (clean、最新 commit は本 handoff PR merge 後に更新)
-**フェーズ**: Phase 8 + 運用監視基盤全環境展開完了 + Phase 2 (#181-#183) + Phase 3 (#188-#190) + Phase 5 (#339/#340/#332/#335) + Phase 6 (#346/#343/#344/#331/#333/#262) + Phase 7 (#338) + Phase 8 (session29 = #334/#196) + Phase 8 (session30 = #360 rescue observability + #358 backfill test lock-in) + Phase 8 (session31 = #365 backfill counter 分割 + #364 rescue per-doc catch test) + Phase 8 (session32 = #370 fatal 分岐 safeLogError 二重呼出防止 test) + Phase 8 (session33 = #200 Gmail/Split 統合テスト + #251 Scope 2 summaryPromptBuilder 分離) + Phase 8 (session34 = #375 Gmail reimportPolicy pure helper 抽出 + #237 tokenizer 3 箇所共通化) + Phase 8 (session35 = Issue triage-only、close 忘れ 1 件整理 = #220) + **Phase 8 (session36 = #239 force-reindex audit log + #152 close、新規 #384 起票)** 完遂
+**更新日**: 2026-04-23 session37 (**#384 (Cloud Logging 反映未確認 P1) を完遂**。process.exit() で in-flight gRPC writes が drop される根本原因を特定し process.exitCode + flushAndCloseLogging + try/finally で修正。3環境 (dev/kanameone/cocoro) で実 Cloud Logging 受信確認済。`/review-pr` 6 エージェント並列で Critical 2 + Important 3 を反映、Codex セカンドオピニオン Approve。Issue Net **0** (#384 close + #387 起票、KPI 進捗ゼロ扱いだが #384 真の解決は達成))
+**ブランチ**: main (clean、PR #386 merged: 1118ddd)
+**フェーズ**: Phase 8 + 運用監視基盤全環境展開完了 + Phase 2 (#181-#183) + Phase 3 (#188-#190) + Phase 5 (#339/#340/#332/#335) + Phase 6 (#346/#343/#344/#331/#333/#262) + Phase 7 (#338) + Phase 8 (session29 = #334/#196) + Phase 8 (session30 = #360 rescue observability + #358 backfill test lock-in) + Phase 8 (session31 = #365 backfill counter 分割 + #364 rescue per-doc catch test) + Phase 8 (session32 = #370 fatal 分岐 safeLogError 二重呼出防止 test) + Phase 8 (session33 = #200 Gmail/Split 統合テスト + #251 Scope 2 summaryPromptBuilder 分離) + Phase 8 (session34 = #375 Gmail reimportPolicy pure helper 抽出 + #237 tokenizer 3 箇所共通化) + Phase 8 (session35 = Issue triage-only、close 忘れ 1 件整理 = #220) + Phase 8 (session36 = #239 force-reindex audit log + #152 close、新規 #384 起票) + **Phase 8 (session37 = #384 完遂、新規 #387 起票)** 完遂
+
+<a id="session37"></a>
+## ✅ session37 完了サマリー (2026-04-23: #384 完遂、PR #386 merged + 新規 #387 起票で Net 0)
+
+session36 で起票した P1 bug #384 (force_reindex audit log が Cloud Logging に書き込まれていない問題) を完遂。`@google-cloud/logging` の `Log.write()` async batch dispatch が `process.exit()` で drop される根本原因を特定。3 並列 Agent で 3 仮説を検証 (gRPC drop 確定、SA 権限 OK、resource:global OK) し、`process.exitCode` + `flushAndCloseLogging()` (gRPC channel graceful close) + `try/finally` 統合で修正。`/review-pr` 6 エージェント並列で silent-failure-hunter Critical 2 + Important 3 を反映、Codex セカンドオピニオン Approve。3 環境 (dev/kanameone/cocoro) で実 Cloud Logging 受信を実証。
+
+### PR 一覧
+
+| PR | 内容 | closed Issues | merged commit |
+|----|------|--------------|--------------|
+| **#386** | fix(scripts): force-reindex audit log の Cloud Logging 反映問題を修正 (process.exitCode + LoggingServiceV2Client.close + try/finally + silent failure 排除) | #384 | `1118ddd` |
+
+### 主要成果
+
+| 項目 | 内容 |
+|------|------|
+| **merged PR** | 1 本 (#386) |
+| **closed Issue** | #384 (1 件、auto-close 成功) |
+| **新規 follow-up Issue** | #387 (entrypoint test、pr-test-analyzer rating 7 + Codex follow-up #1 = triage 基準 #4 該当) |
+| **Issue Net 変化** | Close 1 / 起票 1 = **0** (KPI 進捗ゼロ扱い、ただし P1 bug 真の解決は達成) |
+| **functions/ test** | 797 → **805 passing** (+8: flushAndCloseLogging 7 cases + 同期 throw 1 case) |
+| **コード量** | 3 ファイル / +275/-27 (auditLogger.js: +71, force-reindex.js: +88/-27, auditLogger.test.ts: +143) |
+| **実 Cloud Logging 受信実証** | dev (run_id 24815729133, 24816478814) + kanameone (24816768269: processed=4561, drifted=27) + cocoro (24816770503: processed=385, drifted=0) |
+
+### 根本原因と修正方針
+
+| 仮説 | 検証結果 | 採否 |
+|---|---|---|
+| 1. gRPC async batch write の drop | 公式は serverless 環境で `LogSync` または明示的 channel close を推奨。`process.exit` で event loop 即時停止 = in-flight gRPC drop | ✅ 確定 |
+| 2. SA `roles/logging.logWriter` 権限不足 | `docsplit-cloud-build@doc-split-dev` に付与済 (IAM policy 確認) | ❌ 否定 |
+| 3. `resource: { type: 'global' }` silent reject | `global` は valid な monitored resource type、known issue なし | ❌ 否定 |
+
+### Quality Gate 実施記録
+
+| ステージ | 内容 | 結果 |
+|---|---|---|
+| `/impl-plan` | Plan A 承認 (process.exitCode + gRPC close + try/finally) | AC 6 件定義 |
+| `/simplify` 3並列 | reuse / quality / efficiency | Quality High (try/finally 統合) + Medium (logging?. 過剰防御除去) を反映 |
+| `/safe-refactor` | DRY/未使用/複雑度/命名/型/エラー処理 | 全項目クリア |
+| `/review-pr` 6エージェント並列 | code-reviewer / pr-test-analyzer / silent-failure-hunter / type-design-analyzer / comment-analyzer / code-simplifier | silent-failure-hunter Critical 2 + Important 3 を本 PR で反映、I-1 (entrypoint test) は #387 で follow-up |
+| `/codex review` セカンドオピニオン | gpt-5.2 (gpt-5.2-codex 不可 → fallback) | **Approve** (High/Medium 追加指摘なし) |
+
+### 設計判断 / Lessons Learned (本セッション重要知見)
+
+1. **`@google-cloud/logging` v11 の `Log.write()` は内部 gRPC stream で async batch dispatch する** → `await` で resolve しても in-flight が残る。`process.exit()` で event loop を即時停止すると drop される。Cloud Logging 公式は serverless 環境で `LogSync` または明示的な channel close (`LoggingServiceV2Client.close()`) を推奨。
+
+2. **Node.js 標準パターン: `process.exit(N)` ではなく `process.exitCode = N` + return** で event loop が natural drain する。`process.exit()` を呼ばない場合、in-flight Promise / gRPC stream / file handle 等が完了するまで Node が待つ。
+
+3. **silent failure の排除は fail-open invariant と両立する**: `Promise.resolve(...).catch(() => {})` の空 catch は silent failure。`_safeWriteStderr(JSON.stringify({event, projectId, errorMessage, ...}))` で診断情報を必ず残しつつ、本体終了は止めない設計が公式の `_failOpen` パターンと整合 (今回 LOGGING_CLOSE_FAILED / LOGGING_CLOSE_UNAVAILABLE event を新設)。
+
+4. **try/finally で flush 統合**: `then`/`catch` の両方に同じ flush 呼び出しを書くと、then 内 throw 時に flush 漏れが発生し得る。try/finally + `process.exitCode` を flush より先に設定することで、flush throw でも exit code 反映を保証。
+
+5. **同期 throw 対応**: `Promise.resolve(syncThrowingFn())` は sync throw を Promise reject に変換しない (`syncThrowingFn()` の評価で外側に throw)。`Promise.resolve().then(syncThrowingFn).catch()` で sync throw も catch 可能。
+
+6. **library internal property への依存はリスクを stderr 出力で可視化**: `loggingService` は `@google-cloud/logging` v11 の internal property だが public な `Logging.close()` がないため唯一の graceful shutdown 経路。v12 で rename されると silent skip リスクあるため `LOGGING_CLOSE_UNAVAILABLE` event で API drift を検知可能に。
+
+7. **Issue Net 0 の正当性判断**: rating 7+ confidence 80+ の review 指摘 (entrypoint test) は CLAUDE.md triage 基準 #4 を満たす正当な Issue 化。Net 0 は KPI 進捗ゼロ扱いだが、P1 bug 完遂と引き換えに entrypoint refactor を別 Issue 化する判断は技術的に妥当。
+
+### 次セッション着手候補 (open Issues)
+
+- #387 (今回起票): force-reindex.js entrypoint (try/finally + process.exitCode + flushAndCloseLogging) を export して unit test でカバー (P2)
+- #251: summaryGenerator unit test 追加 + buildSummaryPrompt 別モジュール分離 (P2)
+- #299: capPageResultsAggregate 動的 safeLogError invocation test (ts-node/esm 環境整備込み、P2)
+- #238: force-reindex に孤児 posting 検出モード追加 (P2)。**今セッションで kanameone に drift 27 件検出 → 関連性高い**
+
+---
 
 <a id="session36"></a>
 ## ✅ session36 完了サマリー (2026-04-22: 待機時間活用、#239 PR #383 merged + #152 作業不要 close、新規 #384 起票で Net -1)
@@ -411,174 +477,7 @@ PR #199 (Gmail 重複取得の根本対策) に不足していたテストを #2
 
 ---
 
-<a id="session32"></a>
-## ✅ session32 完了サマリー (2026-04-22: #370 完遂、1 PR merged)
-
-session31 handoff で起票した follow-up #370 (rescue fatal 分岐 safeLogError 二重呼出防止 test) を完遂。PR 内で /review-pr 6 エージェント並列、silent-failure-hunter F-1 (HIGH rating 7, confidence 85%) を PR 内で修正反映。polyfill 設計を「1 回目 reject / 2 回目以降 resolve」から「常に throw」に変更し、より広い regression scenario を検知可能にした。
-
-### PR 一覧
-
-| PR | 内容 | closed Issues | merged commit |
-|----|------|--------------|--------------|
-| **#372** | test: fatal 分岐 safeLogError 二重呼出防止 integration test (withFailingSafeLogError polyfill + rescueError + callCount 二重 invariant) | #370 | `44e873c` |
-
-### 主要成果
-
-| 項目 | 内容 |
-|------|------|
-| **merged PR** | 1 本 (#372) |
-| **closed Issue** | #370 (1 件、auto-close 成功) |
-| **新規 follow-up Issue** | なし (/review-pr 指摘は全て PR 内修正 or PR コメントレベル) |
-| **Issue Net 変化** | Close 1 / 起票 0 = **-1** (feedback_issue_triage.md: Net < 0 は KPI 前進、Net = 0 (Close N / 起票 N) は進捗ゼロ扱い → 本セッションは KPI 前進) |
-| **BE integration テスト** | 23 → **24 passing** (+1 from #370: fatal 分岐 safeLogError 失敗時の二重呼出防止) |
-| **BE unit テスト** | 677 passing + 6 pending (変化なし) |
-| **コード量** | 初版 +91/-0 → review 反映 -40/+33 → 最終 +84/-0 (1 ファイル: test/rescueStuckProcessingIntegration.test.ts) |
-| **品質改善** | fatal 分岐 inner try/catch を call count + rescueError の二重 invariant で lock-in / CJS namespace dynamic lookup を利用した sinon 不依存 polyfill / signature drift を LogErrorParams 型で compile-time 検知 |
-
-### Quality Gate 実施記録 (6 エージェント並列)
-
-| エージェント | Rating | 主な指摘 | 対応 |
-|------------|--------|----------|------|
-| **code-reviewer** | 9/10 | 問題なし | Approve |
-| **pr-test-analyzer** | 8/10 | PR コメントレベルのみ | 対応不要 |
-| **code-simplifier** | 提案なし | - | - |
-| **silent-failure-hunter** | **7.5/10** (F-1 rating 7, confidence 85%) | polyfill「2 回目 resolve」が outer catch throw 挙動を silent に書き換え | **PR 内修正: 「常に throw」に変更** |
-| **type-design-analyzer** | 6/10 | `params: unknown` で signature drift 検知不可 | **PR 内修正: `LogErrorParams` 型に変更** |
-| **comment-analyzer** | 6/10 | 行番号参照は rot 耐性低 + 冗長 block comment | **PR 内修正: 記号参照化 + assertion message に集約 + `errors/` 0 件 assertion 削除** |
-
-### 設計判断 / Lessons Learned (本セッション重要知見)
-
-1. **polyfill「常に throw」設計の regression 検知力 (F-1 HIGH 対応)**: 旧設計「1 回目 reject / 2 回目以降 resolve」は outer catch 内 safeLogError (try/catch なし、processOCR.ts:241) の throw 挙動を silent に resolve に書き換えていた → production 実挙動から乖離。「常に throw」+ test 側 `rescueError` 捕捉で、inner try/catch 削除 regression (rescue 全体 reject) と outer catch 経路の test 観測可能性の両方を確保。silent-failure-hunter F-1 (HIGH) の指摘は polyfill 設計の盲点を的確に突いた — 「stub は production 挙動を silent に補完してはいけない」の実例
-
-2. **CJS namespace dynamic lookup を利用した sinon 不依存 stub**: TypeScript CJS compile 後の `await (0, errorLogger_1.safeLogError)(...)` は namespace object の dynamic property lookup であり、test 側で `errorLoggerModule.safeLogError = stub` で property rewrite すると production code の次の呼出で反映される。PR #369 の `withFailingRunTransaction` (db オブジェクトのメソッド書換) と同方針で、sinon 導入不要。compile 後の emit を `tsc --outDir /tmp/...` で peek して mechanism を事前検証することで、「仕様上動くはず」の推測を「実体で確認」に昇格
-
-3. **signature drift の compile-time 検知 (type-design 対応)**: polyfill 内 `params: unknown` だと production 側 `LogErrorParams` に required フィールド追加時に静かに drift し、stub だけ古い signature のまま passing が続く。`import type { LogErrorParams }` + `params: LogErrorParams` に変更で 1 行 cost で compile-time safety 獲得。test ファイルでも型 honesty は維持すべき
-
-4. **コメント密度の適正化 (comment 対応)**: 1 ファイル test で 35+ 行コメントは過剰、かつ行番号 `processOCR.ts:222-232` は rot 耐性低。記号参照 (`rescueStuckProcessingDocs の fatal 分岐 inner try/catch`) + assertion message への集約で、コメント削減しつつ意図伝達力は維持。comment-analyzer rating 6 以下の指摘でも累積効果があるので一括反映が効率的
-
-5. **rating 7 境界の取扱い (Issue triage)**: CLAUDE.md CRITICAL「rating ≥ 7 かつ confidence ≥ 80 は Issue 起票候補」は**新規 Issue 起票の閾値**。本 PR 内で修正対応する場合は Issue 起票不要で直接反映が正解。本セッション F-1 rating 7 confidence 85% を PR 内修正で解消 → follow-up Issue ゼロを維持 (feedback_issue_triage.md「Close N + 起票 N = net 0 は進捗ゼロ」の net -1 達成)
-
-6. **初版 → review 修正の 2 commit 運用**: 初版 PR 作成直後に `/review-pr` を走らせ、指摘反映を別 commit (amend せず) で push。reviewer が差分を追跡可能、初版の判断過程を history に残す。CLAUDE.md「新規 commit を作成する」原則の実運用。本 PR は commit 2 本を `--squash` merge で 1 本に集約して main に入った (c159136 + 2051f5e → 44e873c)
-
-### 次セッション着手候補 (WBS 進捗)
-
-**軽量 (0.5 セッション)**: 該当なし (session32 終了時点の open Issue 一覧に 0.5 セッション相当タスクなし)
-
-**中規模 (1 セッション)**:
-- **#200 checkGmailAttachments/splitPdf 統合テスト**: Gmail 連携経路の integration test
-- **#251 summaryGenerator test + buildSummaryPrompt 分離**: 既存の summary 処理を testable に切り出し
-- **#239 force-reindex audit log**: Cloud Logging に構造化 audit log 出力
-
-**大物 (2 セッション、`/impl-plan` 必須)**:
-- **#237 search tokenizer 共通化**: session29 から持ち越し継続、Evaluator 分離必須 (5+ ファイル + アーキテクチャ影響)
-- **#299 capPageResultsAggregate 動的 safeLogError test** (最難): ts-node/esm 環境整備込み。ESM loader 問題 (#360/#364 で知見獲得済) を活用できる
-
-**session 外 Open Issues** (引き続き持ち越し): #238 (force-reindex 孤児 posting) / #220 (OOM/truncated metric + alert) / #152 (dev setup-tenant、雛形として open 維持が正しい状態、active 作業不要)
-
-### Test plan 実行結果
-
-- [x] BE `npm --prefix functions run type-check:test` EXIT 0
-- [x] BE `npm --prefix functions test` **677 passing + 6 pending** (変化なし)
-- [x] BE `firebase emulators:exec --only firestore --project rescue-stuck-integration-test 'npm --prefix functions run test:integration'` **24 passing** (23 → +1 from #370)
-- [x] `npm run lint` 0 errors, **25 warnings** (新規 warning ゼロ、PR #369 と同水準)
-- [x] 動作確認: integration test ログで `safeLogError failed for stuck-fatal-log-fail (fatal branch): Error: Simulated safeLogError failure for #370 test` を確認 → processOCR.ts:224 inner try/catch が期待通り swallow、rescue 完了
-- [x] PR #372 main マージ時 CodeRabbit / GitGuardian SUCCESS、CI 実行済み (44e873c)
-- [x] `gh issue view 370` で CLOSED 確認 (squash merge で auto-close 成功)
-- [ ] main Deploy #372 (44e873c) IN_PROGRESS (merge 直後、次セッション開始時に `gh run list --workflow=Deploy` で SUCCESS 確認必要)
 
 ---
 
-<a id="session31"></a>
-## ✅ session31 完了サマリー (2026-04-22: #365 + #364 完遂、2 PR merged)
-
-session30 handoff で起票した直近 follow-up (#364 / #365) をまとめて片付け。両 PR とも Critical/Important 全解消を本 PR 内で完了、review agent 指摘で scope creep が発生する test 追加のみ follow-up Issue (#370) に分離。
-
-### PR 一覧
-
-| PR | 内容 | closed Issues | merged commit |
-|----|------|--------------|--------------|
-| **#368** | feat(ops): backfill-display-filename の totalSkipped を existing/noop に分割 (counter 分割 + fatal log 拡張 + _migrations record 後方互換 + invariant runtime assertion) | #365 | `f831692` |
-| **#369** | test: rescueStuckProcessingDocs の per-doc catch 経路 integration test (runTransaction 差し替え polyfill + 全件 forEach 検証 + doc 不変条件拡張) | #364 | `caa082c` |
-
-### 主要成果
-
-| 項目 | 内容 |
-|------|------|
-| **merged PR** | 2 本 (#368 / #369) |
-| **closed Issue** | #365 / #364 (計 2 件、auto-close 両方成功) |
-| **新規 follow-up Issue** | #370 (fatal 分岐 safeLogError 二重呼出防止 test、P2、silent-failure-hunter I2 由来) |
-| **Issue Net 変化** | Close 2 / 起票 1 = **+1** (ルール: Net ≤ 0 は進捗ゼロ扱い) |
-| **BE unit テスト** | 677 passing + 6 pending (変化なし、sinon 除去で既存影響ゼロ) |
-| **BE integration テスト** | 21 → **23 passing** (+2 from #364: per-doc catch 経路 + partial failure ループ継続) |
-| **コード量** | #368: +29/-6 (1 ファイル) / #369: +107/-11 (2 ファイル: test + package.json) 合計 +136/-17 |
-| **品質改善** | backfill counter の運用可視性向上 (existing/noop 分離) / invariant runtime assertion で _migrations への silent 汚染防止 / rescue per-doc catch 経路の直接 lock-in / 既存 convention 尊重 (sinon 不採用、polyfill pattern 採用) |
-
-### Quality Gate 実施記録 (合計 12 エージェントレビュー)
-
-**PR #368 (backfill counter 分割)**:
-- /impl-plan で Acceptance Criteria 5 項目 + タスク分解 (counter 分割 / fatal log / _migrations / 結果サマリー)
-- /review-pr 6 並列 (code-reviewer / silent-failure-hunter / pr-test-analyzer / comment-analyzer / type-design-analyzer / code-simplifier)
-  - Critical 0 / Important 1 対応: silent-failure-hunter I4 MEDIUM (`--force=false` 時の `totalSkippedNoop === 0` invariant を runtime assertion で lock-in、`_migrations` 書き込み前に配置)
-  - Suggestion 対応: comment-analyzer B (L57 動機追加) / comment-analyzer C (L189 invariant 保証元言及)
-  - Suggestion 不対応 (rating 5-6、PR コメントレベル): pr-test-analyzer I1 (aggregateSkipCounts helper 抽出) / type-design-analyzer C1/C2 (`_migrations` 型化 + ログ prefix 定数化)
-
-**PR #369 (rescue per-doc catch test)**:
-- /review-pr 6 並列
-  - **code-reviewer I1 (IMPORTANT, confidence 85)**: sinon 導入が既存 convention「sinon 依存を新規追加しない polyfill」(`buildPageResult.test.ts:74`) に反する → **sinon 除去して `withFailingRunTransaction` helper で代替** (try/finally で原値復元、既存 withWarnSpy と同方針)
-  - silent-failure-hunter C1 (CRITICAL): sinon.restore() leak → sinon 除去で構造的解消
-  - silent-failure-hunter I1 (HIGH): errs.docs[0] のみ assert → `errs.docs.forEach(...)` で全件検証に昇格
-  - silent-failure-hunter I4 (HIGH): doc 不変条件を `retryAfter` / `lastErrorMessage` undefined まで拡張
-  - silent-failure-hunter I2 (HIGH): fatal 分岐 safeLogError 二重呼出防止 test → **scope creep のため Follow-up Issue #370 化**
-  - Suggestion 不対応 (rating 3-6、PR コメントレベル): comment-analyzer 3件 / type-design-analyzer (ErrorLogFixture 型化) / code-simplifier 全提案
-
-### 設計判断 / Lessons Learned (本セッション重要知見)
-
-1. **既存 convention の尊重 (sinon 不採用)**: `buildPageResult.test.ts:74` に「sinon 依存を新規追加しない polyfill」方針が明記されている以上、新 PR で sinon を導入するなら同時に既存の deferred skip (`summaryWritePayloadContract.test.ts` の `it.skip` ブロック) を一括解禁すべき。本 PR は純粋な test 追加で scope を狭く保つため、`withFailingRunTransaction` helper による inline monkey-patch を採用。try/finally で原値復元を保証することで leak 耐性も担保
-
-2. **invariant を runtime assertion で lock-in**: `--force=false → totalSkippedNoop === 0` は論理的に保証されるが、将来の L94 条件 tweak で破れる silent failure の温床。`_migrations` 書き込み前に `process.exit(1)` で abort する assertion を 1 block 追加することで、運用 audit 証跡への silent 汚染を防げる。コスト数行、恩恵 (dashboard 誤認防止) 大
-
-3. **Quality Gate 2 tier 構造 の現場適用**: 単一ファイル +18 行の極小 PR でも hook が 6 エージェント並列を強制発動 → Important 1 件検出 (silent-failure-hunter I4)。規模に対する過剰感はあるが、invariant assertion の価値は規模と独立なため、1-2 ファイルでも省略しない方針は妥当。次回からは同規模で silent-failure-hunter + code-reviewer の 2 並列に絞ることで cost 対効果を改善できる可能性 (rules/quality-gate.md 改定候補)
-
-4. **review agent rating 5-6 の Issue triage 徹底**: 本セッションの 12 エージェントから計 20+ 件の提案が出たが、Issue 化したのは silent-failure-hunter I2 (rating HIGH + scope creep) の 1 件のみ。rating 5-6 は全て PR コメントレベル or 現状維持判断で close。`feedback_issue_triage.md` ルール (Close N + 起票 N = net 0 は進捗ゼロ扱い) に沿って Net +1 を維持
-
-5. **sinon 要否判断の system-level 評価**: 単一ファイル test の視点だと sinon はシンプル解決だが、コードベース全体では `withWarnSpy` (buildPageResult.test.ts), `withSilentConsoleError` 等の polyfill pattern が既に確立されている。feedback_evaluate_as_system.md に従い、ファイル単体ではなくシステム全体の convention 整合性で判断するのが正しい。「新パターンを許容するなら deferred な skip 解禁まで PR scope を広げる」が正道
-
-6. **polyfill pattern の再利用性**: `withFailingRunTransaction` は `withWarnSpy` と同じ try/finally 構造。将来 `withFailingSafeLogError` (Issue #370 向け) や他の Firestore method 差し替えが必要になった時、同じ pattern でスケール可能。helper 化は YAGNI で今は各 describe 内に置く
-
-### 次セッション着手候補 (WBS 進捗)
-
-**軽量 (0.5 セッション)**:
-- **#370 rescue fatal 分岐 safeLogError 二重呼出防止 test** (本セッション起票): `errorLogger` モジュールを polyfill 差し替えで失敗させ、内部 try/catch nest の lock-in。PR #369 の `withFailingRunTransaction` helper 応用で実装可
-
-**中規模 (1 セッション)**:
-- **#239 force-reindex audit log**: Cloud Logging に構造化 audit log 出力、compliance 対応の延長
-- **#251 summaryGenerator test + buildSummaryPrompt 分離**: 既存の summary 処理を testable に切り出し
-- **#200 checkGmailAttachments/splitPdf 統合テスト**: Gmail 連携経路の integration test
-
-**大物 (2 セッション、`/impl-plan` 必須)**:
-- **#237 search tokenizer 共通化**: FE/BE/script 3 箇所の重複を `shared/` に集約。session29-31 で持ち越し継続、Evaluator 分離必須 (5+ ファイル + アーキテクチャ影響)
-- **#299 capPageResultsAggregate 動的 safeLogError test** (最難): ts-node/esm 環境整備込み。ESM loader 問題 (#360/#364 で知見獲得済) を活用できる
-
-**session 外 Open Issues** (引き続き持ち越し): #238 (force-reindex 孤児 posting) / #220 (OOM/truncated metric + alert) / #152 (dev setup-tenant、雛形として open 維持が正しい状態、active 作業不要)
-
-### Test plan 実行結果
-
-- [x] BE `npx tsc --noEmit` EXIT 0 (両 PR 確認)
-- [x] BE `npm test` **677 passing + 6 pending** (変化なし、sinon 導入/除去とも既存影響ゼロ)
-- [x] BE `npm run test:integration` (emulator) **23 passing** (21 既存 + 2 新規 from #364)
-- [x] BE `npm run lint` 0 errors, 25 warnings (本 PR 新規 warning ゼロ、sinon 除去で eslint-disable 不要化 → 既存 warning 2 件削減)
-- [x] scripts `npx tsc --noEmit -p scripts/tsconfig.json` EXIT 0 (#368 確認)
-- [x] main CI 3/3 green × 2 PR (lint-build-test / CodeRabbit / GitGuardian 全 pass)
-- [x] `gh issue view 365 / 364` で CLOSED 確認 (squash merge で 2 件とも auto-close 成功)
-- [x] follow-up Issue #370 起票確認
-- [x] GitHub Actions で dev 環境 `backfill-display-filename --dry-run` 実行 2 回 success、新サマリー文字列「スキップ（設定済み・--forceなし）: 2件」出力確認、invariant assertion 未発動 (正常経路)
-- [ ] main Deploy #369 (caa082c) IN_PROGRESS (merge 直後、次セッション開始時に `gh run list --workflow=Deploy` で SUCCESS 確認必要)
-
----
-
-**過去セッション (session15〜30) は `docs/handoff/archive/2026-04-history.md` に移管済み** (session34 handoff 時に session29/30 を追加移管、2026-04-22)。
-
-直近前セッション (LATEST 保持):
-- **session33** (2026-04-22): #200 完遂 + #251 Scope 2 完了 (2 PR #374/#376)、logic-reproduction pattern + grep-based isolation contract
-- **session32** (2026-04-22): #370 完遂 (1 PR #372)、polyfill 「常に throw」設計で silent-failure-hunter F-1 対応
-- **session31** (2026-04-22): #365 + #364 完遂 (2 PR #368/#369)、sinon 不採用で既存 convention 尊重
+*session32 / session31 / 以前は [docs/handoff/archive/2026-04-history.md](archive/2026-04-history.md) を参照。*

--- a/docs/handoff/archive/2026-04-history.md
+++ b/docs/handoff/archive/2026-04-history.md
@@ -1,14 +1,188 @@
-# ハンドオフ履歴アーカイブ (〜2026-04-21 session27)
+# ハンドオフ履歴アーカイブ (〜2026-04-22 session32)
 
 `docs/handoff/LATEST.md` の肥大化に伴い、
 2026-04-16 session3 で過去履歴を本ファイルへ初回アーカイブ。
 2026-04-18 session11 で session9 セクションを LATEST から archive へ移管 (cut & append)。
 2026-04-22 session31 で session27 セクションを LATEST から archive へ移管 (prepend)。
+2026-04-23 session37 で session31/32 セクションを LATEST から archive へ移管 (prepend)。
 
 最新状況は `docs/handoff/LATEST.md` 参照。
 
 ---
 
+<a id="session32"></a>
+## ✅ session32 完了サマリー (2026-04-22: #370 完遂、1 PR merged)
+
+session31 handoff で起票した follow-up #370 (rescue fatal 分岐 safeLogError 二重呼出防止 test) を完遂。PR 内で /review-pr 6 エージェント並列、silent-failure-hunter F-1 (HIGH rating 7, confidence 85%) を PR 内で修正反映。polyfill 設計を「1 回目 reject / 2 回目以降 resolve」から「常に throw」に変更し、より広い regression scenario を検知可能にした。
+
+### PR 一覧
+
+| PR | 内容 | closed Issues | merged commit |
+|----|------|--------------|--------------|
+| **#372** | test: fatal 分岐 safeLogError 二重呼出防止 integration test (withFailingSafeLogError polyfill + rescueError + callCount 二重 invariant) | #370 | `44e873c` |
+
+### 主要成果
+
+| 項目 | 内容 |
+|------|------|
+| **merged PR** | 1 本 (#372) |
+| **closed Issue** | #370 (1 件、auto-close 成功) |
+| **新規 follow-up Issue** | なし (/review-pr 指摘は全て PR 内修正 or PR コメントレベル) |
+| **Issue Net 変化** | Close 1 / 起票 0 = **-1** (feedback_issue_triage.md: Net < 0 は KPI 前進、Net = 0 (Close N / 起票 N) は進捗ゼロ扱い → 本セッションは KPI 前進) |
+| **BE integration テスト** | 23 → **24 passing** (+1 from #370: fatal 分岐 safeLogError 失敗時の二重呼出防止) |
+| **BE unit テスト** | 677 passing + 6 pending (変化なし) |
+| **コード量** | 初版 +91/-0 → review 反映 -40/+33 → 最終 +84/-0 (1 ファイル: test/rescueStuckProcessingIntegration.test.ts) |
+| **品質改善** | fatal 分岐 inner try/catch を call count + rescueError の二重 invariant で lock-in / CJS namespace dynamic lookup を利用した sinon 不依存 polyfill / signature drift を LogErrorParams 型で compile-time 検知 |
+
+### Quality Gate 実施記録 (6 エージェント並列)
+
+| エージェント | Rating | 主な指摘 | 対応 |
+|------------|--------|----------|------|
+| **code-reviewer** | 9/10 | 問題なし | Approve |
+| **pr-test-analyzer** | 8/10 | PR コメントレベルのみ | 対応不要 |
+| **code-simplifier** | 提案なし | - | - |
+| **silent-failure-hunter** | **7.5/10** (F-1 rating 7, confidence 85%) | polyfill「2 回目 resolve」が outer catch throw 挙動を silent に書き換え | **PR 内修正: 「常に throw」に変更** |
+| **type-design-analyzer** | 6/10 | `params: unknown` で signature drift 検知不可 | **PR 内修正: `LogErrorParams` 型に変更** |
+| **comment-analyzer** | 6/10 | 行番号参照は rot 耐性低 + 冗長 block comment | **PR 内修正: 記号参照化 + assertion message に集約 + `errors/` 0 件 assertion 削除** |
+
+### 設計判断 / Lessons Learned (本セッション重要知見)
+
+1. **polyfill「常に throw」設計の regression 検知力 (F-1 HIGH 対応)**: 旧設計「1 回目 reject / 2 回目以降 resolve」は outer catch 内 safeLogError (try/catch なし、processOCR.ts:241) の throw 挙動を silent に resolve に書き換えていた → production 実挙動から乖離。「常に throw」+ test 側 `rescueError` 捕捉で、inner try/catch 削除 regression (rescue 全体 reject) と outer catch 経路の test 観測可能性の両方を確保。silent-failure-hunter F-1 (HIGH) の指摘は polyfill 設計の盲点を的確に突いた — 「stub は production 挙動を silent に補完してはいけない」の実例
+
+2. **CJS namespace dynamic lookup を利用した sinon 不依存 stub**: TypeScript CJS compile 後の `await (0, errorLogger_1.safeLogError)(...)` は namespace object の dynamic property lookup であり、test 側で `errorLoggerModule.safeLogError = stub` で property rewrite すると production code の次の呼出で反映される。PR #369 の `withFailingRunTransaction` (db オブジェクトのメソッド書換) と同方針で、sinon 導入不要。compile 後の emit を `tsc --outDir /tmp/...` で peek して mechanism を事前検証することで、「仕様上動くはず」の推測を「実体で確認」に昇格
+
+3. **signature drift の compile-time 検知 (type-design 対応)**: polyfill 内 `params: unknown` だと production 側 `LogErrorParams` に required フィールド追加時に静かに drift し、stub だけ古い signature のまま passing が続く。`import type { LogErrorParams }` + `params: LogErrorParams` に変更で 1 行 cost で compile-time safety 獲得。test ファイルでも型 honesty は維持すべき
+
+4. **コメント密度の適正化 (comment 対応)**: 1 ファイル test で 35+ 行コメントは過剰、かつ行番号 `processOCR.ts:222-232` は rot 耐性低。記号参照 (`rescueStuckProcessingDocs の fatal 分岐 inner try/catch`) + assertion message への集約で、コメント削減しつつ意図伝達力は維持。comment-analyzer rating 6 以下の指摘でも累積効果があるので一括反映が効率的
+
+5. **rating 7 境界の取扱い (Issue triage)**: CLAUDE.md CRITICAL「rating ≥ 7 かつ confidence ≥ 80 は Issue 起票候補」は**新規 Issue 起票の閾値**。本 PR 内で修正対応する場合は Issue 起票不要で直接反映が正解。本セッション F-1 rating 7 confidence 85% を PR 内修正で解消 → follow-up Issue ゼロを維持 (feedback_issue_triage.md「Close N + 起票 N = net 0 は進捗ゼロ」の net -1 達成)
+
+6. **初版 → review 修正の 2 commit 運用**: 初版 PR 作成直後に `/review-pr` を走らせ、指摘反映を別 commit (amend せず) で push。reviewer が差分を追跡可能、初版の判断過程を history に残す。CLAUDE.md「新規 commit を作成する」原則の実運用。本 PR は commit 2 本を `--squash` merge で 1 本に集約して main に入った (c159136 + 2051f5e → 44e873c)
+
+### 次セッション着手候補 (WBS 進捗)
+
+**軽量 (0.5 セッション)**: 該当なし (session32 終了時点の open Issue 一覧に 0.5 セッション相当タスクなし)
+
+**中規模 (1 セッション)**:
+- **#200 checkGmailAttachments/splitPdf 統合テスト**: Gmail 連携経路の integration test
+- **#251 summaryGenerator test + buildSummaryPrompt 分離**: 既存の summary 処理を testable に切り出し
+- **#239 force-reindex audit log**: Cloud Logging に構造化 audit log 出力
+
+**大物 (2 セッション、`/impl-plan` 必須)**:
+- **#237 search tokenizer 共通化**: session29 から持ち越し継続、Evaluator 分離必須 (5+ ファイル + アーキテクチャ影響)
+- **#299 capPageResultsAggregate 動的 safeLogError test** (最難): ts-node/esm 環境整備込み。ESM loader 問題 (#360/#364 で知見獲得済) を活用できる
+
+**session 外 Open Issues** (引き続き持ち越し): #238 (force-reindex 孤児 posting) / #220 (OOM/truncated metric + alert) / #152 (dev setup-tenant、雛形として open 維持が正しい状態、active 作業不要)
+
+### Test plan 実行結果
+
+- [x] BE `npm --prefix functions run type-check:test` EXIT 0
+- [x] BE `npm --prefix functions test` **677 passing + 6 pending** (変化なし)
+- [x] BE `firebase emulators:exec --only firestore --project rescue-stuck-integration-test 'npm --prefix functions run test:integration'` **24 passing** (23 → +1 from #370)
+- [x] `npm run lint` 0 errors, **25 warnings** (新規 warning ゼロ、PR #369 と同水準)
+- [x] 動作確認: integration test ログで `safeLogError failed for stuck-fatal-log-fail (fatal branch): Error: Simulated safeLogError failure for #370 test` を確認 → processOCR.ts:224 inner try/catch が期待通り swallow、rescue 完了
+- [x] PR #372 main マージ時 CodeRabbit / GitGuardian SUCCESS、CI 実行済み (44e873c)
+- [x] `gh issue view 370` で CLOSED 確認 (squash merge で auto-close 成功)
+- [ ] main Deploy #372 (44e873c) IN_PROGRESS (merge 直後、次セッション開始時に `gh run list --workflow=Deploy` で SUCCESS 確認必要)
+
+---
+
+<a id="session31"></a>
+## ✅ session31 完了サマリー (2026-04-22: #365 + #364 完遂、2 PR merged)
+
+session30 handoff で起票した直近 follow-up (#364 / #365) をまとめて片付け。両 PR とも Critical/Important 全解消を本 PR 内で完了、review agent 指摘で scope creep が発生する test 追加のみ follow-up Issue (#370) に分離。
+
+### PR 一覧
+
+| PR | 内容 | closed Issues | merged commit |
+|----|------|--------------|--------------|
+| **#368** | feat(ops): backfill-display-filename の totalSkipped を existing/noop に分割 (counter 分割 + fatal log 拡張 + _migrations record 後方互換 + invariant runtime assertion) | #365 | `f831692` |
+| **#369** | test: rescueStuckProcessingDocs の per-doc catch 経路 integration test (runTransaction 差し替え polyfill + 全件 forEach 検証 + doc 不変条件拡張) | #364 | `caa082c` |
+
+### 主要成果
+
+| 項目 | 内容 |
+|------|------|
+| **merged PR** | 2 本 (#368 / #369) |
+| **closed Issue** | #365 / #364 (計 2 件、auto-close 両方成功) |
+| **新規 follow-up Issue** | #370 (fatal 分岐 safeLogError 二重呼出防止 test、P2、silent-failure-hunter I2 由来) |
+| **Issue Net 変化** | Close 2 / 起票 1 = **+1** (ルール: Net ≤ 0 は進捗ゼロ扱い) |
+| **BE unit テスト** | 677 passing + 6 pending (変化なし、sinon 除去で既存影響ゼロ) |
+| **BE integration テスト** | 21 → **23 passing** (+2 from #364: per-doc catch 経路 + partial failure ループ継続) |
+| **コード量** | #368: +29/-6 (1 ファイル) / #369: +107/-11 (2 ファイル: test + package.json) 合計 +136/-17 |
+| **品質改善** | backfill counter の運用可視性向上 (existing/noop 分離) / invariant runtime assertion で _migrations への silent 汚染防止 / rescue per-doc catch 経路の直接 lock-in / 既存 convention 尊重 (sinon 不採用、polyfill pattern 採用) |
+
+### Quality Gate 実施記録 (合計 12 エージェントレビュー)
+
+**PR #368 (backfill counter 分割)**:
+- /impl-plan で Acceptance Criteria 5 項目 + タスク分解 (counter 分割 / fatal log / _migrations / 結果サマリー)
+- /review-pr 6 並列 (code-reviewer / silent-failure-hunter / pr-test-analyzer / comment-analyzer / type-design-analyzer / code-simplifier)
+  - Critical 0 / Important 1 対応: silent-failure-hunter I4 MEDIUM (`--force=false` 時の `totalSkippedNoop === 0` invariant を runtime assertion で lock-in、`_migrations` 書き込み前に配置)
+  - Suggestion 対応: comment-analyzer B (L57 動機追加) / comment-analyzer C (L189 invariant 保証元言及)
+  - Suggestion 不対応 (rating 5-6、PR コメントレベル): pr-test-analyzer I1 (aggregateSkipCounts helper 抽出) / type-design-analyzer C1/C2 (`_migrations` 型化 + ログ prefix 定数化)
+
+**PR #369 (rescue per-doc catch test)**:
+- /review-pr 6 並列
+  - **code-reviewer I1 (IMPORTANT, confidence 85)**: sinon 導入が既存 convention「sinon 依存を新規追加しない polyfill」(`buildPageResult.test.ts:74`) に反する → **sinon 除去して `withFailingRunTransaction` helper で代替** (try/finally で原値復元、既存 withWarnSpy と同方針)
+  - silent-failure-hunter C1 (CRITICAL): sinon.restore() leak → sinon 除去で構造的解消
+  - silent-failure-hunter I1 (HIGH): errs.docs[0] のみ assert → `errs.docs.forEach(...)` で全件検証に昇格
+  - silent-failure-hunter I4 (HIGH): doc 不変条件を `retryAfter` / `lastErrorMessage` undefined まで拡張
+  - silent-failure-hunter I2 (HIGH): fatal 分岐 safeLogError 二重呼出防止 test → **scope creep のため Follow-up Issue #370 化**
+  - Suggestion 不対応 (rating 3-6、PR コメントレベル): comment-analyzer 3件 / type-design-analyzer (ErrorLogFixture 型化) / code-simplifier 全提案
+
+### 設計判断 / Lessons Learned (本セッション重要知見)
+
+1. **既存 convention の尊重 (sinon 不採用)**: `buildPageResult.test.ts:74` に「sinon 依存を新規追加しない polyfill」方針が明記されている以上、新 PR で sinon を導入するなら同時に既存の deferred skip (`summaryWritePayloadContract.test.ts` の `it.skip` ブロック) を一括解禁すべき。本 PR は純粋な test 追加で scope を狭く保つため、`withFailingRunTransaction` helper による inline monkey-patch を採用。try/finally で原値復元を保証することで leak 耐性も担保
+
+2. **invariant を runtime assertion で lock-in**: `--force=false → totalSkippedNoop === 0` は論理的に保証されるが、将来の L94 条件 tweak で破れる silent failure の温床。`_migrations` 書き込み前に `process.exit(1)` で abort する assertion を 1 block 追加することで、運用 audit 証跡への silent 汚染を防げる。コスト数行、恩恵 (dashboard 誤認防止) 大
+
+3. **Quality Gate 2 tier 構造 の現場適用**: 単一ファイル +18 行の極小 PR でも hook が 6 エージェント並列を強制発動 → Important 1 件検出 (silent-failure-hunter I4)。規模に対する過剰感はあるが、invariant assertion の価値は規模と独立なため、1-2 ファイルでも省略しない方針は妥当。次回からは同規模で silent-failure-hunter + code-reviewer の 2 並列に絞ることで cost 対効果を改善できる可能性 (rules/quality-gate.md 改定候補)
+
+4. **review agent rating 5-6 の Issue triage 徹底**: 本セッションの 12 エージェントから計 20+ 件の提案が出たが、Issue 化したのは silent-failure-hunter I2 (rating HIGH + scope creep) の 1 件のみ。rating 5-6 は全て PR コメントレベル or 現状維持判断で close。`feedback_issue_triage.md` ルール (Close N + 起票 N = net 0 は進捗ゼロ扱い) に沿って Net +1 を維持
+
+5. **sinon 要否判断の system-level 評価**: 単一ファイル test の視点だと sinon はシンプル解決だが、コードベース全体では `withWarnSpy` (buildPageResult.test.ts), `withSilentConsoleError` 等の polyfill pattern が既に確立されている。feedback_evaluate_as_system.md に従い、ファイル単体ではなくシステム全体の convention 整合性で判断するのが正しい。「新パターンを許容するなら deferred な skip 解禁まで PR scope を広げる」が正道
+
+6. **polyfill pattern の再利用性**: `withFailingRunTransaction` は `withWarnSpy` と同じ try/finally 構造。将来 `withFailingSafeLogError` (Issue #370 向け) や他の Firestore method 差し替えが必要になった時、同じ pattern でスケール可能。helper 化は YAGNI で今は各 describe 内に置く
+
+### 次セッション着手候補 (WBS 進捗)
+
+**軽量 (0.5 セッション)**:
+- **#370 rescue fatal 分岐 safeLogError 二重呼出防止 test** (本セッション起票): `errorLogger` モジュールを polyfill 差し替えで失敗させ、内部 try/catch nest の lock-in。PR #369 の `withFailingRunTransaction` helper 応用で実装可
+
+**中規模 (1 セッション)**:
+- **#239 force-reindex audit log**: Cloud Logging に構造化 audit log 出力、compliance 対応の延長
+- **#251 summaryGenerator test + buildSummaryPrompt 分離**: 既存の summary 処理を testable に切り出し
+- **#200 checkGmailAttachments/splitPdf 統合テスト**: Gmail 連携経路の integration test
+
+**大物 (2 セッション、`/impl-plan` 必須)**:
+- **#237 search tokenizer 共通化**: FE/BE/script 3 箇所の重複を `shared/` に集約。session29-31 で持ち越し継続、Evaluator 分離必須 (5+ ファイル + アーキテクチャ影響)
+- **#299 capPageResultsAggregate 動的 safeLogError test** (最難): ts-node/esm 環境整備込み。ESM loader 問題 (#360/#364 で知見獲得済) を活用できる
+
+**session 外 Open Issues** (引き続き持ち越し): #238 (force-reindex 孤児 posting) / #220 (OOM/truncated metric + alert) / #152 (dev setup-tenant、雛形として open 維持が正しい状態、active 作業不要)
+
+### Test plan 実行結果
+
+- [x] BE `npx tsc --noEmit` EXIT 0 (両 PR 確認)
+- [x] BE `npm test` **677 passing + 6 pending** (変化なし、sinon 導入/除去とも既存影響ゼロ)
+- [x] BE `npm run test:integration` (emulator) **23 passing** (21 既存 + 2 新規 from #364)
+- [x] BE `npm run lint` 0 errors, 25 warnings (本 PR 新規 warning ゼロ、sinon 除去で eslint-disable 不要化 → 既存 warning 2 件削減)
+- [x] scripts `npx tsc --noEmit -p scripts/tsconfig.json` EXIT 0 (#368 確認)
+- [x] main CI 3/3 green × 2 PR (lint-build-test / CodeRabbit / GitGuardian 全 pass)
+- [x] `gh issue view 365 / 364` で CLOSED 確認 (squash merge で 2 件とも auto-close 成功)
+- [x] follow-up Issue #370 起票確認
+- [x] GitHub Actions で dev 環境 `backfill-display-filename --dry-run` 実行 2 回 success、新サマリー文字列「スキップ（設定済み・--forceなし）: 2件」出力確認、invariant assertion 未発動 (正常経路)
+- [ ] main Deploy #369 (caa082c) IN_PROGRESS (merge 直後、次セッション開始時に `gh run list --workflow=Deploy` で SUCCESS 確認必要)
+
+---
+
+**過去セッション (session15〜30) は `docs/handoff/archive/2026-04-history.md` に移管済み** (session34 handoff 時に session29/30 を追加移管、2026-04-22)。
+
+直近前セッション (LATEST 保持):
+- **session33** (2026-04-22): #200 完遂 + #251 Scope 2 完了 (2 PR #374/#376)、logic-reproduction pattern + grep-based isolation contract
+- **session32** (2026-04-22): #370 完遂 (1 PR #372)、polyfill 「常に throw」設計で silent-failure-hunter F-1 対応
+- **session31** (2026-04-22): #365 + #364 完遂 (2 PR #368/#369)、sinon 不採用で既存 convention 尊重
+
+---
 <a id="session27"></a>
 ## ✅ session27 完了サマリー (WBS Phase 1-3 完遂)
 


### PR DESCRIPTION
## Summary

- session37 handoff documentation update
- session32 / session31 を `docs/handoff/archive/2026-04-history.md` へ prepend
- `docs/handoff/LATEST.md` は 584 → 483 行に縮小 (500 行制限内)

## session37 完遂サマリー

P1 bug #384 (force_reindex audit log が Cloud Logging に書き込まれていない) を完遂:
- 根本原因: `@google-cloud/logging` の `Log.write()` async batch dispatch が `process.exit()` で drop される
- 修正: `process.exitCode` + `flushAndCloseLogging()` (gRPC channel graceful close) + `try/finally`
- 検証: 3 環境 (dev/kanameone/cocoro) で実 Cloud Logging 受信を実証
- Quality Gate: `/simplify` (3並列) + `/safe-refactor` + `/review-pr` (6エージェント) + `/codex review` (Approve)
- silent-failure-hunter Critical 2 + Important 3 を本 PR で反映

## Issue Net 変化

- Close: 1 (#384)
- 起票: 1 (#387 entrypoint test follow-up、triage 基準 #4 該当 rating 7/confidence 85)
- **Net: 0** (KPI 進捗ゼロ扱いだが #384 真の解決は達成)

## Test plan

- [x] `wc -l docs/handoff/LATEST.md` → 483 行 (500 内)
- [x] archive 移管後の LATEST.md / archive 整合性 (session37 entry 追加 / session32+31 移管)
- [x] 構文確認 (markdown structure intact、`<a id="session*">` anchor 整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated handoff documentation with session37 completion summary and verification metrics.
  * Archived historical session records for reference tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->