### PR TITLE
chore(ops): cleanup-office-name スクリプト追加（事業所名統合 + 旧マスター削除）

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -41,6 +41,8 @@ on:
           - force-reindex --doc-id
           - force-reindex --doc-id --execute
           - investigate-office-duplicate
+          - cleanup-office-name --dry-run
+          - cleanup-office-name --execute
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false
@@ -53,6 +55,29 @@ on:
         default: ''
       name2:
         description: 'Office name 2 (optional, for paired comparison; e.g. duplicate candidate variant like the trailing-zero suffix case)'
+        required: false
+        type: string
+        default: ''
+      from_name:
+        description: 'cleanup-office-name: 書き換え元の事業所名（例: ケア21上飯田0）'
+        required: false
+        type: string
+        default: ''
+      to_name:
+        description: 'cleanup-office-name: 書き換え先の事業所名（例: ケア21上飯田）'
+        required: false
+        type: string
+        default: ''
+      delete_from_master:
+        description: 'cleanup-office-name: 旧マスターを削除するか（true で削除）'
+        required: false
+        type: choice
+        default: 'false'
+        options:
+          - 'false'
+          - 'true'
+      expected_count:
+        description: 'cleanup-office-name: 影響件数の事前確認用（数値、不一致なら中断）'
         required: false
         type: string
         default: ''
@@ -137,6 +162,10 @@ jobs:
           SCRIPT_ARGS: ${{ steps.parse.outputs.script_args }}
           NAME1: ${{ github.event.inputs.name1 }}
           NAME2: ${{ github.event.inputs.name2 }}
+          FROM_NAME: ${{ github.event.inputs.from_name }}
+          TO_NAME: ${{ github.event.inputs.to_name }}
+          DELETE_FROM_MASTER: ${{ github.event.inputs.delete_from_master }}
+          EXPECTED_COUNT: ${{ github.event.inputs.expected_count }}
         run: |
           set -euo pipefail
           if [ -z "$PROJECT_ID" ]; then
@@ -158,6 +187,32 @@ jobs:
             fi
             ARGS=( --name "$NAME1" )
             if [ -n "$NAME2" ]; then ARGS+=( --name "$NAME2" ); fi
+            NODE_PATH=./functions/node_modules \
+              FIREBASE_PROJECT_ID="$PROJECT_ID" \
+              node "scripts/${SCRIPT_NAME}.js" "${ARGS[@]}"
+          elif [ "$SCRIPT_NAME" = "cleanup-office-name" ]; then
+            if [[ ! "$FROM_NAME" =~ [^[:space:]] ]]; then
+              echo "ERROR: from_name must contain non-whitespace characters" >&2
+              exit 1
+            fi
+            if [[ ! "$TO_NAME" =~ [^[:space:]] ]]; then
+              echo "ERROR: to_name must contain non-whitespace characters" >&2
+              exit 1
+            fi
+            ARGS=( --from "$FROM_NAME" --to "$TO_NAME" )
+            if [ "$DELETE_FROM_MASTER" = "true" ]; then
+              ARGS+=( --delete-from-master )
+            fi
+            if [ -n "$EXPECTED_COUNT" ]; then
+              if ! [[ "$EXPECTED_COUNT" =~ ^[0-9]+$ ]]; then
+                echo "ERROR: expected_count must be a non-negative integer (got: \"$EXPECTED_COUNT\")" >&2
+                exit 1
+              fi
+              ARGS+=( --expected-count "$EXPECTED_COUNT" )
+            fi
+            # SCRIPT_ARGS には --dry-run / --execute が入っている。read -ra で word splitting して array に追加
+            read -ra SUFFIX_ARGS <<< "$SCRIPT_ARGS"
+            ARGS+=( "${SUFFIX_ARGS[@]}" )
             NODE_PATH=./functions/node_modules \
               FIREBASE_PROJECT_ID="$PROJECT_ID" \
               node "scripts/${SCRIPT_NAME}.js" "${ARGS[@]}"

--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -7,6 +7,9 @@ name: Run Operations Script
 # 環境別SA: GCP_SA_KEY_KANAMEONE / GCP_SA_KEY_DEV / GCP_SA_KEY(cocoro、将来GCP_SA_KEY_COCOROに移行)
 
 on:
+  # 注: workflow_dispatch.inputs は GitHub Actions の仕様上最大 10 個まで定義可能。
+  # 現在 9 個使用中（残り 1）。スクリプト固有の引数追加で上限超過する場合は、
+  # 共通 inputs を JSON 文字列に統合する設計（例: script_args_json）への移行を検討。
   workflow_dispatch:
     inputs:
       environment:
@@ -77,7 +80,7 @@ on:
           - 'false'
           - 'true'
       expected_count:
-        description: 'cleanup-office-name: 影響件数の事前確認用（数値、不一致なら中断）'
+        description: 'cleanup-office-name: 影響件数の事前確認（数値；省略時はチェック無効、指定時は不一致で中断）'
         required: false
         type: string
         default: ''

--- a/scripts/cleanup-office-name.js
+++ b/scripts/cleanup-office-name.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * 事業所名一括書き換え + 旧マスター削除スクリプト（kanameone「ケア21上飯田0」重複対応で初版作成）
+ *
+ * 処理:
+ *   1. --from / --to のマスター実体を取得し、両方が完全一致 1 件で存在することを assert
+ *   2. documents.officeName == --from の書類を全件取得し、JSON バックアップを保存
+ *   3. --execute 時のみ:
+ *      a. 書類の officeName / officeId を --to のものに batch update
+ *      b. --delete-from-master 指定時は --from マスターを delete
+ *   4. 検証クエリで残存件数を出力
+ *
+ * 使用方法（GitHub Actions 推奨）:
+ *   gh workflow run 'Run Operations Script' \
+ *     -f environment=kanameone \
+ *     -f script='cleanup-office-name --dry-run' \
+ *     -f from_name='ケア21上飯田0' -f to_name='ケア21上飯田' \
+ *     -f delete_from_master=true -f expected_count=9
+ *
+ * オプション:
+ *   --from <事業所名>          (必須) 書き換え元の名前
+ *   --to <事業所名>            (必須) 書き換え先の名前
+ *   --delete-from-master       (任意) 書き換え後に --from のマスターを削除
+ *   --expected-count <N>       (任意) 影響件数の事前確認（race condition 防止）
+ *   --dry-run                  (default) 変更なし、影響範囲のみ表示
+ *   --execute                  実行
+ */
+
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID 環境変数を設定してください');
+  process.exit(1);
+}
+
+// === 引数 parse ===
+const args = process.argv.slice(2);
+let from = null;
+let to = null;
+let deleteFromMaster = false;
+let expectedCount = null;
+let execute = false;
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--from' && args[i + 1]) {
+    from = args[i + 1];
+    i++;
+  } else if (args[i] === '--to' && args[i + 1]) {
+    to = args[i + 1];
+    i++;
+  } else if (args[i] === '--delete-from-master') {
+    deleteFromMaster = true;
+  } else if (args[i] === '--expected-count' && args[i + 1]) {
+    expectedCount = Number.parseInt(args[i + 1], 10);
+    if (!Number.isFinite(expectedCount) || expectedCount < 0) {
+      console.error(`ERROR: --expected-count は 0 以上の整数を指定してください（受領: "${args[i + 1]}"）`);
+      process.exit(1);
+    }
+    i++;
+  } else if (args[i] === '--execute') {
+    execute = true;
+  } else if (args[i] === '--dry-run') {
+    execute = false;
+  }
+}
+
+if (!from || !to) {
+  console.error('Usage: --from <旧事業所名> --to <新事業所名> [--delete-from-master] [--expected-count N] [--dry-run|--execute]');
+  process.exit(1);
+}
+if (from === to) {
+  console.error('ERROR: --from と --to が同じです');
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+const BATCH_CHUNK_SIZE = 400;
+
+async function main() {
+  console.log(`プロジェクト: ${projectId}`);
+  console.log(`モード: ${execute ? '実行 (--execute)' : 'DRY RUN（--execute で実行）'}`);
+  console.log(`書き換え: officeName / officeId  "${from}" → "${to}"`);
+  console.log(`旧マスター削除: ${deleteFromMaster ? 'YES' : 'NO'}`);
+  if (expectedCount !== null) {
+    console.log(`期待件数: ${expectedCount}`);
+  }
+  console.log('---\n');
+
+  // === 1. マスター実体の取得 + assertion ===
+  console.log('=== マスター存在確認 ===');
+  const fromQuery = await db.collection('masters/offices/items').where('name', '==', from).get();
+  if (fromQuery.size === 0) {
+    console.error(`ERROR: "from" マスター "${from}" が存在しません`);
+    process.exit(1);
+  }
+  if (fromQuery.size > 1) {
+    console.error(`ERROR: "from" マスター "${from}" が ${fromQuery.size} 件存在します（1 件のみ想定）`);
+    process.exit(1);
+  }
+  const fromMaster = { id: fromQuery.docs[0].id, data: fromQuery.docs[0].data() };
+  console.log(`from: id=${fromMaster.id} name="${fromMaster.data.name}"`);
+
+  const toQuery = await db.collection('masters/offices/items').where('name', '==', to).get();
+  if (toQuery.size === 0) {
+    console.error(`ERROR: "to" マスター "${to}" が存在しません`);
+    process.exit(1);
+  }
+  if (toQuery.size > 1) {
+    console.error(`ERROR: "to" マスター "${to}" が ${toQuery.size} 件存在します（1 件のみ想定）`);
+    process.exit(1);
+  }
+  const toMaster = { id: toQuery.docs[0].id, data: toQuery.docs[0].data() };
+  console.log(`to:   id=${toMaster.id} name="${toMaster.data.name}"`);
+
+  // === 2. 影響書類取得 + 期待件数チェック ===
+  console.log('\n=== 影響書類 ===');
+  const docsSnap = await db.collection('documents').where('officeName', '==', from).get();
+  console.log(`officeName == "${from}" の書類: ${docsSnap.size} 件`);
+
+  if (expectedCount !== null && docsSnap.size !== expectedCount) {
+    console.error(
+      `ERROR: 期待件数 ${expectedCount} と実際の件数 ${docsSnap.size} が一致しません。データに変更があった可能性があります。`
+    );
+    console.error('   --expected-count を最新の件数に更新するか、再度 dry-run で内容を確認してください。');
+    process.exit(1);
+  }
+
+  if (docsSnap.size === 0 && !deleteFromMaster) {
+    console.log('影響書類なし、削除フラグもなし → 処理対象なし');
+    process.exit(0);
+  }
+
+  // === 3. バックアップ JSON 保存 ===
+  const backupDir = path.join(__dirname, '..', 'backups');
+  if (!fs.existsSync(backupDir)) fs.mkdirSync(backupDir, { recursive: true });
+  const backupFile = path.join(backupDir, `office-name-cleanup-${projectId}-${Date.now()}.json`);
+
+  const backupData = {
+    exportedAt: new Date().toISOString(),
+    projectId,
+    from: { id: fromMaster.id, name: fromMaster.data.name, master: fromMaster.data },
+    to: { id: toMaster.id, name: toMaster.data.name, master: toMaster.data },
+    deleteFromMaster,
+    affectedDocuments: docsSnap.docs.map((d) => ({ id: d.id, ...d.data() })),
+  };
+
+  // Firestore Timestamp を ISO 文字列にシリアライズ
+  const serializable = JSON.parse(
+    JSON.stringify(backupData, (_key, value) => {
+      if (value && typeof value === 'object' && '_seconds' in value && '_nanoseconds' in value) {
+        return new Date(value._seconds * 1000).toISOString();
+      }
+      return value;
+    })
+  );
+  fs.writeFileSync(backupFile, JSON.stringify(serializable, null, 2));
+  console.log(`\nバックアップ: ${backupFile}`);
+
+  // === 4. 影響書類サンプル表示 ===
+  console.log('\n=== 影響書類一覧（最大 30 件まで表示） ===');
+  const sample = docsSnap.docs.slice(0, 30);
+  for (const d of sample) {
+    const data = d.data();
+    console.log(
+      `  id=${d.id} fileName="${data.fileName || ''}" customerName="${data.customerName || ''}" ` +
+        `officeId="${data.officeId || ''}" fileDate="${data.fileDateFormatted || ''}"`
+    );
+  }
+  if (docsSnap.size > 30) {
+    console.log(`  ... 他 ${docsSnap.size - 30} 件`);
+  }
+
+  // === 5. dry-run なら終了 ===
+  if (!execute) {
+    console.log('\nDRY RUN モード。--execute で実行します。');
+    process.exit(0);
+  }
+
+  // === 6. 書類更新（batch、500件上限対策で chunk 分割） ===
+  console.log('\n=== 書類更新実行 ===');
+  let updated = 0;
+  for (let i = 0; i < docsSnap.docs.length; i += BATCH_CHUNK_SIZE) {
+    const chunk = docsSnap.docs.slice(i, i + BATCH_CHUNK_SIZE);
+    const batch = db.batch();
+    for (const d of chunk) {
+      batch.update(d.ref, {
+        officeName: to,
+        officeId: toMaster.id,
+      });
+    }
+    await batch.commit();
+    updated += chunk.length;
+    console.log(`  ${updated}/${docsSnap.size} 件更新`);
+  }
+
+  // === 7. 旧マスター削除 ===
+  if (deleteFromMaster) {
+    console.log('\n=== 旧マスター削除 ===');
+    await db.collection('masters/offices/items').doc(fromMaster.id).delete();
+    console.log(`  削除完了: id=${fromMaster.id} name="${fromMaster.data.name}"`);
+  }
+
+  // === 8. 検証 ===
+  console.log('\n=== 検証 ===');
+  const verifyDocs = await db.collection('documents').where('officeName', '==', from).get();
+  console.log(
+    `officeName == "${from}" の残書類: ${verifyDocs.size} 件 ${verifyDocs.size === 0 ? '✅' : '⚠️ 残存'}`
+  );
+
+  if (deleteFromMaster) {
+    const masterCheck = await db.collection('masters/offices/items').doc(fromMaster.id).get();
+    console.log(`旧マスター ${fromMaster.id}: ${masterCheck.exists ? '⚠️ 残存' : '✅ 削除済'}`);
+  }
+
+  const toVerify = await db.collection('documents').where('officeName', '==', to).get();
+  console.log(`officeName == "${to}" の書類（統合後）: ${toVerify.size} 件`);
+
+  console.log('\n完了');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('エラー:', err);
+  process.exit(1);
+});

