### PR TITLE
fix(documents): 編集モーダル保存時に customerConfirmed/officeConfirmed フラグ更新 (Closes #396)

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
@@ -192,3 +192,323 @@ describe('useDocumentEdit - careManager自動補完', () => {
     })
   })
 })
+
+// ============================================
+// 確定フラグ更新（Issue #396）
+// ============================================
+// 編集モーダルで顧客名・事業所名を選択して保存したとき、確定フラグ
+// (customerConfirmed/officeConfirmed/needsManualCustomerSelection) を
+// 適切に更新することを検証する。
+
+describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('AC1: 有効な顧客名選択時は customerConfirmed=true を書き込む', () => {
+    it('customerName を有効値に変更 → customerConfirmed=true & needsManualCustomerSelection=false', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.customerConfirmed).toBe(true)
+      expect(updateData.needsManualCustomerSelection).toBe(false)
+    })
+  })
+
+  describe('AC2: 有効な事業所名選択時は officeConfirmed=true + By/At を書き込む', () => {
+    it('officeName を有効値に変更 → officeConfirmed=true & officeConfirmedBy=uid & officeConfirmedAt=serverTimestamp', async () => {
+      const doc = makeDocument({
+        officeName: '未判定',
+        officeConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('officeName', 'ケアサポートきらり'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.officeConfirmed).toBe(true)
+      expect(updateData.officeConfirmedBy).toBe('user-001')
+      expect(updateData.officeConfirmedAt).toBe('SERVER_TIMESTAMP')
+    })
+  })
+
+  describe('AC3: invalid 値選択時はフラグを書き込まない', () => {
+    it.each([
+      ['空文字', ''],
+      ['未判定', '未判定'],
+      ['不明顧客', '不明顧客'],
+    ])('customerName を "%s" に変更 → customerConfirmed が updateData に含まれない', async (_label, invalidValue) => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', invalidValue))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.customerConfirmed).toBeUndefined()
+      expect(updateData.needsManualCustomerSelection).toBeUndefined()
+    })
+
+    it.each([
+      ['空文字', ''],
+      ['未判定', '未判定'],
+      ['不明事業所', '不明事業所'],
+    ])('officeName を "%s" に変更 → officeConfirmed が updateData に含まれない', async (_label, invalidValue) => {
+      const doc = makeDocument({
+        officeName: 'テスト事業所',
+        officeConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('officeName', invalidValue))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.officeConfirmed).toBeUndefined()
+      expect(updateData.officeConfirmedBy).toBeUndefined()
+      expect(updateData.officeConfirmedAt).toBeUndefined()
+    })
+  })
+
+  describe('AC3.5: 既存 confirmed=true を invalid 値で false に戻さない', () => {
+    it('customerConfirmed=true のドキュメントで invalid 値選択 → customerConfirmed が updateData に含まれない', async () => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '未判定'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      // customerConfirmed が updateData に含まれない（false に上書きされない）
+      expect('customerConfirmed' in updateData).toBe(false)
+    })
+
+    it('officeConfirmed=true のドキュメントで invalid 値選択 → officeConfirmed/By/At が updateData に含まれない', async () => {
+      const doc = makeDocument({
+        officeName: 'テスト事業所',
+        officeConfirmed: true,
+        officeConfirmedBy: 'previous-user',
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('officeName', '未判定'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect('officeConfirmed' in updateData).toBe(false)
+      expect('officeConfirmedBy' in updateData).toBe(false)
+      expect('officeConfirmedAt' in updateData).toBe(false)
+    })
+  })
+
+  describe('AC4: 既に両方 confirmed=true で変更なし保存 → updateDoc 呼ばない', () => {
+    it('両方 confirmed=true、編集モードを開いて何も変更せず保存 → updateDoc 呼ばれない', async () => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: true,
+        officeName: 'テスト事業所',
+        officeConfirmed: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      // 何も変更しない
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      expect(mockUpdateDoc).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('AC5: customerConfirmed=false で変更なし保存（現在値が有効）→ confirmed のみ書き込み', () => {
+    it('既存 needsManualCustomerSelection=true のドキュメント、変更なし保存 → customerConfirmed=true & needsManualCustomerSelection=false', async () => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,  // 既存値あり → 同期更新対象
+        officeName: 'テスト事業所',
+        officeConfirmed: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      expect(mockUpdateDoc).toHaveBeenCalledTimes(1)
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.customerConfirmed).toBe(true)
+      expect(updateData.needsManualCustomerSelection).toBe(false)
+      expect('officeConfirmed' in updateData).toBe(false)
+      expect(mockAddDoc).not.toHaveBeenCalled()
+    })
+
+    it('needsManualCustomerSelection=undefined のドキュメント、変更なし保存 → customerConfirmed=true のみ書き込み（needsManualCustomerSelection は新規作成しない）', async () => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: false,
+        // needsManualCustomerSelection: undefined（明示しない）
+        officeName: 'テスト事業所',
+        officeConfirmed: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      expect(mockUpdateDoc).toHaveBeenCalledTimes(1)
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.customerConfirmed).toBe(true)
+      // 新規フィールドを生成しない（不要な書き込みを避ける）
+      expect('needsManualCustomerSelection' in updateData).toBe(false)
+    })
+  })
+
+  describe('AC8: Firestore 書き込み失敗時、確定フラグもロールバックされる', () => {
+    it('customerConfirmed のロールバック: write 失敗 → optimisticData の true を元の false に復元', async () => {
+      mockUpdateDoc.mockRejectedValueOnce(new Error('write failed'))
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const { updateDocumentInListCache } = await import('../useDocuments')
+      const calls = vi.mocked(updateDocumentInListCache).mock.calls
+      // 楽観的更新 + ロールバックで 2 回呼ばれる
+      expect(calls.length).toBe(2)
+      const rollbackData = calls[1]?.[2] as Record<string, unknown>
+      expect(rollbackData.customerConfirmed).toBe(false)
+      expect(rollbackData.needsManualCustomerSelection).toBe(true)
+    })
+
+    it('officeConfirmed のロールバック: write 失敗 → optimisticData の true/By/At を元の値に復元', async () => {
+      mockUpdateDoc.mockRejectedValueOnce(new Error('write failed'))
+      const doc = makeDocument({
+        officeName: '未判定',
+        officeConfirmed: false,
+        officeConfirmedBy: null,
+        officeConfirmedAt: null,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('officeName', 'ケアサポートきらり'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const { updateDocumentInListCache } = await import('../useDocuments')
+      const calls = vi.mocked(updateDocumentInListCache).mock.calls
+      expect(calls.length).toBe(2)
+      const rollbackData = calls[1]?.[2] as Record<string, unknown>
+      expect(rollbackData.officeConfirmed).toBe(false)
+      expect(rollbackData.officeConfirmedBy).toBeNull()
+      expect(rollbackData.officeConfirmedAt).toBeNull()
+    })
+  })
+
+  describe('AC5.5: optimisticData にも confirmed フラグを反映', () => {
+    it('AC1 実行時、updateDocumentInListCache に customerConfirmed=true が渡される', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const { updateDocumentInListCache } = await import('../useDocuments')
+      const calls = vi.mocked(updateDocumentInListCache).mock.calls
+      expect(calls.length).toBeGreaterThanOrEqual(1)
+      const optimistic = calls[0]?.[2] as Record<string, unknown>
+      expect(optimistic.customerConfirmed).toBe(true)
+      expect(optimistic.needsManualCustomerSelection).toBe(false)
+    })
+
+    it('AC2 実行時、updateDocumentInListCache に officeConfirmed=true & officeConfirmedBy & officeConfirmedAt が渡される', async () => {
+      const doc = makeDocument({
+        officeName: '未判定',
+        officeConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('officeName', 'ケアサポートきらり'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const { updateDocumentInListCache } = await import('../useDocuments')
+      const calls = vi.mocked(updateDocumentInListCache).mock.calls
+      expect(calls.length).toBeGreaterThanOrEqual(1)
+      const optimistic = calls[0]?.[2] as Record<string, unknown>
+      expect(optimistic.officeConfirmed).toBe(true)
+      expect(optimistic.officeConfirmedBy).toBe('user-001')
+      // optimisticData は Timestamp.now() を使う（serverTimestamp はサーバー側のみ）
+      expect(optimistic.officeConfirmedAt).toBeInstanceOf(Timestamp)
+    })
+  })
+})

--- a/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
@@ -199,6 +199,19 @@ describe('useDocumentEdit - careManager自動補完', () => {
 // 編集モーダルで顧客名・事業所名を選択して保存したとき、確定フラグ
 // (customerConfirmed/officeConfirmed/needsManualCustomerSelection) を
 // 適切に更新することを検証する。
+//
+// Acceptance Criteria（PR #397 で定義）:
+// - AC1:   有効な顧客名選択 → customerConfirmed=true & needsManualCustomerSelection=false
+// - AC2:   有効な事業所名選択 → officeConfirmed=true + officeConfirmedBy=uid + officeConfirmedAt
+// - AC3:   invalid sentinel 選択 → 確定フラグを書き込まない
+// - AC3.5: 既存 confirmed=true を invalid 値で false に上書きしない（regression 防止）
+// - AC4:   既に両方 confirmed=true & 変更なし保存 → updateDoc/cache 更新/監査ログ全て呼ばれない
+// - AC5:   confirmed=false の有効ドキュメント、変更なし保存 → 確定フラグのみ書き込み
+// - AC5.5: optimisticData にも確定フラグを反映
+// - AC6/7: dev 環境ホーム画面/編集モーダルの目視確認（テスト対象外、PR Test plan 参照）
+// - AC8:   Firestore 書き込み失敗時、optimistic で立てた確定フラグをロールバック
+// - AC9:   invalid 値・downgrade attempt の挙動 pin（review-pr 指摘 T2/T3/T4 対応）
+// - AC10:  rollback 対称性 — optimistic で書き込んだ全 key が rollback で復元される（drift 防止）
 
 describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
   beforeEach(() => {
@@ -341,7 +354,7 @@ describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
   })
 
   describe('AC4: 既に両方 confirmed=true で変更なし保存 → updateDoc 呼ばない', () => {
-    it('両方 confirmed=true、編集モードを開いて何も変更せず保存 → updateDoc 呼ばれない', async () => {
+    it('両方 confirmed=true、編集モードを開いて何も変更せず保存 → updateDoc/cache/監査ログ全て呼ばれない', async () => {
       const doc = makeDocument({
         customerName: '田村 勝義',
         customerConfirmed: true,
@@ -351,13 +364,16 @@ describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
       const { result } = renderHook(() => useDocumentEdit(doc))
 
       act(() => result.current.startEditing())
-      // 何も変更しない
 
       await act(async () => {
         await result.current.saveChanges()
       })
 
+      // early-return が cache 更新前に走っていることを保証（AC4 強化、review-pr T1）
       expect(mockUpdateDoc).not.toHaveBeenCalled()
+      expect(mockAddDoc).not.toHaveBeenCalled()
+      const { updateDocumentInListCache } = await import('../useDocuments')
+      expect(updateDocumentInListCache).not.toHaveBeenCalled()
     })
   })
 
@@ -509,6 +525,128 @@ describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
       expect(optimistic.officeConfirmedBy).toBe('user-001')
       // optimisticData は Timestamp.now() を使う（serverTimestamp はサーバー側のみ）
       expect(optimistic.officeConfirmedAt).toBeInstanceOf(Timestamp)
+    })
+  })
+
+  describe('AC9: invalid 値・downgrade attempt の挙動 pin', () => {
+    it('whitespace-only 入力（空白3つ）で保存 → customerName は trim せず書き込み、確定フラグは立てない', async () => {
+      // ユーザーが半角空白のみ入力したケース。isValidCustomerSelection は trim 後判定で
+      // false を返すため確定フラグは立たない一方、customerName 自体は editedFields の値が
+      // そのまま書き込まれる（既存の挙動 = MasterSelectField から空白文字列が来ても許容）。
+      // 将来この挙動を変える場合（例: バリデーションで弾く）、このテストが先に落ちて意図が伝わる。
+      const doc = makeDocument({
+        customerName: '河野 文江',
+        customerConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '   '))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.customerName).toBe('   ')
+      expect('customerConfirmed' in updateData).toBe(false)
+    })
+
+    it('混合変更: documentType 変更 + customerName を未判定に → customerName 書き込み + customerConfirmed は立てない', async () => {
+      // 他フィールドの変更と invalid sentinel 選択が同時に発生するケース。
+      // changes.length > 0 で updateDoc は呼ばれるが、customerConfirmed フラグは
+      // invalid 値のため書き込まれない。
+      const doc = makeDocument({
+        customerName: '河野 文江',
+        customerConfirmed: false,
+        documentType: '請求書',
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('documentType', '実績'))
+      act(() => result.current.updateField('customerName', '未判定'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.documentType).toBe('実績')
+      expect(updateData.customerName).toBe('未判定')
+      expect('customerConfirmed' in updateData).toBe(false)
+    })
+
+    it('downgrade attempt: customerConfirmed=false + 名前を未判定に変更 → customerName 書き込み・確定フラグ立てない', async () => {
+      // 既に customerConfirmed=false のドキュメントで invalid 値を選ぶケース。
+      // customerName 自体は書き込まれるが、確定フラグは false のままで上書きしない。
+      const doc = makeDocument({
+        customerName: '河野 文江',
+        customerConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '未判定'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(updateData.customerName).toBe('未判定')
+      expect('customerConfirmed' in updateData).toBe(false)
+      expect('needsManualCustomerSelection' in updateData).toBe(false)
+    })
+  })
+
+  describe('AC10: rollback 対称性 — optimistic で書き込んだ確定フラグ全 key が rollback で復元される', () => {
+    // review-pr S2 (rollback drift-prone) 対応。
+    // 次に確定フラグが追加されたとき、optimistic に書いて rollback に追加し忘れる
+    // ケースを検出するための「対称性テスト」。AC8 がフラグ値を検証するのに対し、
+    // ここでは optimistic で書いた key 集合 ⊆ rollback で復元した key 集合 を保証する。
+    it('write 失敗時、optimistic 側で書いた確定フラグ key 全てが rollback の対象に含まれる', async () => {
+      mockUpdateDoc.mockRejectedValueOnce(new Error('write failed'))
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,
+        officeName: '未判定',
+        officeConfirmed: false,
+        officeConfirmedBy: null,
+        officeConfirmedAt: null,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+      act(() => result.current.updateField('officeName', 'ケアサポートきらり'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const { updateDocumentInListCache } = await import('../useDocuments')
+      const calls = vi.mocked(updateDocumentInListCache).mock.calls
+      expect(calls.length).toBe(2)
+      const optimisticData = calls[0]?.[2] as Record<string, unknown>
+      const rollbackData = calls[1]?.[2] as Record<string, unknown>
+
+      // 確定フラグ系の key を抽出（他フィールドの差分は AC8 / 既存テストでカバー済み）
+      const confirmedFlagKeys = [
+        'customerConfirmed',
+        'needsManualCustomerSelection',
+        'officeConfirmed',
+        'officeConfirmedBy',
+        'officeConfirmedAt',
+      ]
+      const optimisticFlagKeys = confirmedFlagKeys.filter((k) => k in optimisticData)
+      const rollbackFlagKeys = confirmedFlagKeys.filter((k) => k in rollbackData)
+
+      // optimistic で書いた確定フラグ key は全て rollback でも復元対象になっていること
+      expect(optimisticFlagKeys.sort()).toEqual(rollbackFlagKeys.sort())
+      // 念のため空集合でないことも確認（optimistic 自体が機能しているか）
+      expect(optimisticFlagKeys.length).toBeGreaterThan(0)
     })
   })
 })

--- a/frontend/src/hooks/useDocumentEdit.ts
+++ b/frontend/src/hooks/useDocumentEdit.ts
@@ -3,6 +3,7 @@ import { doc, updateDoc, collection, addDoc, serverTimestamp, Timestamp, deleteF
 import { useQueryClient } from '@tanstack/react-query'
 import { db, auth } from '../lib/firebase'
 import { updateDocumentInListCache } from './useDocuments'
+import { isValidCustomerSelection, isValidOfficeSelection } from '../lib/documentUtils'
 import { generateDisplayFileName } from '@shared/generateDisplayFileName'
 import type { Document } from '../../../shared/types'
 
@@ -160,7 +161,19 @@ export function useDocumentEdit(document: Document | null | undefined): UseDocum
         })
       }
 
-      if (changes.length === 0) {
+      // 確定フラグの判定（Issue #396）
+      // 「保存=確定」操作として、有効な顧客名/事業所名が現在値（編集後）に
+      // セットされていて、かつ既存 confirmed が true でない場合に true を立てる。
+      // invalid 値（空・「未判定」等）の場合や既に true の場合は updateData に含めず、
+      // 既存値を上書きしない（false への退行を防ぐ）。
+      const finalCustomerName = editedFields.customerName ?? document.customerName ?? ''
+      const finalOfficeName = editedFields.officeName ?? document.officeName ?? ''
+      const shouldSetCustomerConfirmed =
+        isValidCustomerSelection(finalCustomerName) && document.customerConfirmed !== true
+      const shouldSetOfficeConfirmed =
+        isValidOfficeSelection(finalOfficeName) && document.officeConfirmed !== true
+
+      if (changes.length === 0 && !shouldSetCustomerConfirmed && !shouldSetOfficeConfirmed) {
         setIsEditing(false)
         return true
       }
@@ -174,6 +187,28 @@ export function useDocumentEdit(document: Document | null | undefined): UseDocum
 
       // キャッシュ楽観的更新用データ（serverTimestampはクライアント値で代替）
       const optimisticData: Partial<Document> = {}
+
+      // 確定フラグの書き込み
+      // needsManualCustomerSelection はレガシーフォールバック。既存ドキュメントに値が
+      // 存在する場合のみ false に同期更新し、undefined のドキュメントには書き込まない
+      // （customerConfirmed=true で判定優先されるため、新規フィールド作成を避ける）。
+      if (shouldSetCustomerConfirmed) {
+        updateData.customerConfirmed = true
+        optimisticData.customerConfirmed = true
+        if (document.needsManualCustomerSelection !== undefined) {
+          updateData.needsManualCustomerSelection = false
+          optimisticData.needsManualCustomerSelection = false
+        }
+      }
+      // optimisticData は serverTimestamp が使えないため Timestamp.now() で代替。
+      if (shouldSetOfficeConfirmed) {
+        updateData.officeConfirmed = true
+        updateData.officeConfirmedBy = auth.currentUser.uid
+        updateData.officeConfirmedAt = serverTimestamp()
+        optimisticData.officeConfirmed = true
+        optimisticData.officeConfirmedBy = auth.currentUser.uid
+        optimisticData.officeConfirmedAt = Timestamp.now()
+      }
 
       // 変更されたフィールドを追加
       if (editedFields.customerName !== undefined) {
@@ -291,6 +326,18 @@ export function useDocumentEdit(document: Document | null | undefined): UseDocum
         }
         if (editedFields.fileName !== undefined) rollbackData.fileName = document.fileName
         if (editedFields.fileDate !== undefined) rollbackData.fileDate = document.fileDate
+        // 確定フラグもロールバック対象（楽観的更新で立てた値を元に戻す）
+        if (shouldSetCustomerConfirmed) {
+          rollbackData.customerConfirmed = document.customerConfirmed
+          if (document.needsManualCustomerSelection !== undefined) {
+            rollbackData.needsManualCustomerSelection = document.needsManualCustomerSelection
+          }
+        }
+        if (shouldSetOfficeConfirmed) {
+          rollbackData.officeConfirmed = document.officeConfirmed
+          rollbackData.officeConfirmedBy = document.officeConfirmedBy
+          rollbackData.officeConfirmedAt = document.officeConfirmedAt
+        }
         updateDocumentInListCache(queryClient, document.id, rollbackData)
         throw writeErr
       }

--- a/frontend/src/lib/__tests__/documentUtils.test.ts
+++ b/frontend/src/lib/__tests__/documentUtils.test.ts
@@ -1,0 +1,82 @@
+/**
+ * documentUtils テスト
+ *
+ * 顧客名・事業所名の有効性判定 (isValidCustomerSelection / isValidOfficeSelection) は
+ * useDocumentEdit.saveChanges で「保存=確定」操作時に確定フラグを立てるか判定するために使用される。
+ * Sentinel 値（'未判定'/'不明顧客'/'不明事業所'）を invalid 扱いし、空文字・null・undefined・
+ * 空白のみ文字列も invalid とする。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isValidCustomerSelection, isValidOfficeSelection } from '../documentUtils';
+
+describe('isValidCustomerSelection', () => {
+  describe('invalid 値（フラグを立てない）', () => {
+    it.each([
+      ['空文字', ''],
+      ['空白のみ', '   '],
+      ['タブ・改行のみ', '\t\n '],
+      ['「未判定」sentinel', '未判定'],
+      ['「不明顧客」sentinel', '不明顧客'],
+      ['前後空白付き「未判定」', '  未判定  '],
+    ])('"%s" は false を返す', (_label, input) => {
+      expect(isValidCustomerSelection(input)).toBe(false);
+    });
+
+    it('null は false を返す', () => {
+      expect(isValidCustomerSelection(null)).toBe(false);
+    });
+
+    it('undefined は false を返す', () => {
+      expect(isValidCustomerSelection(undefined)).toBe(false);
+    });
+  });
+
+  describe('valid 値（確定フラグを立てる）', () => {
+    it.each([
+      ['通常の顧客名', '河野 文江'],
+      ['英数字混在', 'Customer A'],
+      ['前後空白付き有効値', '  河野 文江  '],
+      ['事業所形式の文字列でも顧客名としては有効', 'ケアサポートきらり'],
+    ])('"%s" は true を返す', (_label, input) => {
+      expect(isValidCustomerSelection(input)).toBe(true);
+    });
+  });
+});
+
+describe('isValidOfficeSelection', () => {
+  describe('invalid 値（フラグを立てない）', () => {
+    it.each([
+      ['空文字', ''],
+      ['空白のみ', '   '],
+      ['「未判定」sentinel', '未判定'],
+      ['「不明事業所」sentinel', '不明事業所'],
+      ['前後空白付き「不明事業所」', '  不明事業所  '],
+    ])('"%s" は false を返す', (_label, input) => {
+      expect(isValidOfficeSelection(input)).toBe(false);
+    });
+
+    it('null は false を返す', () => {
+      expect(isValidOfficeSelection(null)).toBe(false);
+    });
+
+    it('undefined は false を返す', () => {
+      expect(isValidOfficeSelection(undefined)).toBe(false);
+    });
+
+    it('「不明顧客」は事業所判定では invalid 扱いしない（顧客側 sentinel のため）', () => {
+      // 防御的だが、事業所側 sentinel のみが対象であることを明示するためのテスト
+      expect(isValidOfficeSelection('不明顧客')).toBe(true);
+    });
+  });
+
+  describe('valid 値（確定フラグを立てる）', () => {
+    it.each([
+      ['通常の事業所名', 'ケアサポートきらり'],
+      ['法人形式', '株式会社サンプル'],
+      ['前後空白付き有効値', '  ケアサポートきらり  '],
+    ])('"%s" は true を返す', (_label, input) => {
+      expect(isValidOfficeSelection(input)).toBe(true);
+    });
+  });
+});

--- a/frontend/src/lib/documentUtils.ts
+++ b/frontend/src/lib/documentUtils.ts
@@ -61,3 +61,35 @@ export function formatTimestamp(
     return '-';
   }
 }
+
+// ============================================
+// 顧客名・事業所名の有効性判定
+// ============================================
+// 編集モーダル保存時に「選択確定フラグ」(customerConfirmed/officeConfirmed) を
+// true にするか判定するために使用する。Sentinel 値（'未判定'/'不明顧客'/'不明事業所'）
+// は OCR 失敗・未判定状態を示すため、選択として無効扱いにする。
+
+const CUSTOMER_INVALID_SENTINELS: ReadonlySet<string> = new Set(['未判定', '不明顧客']);
+const OFFICE_INVALID_SENTINELS: ReadonlySet<string> = new Set(['未判定', '不明事業所']);
+
+/**
+ * 顧客名が「確定可能な有効値」かを判定する。
+ * 空文字・null・undefined・空白のみ・sentinel 値（'未判定'/'不明顧客'）は false を返す。
+ */
+export function isValidCustomerSelection(name: string | null | undefined): boolean {
+  if (name == null) return false;
+  const trimmed = name.trim();
+  if (trimmed === '') return false;
+  return !CUSTOMER_INVALID_SENTINELS.has(trimmed);
+}
+
+/**
+ * 事業所名が「確定可能な有効値」かを判定する。
+ * 空文字・null・undefined・空白のみ・sentinel 値（'未判定'/'不明事業所'）は false を返す。
+ */
+export function isValidOfficeSelection(name: string | null | undefined): boolean {
+  if (name == null) return false;
+  const trimmed = name.trim();
+  if (trimmed === '') return false;
+  return !OFFICE_INVALID_SENTINELS.has(trimmed);
+}


### PR DESCRIPTION
## Summary

- 編集モーダルで顧客名・事業所名を選択して保存しても、確定フラグ (`customerConfirmed`/`officeConfirmed`/`needsManualCustomerSelection`) が Firestore に書き込まれず、ホーム画面の「選択待ち」と候補警告が消えなかったバグを修正
- Phase 7 で `customerConfirmed` フィールド導入時、編集パス (`useDocumentEdit.saveChanges`) への追従が漏れていたのが原因
- `isValidCustomerSelection` / `isValidOfficeSelection` ヘルパーを `frontend/src/lib/documentUtils.ts` に追加して保守性確保

## 背景

kanameone 環境のユーザーから 2026-04-27 に報告（Issue #396）。Codex セカンドオピニオンで方針 A（クライアント側 saveChanges 修正）を採用。`/simplify` でロールバック漏れ・無駄なフィールド書き込みを修正、`/safe-refactor` で型安全性・副作用順序を最終確認済み。

## 変更ファイル

| ファイル | 変更 | 行 |
|---------|------|----|
| `frontend/src/lib/documentUtils.ts` | `isValidCustomerSelection` / `isValidOfficeSelection` 追加 | +32 |
| `frontend/src/lib/__tests__/documentUtils.test.ts` | 新規 23 テスト | +新規 |
| `frontend/src/hooks/useDocumentEdit.ts` | `saveChanges` に確定フラグ書き込み + ロールバック対応 | +49 / -1 |
| `frontend/src/hooks/__tests__/useDocumentEdit.test.ts` | 17 テスト追加 (AC1-AC5.5, AC8) | +320 |

## 修正方針

1. 有効な顧客名選択時 → `customerConfirmed: true`（`needsManualCustomerSelection` は既存値が定義済みのときのみ `false` に同期更新、新規フィールド作成回避）
2. 有効な事業所名選択時 → `officeConfirmed: true` + `officeConfirmedBy: uid` + `officeConfirmedAt: serverTimestamp()`
3. invalid 値（空・`'未判定'`/`'不明顧客'`/`'不明事業所'`）や既に `true` の場合は updateData に含めない（false への退行を防ぐ）
4. 「変更なし保存」も「ユーザーの確定意思」として扱い、現在値が有効なら確定
5. 楽観的更新 (`optimisticData`) にも確定フラグを反映（`Timestamp.now()` で代替）
6. Firestore 書き込み失敗時のロールバック処理を確定フラグ対応に拡張

## Acceptance Criteria（自動検証済み）

- [x] AC1: 顧客選択保存 → `customerConfirmed=true` & `needsManualCustomerSelection=false` 書き込み
- [x] AC2: 事業所選択保存 → `officeConfirmed=true` & `officeConfirmedBy=uid` & `officeConfirmedAt=Timestamp` 書き込み
- [x] AC3: invalid 値選択時はフラグ書き込まない（顧客 3 ケース + 事業所 3 ケース）
- [x] AC3.5: 既存 `confirmed=true` を invalid 値で false に戻さない
- [x] AC4: 既に両方 confirmed=true で変更なし保存 → updateDoc 呼ばない
- [x] AC5: `customerConfirmed=false` で変更なし保存（現在値有効）→ confirmed のみ書き込み
  - [x] 既存 `needsManualCustomerSelection=true` のケース
  - [x] `needsManualCustomerSelection=undefined` のケース（新規フィールド作成しない）
- [x] AC5.5: `optimisticData` にも confirmed フラグ反映
- [x] AC8: Firestore 書き込み失敗時、`customerConfirmed`/`officeConfirmed`/`By`/`At`/`needsManualCustomerSelection` がロールバックされる

## Test plan

### 自動検証（マージ前に CI で実行）
- [x] `cd frontend && npm test` → 170/170 passed
- [x] `cd frontend && npm run typecheck` → exit 0
- [x] `cd frontend && npm run lint` → exit 0
- [x] `cd frontend && npm run build` → exit 0

### dev 環境動作確認（マージ後・自動デプロイ後に実施）
- [ ] AC6: dev (`https://doc-split-dev.web.app`) で「選択待ち」状態のドキュメントを編集 → 顧客名/事業所名選択 → 保存 → ホーム画面のバッジが「選択待ち」→「完了」(緑) に切り替わる
- [ ] AC7: 編集モーダル内の「○件の候補があります」警告が確定後の表示で消える
- [ ] AC4 確認: 既に確定済みドキュメントを編集モードで開いて何も変更せず保存 → Firestore に余計な書き込みが発生しない（Network タブで updateDoc 呼出なし）

### 本番展開（dev 確認後・kanameone への展開後に実施）
- [ ] kanameone (`https://doc-split-kanameone.web.app` 等) で同症状ドキュメントを編集 → AC6/AC7 と同等の挙動を確認
- [ ] cocoro 環境でも同様確認
- [ ] kanameone ユーザー（報告者）に再現テスト依頼

## 既知の見送り項目（別 PR 候補）

`/simplify` レビューで挙がったが今回スコープ外として見送り：
- Sentinel (`'未判定'` 等) の `export` と DocumentDetailModal/MasterSelectField/ExtractionInfoPopover への伝播（重複の解消）
- `saveChanges` 関数全体のリファクタリング（既存の 285 行を機能別関数に分割）

## 関連

- Issue: #396
- Phase 7 customerConfirmed 導入: PR #178 / #273 系列
- Codex thread: `019dcbba-7ca2-7580-837c-eff14ba37454`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced document editing with automatic validation and confirmation tracking for customer and office selections. Confirmation states are now properly managed, tracked, and persisted throughout the save workflow. If save operations fail, prior confirmation states are reliably restored to ensure complete data consistency and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->