### PR TITLE
feat(documents): 書類種別タブをカテゴリ階層化（kaname 要望）

### DIFF
--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -271,13 +271,19 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
 
   // 顧客別: あいうえお順ソート + フィルター
   // furiganaMap未準備時はソート・フィルターをスキップ（空結果防止）
+  // 書類種別タブ・階層省略時: 全件取得しているので件数降順 + 上位 100 件で従来表示と同等にする
   const displayGroups = useMemo(() => {
     if (!groups) return [];
-    if (!isCustomerView) return groups;
-    if (!isFuriganaReady) return groups;
-    const sorted = sortGroupsByFurigana(groups, furiganaMap);
-    return filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
-  }, [groups, isCustomerView, isFuriganaReady, furiganaMap, selectedKanaRow]);
+    if (isCustomerView) {
+      if (!isFuriganaReady) return groups;
+      const sorted = sortGroupsByFurigana(groups, furiganaMap);
+      return filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
+    }
+    if (isDocumentTypeView && !useCategoryHierarchy) {
+      return [...groups].sort((a, b) => b.count - a.count).slice(0, 100);
+    }
+    return groups;
+  }, [groups, isCustomerView, isDocumentTypeView, useCategoryHierarchy, isFuriganaReady, furiganaMap, selectedKanaRow]);
 
   const config = GROUP_TYPE_CONFIG[groupType];
 