--- a/scripts/cleanup-office-name.js
+++ b/scripts/cleanup-office-name.js
@@ -1,27 +1,40 @@
 #!/usr/bin/env node
 /**
- * 事業所名一括書き換え + 旧マスター削除スクリプト（kanameone「ケア21上飯田0」重複対応で初版作成）
+ * 事業所名一括書き換え + 旧マスター削除スクリプト（汎用ツール、初版: kanameone「ケア21上飯田0」重複対応 PR #420）
  *
  * 処理:
  *   1. --from / --to のマスター実体を取得し、両方が完全一致 1 件で存在することを assert
  *   2. documents.officeName == --from の書類を全件取得し、JSON バックアップを保存
- *   3. --execute 時のみ:
- *      a. 書類の officeName / officeId を --to のものに batch update
- *      b. --delete-from-master 指定時は --from マスターを delete
- *   4. 検証クエリで残存件数を出力
+ *   3. --expected-count 指定時は事前件数チェック（race condition 防止）
+ *   4. --execute 時のみ:
+ *      a. 影響対象の再取得 + ID 集合比較（stale snapshot 防止）
+ *      b. 書類の officeName / officeId を --to のものに batch update（chunk 単位 try/catch、失敗時 committedCount 報告）
+ *      c. --delete-from-master 指定時は --from マスターを delete（中間状態警告付き）
+ *   5. 検証クエリで残存件数を出力（書き込み完了後の検証エラーは process.exit 0 で終了）
  *
  * 使用方法（GitHub Actions 推奨）:
  *   gh workflow run 'Run Operations Script' \
  *     -f environment=kanameone \
  *     -f script='cleanup-office-name --dry-run' \
  *     -f from_name='ケア21上飯田0' -f to_name='ケア21上飯田' \
- *     -f delete_from_master=true -f expected_count=9
+ *     -f delete_from_master='true' -f expected_count='9'
+ *
+ * 実行後の確認事項（trigger 連鎖の確認）:
+ *   - documents の onDocumentWrite trigger により officeKey / documentGroups が
+ *     再集計される（数秒～数十秒の非同期処理）。Firestore Console で確認。
+ *   - searchIndexer の onDocumentWritten trigger により search_index トークンが
+ *     更新される。`force-reindex --all-drift --dry-run` で drift がないか確認推奨。
+ *
+ * バックアップからの復元:
+ *   - backups/office-name-cleanup-<project>-<ts>.json に影響対象を保存
+ *   - JSON 内の Timestamp 系フィールドは ISO 文字列にシリアライズ済。復元時は
+ *     admin.firestore.Timestamp.fromDate(new Date(iso)) で型復元が必要
  *
  * オプション:
  *   --from <事業所名>          (必須) 書き換え元の名前
  *   --to <事業所名>            (必須) 書き換え先の名前
  *   --delete-from-master       (任意) 書き換え後に --from のマスターを削除
- *   --expected-count <N>       (任意) 影響件数の事前確認（race condition 防止）
+ *   --expected-count <N>       (任意) 影響件数の事前確認（指定時は不一致で中断、未指定ならチェック無効）
  *   --dry-run                  (default) 変更なし、影響範囲のみ表示
  *   --execute                  実行
  */
