### PR TITLE
feat(observability): 確定フラグ書き込みを editLogs に記録（#398）

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
@@ -455,7 +455,8 @@ describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
       expect(updateData.customerConfirmed).toBe(true)
       expect(updateData.needsManualCustomerSelection).toBe(false)
       expect('officeConfirmed' in updateData).toBe(false)
-      expect(mockAddDoc).not.toHaveBeenCalled()
+      // #398: 確定フラグ変更は editLogs に記録される（customerConfirmed + needsManualCustomerSelection の2件）
+      expect(mockAddDoc).toHaveBeenCalledTimes(2)
     })
 
     it('needsManualCustomerSelection=undefined のドキュメント、変更なし保存 → customerConfirmed=true のみ書き込み（needsManualCustomerSelection は新規作成しない）', async () => {
@@ -703,6 +704,214 @@ describe('useDocumentEdit - 確定フラグ更新 (#396)', () => {
       expect(optimisticFlagKeys.sort()).toEqual(rollbackFlagKeys.sort())
       // 念のため空集合でないことも確認（optimistic 自体が機能しているか）
       expect(optimisticFlagKeys.length).toBeGreaterThan(0)
+    })
+  })
+})
+
+// =================================================================
+// #398: 確定フラグ書き込みを editLogs に記録（#396 follow-up）
+// =================================================================
+//
+// 背景: PR #397 (Closes #396) で saveChanges に customerConfirmed /
+// officeConfirmed / needsManualCustomerSelection の書き込みを追加したが、
+// これらの確定フラグ変更は editLogs に記録されていなかった。
+// silent-failure-hunter HIGH 指摘: 同じバグが再発しても気づけない。
+//
+// 本ブロックでは、確定フラグの遷移が editLogs に監査ログとして記録される
+// ことを担保する（既存の addDoc(editLogsRef) ループに乗せる）。
+
+describe('useDocumentEdit - 確定フラグ editLogs 記録 (#398)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const findLog = (fieldName: string) => {
+    const calls = mockAddDoc.mock.calls
+    return calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.fieldName === fieldName
+    ) as unknown[] | undefined
+  }
+
+  describe('AC1: customerConfirmed=true 書き込み時に editLogs エントリ作成', () => {
+    it('既存 customerConfirmed=false → true 遷移で editLogs に oldValue:"false", newValue:"true" を記録', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const log = findLog('customerConfirmed')
+      expect(log).toBeDefined()
+      const payload = log![1] as Record<string, unknown>
+      expect(payload.oldValue).toBe('false')
+      expect(payload.newValue).toBe('true')
+      expect(payload.documentId).toBe(doc.id)
+    })
+
+    it('既存 customerConfirmed=undefined → true 遷移で editLogs に oldValue:null, newValue:"true" を記録', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: undefined,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const log = findLog('customerConfirmed')
+      expect(log).toBeDefined()
+      const payload = log![1] as Record<string, unknown>
+      expect(payload.oldValue).toBeNull()
+      expect(payload.newValue).toBe('true')
+    })
+  })
+
+  describe('AC2: officeConfirmed=true 書き込み時に editLogs エントリ作成', () => {
+    it('既存 officeConfirmed=false → true 遷移で editLogs に oldValue:"false", newValue:"true" を記録', async () => {
+      const doc = makeDocument({
+        officeName: '未判定',
+        officeConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('officeName', 'ケアサポートきらり'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const log = findLog('officeConfirmed')
+      expect(log).toBeDefined()
+      const payload = log![1] as Record<string, unknown>
+      expect(payload.oldValue).toBe('false')
+      expect(payload.newValue).toBe('true')
+    })
+  })
+
+  describe('AC3: 確定フラグが書き込まれないケースでは editLogs エントリ未作成', () => {
+    it('既に customerConfirmed=true のドキュメントで invalid 値選択 → editLogs に customerConfirmed エントリなし', async () => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '未判定'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      // customerConfirmed の editLogs エントリは作成されない（書き込み自体スキップ）
+      expect(findLog('customerConfirmed')).toBeUndefined()
+    })
+
+    it('invalid 値（"未判定"）に変更 → editLogs に customerConfirmed エントリなし', async () => {
+      const doc = makeDocument({
+        customerName: '田村 勝義',
+        customerConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '未判定'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      expect(findLog('customerConfirmed')).toBeUndefined()
+    })
+  })
+
+  describe('AC4: 混合変更で customerName と customerConfirmed が並列に記録', () => {
+    it('customerName 変更 + customerConfirmed=false→true → editLogs に両エントリが含まれる', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      // customerName エントリ
+      const nameLog = findLog('customerName')
+      expect(nameLog).toBeDefined()
+      const namePayload = nameLog![1] as Record<string, unknown>
+      expect(namePayload.oldValue).toBe('未判定')
+      expect(namePayload.newValue).toBe('河野 文江')
+
+      // customerConfirmed エントリ（同じ documentId に対して並列記録）
+      const confirmedLog = findLog('customerConfirmed')
+      expect(confirmedLog).toBeDefined()
+      const confirmedPayload = confirmedLog![1] as Record<string, unknown>
+      expect(confirmedPayload.documentId).toBe(doc.id)
+      expect(confirmedPayload.oldValue).toBe('false')
+      expect(confirmedPayload.newValue).toBe('true')
+    })
+  })
+
+  describe('AC5: needsManualCustomerSelection の独立 editLogs エントリ', () => {
+    it('既存 needsManualCustomerSelection=true → false 遷移で独立エントリ記録', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: true,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const log = findLog('needsManualCustomerSelection')
+      expect(log).toBeDefined()
+      const payload = log![1] as Record<string, unknown>
+      expect(payload.oldValue).toBe('true')
+      expect(payload.newValue).toBe('false')
+    })
+
+    it('needsManualCustomerSelection=undefined のドキュメント → editLogs に当該エントリなし（書き込み自体スキップ）', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: undefined,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      // customerConfirmed は記録される
+      expect(findLog('customerConfirmed')).toBeDefined()
+      // needsManualCustomerSelection は undefined のため書き込みスキップ → editLogs エントリも未作成
+      expect(findLog('needsManualCustomerSelection')).toBeUndefined()
     })
   })
 })