--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -42,6 +42,7 @@ import {
 import {
   buildDocumentTypeCategoryGroups,
   isAllUncategorized,
+  summarizeCategoryGroups,
   type CategoryHierarchy,
 } from '@/lib/buildDocumentTypeCategoryGroups';
 import { GroupDocumentList } from './GroupDocumentList';
@@ -174,12 +175,7 @@ function CategoryItem({
   onToggleCategory,
   children,
 }: CategoryItemProps) {
-  const totalDocs = category.groups.reduce((sum, g) => sum + g.count, 0);
-  const latestAt = category.groups.reduce<Timestamp | undefined>((max, g) => {
-    if (!g.latestAt) return max;
-    if (!max) return g.latestAt;
-    return g.latestAt.toMillis() > max.toMillis() ? g.latestAt : max;
-  }, undefined);
+  const { totalDocs, latestAt } = summarizeCategoryGroups(category.groups);
 
   return (
     <div className="border-b border-gray-100 last:border-0">
@@ -202,11 +198,9 @@ function CategoryItem({
               {category.groups.length}種別 / {totalDocs}件
             </Badge>
           </div>
-          {latestAt && (
-            <div className="text-xs text-gray-500 mt-0.5">
-              最終更新: {formatTimestamp(latestAt)}
-            </div>
-          )}
+          <div className="text-xs text-gray-500 mt-0.5">
+            最終更新: {formatTimestamp(latestAt)}
+          </div>
         </div>
       </button>
       {isExpanded && (
@@ -254,7 +248,16 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
     [needsFurigana, customers]
   );
 
-  const { data: documentMasters } = useDocumentTypes();
+  const {
+    data: documentMasters,
+    isError: isMasterError,
+    error: masterError,
+  } = useDocumentTypes();
+
+  if (isDocumentTypeView && isMasterError) {
+    console.warn('[GroupList] 書類マスター取得失敗 → カテゴリ階層を出さずフラット表示にフォールバック', masterError);
+  }
+
   const categoryHierarchy = useMemo(
     () =>
       isDocumentTypeView
@@ -262,7 +265,7 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
         : [],
     [isDocumentTypeView, groups, documentMasters],
   );
-  // カテゴリ運用していない環境では階層を省略して従来表示にフォールバック (AC-5)
+  // カテゴリ未運用テナントでは未分類 1 件にまとまるため、階層 UI を出さず従来のフラット表示に戻す
   const useCategoryHierarchy =
     isDocumentTypeView && categoryHierarchy.length > 0 && !isAllUncategorized(categoryHierarchy);
 
@@ -366,6 +369,12 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
           onSelect={setSelectedKanaRow}
           disabled={!isFuriganaReady}
         />
+      )}
+
+      {isDocumentTypeView && isMasterError && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          書類マスターの取得に失敗したため、カテゴリ階層表示を一時的に無効化しています。再読込で改善する可能性があります。
+        </div>
       )}
 
       {/* グループ一覧 */}

--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -8,7 +8,7 @@
  * 他タブ: 件数順（従来通り）
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, type ReactNode } from 'react';
 import {
   ChevronRight,
   ChevronDown,
@@ -31,7 +31,7 @@ import {
   type GroupType,
   type DocumentGroup,
 } from '@/hooks/useDocumentGroups';
-import { useCustomers } from '@/hooks/useMasters';
+import { useCustomers, useDocumentTypes } from '@/hooks/useMasters';
 import { KanaFilterBar } from '@/components/KanaFilterBar';
 import {
   buildFuriganaMap,
@@ -39,6 +39,11 @@ import {
   filterGroupsByKanaRow,
   type KanaRow,
 } from '@/lib/kanaUtils';
+import {
+  buildDocumentTypeCategoryGroups,
+  isAllUncategorized,
+  type CategoryHierarchy,
+} from '@/lib/buildDocumentTypeCategoryGroups';
 import { GroupDocumentList } from './GroupDocumentList';
 import type { DateRange } from '@/components/DateRangeFilter';
 
@@ -156,16 +161,77 @@ function GroupItem({ group, isExpanded, furiganaMap, dateFilter, onToggle, onDoc
   );
 }
 
+interface CategoryItemProps {
+  category: CategoryHierarchy;
+  isExpanded: boolean;
+  onToggleCategory: () => void;
+  children: ReactNode;
+}
+
+function CategoryItem({
+  category,
+  isExpanded,
+  onToggleCategory,
+  children,
+}: CategoryItemProps) {
+  const totalDocs = category.groups.reduce((sum, g) => sum + g.count, 0);
+  const latestAt = category.groups.reduce<Timestamp | undefined>((max, g) => {
+    if (!g.latestAt) return max;
+    if (!max) return g.latestAt;
+    return g.latestAt.toMillis() > max.toMillis() ? g.latestAt : max;
+  }, undefined);
+
+  return (
+    <div className="border-b border-gray-100 last:border-0">
+      <button
+        onClick={onToggleCategory}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50"
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-5 w-5 flex-shrink-0 text-gray-400" />
+        ) : (
+          <ChevronRight className="h-5 w-5 flex-shrink-0 text-gray-400" />
+        )}
+        <FolderOpen className="h-5 w-5 flex-shrink-0 text-blue-500" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-gray-900 truncate">
+              {category.categoryName}
+            </span>
+            <Badge variant="secondary" className="text-xs">
+              {category.groups.length}種別 / {totalDocs}件
+            </Badge>
+          </div>
+          {latestAt && (
+            <div className="text-xs text-gray-500 mt-0.5">
+              最終更新: {formatTimestamp(latestAt)}
+            </div>
+          )}
+        </div>
+      </button>
+      {isExpanded && (
+        <div className="border-t border-gray-100 bg-gray-50/30 pl-6 divide-y divide-gray-100">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ============================================
 // メインコンポーネント
 // ============================================
 
 export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupListProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [selectedKanaRow, setSelectedKanaRow] = useState<KanaRow | null>(null);
 
   const isCustomerView = groupType === 'customer';
+  const isDocumentTypeView = groupType === 'documentType';
   const needsFurigana = groupType === 'customer' || groupType === 'careManager';
+  // 顧客別: あいうえお順クライアントソート、書類種別: カテゴリ階層化のため全件必要
+  const useClientSort = isCustomerView || isDocumentTypeView;
 
   const {
     data: groups,
@@ -174,9 +240,8 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
     error,
   } = useDocumentGroups({
     groupType,
-    // 顧客別: クライアントソートのためorderBy/limitなし
-    sortBy: isCustomerView ? 'none' : 'count',
-    limitCount: isCustomerView ? undefined : 100,
+    sortBy: useClientSort ? 'none' : 'count',
+    limitCount: useClientSort ? undefined : 100,
   });
 
   const { data: stats } = useGroupStats(groupType);
@@ -188,6 +253,18 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
     () => (needsFurigana && customers ? buildFuriganaMap(customers) : new Map<string, string>()),
     [needsFurigana, customers]
   );
+
+  const { data: documentMasters } = useDocumentTypes();
+  const categoryHierarchy = useMemo(
+    () =>
+      isDocumentTypeView
+        ? buildDocumentTypeCategoryGroups(groups ?? [], documentMasters)
+        : [],
+    [isDocumentTypeView, groups, documentMasters],
+  );
+  // カテゴリ運用していない環境では階層を省略して従来表示にフォールバック (AC-5)
+  const useCategoryHierarchy =
+    isDocumentTypeView && categoryHierarchy.length > 0 && !isAllUncategorized(categoryHierarchy);
 
   // 顧客別: あいうえお順ソート + フィルター
   // furiganaMap未準備時はソート・フィルターをスキップ（空結果防止）
@@ -208,6 +285,18 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
         next.delete(groupId);
       } else {
         next.add(groupId);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleCategory = useCallback((categoryName: string) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(categoryName)) {
+        next.delete(categoryName);
+      } else {
+        next.add(categoryName);
       }
       return next;
     });
@@ -288,17 +377,37 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
           </div>
         )}
         <div className="divide-y divide-gray-100">
-          {displayGroups.map((group) => (
-            <GroupItem
-              key={group.id}
-              group={group}
-              isExpanded={expandedGroups.has(group.id)}
-              furiganaMap={needsFurigana ? furiganaMap : undefined}
-              dateFilter={dateFilter}
-              onToggle={() => toggleGroup(group.id)}
-              onDocumentSelect={onDocumentSelect}
-            />
-          ))}
+          {useCategoryHierarchy
+            ? categoryHierarchy.map((category) => (
+                <CategoryItem
+                  key={category.categoryName}
+                  category={category}
+                  isExpanded={expandedCategories.has(category.categoryName)}
+                  onToggleCategory={() => toggleCategory(category.categoryName)}
+                >
+                  {category.groups.map((group) => (
+                    <GroupItem
+                      key={group.id}
+                      group={group}
+                      isExpanded={expandedGroups.has(group.id)}
+                      dateFilter={dateFilter}
+                      onToggle={() => toggleGroup(group.id)}
+                      onDocumentSelect={onDocumentSelect}
+                    />
+                  ))}
+                </CategoryItem>
+              ))
+            : displayGroups.map((group) => (
+                <GroupItem
+                  key={group.id}
+                  group={group}
+                  isExpanded={expandedGroups.has(group.id)}
+                  furiganaMap={needsFurigana ? furiganaMap : undefined}
+                  dateFilter={dateFilter}
+                  onToggle={() => toggleGroup(group.id)}
+                  onDocumentSelect={onDocumentSelect}
+                />
+              ))}
         </div>
         {/* フィルターで結果0件の場合 */}
         {isCustomerView && selectedKanaRow && displayGroups.length === 0 && (

--- a/frontend/src/lib/__tests__/buildDocumentTypeCategoryGroups.test.ts
+++ b/frontend/src/lib/__tests__/buildDocumentTypeCategoryGroups.test.ts
@@ -1,0 +1,359 @@
+/**
+ * buildDocumentTypeCategoryGroups テスト
+ *
+ * Acceptance Criteria カバー:
+ * - AC-1: カテゴリ階層表示（あいうえお順）
+ * - AC-4: 「未分類」末尾フォールバック
+ * - AC-5: isAllUncategorized 判定（階層省略フォールバックの前提）
+ * - AC-7: マスター取得失敗時のフォールバック（masters=undefined）
+ * - AC-8: ソート安定性（件数によらず名前順）
+ * - AC-9: マスター名と groupKey が正規化照合で一致
+ * - AC-10: category 空文字・空白・undefined → 未分類
+ * - AC-11: 同一カテゴリ内の書類種別もあいうえお順
+ * - AC-12: 100 件超でもカテゴリ欠落しない
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Timestamp } from 'firebase/firestore';
+import type { DocumentMaster } from '@shared/types';
+import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+import {
+  buildDocumentTypeCategoryGroups,
+  isAllUncategorized,
+  UNCATEGORIZED_LABEL,
+} from '../buildDocumentTypeCategoryGroups';
+
+// ============================================
+// Test Helpers
+// ============================================
+
+function makeGroup(overrides: Partial<DocumentGroup>): DocumentGroup {
+  const ts = Timestamp.fromMillis(0);
+  return {
+    id: overrides.id ?? `id-${overrides.groupKey ?? 'x'}`,
+    groupType: 'documentType',
+    groupKey: overrides.groupKey ?? '',
+    displayName: overrides.displayName ?? overrides.groupKey ?? '',
+    count: overrides.count ?? 1,
+    latestAt: ts,
+    latestDocs: [],
+    updatedAt: ts,
+    ...overrides,
+  };
+}
+
+function makeMaster(name: string, category?: string): DocumentMaster {
+  return { name, category };
+}
+
+// ============================================
+// AC-1, AC-4, AC-8: カテゴリ階層化（基本）
+// ============================================
+
+describe('buildDocumentTypeCategoryGroups - 基本階層化', () => {
+  it('AC-1: 複数カテゴリが日本語ロケール昇順で並ぶ（ひらがなカテゴリで予測可能）', () => {
+    const groups = [
+      makeGroup({ groupKey: '請求書', displayName: '請求書' }),
+      makeGroup({ groupKey: 'ケアプラン', displayName: 'ケアプラン' }),
+    ];
+    const masters = [
+      makeMaster('請求書', 'いりょう'),
+      makeMaster('ケアプラン', 'きょたく'),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual(['いりょう', 'きょたく']);
+  });
+
+  it('AC-4: 「未分類」は末尾に並ぶ', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', displayName: 'A' }),
+      makeGroup({ groupKey: 'b', displayName: 'B' }),
+      makeGroup({ groupKey: 'c', displayName: 'C' }),
+    ];
+    const masters = [
+      makeMaster('A', 'いりょう'),
+      makeMaster('B'), // category 未設定
+      makeMaster('C', 'きょたく'),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([
+      'いりょう',
+      'きょたく',
+      UNCATEGORIZED_LABEL,
+    ]);
+  });
+
+  it('AC-8: 件数によらずカテゴリ名の日本語ロケール昇順で並ぶ', () => {
+    const groups = [
+      makeGroup({ groupKey: 'g1', displayName: 'G1', count: 3 }),
+      makeGroup({ groupKey: 'g2', displayName: 'G2', count: 5 }),
+      makeGroup({ groupKey: 'g3', displayName: 'G3', count: 2 }),
+    ];
+    const masters = [
+      makeMaster('G1', 'いりょう'),
+      makeMaster('G2', 'きょたく'),
+      makeMaster('G3', 'ほうもん'),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([
+      'いりょう',
+      'きょたく',
+      'ほうもん',
+    ]);
+  });
+
+  it('複数書類種別が同一カテゴリに集約される', () => {
+    const groups = [
+      makeGroup({ groupKey: '請求書', displayName: '請求書' }),
+      makeGroup({ groupKey: '領収書', displayName: '領収書' }),
+      makeGroup({ groupKey: '診断書', displayName: '診断書' }),
+    ];
+    const masters = [
+      makeMaster('請求書', 'いりょう'),
+      makeMaster('領収書', 'いりょう'),
+      makeMaster('診断書', 'いりょう'),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.categoryName).toBe('いりょう');
+    expect(result[0]?.groups).toHaveLength(3);
+  });
+});
+
+// ============================================
+// AC-9: 正規化キー照合
+// ============================================
+
+describe('buildDocumentTypeCategoryGroups - 正規化キー照合 (AC-9)', () => {
+  it('全角英数字差異があっても master と一致する', () => {
+    const groups = [
+      // groupKey は backend で正規化済み（"abc123"）
+      makeGroup({ groupKey: 'abc123', displayName: 'ＡＢＣ１２３' }),
+    ];
+    const masters = [
+      // master.name は元の表記（全角）
+      makeMaster('ＡＢＣ１２３', 'いりょう'),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual(['いりょう']);
+  });
+
+  it('空白差異があっても master と一致する', () => {
+    const groups = [makeGroup({ groupKey: 'helloworld', displayName: 'hello world' })];
+    const masters = [makeMaster('hello world', 'いりょう')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual(['いりょう']);
+  });
+
+  it('大文字小文字差異があっても master と一致する', () => {
+    const groups = [makeGroup({ groupKey: 'documenttype', displayName: 'DocumentType' })];
+    const masters = [makeMaster('Document Type', 'いりょう')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual(['いりょう']);
+  });
+
+  it('master に存在しない groupKey は未分類になる', () => {
+    const groups = [
+      makeGroup({ groupKey: '未登録書類', displayName: '未登録書類' }),
+    ];
+    const masters = [makeMaster('別の書類', 'いりょう')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([UNCATEGORIZED_LABEL]);
+  });
+});
+
+// ============================================
+// AC-10: 未分類フォールバック
+// ============================================
+
+describe('buildDocumentTypeCategoryGroups - 未分類フォールバック (AC-10)', () => {
+  it('category が undefined の master は未分類になる', () => {
+    const groups = [makeGroup({ groupKey: 'a', displayName: 'A' })];
+    const masters = [makeMaster('A')]; // category 未指定
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([UNCATEGORIZED_LABEL]);
+  });
+
+  it('category が空文字列の master は未分類になる', () => {
+    const groups = [makeGroup({ groupKey: 'a', displayName: 'A' })];
+    const masters = [makeMaster('A', '')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([UNCATEGORIZED_LABEL]);
+  });
+
+  it('category が空白のみの master は未分類になる', () => {
+    const groups = [makeGroup({ groupKey: 'a', displayName: 'A' })];
+    const masters = [makeMaster('A', '   ')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([UNCATEGORIZED_LABEL]);
+  });
+
+  it('category が全角空白のみの master は未分類になる', () => {
+    const groups = [makeGroup({ groupKey: 'a', displayName: 'A' })];
+    const masters = [makeMaster('A', '　　')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual([UNCATEGORIZED_LABEL]);
+  });
+
+  it('category 前後の空白は trim される', () => {
+    const groups = [makeGroup({ groupKey: 'a', displayName: 'A' })];
+    const masters = [makeMaster('A', '  いりょう  ')];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result.map((c) => c.categoryName)).toEqual(['いりょう']);
+  });
+});
+
+// ============================================
+// AC-11: カテゴリ内ソート
+// ============================================
+
+describe('buildDocumentTypeCategoryGroups - カテゴリ内ソート (AC-11)', () => {
+  it('同一カテゴリ内の書類種別は displayName の日本語ロケール昇順', () => {
+    const groups = [
+      makeGroup({ groupKey: 'k1', displayName: 'りょうしゅうしょ' }),
+      makeGroup({ groupKey: 'k2', displayName: 'せいきゅうしょ' }),
+      makeGroup({ groupKey: 'k3', displayName: 'しんだんしょ' }),
+    ];
+    const masters = [
+      makeMaster('りょうしゅうしょ', 'いりょう'),
+      makeMaster('せいきゅうしょ', 'いりょう'),
+      makeMaster('しんだんしょ', 'いりょう'),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    expect(result[0]?.groups.map((g) => g.displayName)).toEqual([
+      'しんだんしょ',
+      'せいきゅうしょ',
+      'りょうしゅうしょ',
+    ]);
+  });
+});
+
+// ============================================
+// AC-7: マスター取得失敗フォールバック
+// ============================================
+
+describe('buildDocumentTypeCategoryGroups - マスター取得失敗 (AC-7)', () => {
+  it('masters が undefined なら全件「未分類」', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', displayName: 'A' }),
+      makeGroup({ groupKey: 'b', displayName: 'B' }),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, undefined);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.categoryName).toBe(UNCATEGORIZED_LABEL);
+    expect(result[0]?.groups).toHaveLength(2);
+  });
+
+  it('masters が空配列なら全件「未分類」', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', displayName: 'A' }),
+      makeGroup({ groupKey: 'b', displayName: 'B' }),
+    ];
+
+    const result = buildDocumentTypeCategoryGroups(groups, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.categoryName).toBe(UNCATEGORIZED_LABEL);
+    expect(result[0]?.groups).toHaveLength(2);
+  });
+
+  it('groups が空配列なら結果も空配列', () => {
+    const result = buildDocumentTypeCategoryGroups([], [makeMaster('A', '医療')]);
+    expect(result).toEqual([]);
+  });
+
+  it('groups と masters どちらも空なら結果も空', () => {
+    const result = buildDocumentTypeCategoryGroups([], []);
+    expect(result).toEqual([]);
+  });
+});
+
+// ============================================
+// AC-12: 大量データでカテゴリ欠落しない
+// ============================================
+
+describe('buildDocumentTypeCategoryGroups - 大量データ (AC-12)', () => {
+  it('100 件超の書類種別が複数カテゴリに分散しても全件保持される', () => {
+    const groups: DocumentGroup[] = [];
+    const masters: DocumentMaster[] = [];
+    for (let i = 0; i < 150; i++) {
+      const name = `doc${String(i).padStart(3, '0')}`;
+      groups.push(makeGroup({ groupKey: name, displayName: name }));
+      // 3 カテゴリに分散
+      const category = ['いりょう', 'きょたく', 'ほうもん'][i % 3]!;
+      masters.push(makeMaster(name, category));
+    }
+
+    const result = buildDocumentTypeCategoryGroups(groups, masters);
+
+    const totalGroups = result.reduce((sum, c) => sum + c.groups.length, 0);
+    expect(totalGroups).toBe(150);
+    expect(result.map((c) => c.categoryName)).toEqual([
+      'いりょう',
+      'きょたく',
+      'ほうもん',
+    ]);
+  });
+});
+
+// ============================================
+// AC-5: isAllUncategorized 判定
+// ============================================
+
+describe('isAllUncategorized - 階層省略判定 (AC-5)', () => {
+  it('「未分類」1 つだけなら true', () => {
+    const hierarchy = [
+      { categoryName: UNCATEGORIZED_LABEL, groups: [makeGroup({ groupKey: 'a' })] },
+    ];
+    expect(isAllUncategorized(hierarchy)).toBe(true);
+  });
+
+  it('「未分類」+ 他カテゴリなら false', () => {
+    const hierarchy = [
+      { categoryName: 'いりょう', groups: [makeGroup({ groupKey: 'a' })] },
+      { categoryName: UNCATEGORIZED_LABEL, groups: [makeGroup({ groupKey: 'b' })] },
+    ];
+    expect(isAllUncategorized(hierarchy)).toBe(false);
+  });
+
+  it('カテゴリ 1 つだけだが「未分類」でないなら false', () => {
+    const hierarchy = [
+      { categoryName: 'いりょう', groups: [makeGroup({ groupKey: 'a' })] },
+    ];
+    expect(isAllUncategorized(hierarchy)).toBe(false);
+  });
+
+  it('空配列なら false', () => {
+    expect(isAllUncategorized([])).toBe(false);
+  });
+});

--- a/frontend/src/lib/__tests__/buildDocumentTypeCategoryGroups.test.ts
+++ b/frontend/src/lib/__tests__/buildDocumentTypeCategoryGroups.test.ts
@@ -20,6 +20,7 @@ import type { DocumentGroup } from '@/hooks/useDocumentGroups';
 import {
   buildDocumentTypeCategoryGroups,
   isAllUncategorized,
+  summarizeCategoryGroups,
   UNCATEGORIZED_LABEL,
 } from '../buildDocumentTypeCategoryGroups';
 
@@ -355,5 +356,68 @@ describe('isAllUncategorized - 階層省略判定 (AC-5)', () => {
 
   it('空配列なら false', () => {
     expect(isAllUncategorized([])).toBe(false);
+  });
+});
+
+// ============================================
+// summarizeCategoryGroups（CategoryItem ヘッダー用集計）
+// ============================================
+
+describe('summarizeCategoryGroups', () => {
+  it('空配列なら totalDocs=0、latestAt=undefined', () => {
+    const result = summarizeCategoryGroups([]);
+    expect(result).toEqual({ totalDocs: 0, latestAt: undefined });
+  });
+
+  it('count を合計する', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', count: 3 }),
+      makeGroup({ groupKey: 'b', count: 5 }),
+      makeGroup({ groupKey: 'c', count: 7 }),
+    ];
+    expect(summarizeCategoryGroups(groups).totalDocs).toBe(15);
+  });
+
+  it('latestAt が全て同じなら、その値を返す', () => {
+    const ts = Timestamp.fromMillis(1000);
+    const groups = [
+      makeGroup({ groupKey: 'a', latestAt: ts }),
+      makeGroup({ groupKey: 'b', latestAt: ts }),
+    ];
+    expect(summarizeCategoryGroups(groups).latestAt?.toMillis()).toBe(1000);
+  });
+
+  it('latestAt の最大値を返す', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', latestAt: Timestamp.fromMillis(1000) }),
+      makeGroup({ groupKey: 'b', latestAt: Timestamp.fromMillis(3000) }),
+      makeGroup({ groupKey: 'c', latestAt: Timestamp.fromMillis(2000) }),
+    ];
+    expect(summarizeCategoryGroups(groups).latestAt?.toMillis()).toBe(3000);
+  });
+
+  it('一部 latestAt が undefined でも、有効な最大値を返す', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', latestAt: undefined as unknown as Timestamp }),
+      makeGroup({ groupKey: 'b', latestAt: Timestamp.fromMillis(2000) }),
+      makeGroup({ groupKey: 'c', latestAt: undefined as unknown as Timestamp }),
+    ];
+    expect(summarizeCategoryGroups(groups).latestAt?.toMillis()).toBe(2000);
+  });
+
+  it('全 latestAt が undefined なら latestAt=undefined', () => {
+    const groups = [
+      makeGroup({ groupKey: 'a', latestAt: undefined as unknown as Timestamp }),
+      makeGroup({ groupKey: 'b', latestAt: undefined as unknown as Timestamp }),
+    ];
+    expect(summarizeCategoryGroups(groups).latestAt).toBeUndefined();
+  });
+
+  it('単一 group の場合も正しく集計', () => {
+    const groups = [makeGroup({ groupKey: 'a', count: 42, latestAt: Timestamp.fromMillis(5000) })];
+    expect(summarizeCategoryGroups(groups)).toEqual({
+      totalDocs: 42,
+      latestAt: Timestamp.fromMillis(5000),
+    });
   });
 });

--- a/frontend/src/lib/__tests__/normalizeGroupKey.test.ts
+++ b/frontend/src/lib/__tests__/normalizeGroupKey.test.ts
@@ -1,0 +1,108 @@
+/**
+ * normalizeGroupKey テスト
+ *
+ * backend (functions/src/utils/groupAggregation.ts) の normalizeGroupKey と
+ * 同じ入出力期待値を担保することで、書類マスター名と documentGroups.groupKey の
+ * 照合精度を保証する。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeGroupKey } from '../normalizeGroupKey';
+
+describe('normalizeGroupKey', () => {
+  describe('空値・null安全性', () => {
+    it('undefined を渡すと空文字列を返す', () => {
+      expect(normalizeGroupKey(undefined)).toBe('');
+    });
+
+    it('null を渡すと空文字列を返す', () => {
+      expect(normalizeGroupKey(null)).toBe('');
+    });
+
+    it('空文字列を渡すと空文字列を返す', () => {
+      expect(normalizeGroupKey('')).toBe('');
+    });
+  });
+
+  describe('英大文字→小文字変換', () => {
+    it('半角英大文字を小文字化する', () => {
+      expect(normalizeGroupKey('Hello')).toBe('hello');
+    });
+
+    it('全て大文字でも小文字化する', () => {
+      expect(normalizeGroupKey('ABC')).toBe('abc');
+    });
+
+    it('既に小文字なら変化しない', () => {
+      expect(normalizeGroupKey('hello')).toBe('hello');
+    });
+  });
+
+  describe('全角→半角変換', () => {
+    it('全角英大文字を半角小文字に変換する', () => {
+      expect(normalizeGroupKey('ＡＢＣ')).toBe('abc');
+    });
+
+    it('全角英小文字を半角小文字に変換する', () => {
+      expect(normalizeGroupKey('ａｂｃ')).toBe('abc');
+    });
+
+    it('全角数字を半角数字に変換する', () => {
+      expect(normalizeGroupKey('０１２')).toBe('012');
+    });
+
+    it('全角英数字混在を半角小文字に正規化する', () => {
+      expect(normalizeGroupKey('ＡＢＣ１２３')).toBe('abc123');
+    });
+  });
+
+  describe('空白除去', () => {
+    it('前後の半角空白を除去する', () => {
+      expect(normalizeGroupKey(' hello ')).toBe('hello');
+    });
+
+    it('文字列中間の半角空白を除去する', () => {
+      expect(normalizeGroupKey('hello world')).toBe('helloworld');
+    });
+
+    it('全角空白(U+3000)を除去する', () => {
+      expect(normalizeGroupKey('hello　world')).toBe('helloworld');
+    });
+
+    it('タブ・改行を除去する', () => {
+      expect(normalizeGroupKey('\thello\n')).toBe('hello');
+    });
+  });
+
+  describe('日本語処理', () => {
+    it('日本語のみの文字列はそのまま', () => {
+      expect(normalizeGroupKey('請求書')).toBe('請求書');
+    });
+
+    it('日本語+前後空白は trim される', () => {
+      expect(normalizeGroupKey(' 請求書 ')).toBe('請求書');
+    });
+
+    it('日本語+中間全角空白は除去される', () => {
+      expect(normalizeGroupKey('請　求書')).toBe('請求書');
+    });
+
+    it('日本語+全角空白+前後空白の組み合わせも正規化', () => {
+      expect(normalizeGroupKey(' 請　求書 ')).toBe('請求書');
+    });
+  });
+
+  describe('複合パターン（実運用想定）', () => {
+    it('英大文字+半角空白+全角空白の混在を正規化', () => {
+      expect(normalizeGroupKey('A B　C')).toBe('abc');
+    });
+
+    it('日本語+英数字混在を正規化', () => {
+      expect(normalizeGroupKey('ケアプラン Ａ１')).toBe('ケアプランa1');
+    });
+
+    it('OCR 抽出名想定の前後余白+大文字混在', () => {
+      expect(normalizeGroupKey('  Document Type   ')).toBe('documenttype');
+    });
+  });
+});

--- a/frontend/src/lib/buildDocumentTypeCategoryGroups.ts
+++ b/frontend/src/lib/buildDocumentTypeCategoryGroups.ts
@@ -1,0 +1,89 @@
+/**
+ * 書類種別グループのカテゴリ階層化ロジック
+ *
+ * useDocumentGroups で取得した書類種別グループを、
+ * 書類マスター (DocumentMaster) の category フィールドで階層化する純粋関数。
+ *
+ * - master.name → normalizeGroupKey でキー化し、group.groupKey と照合
+ * - category 未設定 / master 不在 → 「未分類」フォールバック
+ * - カテゴリ名: あいうえお順、「未分類」は末尾
+ * - 同一カテゴリ内の書類種別: displayName のあいうえお順
+ */
+
+import type { DocumentMaster } from '@shared/types';
+import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+import { normalizeGroupKey } from './normalizeGroupKey';
+
+export const UNCATEGORIZED_LABEL = '未分類';
+
+export interface CategoryHierarchy {
+  categoryName: string;
+  groups: DocumentGroup[];
+}
+
+export function buildDocumentTypeCategoryGroups(
+  groups: readonly DocumentGroup[],
+  masters: readonly DocumentMaster[] | undefined,
+): CategoryHierarchy[] {
+  const keyToCategory = buildMasterCategoryMap(masters);
+
+  const categoryMap = new Map<string, DocumentGroup[]>();
+  for (const group of groups) {
+    const categoryName = resolveCategoryName(group.groupKey, keyToCategory);
+    const list = categoryMap.get(categoryName);
+    if (list) {
+      list.push(group);
+    } else {
+      categoryMap.set(categoryName, [group]);
+    }
+  }
+
+  for (const list of categoryMap.values()) {
+    list.sort((a, b) => a.displayName.localeCompare(b.displayName, 'ja'));
+  }
+
+  return [...categoryMap.entries()]
+    .sort(([a], [b]) => compareCategoryName(a, b))
+    .map(([categoryName, groupList]) => ({
+      categoryName,
+      groups: groupList,
+    }));
+}
+
+/**
+ * 階層化結果が「未分類」1 つだけかを判定する。
+ * カテゴリ未運用環境で階層を省略して従来表示にフォールバックするために使用。
+ *
+ * 注: 空配列は false を返す（呼び出し側の `length > 0` ガードと併用前提）。
+ */
+export function isAllUncategorized(hierarchy: readonly CategoryHierarchy[]): boolean {
+  return hierarchy.length === 1 && hierarchy[0]?.categoryName === UNCATEGORIZED_LABEL;
+}
+
+function buildMasterCategoryMap(
+  masters: readonly DocumentMaster[] | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!masters) return map;
+  for (const master of masters) {
+    const key = normalizeGroupKey(master.name);
+    if (!key) continue;
+    const category = master.category?.trim();
+    if (!category) continue;
+    map.set(key, category);
+  }
+  return map;
+}
+
+function resolveCategoryName(
+  groupKey: string,
+  keyToCategory: Map<string, string>,
+): string {
+  return keyToCategory.get(groupKey) ?? UNCATEGORIZED_LABEL;
+}
+
+function compareCategoryName(a: string, b: string): number {
+  if (a === UNCATEGORIZED_LABEL) return 1;
+  if (b === UNCATEGORIZED_LABEL) return -1;
+  return a.localeCompare(b, 'ja');
+}

--- a/frontend/src/lib/buildDocumentTypeCategoryGroups.ts
+++ b/frontend/src/lib/buildDocumentTypeCategoryGroups.ts
@@ -10,6 +10,7 @@
  * - 同一カテゴリ内の書類種別: displayName のあいうえお順
  */
 
+import type { Timestamp } from 'firebase/firestore';
 import type { DocumentMaster } from '@shared/types';
 import type { DocumentGroup } from '@/hooks/useDocumentGroups';
 import { normalizeGroupKey } from './normalizeGroupKey';
@@ -17,8 +18,13 @@ import { normalizeGroupKey } from './normalizeGroupKey';
 export const UNCATEGORIZED_LABEL = '未分類';
 
 export interface CategoryHierarchy {
-  categoryName: string;
-  groups: DocumentGroup[];
+  readonly categoryName: string;
+  readonly groups: readonly DocumentGroup[];
+}
+
+export interface CategorySummary {
+  totalDocs: number;
+  latestAt: Timestamp | undefined;
 }
 
 export function buildDocumentTypeCategoryGroups(
@@ -48,6 +54,24 @@ export function buildDocumentTypeCategoryGroups(
       categoryName,
       groups: groupList,
     }));
+}
+
+/**
+ * カテゴリ内グループの総件数 + 最新更新日時を集計する純関数。
+ * CategoryItem ヘッダーのバッジ・最終更新日表示で使用する。
+ */
+export function summarizeCategoryGroups(
+  groups: readonly DocumentGroup[],
+): CategorySummary {
+  let totalDocs = 0;
+  let latestAt: Timestamp | undefined;
+  for (const group of groups) {
+    totalDocs += group.count;
+    if (group.latestAt && (!latestAt || group.latestAt.toMillis() > latestAt.toMillis())) {
+      latestAt = group.latestAt;
+    }
+  }
+  return { totalDocs, latestAt };
 }
 
 /**

--- a/frontend/src/lib/normalizeGroupKey.ts
+++ b/frontend/src/lib/normalizeGroupKey.ts
@@ -24,6 +24,6 @@ export function normalizeGroupKey(value: string | undefined | null): string {
       String.fromCharCode(s.charCodeAt(0) - 0xfee0),
     )
     .toLowerCase()
-    .replace(/[\s　]/g, '')
+    .replace(/[\s\u3000]/g, '')
     .trim();
 }

--- a/frontend/src/lib/normalizeGroupKey.ts
+++ b/frontend/src/lib/normalizeGroupKey.ts
@@ -1,0 +1,29 @@
+/**
+ * グループキー正規化ユーティリティ
+ *
+ * documentGroups.groupKey と同等の正規化を frontend 側で再現する。
+ * backend 実装: functions/src/utils/groupAggregation.ts:47-61 (normalizeGroupKey)
+ *
+ * 書類マスター名から groupKey と同形式のキーを生成し、
+ * documentGroups の groupKey と照合して category 情報を join するために使用する。
+ *
+ * 仕様:
+ * - 全角英数字 → 半角
+ * - 英大文字 → 小文字
+ * - 半角・全角空白・タブ・改行を除去
+ * - 注: カタカナ/ひらがなの相互変換は行わない（backend 仕様準拠）
+ *
+ * ⚠ backend の normalizeGroupKey を変更する際は、本ファイルとテストデータも同期更新すること。
+ */
+
+export function normalizeGroupKey(value: string | undefined | null): string {
+  if (!value) return '';
+
+  return value
+    .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) =>
+      String.fromCharCode(s.charCodeAt(0) - 0xfee0),
+    )
+    .toLowerCase()
+    .replace(/[\s　]/g, '')
+    .trim();
+}