@@ -181,44 +194,95 @@ async function main() {
     process.exit(0);
   }
 
-  // === 6. 書類更新（batch、500件上限対策で chunk 分割） ===
+  // === 6. stale snapshot 対策: --execute 直前に再取得して ID 集合を比較 ===
+  console.log('\n=== stale snapshot チェック（実行直前の再取得） ===');
+  const recheckSnap = await db.collection('documents').where('officeName', '==', from).get();
+  const recheckIds = new Set(recheckSnap.docs.map((d) => d.id));
+  const originalIds = new Set(docsSnap.docs.map((d) => d.id));
+  const missingFromRecheck = [...originalIds].filter((id) => !recheckIds.has(id));
+  const newInRecheck = [...recheckIds].filter((id) => !originalIds.has(id));
+  if (missingFromRecheck.length > 0 || newInRecheck.length > 0) {
+    console.error('ERROR: 影響対象の ID 集合が初回取得時と異なります。データに変更があった可能性があります。');
+    console.error(
+      `  初回にあって再取得時にない: ${missingFromRecheck.length} 件 ${missingFromRecheck.slice(0, 5).join(', ')}${missingFromRecheck.length > 5 ? ' ...' : ''}`
+    );
+    console.error(
+      `  再取得時に新規追加: ${newInRecheck.length} 件 ${newInRecheck.slice(0, 5).join(', ')}${newInRecheck.length > 5 ? ' ...' : ''}`
+    );
+    console.error('  --dry-run で再確認してから再実行してください。');
+    process.exit(1);
+  }
+  console.log(`  ID 集合一致 ✅ (${recheckSnap.size} 件)`);
+
+  // === 7. 書類更新（batch、500件上限対策で chunk 分割。chunk 単位の commit 失敗を捕捉） ===
   console.log('\n=== 書類更新実行 ===');
   let updated = 0;