--- a/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
@@ -913,5 +913,31 @@ describe('useDocumentEdit - 確定フラグ editLogs 記録 (#398)', () => {
       // needsManualCustomerSelection は undefined のため書き込みスキップ → editLogs エントリも未作成
       expect(findLog('needsManualCustomerSelection')).toBeUndefined()
     })
+
+    // CodeRabbit 指摘2: needsManualCustomerSelection=false のドキュメントで no-op 監査ログを避ける
+    it('needsManualCustomerSelection=false のドキュメント → editLogs に当該エントリなし（false→false の no-op 防止）', async () => {
+      const doc = makeDocument({
+        customerName: '未判定',
+        customerConfirmed: false,
+        needsManualCustomerSelection: false,
+      })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '河野 文江'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      // customerConfirmed は記録される
+      expect(findLog('customerConfirmed')).toBeDefined()
+      // needsManualCustomerSelection は false のため書き込み・記録ともスキップ（no-op エントリ防止）
+      expect(findLog('needsManualCustomerSelection')).toBeUndefined()
+
+      // updateData にも needsManualCustomerSelection が含まれないこと（Firestore write 削減）
+      const updateData = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>
+      expect('needsManualCustomerSelection' in updateData).toBe(false)
+    })
   })
 })

--- a/frontend/src/hooks/useDocumentEdit.ts
+++ b/frontend/src/hooks/useDocumentEdit.ts
@@ -201,12 +201,12 @@ export function useDocumentEdit(document: Document | null | undefined): UseDocum
           oldValue: document.customerConfirmed === undefined ? null : String(document.customerConfirmed),
           newValue: 'true',
         })
-        if (document.needsManualCustomerSelection !== undefined) {
+        if (document.needsManualCustomerSelection === true) {
           updateData.needsManualCustomerSelection = false
           optimisticData.needsManualCustomerSelection = false
           changes.push({
             field: 'needsManualCustomerSelection',
-            oldValue: String(document.needsManualCustomerSelection),
+            oldValue: 'true',
             newValue: 'false',
           })
         }

--- a/frontend/src/hooks/useDocumentEdit.ts
+++ b/frontend/src/hooks/useDocumentEdit.ts
@@ -195,9 +195,20 @@ export function useDocumentEdit(document: Document | null | undefined): UseDocum
       if (shouldSetCustomerConfirmed) {
         updateData.customerConfirmed = true
         optimisticData.customerConfirmed = true
+        // #398: 確定フラグ変更を editLogs に記録（silent failure 検知用）
+        changes.push({
+          field: 'customerConfirmed',
+          oldValue: document.customerConfirmed === undefined ? null : String(document.customerConfirmed),
+          newValue: 'true',
+        })
         if (document.needsManualCustomerSelection !== undefined) {
           updateData.needsManualCustomerSelection = false
           optimisticData.needsManualCustomerSelection = false
+          changes.push({
+            field: 'needsManualCustomerSelection',
+            oldValue: String(document.needsManualCustomerSelection),
+            newValue: 'false',
+          })
         }
       }
       // optimisticData は serverTimestamp が使えないため Timestamp.now() で代替。
@@ -208,6 +219,11 @@ export function useDocumentEdit(document: Document | null | undefined): UseDocum
         optimisticData.officeConfirmed = true
         optimisticData.officeConfirmedBy = auth.currentUser.uid
         optimisticData.officeConfirmedAt = Timestamp.now()
+        changes.push({
+          field: 'officeConfirmed',
+          oldValue: document.officeConfirmed === undefined ? null : String(document.officeConfirmed),
+          newValue: 'true',
+        })
       }
 
       // 変更されたフィールドを追加


