### PR TITLE
perf(search): searchDocuments perf observability ログ追加 (Issue #402 段階1)

### DIFF
--- a/functions/src/search/searchDocuments.ts
+++ b/functions/src/search/searchDocuments.ts
@@ -167,6 +167,9 @@ export const searchDocuments = onCall<SearchRequest>(
       return cached;
     }
 
+    // perf 計測開始 (cache miss 時のみ。Issue #402 段階1)
+    const startMs = Date.now();
+
     // クエリを単語ごとにトークン化（AND検索用）
     const wordTokenGroups = tokenizeQueryByWords(query);
     if (wordTokenGroups.length === 0) {
@@ -318,6 +321,21 @@ export const searchDocuments = onCall<SearchRequest>(
     };
 
     setCache(cacheKey, result);
+
+    // perf observability ログ (Issue #402 段階1)
+    // 閾値超過時のみ出力。query 自体は PII リスク (顧客名・ファイル名等が含まれ得る) のため
+    // queryLength のみ記録。N の分布・elapsedMs から OOM ガード移行判断 (#402 段階2/3) を行う。
+    const elapsedMs = Date.now() - startMs;
+    if (filteredDocs.length > 100 || elapsedMs > 1000) {
+      console.info('[searchDocuments] perf', {
+        queryLength: query.length,
+        matchedCount: filteredDocs.length,
+        fetchedCount: sortableDocs.length,
+        orphanCount: orphanedDocIds.length,
+        elapsedMs,
+      });
+    }
+
     return result;
   }
 );

--- a/functions/test/searchDocumentsIntegration.test.ts
+++ b/functions/test/searchDocumentsIntegration.test.ts
@@ -612,4 +612,51 @@ describe('searchDocuments handler integration (#401a, Closes #401)', () => {
       expect(safeToMillisWarns.length).to.be.at.least(2);
     });
   });
+
+  // ----------------------------------------
+  // AC9: perf observability ログ (Issue #402 段階1)
+  // ----------------------------------------
+  describe('AC9: perf observability ログ', () => {
+    let originalInfo: typeof console.info;
+    let infoCalls: unknown[][];
+
+    beforeEach(() => {
+      originalInfo = console.info;
+      infoCalls = [];
+      console.info = (...args: unknown[]) => {
+        infoCalls.push(args);
+      };
+    });
+
+    afterEach(() => {
+      console.info = originalInfo;
+    });
+
+    it('閾値未満のマッチでは perf ログが出力されない (ノイズ抑制)', async () => {
+      // Arrange: 5 件のみ seed (matchedCount=5, 100 件閾値未満)
+      await seedUser();
+      const postings: Record<string, { score: number; fieldsMask: number }> = {};
+      for (let i = 1; i <= 5; i++) {
+        postings[`ac9doc${i}`] = { score: 1.0, fieldsMask: 8 };
+      }
+      await seedSearchIndex('ac9smallword', postings);
+      const proc = ts('2026-04-27T12:00:00Z');
+      for (let i = 1; i <= 5; i++) {
+        await seedDocument(`ac9doc${i}`, {
+          fileName: `file-${i}.pdf`,
+          processedAt: proc,
+        });
+      }
+
+      // Act
+      const result = await callSearch({ query: 'ac9smallword' });
+
+      // Assert: 結果は正常 + perf ログは出力されない
+      expect(result.total).to.equal(5);
+      const perfLogs = infoCalls.filter((args) =>
+        args.some((a) => typeof a === 'string' && a.includes('[searchDocuments] perf'))
+      );
+      expect(perfLogs).to.have.lengthOf(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- searchDocuments に latency / read 計測ログを追加（Issue #402 段階1の先行・低リスク対応）
- query 自体は PII リスクのため queryLength のみ記録（Issue #402 Out of scope の PII 抑制も同時対応）
- 閾値超過時のみ出力（matchedCount > 100 または elapsedMs > 1000）でノイズ抑制
- 実運用データから N 分布・elapsedMs を観測し、段階2 (OOM ガード) / 段階3 (posting fileDate 内包) 移行判断材料とする

## 背景
PR #400（検索結果を書類日付の新しい順にソート）で `db.getAll(...allDocRefs)` 方式に変更。マッチ件数 N に対し N 件の document read が発生し、Cloud Functions の 256MiB メモリ + 30 秒タイムアウト超過リスクあり。Issue #402 で 3 段階の対応を計画。本 PR は段階1のみ実装。

## 変更内容

### `functions/src/search/searchDocuments.ts` (+18 行)
- cache miss 時のみ `startMs = Date.now()` を記録（cache hit 経路は計測スキップ）
- 結果返却前に閾値超過時 `console.info('[searchDocuments] perf', ...)` を出力
- 観測項目:
  - `queryLength`: クエリ文字列長（PII 抑制版）
  - `matchedCount`: filteredDocs.length
  - `fetchedCount`: sortableDocs.length（orphan 除外後）
  - `orphanCount`: orphanedDocIds.length
  - `elapsedMs`: cache miss 経路の総処理時間

### `functions/test/searchDocumentsIntegration.test.ts` (+47 行)
- AC9: 閾値未満（5 件マッチ）では perf ログが出力されないこと（ノイズ抑制）

## 影響範囲
- Cloud Functions の searchDocuments のみ変更
- API 契約変更なし（入出力型 SearchRequest / SearchResult は不変）
- FE 影響なし
- 既存 cache 経路・エラー処理経路に変更なし

## 展開要否（feedback_pr_deploy_scope.md 基準）
- 内部 observability の例外ケース: **観測対象が本番運用負荷そのもの**（実運用検索負荷でしか観測できない）
- → kanameone/cocoro への展開が必要だが、PR マージ + 展開はユーザー判断を仰ぐ（4 原則 §3）

## Test plan
- [x] `npm run lint`: 0 errors（既存 warnings 25 件、本 PR で追加なし）
- [x] `npm run build`: PASS
- [x] `npm run test`: 833 passing（unit + type-check）
- [x] `firebase emulators:exec --only firestore 'npm run test:integration'`: 51 passing（AC1-9, 既存 AC8 + 新規 AC9 含む）
- [ ] dev デプロイ後 1-2 週間で kanameone/cocoro 展開判断（実運用観測のため、展開要否はユーザー判断を仰ぐ）

## 段階2/3 への布石
本 PR で 1-2 週間運用後、以下の判断材料を蓄積:
- N の分布 → MAX_GETALL ガード（#402 段階2）閾値の決定
- elapsedMs 分布 → posting fileDate 内包スキーマ移行（#402 段階3）の優先度

Refs: #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)