### PR TITLE
test(scripts): force-reindex.js runEntrypoint の invariant を 5 シナリオで lock-in (#387)

### DIFF
--- a/functions/test/forceReindexEntrypoint.test.ts
+++ b/functions/test/forceReindexEntrypoint.test.ts
@@ -1,0 +1,253 @@
+/**
+ * force-reindex.js の runEntrypoint integration test (Issue #387)
+ *
+ * 対象: #386 で導入した entrypoint 構造 (try/finally + process.exitCode +
+ *       flushAndCloseLogging + emitFailureEvent の try/catch 入れ子) の invariant を
+ *       unit test で lock-in する。
+ *
+ * 受け入れ基準:
+ *   - success / main throw / flush throw / emitFailureEvent throw の 4 シナリオを lock-in
+ *   - #386 review I1 (exitCode を flush より先に設定) の regression 検出
+ *   - #386 review I2 (emitFailureEvent を try/catch で包む) の regression 検出
+ *   - #386 review I3 (初期値 EXIT_PRECONDITION) は main 同期 throw 時の挙動で間接検証
+ *
+ * 設計方針:
+ *   - runEntrypoint({ main, flushAndCloseLogging, emitFailureEvent, buildAuditCtx }) で DI
+ *   - process.exitCode / FIREBASE_PROJECT_ID / stdio は withProcessSandbox で save/restore 集約
+ *   - 文字列 literal ではなく auditLogger の EVENTS/SEVERITIES 定数を参照 (drift 防止)
+ */
+
+import { expect } from 'chai';
+import * as path from 'path';
+import { createRequire } from 'module';
+
+const requireCjs = createRequire(`${process.cwd()}/package.json`);
+const forceReindex = requireCjs(
+  path.resolve(process.cwd(), '../scripts/force-reindex.js'),
+) as {
+  runEntrypoint: (deps?: {
+    main?: () => Promise<number>;
+    flushAndCloseLogging?: () => Promise<void>;
+    emitFailureEvent?: (params: Record<string, unknown>) => Promise<void>;
+    buildAuditCtx?: (projectId: string) => { projectId: string; executedBy: string };
+  }) => Promise<void>;
+  EXIT_OK: number;
+  EXIT_PARTIAL_FAILURE: number;
+};
+const auditLoggerMod = requireCjs(
+  path.resolve(process.cwd(), '../scripts/lib/auditLogger.js'),
+) as {
+  EVENTS: Readonly<Record<string, string>>;
+  SEVERITIES: Readonly<Record<string, string>>;
+};
+
+const { runEntrypoint, EXIT_OK, EXIT_PARTIAL_FAILURE } = forceReindex;
+const { EVENTS, SEVERITIES } = auditLoggerMod;
+
+/**
+ * 各 test の process 副作用 (stdio / exitCode / FIREBASE_PROJECT_ID) を sandbox 化。
+ * overrides で差し替え内容を宣言し、try/finally の boilerplate を一箇所に集約する。
+ * projectId は `null` で明示的削除、`undefined` 省略で現状維持を表現する。
+ */
+async function withProcessSandbox(
+  overrides: {
+    stdout?: (chunk: string | Uint8Array) => boolean;
+    stderr?: (chunk: string | Uint8Array) => boolean;
+    projectId?: string | null;
+  },
+  fn: () => Promise<void>,
+): Promise<void> {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const origExitCode = process.exitCode;
+  const origProjectId = process.env.FIREBASE_PROJECT_ID;
+
+  if (overrides.stdout) {
+    process.stdout.write = overrides.stdout as typeof process.stdout.write;
+  }
+  if (overrides.stderr) {
+    process.stderr.write = overrides.stderr as typeof process.stderr.write;
+  }
+  if (overrides.projectId === null) {
+    delete process.env.FIREBASE_PROJECT_ID;
+  } else if (overrides.projectId !== undefined) {
+    process.env.FIREBASE_PROJECT_ID = overrides.projectId;
+  }
+  // test 観測値が前回の残留 exitCode と混ざらないように unset
+  process.exitCode = undefined;
+
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    process.exitCode = origExitCode;
+    if (origProjectId === undefined) {
+      delete process.env.FIREBASE_PROJECT_ID;
+    } else {
+      process.env.FIREBASE_PROJECT_ID = origProjectId;
+    }
+  }
+}
+
+/** stderr を蓄積する buffer と write 関数のペアを生成 */
+function makeStderrCapture(): { buf: { value: string }; write: (chunk: string | Uint8Array) => boolean } {
+  const buf = { value: '' };
+  const write = (chunk: string | Uint8Array) => {
+    buf.value += String(chunk);
+    return true;
+  };
+  return { buf, write };
+}
+
+const noopWrite = () => true;
+
+describe('force-reindex: runEntrypoint (#387)', () => {
+  it('success path: main 成功 → finally で flush、process.exitCode === EXIT_OK', async () => {
+    const callOrder: string[] = [];
+
+    await withProcessSandbox({ stdout: noopWrite, stderr: noopWrite }, async () => {
+      await runEntrypoint({
+        main: async () => {
+          callOrder.push('main');
+          return EXIT_OK;
+        },
+        flushAndCloseLogging: async () => {
+          callOrder.push('flush');
+        },
+        emitFailureEvent: async () => {
+          callOrder.push('emitFailure');
+        },
+        buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+      });
+
+      expect(callOrder).to.deep.equal(['main', 'flush']);
+      expect(process.exitCode).to.equal(EXIT_OK);
+    });
+  });
+
+  it('main throw: emitFailureEvent → flush の順で呼ばれ process.exitCode === EXIT_PARTIAL_FAILURE', async () => {
+    const callOrder: string[] = [];
+
+    await withProcessSandbox(
+      { stdout: noopWrite, stderr: noopWrite, projectId: 'doc-split-dev' },
+      async () => {
+        await runEntrypoint({
+          main: async () => {
+            callOrder.push('main');
+            throw new Error('simulated async error after initializeApp');
+          },
+          flushAndCloseLogging: async () => {
+            callOrder.push('flush');
+          },
+          emitFailureEvent: async (params: Record<string, unknown>) => {
+            callOrder.push('emitFailure');
+            // FATAL / CRITICAL が投入されることを定数参照で確認 (drift 防止)
+            expect(params.event).to.equal(EVENTS.FATAL);
+            expect(params.severity).to.equal(SEVERITIES.CRITICAL);
+          },
+          buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+        });
+
+        // 順序 invariant: emitFailure が flush より先 (audit log を drop しないため)
+        expect(callOrder).to.deep.equal(['main', 'emitFailure', 'flush']);
+        expect(process.exitCode).to.equal(EXIT_PARTIAL_FAILURE);
+      },
+    );
+  });
+
+  it('flush throw (success 後): process.exitCode を EXIT_PARTIAL_FAILURE に強制上書き (I1 invariant)', async () => {
+    const callOrder: string[] = [];
+    const stderr = makeStderrCapture();
+
+    await withProcessSandbox({ stdout: noopWrite, stderr: stderr.write }, async () => {
+      await runEntrypoint({
+        main: async () => {
+          callOrder.push('main');
+          return EXIT_OK;
+        },
+        flushAndCloseLogging: async () => {
+          callOrder.push('flush');
+          throw new Error('simulated flush failure');
+        },
+        emitFailureEvent: async () => {
+          callOrder.push('emitFailure');
+        },
+        buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+      });
+
+      // main は成功したが flush 失敗 → audit drop の強い示唆として強制失敗扱い
+      expect(callOrder).to.deep.equal(['main', 'flush']);
+      expect(process.exitCode).to.equal(EXIT_PARTIAL_FAILURE);
+      expect(stderr.buf.value).to.include('flushAndCloseLogging failed');
+    });
+  });
+
+  it('emitFailureEvent throw: FATAL silent loss 防止、exitCode === EXIT_PARTIAL_FAILURE 維持 (I2 invariant)', async () => {
+    const callOrder: string[] = [];
+    const stderr = makeStderrCapture();
+
+    await withProcessSandbox(
+      { stdout: noopWrite, stderr: stderr.write, projectId: 'doc-split-dev' },
+      async () => {
+        await runEntrypoint({
+          main: async () => {
+            callOrder.push('main');
+            throw new Error('simulated main failure');
+          },
+          flushAndCloseLogging: async () => {
+            callOrder.push('flush');
+          },
+          emitFailureEvent: async () => {
+            callOrder.push('emitFailure');
+            // JSON circular 等で emitFailureEvent 自体が throw する regression を模擬
+            throw new Error('simulated emit failure');
+          },
+          buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+        });
+
+        // emitFailure throw を吸収し flush まで到達する
+        expect(callOrder).to.deep.equal(['main', 'emitFailure', 'flush']);
+        // main throw 時点で EXIT_PARTIAL_FAILURE に設定済み → emit throw でも維持
+        expect(process.exitCode).to.equal(EXIT_PARTIAL_FAILURE);
+        // 最低限 stderr に original error が残ること (silent loss 防止)
+        expect(stderr.buf.value).to.include('emitFailureEvent failed');
+        expect(stderr.buf.value).to.include('original error');
+      },
+    );
+  });
+
+  it('main throw without FIREBASE_PROJECT_ID: fallback stderr 経路で stringify、flush は実行される', async () => {
+    // I3 関連: projectId 未設定時でも audit ctx 構築に依存せず safe に落ちること
+    const callOrder: string[] = [];
+    const stderr = makeStderrCapture();
+
+    await withProcessSandbox(
+      { stdout: noopWrite, stderr: stderr.write, projectId: null },
+      async () => {
+        await runEntrypoint({
+          main: async () => {
+            throw Object.assign(new Error('simulated fatal'), { code: 13 });
+          },
+          flushAndCloseLogging: async () => {
+            callOrder.push('flush');
+          },
+          emitFailureEvent: async () => {
+            callOrder.push('emitFailure');
+          },
+          buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+        });
+
+        // projectId 未設定 → emitFailureEvent 経路に入らず stderr JSON で fallback
+        expect(callOrder).to.deep.equal(['flush']);
+        expect(process.exitCode).to.equal(EXIT_PARTIAL_FAILURE);
+        const fatalLine = stderr.buf.value.split('\n').find((l) => l.includes(EVENTS.FATAL));
+        expect(fatalLine, 'stderr に FATAL JSON が出力される').to.be.a('string');
+        const parsed = JSON.parse(fatalLine as string);
+        expect(parsed.severity).to.equal(SEVERITIES.CRITICAL);
+        expect(parsed.errorMessage).to.equal('simulated fatal');
+        expect(parsed.errorCode).to.equal(13);
+      },
+    );
+  });
+});

