### PR TITLE
fix(documents): 書類一覧テーブルの 768〜1023px で右端列が見切れる問題を修正

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -86,7 +86,7 @@ function SortableHeader({
 
   return (
     <th
-      className={`px-2 py-2 text-left text-xs font-medium text-gray-700 cursor-pointer hover:bg-gray-100 select-none sm:px-4 sm:py-3 sm:text-sm ${hideOnMobile ? 'hidden md:table-cell' : ''}`}
+      className={`px-2 py-2 text-left text-xs font-medium text-gray-700 cursor-pointer hover:bg-gray-100 select-none sm:px-4 sm:py-3 sm:text-sm ${hideOnMobile ? 'hidden lg:table-cell' : ''}`}
       onClick={() => onClick(field)}
     >
       <div className="flex items-center gap-1">
@@ -267,9 +267,9 @@ function DocumentRow({
         </div>
       </td>
       <td className="px-2 py-2 text-xs text-gray-700 sm:px-4 sm:py-3 sm:text-sm">{document.customerName || '未判定'}</td>
-      <td className="hidden px-4 py-3 text-gray-700 md:table-cell">{document.officeName || '-'}</td>
+      <td className="hidden px-4 py-3 text-gray-700 lg:table-cell">{document.officeName || '-'}</td>
       <td className="px-2 py-2 text-xs text-gray-700 sm:px-4 sm:py-3 sm:text-sm">{formatDateTime(document.processedAt)}</td>
-      <td className="hidden px-4 py-3 text-gray-700 md:table-cell">{formatTimestamp(document.fileDate)}</td>
+      <td className="hidden px-4 py-3 text-gray-700 lg:table-cell">{formatTimestamp(document.fileDate)}</td>
       <td className="px-2 py-2 sm:px-4 sm:py-3">
         {needsReview ? (
           <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">


### PR DESCRIPTION
## Summary
- テーブル列「事業所」「書類日付」の表示切替を md (768px) → lg (1024px) に変更
- iPad 縦持ち (768px) や狭い PC ブラウザ (770〜940px) で右端列が画面外に見切れる問題を解消
- kaname からの問い合わせ対応

## 問題
書類管理ホーム画面で、md ブレークポイント直後 (768〜940px) にテーブル幅 (940px) が
viewport を超過し、右端の「ステータス」「✓」列が画面外に見切れて操作不能になる。

問い合わせ元の報告:
> 1. 画面下部を確認するため、スクロールバーを一番下まで移動させる。
> 2. 次ページが読み込まれたタイミングで、ウィンドウ内の表示が自動的に拡大される。
> 3. その結果、チェック項目などの一部要素が画面外に見切れてしまい、操作に支障が出ている。

## 原因（dev 環境で再現確認済み）
- viewport 768px (iPad 縦) → docScrollWidth 802 / table 940 / overflow 145px
- viewport 820px → docScrollWidth 820 / table 940 / overflow 120px
- viewport 940+ → fit

DocumentsPage.tsx:865-901 のテーブルは md (768px) で 5列 → 7列 (事業所/書類日付追加) +
パディング/フォント拡大が同時に発火するが、最低必要幅は 940px。md (768〜1023px) の範囲では
viewport 不足で overflow-x-auto コンテナ内で右端列が画面外へスクロール（ユーザーは
横スクロールに気づきにくい）。

## 修正
\`hidden md:table-cell\` → \`hidden lg:table-cell\`（3 箇所）

| viewport | 変更前 | 変更後 |
|---|---|---|
| 〜767 (sm) | 5 列 | 5 列 (変化なし) |
| **768〜1023 (md)** | **7 列 → overflow** | **5 列 → fits** |
| 1024+ (lg) | 7 列 | 7 列 (変化なし) |

## Test plan
- [x] \`tsc --noEmit\` PASS
- [x] \`npm test\` 全 241 cases PASS (13 ファイル)
- [x] \`npm run build\` PASS
- [ ] dev 環境（doc-split-dev.web.app）で 768/820/1024/1280px viewport にて Playwright 再現確認
  - [ ] 768px: 5列で fits、右端見切れなし
  - [ ] 820px: 5列で fits、右端見切れなし
  - [ ] 1024px: 7列表示で正常
  - [ ] 1280px: 7列表示で正常（変化なし回帰確認）

## 段階展開
- Phase 1: dev (main マージで自動デプロイ)
- Phase 2: kanameone（要望本元）
- Phase 3: cocoro

## 関連
- 要望: kaname より（書類管理ホーム画面の表示崩れ）
- 影響範囲: DocumentsPage.tsx の「書類一覧」タブのみ。グループ化タブ（PR #422 修正済み）は無影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table responsiveness by adjusting when certain columns are visible on different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->