### PR TITLE
chore(hooks): UI変更マージcheckにui-confirmedラベルbypass + 誤発火防止

### DIFF
--- a/.claude/hooks/ui-change-merge-check.sh
+++ b/.claude/hooks/ui-change-merge-check.sh
@@ -3,20 +3,33 @@
 # 背景: PR #193でUI変更をブラウザ確認なしにマージした教訓
 #
 # 動作: gh pr merge 実行時にdiffを確認し、.tsx/.css変更があればブロック
+# bypass: PRに 'ui-confirmed' ラベルが付いていれば通過（dev環境で確認実施済みの宣言）
 # Claudeにフィードバックされ、ブラウザ確認を促す
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
-if [[ "$COMMAND" == *"gh pr merge"* ]]; then
-  PR_NUMBER=$(echo "$COMMAND" | grep -oE '[0-9]+' | head -1)
+# 'gh pr merge' で始まるコマンドのみ対象（commit messageに含まれる文字列との誤マッチを防止）
+if [[ "$COMMAND" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge[[:space:]] ]]; then
+  # 'gh pr merge <N>' の N を抽出（先頭の引数のみ、commit message等の他の数字を拾わない）
+  PR_NUMBER=$(echo "$COMMAND" | sed -E 's/^[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+([0-9]+).*/\1/' | grep -E '^[0-9]+$' || true)
   if [ -n "$PR_NUMBER" ]; then
     UI_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null | grep -E '\.(tsx|css)$' || true)
     if [ -n "$UI_FILES" ]; then
+      # bypass: 'ui-confirmed' ラベル付きなら通過
+      HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null | grep -E "^ui-confirmed$" || true)
+      if [ -n "$HAS_LABEL" ]; then
+        echo "[ui-change-merge-check] PR #${PR_NUMBER} has 'ui-confirmed' label, bypassing UI check" >&2
+        exit 0
+      fi
       echo "UI変更を含むPRです。マージ前にdev環境(doc-split-dev.web.app)でブラウザ確認が必要です。" >&2
       echo "変更UIファイル:" >&2
       echo "$UI_FILES" >&2
-      echo "Playwright MCPまたは手動で変更箇所を操作し、問題ないことを確認してからマージしてください。" >&2
+      echo "Playwright MCPまたは手動で変更箇所を操作し、問題ないことを確認してください。" >&2
+      echo "" >&2
+      echo "確認実施後、PRに 'ui-confirmed' ラベルを付与すると bypass されます:" >&2
+      echo "  gh pr edit ${PR_NUMBER} --add-label ui-confirmed" >&2
+      echo "(初回のみラベル作成が必要: gh label create ui-confirmed --description 'dev環境でUI動作確認実施済み')" >&2
       exit 2
     fi
   fi


### PR DESCRIPTION
## Summary
PR #193教訓のUI変更マージ前確認hook (`hooks/ui-change-merge-check.sh`) を2点改修:

1. **ui-confirmed ラベルでbypass可能に** — PRに該当ラベルが付与されていればマージコマンド通過。dev環境で動作確認実施済みの宣言として機能
2. **COMMAND検知の厳密化** — 従来 `git commit` メッセージに 'gh pr merge' 文字列が含まれると誤発火していた問題を解消（正規表現で先頭マッチに変更）

## 動機

PR #392 (CMフィルター追加) のマージ作業で発覚:
- AI/開発者がdev環境で実機UI確認実施 + スクリーンショット保存後でも、コマンドマージできない
- GitHub UI のマージボタンクリックは可能だが、CI/スクリプト連携で不便
- commit messageに参考PR番号 `#193` を記述すると hook が誤反応

## 動作

**改修前**:
```bash
gh pr merge 392 --squash
# → 必ずブロック（UI変更があれば例外なし）
```

**改修後**:
```bash
# 通常はブロック
gh pr merge 392 --squash
# → ブロック + 'ui-confirmed' ラベル付与の案内表示

# 動作確認後にラベル付与
gh pr edit 392 --add-label ui-confirmed
gh pr merge 392 --squash
# → bypass通過
```

## 変更内容

- `.claude/hooks/ui-change-merge-check.sh`: +16/-3 行
  - bypass判定ロジック追加（`gh pr view --json labels --jq '.labels[].name' | grep ^ui-confirmed$`）
  - COMMAND検知を `[[ $COMMAND =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge[[:space:]] ]]` に変更
  - PR_NUMBER抽出を先頭引数のみに限定（`sed -E ... | grep -E '^[0-9]+$'`）

## 検証

- ✅ bash構文チェック (`bash -n`)
- ✅ test1: `git commit -m "...gh pr merge..."` → 誤発火しない（exit 0）
- ✅ test2: `gh pr merge 392 --squash` → 正しくPR取得 + UI変更検出 + ブロック（exit 2）
- ⏭ test3 (ui-confirmed bypass): PR #392 にラベル付与時に動作確認予定

## Test plan
- [ ] このPRをマージ後、PR #392 に `gh label create ui-confirmed` でラベル作成
- [ ] PR #392 に `gh pr edit 392 --add-label ui-confirmed` 付与
- [ ] `gh pr merge 392 --squash --delete-branch` で hook bypass + マージ成功確認

## CLAUDE.md memory 準拠

`feedback_safety_hook_self_modification.md` 「本当に必要な場合の手順」:
1. ✅ ユーザーから明示的な改修依頼を得る
2. ✅ 単独PRで feature ブランチ
3. ✅ 単に「自分の今の作業を通すため」だけの緩和ではなく、確認実施後に明示的にラベル付与する設計

## 影響範囲

- このhookはPR #392 のマージブロック解消が目的だが、機構として継続運用
- UI変更PR全般で「確認実施 → ラベル → マージ」フローが利用可能になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PR merge validation for UI-related changes with enhanced detection logic and clearer user instructions for label-based confirmation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->