--- a/functions/test/forceReindexEntrypoint.test.ts
+++ b/functions/test/forceReindexEntrypoint.test.ts
@@ -1,15 +1,18 @@
 /**
- * force-reindex.js の runEntrypoint integration test (Issue #387)
+ * force-reindex.js の runEntrypoint integration test
  *
- * 対象: #386 で導入した entrypoint 構造 (try/finally + process.exitCode +
- *       flushAndCloseLogging + emitFailureEvent の try/catch 入れ子) の invariant を
- *       unit test で lock-in する。
+ * 対象: entrypoint 構造 (try/finally + process.exitCode + flushAndCloseLogging +
+ *       emitFailureEvent の try/catch 入れ子) の invariant を unit test で lock-in。
  *
- * 受け入れ基準:
- *   - success / main throw / flush throw / emitFailureEvent throw の 4 シナリオを lock-in
- *   - #386 review I1 (exitCode を flush より先に設定) の regression 検出
- *   - #386 review I2 (emitFailureEvent を try/catch で包む) の regression 検出
- *   - #386 review I3 (初期値 EXIT_PRECONDITION) は main 同期 throw 時の挙動で間接検証
+ * ロック対象:
+ *   - I1 (exitCode を flush より先に設定) の regression 検出
+ *   - I2 (emitFailureEvent を try/catch で包む) の regression 検出
+ *   - main throw + flush throw 複合時の exitCode guard (EXIT_PARTIAL_FAILURE 維持)
+ *   - projectId 未設定時の stderr JSON fallback + stringify throw 時の original error surface
+ *
+ * 非対象:
+ *   - I3 (初期値 EXIT_PRECONDITION) は defensive fallback として保持されるのみで
+ *     現行制御フローでは observable でないため assertion しない
  *
  * 設計方針:
  *   - runEntrypoint({ main, flushAndCloseLogging, emitFailureEvent, buildAuditCtx }) で DI
@@ -213,6 +216,77 @@ describe('force-reindex: runEntrypoint (#387)', () => {
         // 最低限 stderr に original error が残ること (silent loss 防止)
         expect(stderr.buf.value).to.include('emitFailureEvent failed');
         expect(stderr.buf.value).to.include('original error');
+      },
+    );
+  });
+
+  it('main throw + flush throw: 複合失敗でも process.exitCode === EXIT_PARTIAL_FAILURE 維持 (flush catch guard)', async () => {
+    // flush catch の `if (process.exitCode === EXIT_OK)` guard が regression で
+    // 消えた/緩められた場合に検出する。main throw 後は既に EXIT_PARTIAL_FAILURE で、
+    // flush 失敗が exit code を上書きしてはならない (情報劣化防止)。
+    const callOrder: string[] = [];
+    const stderr = makeStderrCapture();
+
+    await withProcessSandbox(
+      { stdout: noopWrite, stderr: stderr.write, projectId: 'doc-split-dev' },
+      async () => {
+        await runEntrypoint({
+          main: async () => {
+            callOrder.push('main');
+            throw new Error('simulated main failure');
+          },
+          flushAndCloseLogging: async () => {
+            callOrder.push('flush');
+            throw new Error('simulated flush failure');
+          },
+          emitFailureEvent: async () => {
+            callOrder.push('emitFailure');
+          },
+          buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+        });
+
+        expect(callOrder).to.deep.equal(['main', 'emitFailure', 'flush']);
+        expect(process.exitCode).to.equal(EXIT_PARTIAL_FAILURE);
+        expect(stderr.buf.value).to.include('flushAndCloseLogging failed');
+      },
+    );
+  });
+
+  it('projectId 未設定 + stringify throw: original error も silent loss しない', async () => {
+    // BigInt を error.code に仕込むと JSON.stringify は
+    // "Do not know how to serialize a BigInt" で throw する。
+    // その時 original error の code / message を stderr に別行で surface しないと
+    // #386 で防いだ silent loss パターンが fallback 経路で再発する。
+    const callOrder: string[] = [];
+    const stderr = makeStderrCapture();
+
+    await withProcessSandbox(
+      { stdout: noopWrite, stderr: stderr.write, projectId: null },
+      async () => {
+        const errWithBigIntCode: Error & { code?: bigint } = Object.assign(
+          new Error('simulated fatal bigint'),
+          { code: BigInt(42) },
+        );
+
+        await runEntrypoint({
+          main: async () => {
+            throw errWithBigIntCode;
+          },
+          flushAndCloseLogging: async () => {
+            callOrder.push('flush');
+          },
+          emitFailureEvent: async () => {
+            callOrder.push('emitFailure');
+          },
+          buildAuditCtx: (projectId) => ({ projectId, executedBy: 'test' }),
+        });
+
+        expect(callOrder).to.deep.equal(['flush']);
+        expect(process.exitCode).to.equal(EXIT_PARTIAL_FAILURE);
+        expect(stderr.buf.value).to.include('error stringify failed');
+        // 重要: original error の message / code が silent loss していないこと
+        expect(stderr.buf.value).to.include('simulated fatal bigint');
+        expect(stderr.buf.value).to.include('code=42');
       },
     );
   });

--- a/scripts/force-reindex.js
+++ b/scripts/force-reindex.js
@@ -526,65 +526,82 @@ async function main() {
   return exitCode;
 }
 
-// テスト時は main 呼び出しをスキップ
-if (require.main === module) {
-  // process.exit() は in-flight gRPC を切断するため使用しない (#384)。
-  // process.exitCode を設定し、Logging client を gracefully close することで
-  // event loop が natural drain し audit 書き込みの完全性を保証する。
-  // #386 review I1: process.exitCode は flush より先に設定し、flush throw でも反映を保証。
-  // #386 review I2: emitFailureEvent も try/catch で包み FATAL audit log の silent loss を防止。
-  // #386 review I3: 初期値は意味的定数 EXIT_PRECONDITION (main() 同期 throw 時の事前検証エラー扱い)。
-  (async () => {
-    let exitCode = EXIT_PRECONDITION;
-    try {
-      exitCode = await main();
-      console.log(exitCode === EXIT_OK ? '完了' : `部分失敗で終了 (exit code=${exitCode})`);
-    } catch (error) {
-      // main() 内のエラー (projectId 未設定 / parseArgs 失敗 / args.help) は
-      // EXIT_PRECONDITION/EXIT_OK で return するため、ここに到達するのは
-      // admin.initializeApp 以降に発生した未捕捉 async エラーに限られる
-      exitCode = EXIT_PARTIAL_FAILURE;
-      const projectId = process.env.FIREBASE_PROJECT_ID;
-      if (projectId) {
-        try {
-          await emitFailureEvent({
-            event: EVENTS.FATAL,
-            severity: SEVERITIES.CRITICAL,
-            error,
-            auditCtx: buildAuditCtx(projectId),
-          });
-        } catch (emitErr) {
-          // emitFailureEvent 自体の throw (JSON circular 等) を最低限 stderr に残す
-          console.error(`fatal: emitFailureEvent failed: ${emitErr?.message ?? emitErr}`);
-          console.error(`original error: ${error?.message ?? error}`);
-        }
-      } else {
-        try {
-          console.error(JSON.stringify({
-            severity: SEVERITIES.CRITICAL,
-            event: EVENTS.FATAL,
-            errorCode: error?.code ?? null,
-            errorMessage: error?.message ?? String(error),
-            stack: error?.stack,
-          }));
-        } catch (stringifyErr) {
-          console.error(`fatal: error stringify failed: ${stringifyErr?.message}`);
-        }
-      }
-    } finally {
-      // exit code を flush より先に設定 (flush throw でも反映を保証)
-      process.exitCode = exitCode;
+/**
+ * CLI entrypoint の本体。テストから DI で mock 注入して invariant を lock-in する
+ * (Issue #387)。defaults は module-scope の関数を参照するため CLI 経由の挙動は不変。
+ *
+ * 保証する invariant (#386 review I1/I2/I3):
+ *   I1: process.exitCode は flushAndCloseLogging 呼び出しより先に設定する
+ *       (flush throw でも exit code 反映を保証)
+ *   I2: emitFailureEvent も try/catch で包む (FATAL audit log の silent loss 防止)
+ *   I3: 初期値は EXIT_PRECONDITION (main() 同期 throw 時の事前検証エラー扱い)
+ *
+ * process.exit() は in-flight gRPC を切断するため使用しない (#384)。
+ * process.exitCode 設定 + Logging client gracefully close により event loop が
+ * natural drain し audit 書き込みの完全性を保証する。
+ */
+async function runEntrypoint(deps = {}) {
+  const {
+    main: runMain = main,
+    flushAndCloseLogging: flushFn = flushAndCloseLogging,
+    emitFailureEvent: emitFailure = emitFailureEvent,
+    buildAuditCtx: buildCtx = buildAuditCtx,
+  } = deps;
+
+  let exitCode = EXIT_PRECONDITION;
+  try {
+    exitCode = await runMain();
+    console.log(exitCode === EXIT_OK ? '完了' : `部分失敗で終了 (exit code=${exitCode})`);
+  } catch (error) {
+    // main() 内のエラー (projectId 未設定 / parseArgs 失敗 / args.help) は
+    // EXIT_PRECONDITION/EXIT_OK で return するため、ここに到達するのは
+    // admin.initializeApp 以降に発生した未捕捉 async エラーに限られる
+    exitCode = EXIT_PARTIAL_FAILURE;
+    const projectId = process.env.FIREBASE_PROJECT_ID;
+    if (projectId) {
       try {
-        await flushAndCloseLogging();
-      } catch (flushErr) {
-        // flush 自体の throw は audit drop の強い示唆。exit code を強制的に失敗扱いに
-        console.error(`fatal: flushAndCloseLogging failed: ${flushErr?.message ?? flushErr}`);
-        if (process.exitCode === EXIT_OK) {
-          process.exitCode = EXIT_PARTIAL_FAILURE;
-        }
+        await emitFailure({
+          event: EVENTS.FATAL,
+          severity: SEVERITIES.CRITICAL,
+          error,
+          auditCtx: buildCtx(projectId),
+        });
+      } catch (emitErr) {
+        // emitFailureEvent 自体の throw (JSON circular 等) を最低限 stderr に残す
+        console.error(`fatal: emitFailureEvent failed: ${emitErr?.message ?? emitErr}`);
+        console.error(`original error: ${error?.message ?? error}`);
+      }
+    } else {
+      try {
+        console.error(JSON.stringify({
+          severity: SEVERITIES.CRITICAL,
+          event: EVENTS.FATAL,
+          errorCode: error?.code ?? null,
+          errorMessage: error?.message ?? String(error),
+          stack: error?.stack,
+        }));
+      } catch (stringifyErr) {
+        console.error(`fatal: error stringify failed: ${stringifyErr?.message}`);
       }
     }
-  })();
+  } finally {
+    // I1: exit code を flush より先に設定 (flush throw でも反映を保証)
+    process.exitCode = exitCode;
+    try {
+      await flushFn();
+    } catch (flushErr) {
+      // flush 自体の throw は audit drop の強い示唆。exit code を強制的に失敗扱いに
+      console.error(`fatal: flushAndCloseLogging failed: ${flushErr?.message ?? flushErr}`);
+      if (process.exitCode === EXIT_OK) {
+        process.exitCode = EXIT_PARTIAL_FAILURE;
+      }
+    }
+  }
+}
+
+// テスト時は entrypoint 呼び出しをスキップ
+if (require.main === module) {
+  runEntrypoint();
 }
 
 module.exports = {
@@ -594,4 +611,8 @@ module.exports = {
   reindexDocument,
   emitFailureEvent,
   buildAuditCtx,
+  runEntrypoint,
+  EXIT_OK,
+  EXIT_PRECONDITION,
+  EXIT_PARTIAL_FAILURE,
 };

--- a/scripts/force-reindex.js
+++ b/scripts/force-reindex.js
@@ -527,16 +527,18 @@ async function main() {
 }
 
 /**
- * CLI entrypoint の本体。テストから DI で mock 注入して invariant を lock-in する
- * (Issue #387)。defaults は module-scope の関数を参照するため CLI 経由の挙動は不変。
+ * CLI entrypoint の本体。テストから DI で mock 注入して invariant を lock-in する。
+ * defaults は module-scope の関数を参照するため CLI 経由の挙動は不変。
  *
- * 保証する invariant (#386 review I1/I2/I3):
+ * 保証する invariant:
  *   I1: process.exitCode は flushAndCloseLogging 呼び出しより先に設定する
  *       (flush throw でも exit code 反映を保証)
  *   I2: emitFailureEvent も try/catch で包む (FATAL audit log の silent loss 防止)
- *   I3: 初期値は EXIT_PRECONDITION (main() 同期 throw 時の事前検証エラー扱い)
+ *   I3: 初期値 EXIT_PRECONDITION は defensive fallback として保持。現行制御フローでは
+ *       catch 先頭で EXIT_PARTIAL_FAILURE に上書きされるため observable ではないが、
+ *       将来 runMain 呼出前に初期化処理が追加され throw された場合の安全側 default。
  *
- * process.exit() は in-flight gRPC を切断するため使用しない (#384)。
+ * process.exit() は in-flight gRPC を切断するため使用しない。
  * process.exitCode 設定 + Logging client gracefully close により event loop が
  * natural drain し audit 書き込みの完全性を保証する。
  */
@@ -581,7 +583,13 @@ async function runEntrypoint(deps = {}) {
           stack: error?.stack,
         }));
       } catch (stringifyErr) {
+        // stringify throw 時も original error を surface (silent loss 防止)。
+        // projectId 有り分岐の emit catch と対称な二行出力とし、
+        // 最低限 operator が何が起きたか追跡可能にする。
         console.error(`fatal: error stringify failed: ${stringifyErr?.message}`);
+        console.error(
+          `original error: code=${error?.code ?? 'n/a'} message=${error?.message ?? String(error)}`,
+        );
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

- PR #386 (#384 fix) で導入した entrypoint 構造 (try/finally + process.exitCode + flushAndCloseLogging + emitFailureEvent の try/catch 入れ子) を unit test で lock-in
- IIFE を `runEntrypoint(deps)` 関数として切り出して DI 可能化、defaults は module-scope 参照で CLI 挙動不変
- `/review-pr` (6 エージェント) で検出した rating ≥ 7 findings を 2 commit 目で反映済

## 変更内容

| ファイル | 変更 |
|---------|------|
| `scripts/force-reindex.js` | IIFE → `runEntrypoint(deps)` 関数化 + export。projectId 未設定 + stringify throw 時の fallback に original error 出力追加。`EXIT_OK` / `EXIT_PRECONDITION` / `EXIT_PARTIAL_FAILURE` も export。 |
| `functions/test/forceReindexEntrypoint.test.ts` (新規) | 7 シナリオ integration test。`withProcessSandbox` helper で process 副作用を集約。 |

## ロック対象 invariant

| # | invariant | test |
|---|-----------|------|
| I1 | `process.exitCode` は flush 呼び出しより先に設定 (flush throw でも反映) | "flush throw (success 後)" |
| I2 | `emitFailureEvent` も try/catch で包む (FATAL audit log silent loss 防止) | "emitFailureEvent throw" |
| — | main throw + flush throw 複合時の exitCode guard | "main throw + flush throw" |
| — | fallback 経路 (projectId 未設定) の stringify throw 時 original error surface | "projectId 未設定 + stringify throw" |

**I3 (初期値 `EXIT_PRECONDITION`) は defensive fallback として保持のみ** — 現行制御フローでは catch 先頭で `EXIT_PARTIAL_FAILURE` に上書きされるため observable でなく、assertion 対象外。将来 `runMain` 呼出前の初期化処理で throw された場合の安全側 default として保持。

## /simplify quality gate (1 commit 目反映済)

- quality rating 6: `withProcessSandbox` helper で save/restore 重複を集約
- quality rating 6: stringly-typed `'force_reindex_fatal'` / `'CRITICAL'` を `EVENTS.FATAL` / `SEVERITIES.CRITICAL` 参照に変更

## /review-pr findings (2 commit 目反映済)

| rating / conf | 指摘 | agent | 対応 |
|---|---|---|---|
| **8 / 90** | I3 invariant lock-in 不成立 — 初期値 `EXIT_PRECONDITION` が observable でない | code-reviewer | ✅ 文言修正 (defensive fallback として明示) |
| **8 / 85** | main throw + flush throw 複合シナリオ test 欠落 | code-reviewer | ✅ 6 番目シナリオ追加 |
| **7 相当** | projectId 未設定 + stringify throw で original error silent loss | silent-failure-hunter | ✅ fallback に original error 出力 + 7 番目シナリオ追加 |

## 別 Issue / follow-up PR 候補

| rating / conf | 指摘 | 扱い |
|---|---|---|
| 6→7 / 85 | bare `console.error` の EPIPE 耐性 (`_safeWriteStderr` 横展開) | scope 拡大のため別 PR 推奨 |
| 6 / 85 | emitFailure 引数 payload (`.error`, `.auditCtx`) の assertion 不足 | follow-up commit 候補 |
| 5-6 / 70-80 | Issue 番号参照コメント圧縮、JSDoc/inline 重複 | PR コメント扱い (confidence 閾値ギリギリ未満) |

## Test plan

- [x] `npm test` → 812 passing (+7 from main) / 6 pending / 0 failing
- [x] `npm run type-check:test` → pass
- [x] `npm run lint` → 0 errors / 新規ファイルの warning なし
- [x] 7 シナリオ全 pass 確認
  - [x] success path
  - [x] main throw (emitFailure → flush 順)
  - [x] flush throw (success 後) — I1 invariant
  - [x] emitFailureEvent throw — I2 invariant
  - [x] main throw + flush throw 複合 — flush catch guard
  - [x] projectId 未設定 + stringify throw — original error silent loss 防止
  - [x] main throw without FIREBASE_PROJECT_ID — fallback stderr JSON

## 影響

- 機能影響: なし (test 追加 + 構造の export 化 + stderr fallback 強化のみ、本体ロジック変更なし)
- リスク: 低

## 関連

- Closes #387
- PR #386 (#384 本修正) - この PR で lock-in する invariant の由来
- ADR-0015 (search_index silent failure policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)