-  for (let i = 0; i < docsSnap.docs.length; i += BATCH_CHUNK_SIZE) {
-    const chunk = docsSnap.docs.slice(i, i + BATCH_CHUNK_SIZE);
-    const batch = db.batch();
-    for (const d of chunk) {
-      batch.update(d.ref, {
-        officeName: to,
-        officeId: toMaster.id,
-      });
+  const totalChunks = Math.ceil(docsSnap.docs.length / BATCH_CHUNK_SIZE);
+  try {
+    for (let i = 0; i < docsSnap.docs.length; i += BATCH_CHUNK_SIZE) {
+      const chunk = docsSnap.docs.slice(i, i + BATCH_CHUNK_SIZE);
+      const chunkNum = Math.floor(i / BATCH_CHUNK_SIZE) + 1;
+      const batch = db.batch();
+      for (const d of chunk) {
+        batch.update(d.ref, {
+          officeName: to,
+          officeId: toMaster.id,
+        });
+      }
+      await batch.commit();
+      updated += chunk.length;
+      console.log(`  batch ${chunkNum}/${totalChunks}: ${chunk.length} 件 commit (累計 ${updated}/${docsSnap.size})`);
     }
-    await batch.commit();
-    updated += chunk.length;
-    console.log(`  ${updated}/${docsSnap.size} 件更新`);
+  } catch (commitErr) {
+    const skipped = docsSnap.docs.slice(updated).map((d) => d.id);
+    console.error(
+      `\n⚠️ batch.commit() 失敗: ${updated}/${docsSnap.size} 件は書き込み済、${skipped.length} 件は未処理`
+    );
+    console.error(
+      `未処理 docId（最初の 20 件）: ${skipped.slice(0, 20).join(', ')}${skipped.length > 20 ? ` ...(他 ${skipped.length - 20} 件)` : ''}`
+    );
+    console.error('復旧手順: backup JSON の affectedDocuments[].id を参照して未処理書類の officeName/officeId を確認');
+    console.error(
+      '再実行する場合は --expected-count を残件数に更新してから --dry-run で確認してください。'
+    );
+    throw commitErr;
   }
 
-  // === 7. 旧マスター削除 ===
+  // === 8. 旧マスター削除（書類更新成功後の中間状態警告付き） ===
   if (deleteFromMaster) {
     console.log('\n=== 旧マスター削除 ===');
-    await db.collection('masters/offices/items').doc(fromMaster.id).delete();
-    console.log(`  削除完了: id=${fromMaster.id} name="${fromMaster.data.name}"`);
+    try {
+      await db.collection('masters/offices/items').doc(fromMaster.id).delete();
+      console.log(`  削除完了: id=${fromMaster.id} name="${fromMaster.data.name}"`);
+    } catch (deleteErr) {
+      console.error(
+        `\n⚠️ マスター delete 失敗: 書類 ${updated} 件は更新済、旧マスターが残存している中間状態です。`
+      );
+      console.error(`  対象: id=${fromMaster.id} name="${fromMaster.data.name}"`);
+      console.error('  Firestore Console で手動削除してください。');
+      throw deleteErr;
+    }
   }
 
-  // === 8. 検証 ===
+  // === 9. 検証（書き込み完了後なので、検証クエリ失敗は exit 0 で終了し警告のみ） ===
   console.log('\n=== 検証 ===');
-  const verifyDocs = await db.collection('documents').where('officeName', '==', from).get();
-  console.log(
-    `officeName == "${from}" の残書類: ${verifyDocs.size} 件 ${verifyDocs.size === 0 ? '✅' : '⚠️ 残存'}`
-  );
+  try {
+    const verifyDocs = await db.collection('documents').where('officeName', '==', from).get();
+    console.log(
+      `officeName == "${from}" の残書類: ${verifyDocs.size} 件 ${verifyDocs.size === 0 ? '✅' : '⚠️ 残存'}`
+    );
 
-  if (deleteFromMaster) {
-    const masterCheck = await db.collection('masters/offices/items').doc(fromMaster.id).get();
-    console.log(`旧マスター ${fromMaster.id}: ${masterCheck.exists ? '⚠️ 残存' : '✅ 削除済'}`);
+    if (deleteFromMaster) {
+      const masterCheck = await db.collection('masters/offices/items').doc(fromMaster.id).get();
+      console.log(`旧マスター ${fromMaster.id}: ${masterCheck.exists ? '⚠️ 残存' : '✅ 削除済'}`);
+    }
+
+    const toVerify = await db.collection('documents').where('officeName', '==', to).get();
+    console.log(`officeName == "${to}" の書類（統合後）: ${toVerify.size} 件`);
+  } catch (verifyErr) {
+    console.error('\n⚠️ 検証クエリ失敗（書き込みは完了済の可能性が高いため exit 0 で終了します）:', verifyErr);
+    console.error('  Firestore Console で officeName=旧 の書類数 / 旧マスター存在を必ず手動確認してください。');
   }
-
-  const toVerify = await db.collection('documents').where('officeName', '==', to).get();
-  console.log(`officeName == "${to}" の書類（統合後）: ${toVerify.size} 件`);
 
   console.log('\n完了');
   process.exit(0);


### PR DESCRIPTION
## Summary
- 事業所マスター重複（kanameone「ケア21上飯田0」=「ケア21上飯田」）の解消用スクリプト追加
- documents.officeName / officeId を一括書き換え + 旧マスター削除
- dry-run + バックアップ JSON + 期待件数チェック + stale snapshot 再取得比較 + chunk 単位 try/catch の多重防御

## Background
PR #419 の調査スクリプト（merged）で kanameone 環境を実調査した結果:

| 事業所名 | マスター ID | 紐付き書類数 |
|---------|------------|------------|
| ケア21上飯田 | `YGJaUOjpx8hC0nMYT6Ox` | 1件 |
| ケア21上飯田0 | `2ytAHt9jw2RoYomPPshe` | 9件 |

両マスターとも `import-masters.js` 由来（ランダム ID、timestamp なし）で、CSV インポート時のデータエラーで「ケア21上飯田0」が登録されたと推定。kaname の業務認識「これらは同じ事業所」に従い、9件の書類を「ケア21上飯田」に統合 + 「ケア21上飯田0」マスターを削除する。

## Changes

### `scripts/cleanup-office-name.js`（新規）
- 引数: `--from <旧名> --to <新名> [--delete-from-master] [--expected-count N] [--dry-run|--execute]`
- 多重防御:
  1. `--from` / `--to` のマスターが完全一致 1 件で存在することを assert
  2. `--expected-count` 一致確認（race condition 検出）
  3. **`--execute` 直前に影響対象 docSnap を再取得 + ID 集合比較**（stale snapshot 防止）
  4. **chunk 単位 try/catch + committedCount 報告**（部分失敗時の復旧支援）
  5. **マスター delete 失敗時に中間状態警告**（書類更新済 / マスター残存）
  6. **検証クエリは別 try/catch（書き込み完了済前提）**
  7. バックアップ JSON `backups/office-name-cleanup-<project>-<ts>.json` 自動保存（復元時の Timestamp 復元手順は JSDoc 参照）

### `.github/workflows/run-ops-script.yml`
- `script` choice に `cleanup-office-name --dry-run` / `--execute` 追加
- inputs 追加（合計 9/10、残り 1）:
  - `from_name` / `to_name`（string）
  - `delete_from_master`（choice: 'false' / 'true'）
  - `expected_count`（string、bash で `^[0-9]+$` 検証）
- inputs 上限到達時の対処を YAML 内コメントで明記
- Run script 分岐: env 経由で受け取り、bash array `"${ARGS[@]}"` で word splitting 安全に渡す

## Test plan

### マージ前検証
- [x] node syntax check (`node --check`)
- [x] yaml syntax check (`python3 yaml.safe_load`)
- [x] レビュー対応（code-reviewer / silent-failure-hunter / comment-analyzer / codex review × 4 並列）

### マージ後 dry-run（kanameone）
```bash
gh workflow run 'Run Operations Script' \
  -f environment=kanameone \
  -f script='cleanup-office-name --dry-run' \
  -f from_name='ケア21上飯田0' \
  -f to_name='ケア21上飯田' \
  -f delete_from_master='true' \
  -f expected_count='9'
```
- [ ] 期待件数 9 件一致を確認
- [ ] バックアップ JSON 保存確認
- [ ] 影響書類サンプル一覧確認（PR #419 調査と同じ 9 件であること）

### dry-run 結果承認後の execute
```bash
gh workflow run 'Run Operations Script' \
  -f environment=kanameone \
  -f script='cleanup-office-name --execute' \
  -f from_name='ケア21上飯田0' \
  -f to_name='ケア21上飯田' \
  -f delete_from_master='true' \
  -f expected_count='9'
```
- [ ] stale snapshot チェック通過（ID 集合一致）
- [ ] 9 件 commit 成功
- [ ] 旧マスター削除成功
- [ ] 検証クエリで `officeName == "ケア21上飯田0"` の残書類 0 件、旧マスター削除済、`officeName == "ケア21上飯田"` 10 件統合確認

### 実行後の trigger 連鎖確認（必須）
- [ ] **onDocumentWrite trigger** による `officeKey` / `documentGroups` 再集計を待機（30 秒〜数分）
- [ ] **searchIndexer 連鎖**: `force-reindex --all-drift --dry-run` を実行して drift がないことを確認
  ```bash
  gh workflow run 'Run Operations Script' \
    -f environment=kanameone \
    -f script='force-reindex --all-drift'
  ```
- [ ] kanameone UI で「上飯田」検索 → 1 グループ（10 件）に統合されたことを目視確認
- [ ] kaname へ完了報告

## Security
- workflow inputs は **env 経由** で受け取り、bash の `"$VAR"` 展開のみで参照
- node script への引数渡しは bash array `"${ARGS[@]}"` で word splitting 安全
- `expected_count` は bash 側で `^[0-9]+$` regex 検証（注入対策）
- バックアップ JSON 保存後にしか書き込みを実行しない
- Firestore ネイティブバックアップ（kanameone は 7 日保持の日次スケジュール稼働中、確認済）と二重防御

## 後続タスク（別 Issue 化検討）
- `import-masters.js` に「同名 / 類似名（trailing digit / whitespace 違い）の既存マスター検出 → warn or skip」機構を追加（再発防止）
- workflow_dispatch.inputs 上限 10 個に到達した場合の `script_args_json` 化設計
- ※ 本 PR のスコープ外、今回の修正完了後に検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)