--- a/frontend/src/lib/normalizeGroupKey.ts
+++ b/frontend/src/lib/normalizeGroupKey.ts
@@ -2,7 +2,7 @@
  * グループキー正規化ユーティリティ
  *
  * documentGroups.groupKey と同等の正規化を frontend 側で再現する。
- * backend 実装: functions/src/utils/groupAggregation.ts:47-61 (normalizeGroupKey)
+ * backend 実装: functions/src/utils/groupAggregation.ts の normalizeGroupKey
  *
  * 書類マスター名から groupKey と同形式のキーを生成し、
  * documentGroups の groupKey と照合して category 情報を join するために使用する。


### PR DESCRIPTION
## Summary
- kaname 要望対応: 書類種別タブを「カテゴリ → 書類種別 → 書類リスト」の 3 階層化
- backend 修正なし、frontend で書類マスター（`DocumentMaster.category`）と `documentGroups` をクライアント側 join
- 「未分類」末尾フォールバック、全件未分類時は階層省略で従来表示にフォールバック
- 書類種別タブのみ階層化、他タブ（顧客別/事業所別/担当CM別）は完全に無影響

## 設計判断
- **クライアント側 join**: backend `documentGroups` 集計修正を避け、運用リスク低減
- **normalizeGroupKey 同期**: frontend にコピーし、backend (`functions/src/utils/groupAggregation.ts:47-61`) と同期維持。コメントで明示
- **localeCompare('ja')**: ICU 日本語ロケール昇順（厳密「あいうえお順」が必要ならカテゴリにふりがな追加が将来課題）
- **CategoryItem children パターン**: GroupItem を children として流し込み、props drilling 削減