### PR DESCRIPTION
## Summary

- PR #397 (Closes #396) で追加した確定フラグ書き込み (`customerConfirmed` / `officeConfirmed` / `needsManualCustomerSelection`) を `editLogs` コレクションに監査記録する
- silent-failure-hunter HIGH 指摘 (#398): 確定フラグ書き込みのログがないため、同じバグが再発しても気づけない問題に対処
- 既存の `addDoc(editLogsRef)` ループに乗せるだけで、editLogs スキーマ変更なし
- functions / rules / indexes 変更なし → frontend hosting デプロイのみで完結

## なぜ必要か

PR #396 では「`customerConfirmed=true` が書き込まれない」というバグが kanameone ユーザー報告まで気づけなかった。将来 `saveChanges` の refactor で `shouldSetCustomerConfirmed` のガードが反転したり sentinel set が drift しても、編集 UI 上は何も起きないため検知が遅れる。

editLogs に確定フラグ変更を記録すれば、Firestore クエリで「いつ・誰が・どのドキュメントの確定フラグを変えたか」を後から検証でき、サイレント failure を検知可能になる。

## 変更ファイル

| ファイル | 内容 | 規模 |
|---|---|---|
| `frontend/src/hooks/useDocumentEdit.ts` | 確定フラグ書き込みブロックに `changes.push` 3 箇所追加 | +16 行 |
| `frontend/src/hooks/__tests__/useDocumentEdit.test.ts` | editLogs 検証用 9 ケース追加 + 既存 L458 期待値更新 | +210 行 / -1 行 |

## 設計判断

| 論点 | 判断 | 理由 |
|------|------|------|
| `oldValue` の boolean→string 変換 | `String(value)` で `'true'` / `'false'`、`undefined` は `null` | 既存 changes 配列スキーマ (`oldValue: string \| null`) に合わせる |
| `needsManualCustomerSelection` の扱い | 独立 changes エントリとして記録 (案 A) | レガシーフィールドの drift 検知に有用、コスト数行のみ |
| ヘルパー関数化 | しない | 3 箇所のみで oldValue 計算が異なる、現状抽象化コスト > 利得 |

## Acceptance Criteria

- [x] **AC1**: `customerConfirmed=false → true` 遷移で editLogs に `{fieldName: 'customerConfirmed', oldValue: 'false', newValue: 'true'}` 記録
- [x] **AC1'**: `customerConfirmed=undefined → true` 遷移で `oldValue: null, newValue: 'true'` 記録
- [x] **AC2**: `officeConfirmed=false → true` 遷移で editLogs エントリ作成
- [x] **AC3**: 既に `customerConfirmed=true` のドキュメント / invalid 値選択時は editLogs エントリ未作成
- [x] **AC4**: 混合変更（customerName + customerConfirmed）で両エントリが同 documentId に並列記録
- [x] **AC5**: `needsManualCustomerSelection=true → false` の独立エントリ記録、`undefined` 時はスキップ
- [x] **AC6**: 既存テスト L458 期待値更新 (`mockAddDoc.not.toHaveBeenCalled()` → `toHaveBeenCalledTimes(2)`、#398 仕様変更を反映)
- [ ] **AC7**: dev 環境で書類詳細モーダル編集→保存→Firestore Console で editLogs に確定フラグエントリが記録されることを確認 (マージ後 main push 自動デプロイで検証)

## Test plan

- [x] `npx vitest run` 189/189 PASS（既存 + 新規 9 ケース）
- [x] `npx tsc --noEmit` クリーン
- [x] `npm run lint` クリーン
- [ ] dev 環境で実機確認 (任意・運用判断)

## スコープ外（明示）

- Sentry / Cloud Logging への通知（必要なら別 Issue）
- editLogs スキーマ変更（既存 `fieldName` を文字列識別子として再利用）
- 確定フラグ以外の派生フィールド (`needsManualOfficeSelection` 等) の追加記録（drift があれば別 Issue）

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Document confirmation flags are now properly recorded in the audit log, ensuring complete change tracking for customer confirmation, office confirmation, and manual selection requirement updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->