## 主要変更
- `frontend/src/lib/normalizeGroupKey.ts`（新規）: backend と同期した正規化関数
- `frontend/src/lib/buildDocumentTypeCategoryGroups.ts`（新規）: 階層化純粋関数 + `isAllUncategorized` 判定
- `frontend/src/components/views/GroupList.tsx`（修正）: `CategoryItem` 追加、書類種別タブで `sortBy: 'none'` で全件取得、`useDocumentTypes` join、ネストアコーディオン

## Quality Gate
- `/simplify`: H1/H2/L4/M1 適用（CategoryItem props 削減・children パターン化、空文字 map 登録省略、JSX ネスト統合、不要コメント削除）
- `/safe-refactor`: 問題なし（5 ファイルクリア）
- evaluator: AC 13 個機械検証、conditional-go → CategoryItem に latestAt 追加 + LOW コメント追記で **AC-2 完全 PASS**
- /codex plan: セカンドオピニオン取得済み（Top 3 改善 全反映）

## Acceptance Criteria（13 個）
- AC-1: カテゴリ階層表示（日本語ロケール昇順）✅
- AC-2: カテゴリ展開で書類種別表示（CategoryItem に種別数 + 件数 + 最終更新日）✅
- AC-3: 書類種別展開で書類リスト表示（既存 GroupDocumentList 維持）✅
- AC-4: 「未分類」末尾フォールバック ✅
- AC-5: 全件未分類時の階層省略フォールバック ✅
- AC-6: 他タブ無影響（回帰防止）✅
- AC-7: マスター取得失敗時のフォールバック ✅
- AC-8: ソート安定性（件数によらず名前順）✅
- AC-9: 正規化キー照合（全角/半角/大小/空白の揺れ吸収）✅
- AC-10: category 空文字・空白・undefined → 未分類 ✅
- AC-11: 同一カテゴリ内ソート安定性 ✅
- AC-12: 大量データでカテゴリ欠落しない（150件テスト済み）✅
- AC-13: マスター取得中はブロックしない ✅

## Test plan
- [x] 単体テスト 44 cases 全 PASS（normalizeGroupKey 21 + buildDocumentTypeCategoryGroups 23）
- [x] 既存テスト 234 cases 全 PASS（回帰なし）
- [x] tsc OK
- [x] build OK
- [ ] dev 環境（doc-split-dev.web.app）で書類種別タブを Playwright 操作確認 + スクリーンショット
  - [ ] カテゴリ展開 → 書類種別展開 → 書類リスト の 3 階層動作
  - [ ] 「未分類」フォールバック動作
  - [ ] 他タブ無影響（顧客別/事業所別/担当CM別）

## 段階展開
- Phase 1: dev (main マージで自動)
- Phase 2: kanameone（要望本元）
- Phase 3: cocoro

## 関連
- 要望: kaname より（書類種別タブの階層化）
- 設計: backend 修正なしのクライアント join アプローチ
- shared/types.ts:195 の #338（DocumentMaster.category 欠損想定）コメントが「未分類」フォールバック設計の裏付け

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the group list view with a new category hierarchy for document types, allowing users to expand and collapse categories for improved organization and visibility.

* **Tests**
  * Added comprehensive test coverage for document type categorization and key normalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->