### PR TITLE
feat(scripts): inspect-document — Storage 404 調査用 read-only スクリプト

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -46,8 +46,17 @@ on:
           - investigate-office-duplicate
           - cleanup-office-name --dry-run
           - cleanup-office-name --execute
+          - inspect-document --file-name
+          - inspect-document --file-name --include-related
+          - inspect-document --doc-id
+          - inspect-document --doc-id --include-related
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
+        required: false
+        type: string
+        default: ''
+      file_name:
+        description: 'fileName (required when script contains "inspect-document --file-name"; ignored otherwise)'
         required: false
         type: string
         default: ''
@@ -169,6 +178,8 @@ jobs:
           TO_NAME: ${{ github.event.inputs.to_name }}
           DELETE_FROM_MASTER: ${{ github.event.inputs.delete_from_master }}
           EXPECTED_COUNT: ${{ github.event.inputs.expected_count }}
+          FILE_NAME: ${{ github.event.inputs.file_name }}
+          DOC_ID: ${{ github.event.inputs.doc_id }}
         run: |
           set -euo pipefail
           if [ -z "$PROJECT_ID" ]; then
@@ -224,6 +235,36 @@ jobs:
             NODE_PATH=../functions/node_modules \
               FIREBASE_PROJECT_ID="$PROJECT_ID" \
               npx ts-node "${SCRIPT_NAME}.ts" $SCRIPT_ARGS
+          elif [ "$SCRIPT_NAME" = "inspect-document" ]; then
+            # SCRIPT_ARGS は workflow_dispatch で選んだ "--file-name" / "--doc-id" / "... --include-related"
+            # FILE_NAME / DOC_ID は env 経由で受け取り、配列に積んで execv 渡しでシェル展開を経由しない
+            ARGS=()
+            INCLUDE_RELATED=0
+            if echo "$SCRIPT_ARGS" | grep -q -- '--include-related'; then
+              INCLUDE_RELATED=1
+            fi
+            if echo "$SCRIPT_ARGS" | grep -q -- '--file-name'; then
+              if [[ ! "$FILE_NAME" =~ [^[:space:]] ]]; then
+                echo "ERROR: file_name input is required when script contains --file-name" >&2
+                exit 1
+              fi
+              ARGS+=( --file-name "$FILE_NAME" )
+            fi
+            if echo "$SCRIPT_ARGS" | grep -q -- '--doc-id'; then
+              # parse 段階で DOC_ID validation 済み (英数字_-)、SCRIPT_ARGS 側は "--doc-id <DOC_ID>" の形
+              # ARGS には DOC_ID を直接入れる（execv 経由でシェル展開されない）
+              if [ -z "${DOC_ID:-}" ]; then
+                echo "ERROR: doc_id input is required when script contains --doc-id" >&2
+                exit 1
+              fi
+              ARGS+=( --doc-id "$DOC_ID" )
+            fi
+            if [ "$INCLUDE_RELATED" = "1" ]; then
+              ARGS+=( --include-related )
+            fi
+            NODE_PATH=./functions/node_modules \
+              FIREBASE_PROJECT_ID="$PROJECT_ID" \
+              node "scripts/${SCRIPT_NAME}.js" "${ARGS[@]}"
           else
             NODE_PATH=./functions/node_modules \
               FIREBASE_PROJECT_ID="$PROJECT_ID" \

--- a/scripts/inspect-document.js
+++ b/scripts/inspect-document.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Firestore documents 詳細出力スクリプト（read-only）
+ *
+ * Storage 404 / fileUrl 不整合 / 孤児ドキュメント等の調査に使用する。
+ * documents コレクションを fileName 完全一致で検索し、エラー原因究明に必要な
+ * フィールド一式（status / fileUrl / parentDocumentId / splitFromPages / pageRotations 等）
+ * を JSON で出力する。書き込みは一切行わない。
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=docsplit-kanameone node scripts/inspect-document.js \
+ *     --file-name 20260509_未判定_未判定_p3.pdf
+ *
+ *   FIREBASE_PROJECT_ID=docsplit-kanameone node scripts/inspect-document.js \
+ *     --doc-id <document-id>
+ *
+ * オプション:
+ *   --file-name <name>  fileName 完全一致でドキュメント検索（必須または --doc-id）
+ *   --doc-id <id>       ドキュメント ID 指定で取得
+ *   --include-related   parentDocumentId / splitInto を辿って関連ドキュメントも出力
+ */
+
+const admin = require('firebase-admin');
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+
+function getOpt(name) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+
+const fileName = getOpt('--file-name');
+const docId = getOpt('--doc-id');
+const includeRelated = process.argv.includes('--include-related');
+
+if (!fileName && !docId) {
+  console.error('--file-name <name> または --doc-id <id> を指定してください');
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+function tsToIso(ts) {
+  if (!ts) return null;
+  if (typeof ts.toDate === 'function') return ts.toDate().toISOString();
+  return String(ts);
+}
+
+function summarize(doc) {
+  const d = doc.data();
+  return {
+    id: doc.id,
+    status: d.status,
+    fileName: d.fileName,
+    displayFileName: d.displayFileName,
+    fileUrl: d.fileUrl,
+    mimeType: d.mimeType,
+    totalPages: d.totalPages,
+    parentDocumentId: d.parentDocumentId,
+    splitFromPages: d.splitFromPages,
+    splitInto: d.splitInto,
+    isSplitSource: d.isSplitSource,
+    pageRotations: d.pageRotations,
+    rotatedAt: tsToIso(d.rotatedAt),
+    processedAt: tsToIso(d.processedAt),
+    updatedAt: tsToIso(d.updatedAt),
+    fileDate: tsToIso(d.fileDate),
+    retryCount: d.retryCount,
+    retryAfter: tsToIso(d.retryAfter),
+    lastErrorMessage: d.lastErrorMessage,
+    confirmedBy: d.confirmedBy,
+    confirmedAt: tsToIso(d.confirmedAt),
+  };
+}
+
+async function fetchById(id) {
+  const snap = await db.doc(`documents/${id}`).get();
+  if (!snap.exists) return null;
+  return snap;
+}
+
+async function main() {
+  const found = [];
+
+  if (docId) {
+    const snap = await fetchById(docId);
+    if (snap) found.push(snap);
+    else console.error(`docId ${docId} not found`);
+  }
+
+  if (fileName) {
+    const snap = await db
+      .collection('documents')
+      .where('fileName', '==', fileName)
+      .get();
+    snap.forEach((doc) => found.push(doc));
+  }
+
+  console.log(`=== Found ${found.length} document(s) ===`);
+  for (const doc of found) {
+    console.log(JSON.stringify(summarize(doc), null, 2));
+  }
+
+  if (includeRelated) {
+    const seen = new Set(found.map((d) => d.id));
+    const queue = [];
+    for (const doc of found) {
+      const d = doc.data();
+      if (d.parentDocumentId && !seen.has(d.parentDocumentId)) {
+        queue.push({ id: d.parentDocumentId, role: 'parent' });
+      }
+      if (Array.isArray(d.splitInto)) {
+        for (const childId of d.splitInto) {
+          if (!seen.has(childId)) queue.push({ id: childId, role: 'child' });
+        }
+      }
+    }
+
+    if (queue.length > 0) {
+      console.log(`\n=== Related documents (${queue.length}) ===`);
+      for (const { id, role } of queue) {
+        const snap = await fetchById(id);
+        if (snap) {
+          console.log(`-- ${role}: ${id} --`);
+          console.log(JSON.stringify(summarize(snap), null, 2));
+        } else {
+          console.log(`-- ${role}: ${id} (not found) --`);
+        }
+      }
+    }
+  }
+
+  await admin.app().delete();
+}
+
+main().catch((err) => {
+  console.error('Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- kanameone 環境のヘルスレポート（2026-05-10）で検出された Storage 404 エラー `No such object: docsplit-kanameone.firebasestorage.app/processed/20260509_未判定_未判定_p3.pdf` の根本原因究明用に、`scripts/inspect-document.js` を追加（read-only）。
- `run-ops-script.yml` workflow_dispatch に `inspect-document --file-name` / `--doc-id`（各 `--include-related` 付き）を追加し、GitHub Actions 経由で環境別に実行可能化。
- FILE_NAME / DOC_ID は env 経由で受け取り配列 ARGS で execv 渡し → command injection 対策（既存パターン踏襲）。

## 背景（調査結果）

Storage 側を `gsutil ls` で確認したところ:
- ✗ `processed/20260509_未判定_未判定_p3.pdf` ← 存在しない（エラーが指している）
- ✓ `processed/20260509_未判定_未判定_p3_r1778340000575.pdf` ← 回転後ファイル（`rotatePdfPages` の `_r{timestamp}` パターン）

`rotatePdfPages` (`functions/src/pdf/pdfOperations.ts:457-575`) は新ファイル save → 古ファイル delete → Firestore `fileUrl` update の順で実行する。何らかの理由で `documents.fileUrl` が旧パスのまま残った可能性が高く、再 OCR 時に旧パスを download → Storage 404 → status:error 確定。本スクリプトで documents コレクションの実態を確認する。

## Test plan

- [ ] PR merge 後、Actions → "Run Operations Script" → `environment: kanameone` / `script: inspect-document --file-name --include-related` / `file_name: 20260509_未判定_未判定_p3.pdf` で実行
- [ ] 出力された fileUrl / parentDocumentId / pageRotations / rotatedAt / splitInto を確認し、根本原因（fileUrl 更新漏れ / 重複 docId / その他）を特定
- [ ] dev 環境でも同様に実行（documents コレクションが空でも script 自体が正常終了することを確認）

## Acceptance Criteria

- inspect-document --file-name で fileName 完全一致のドキュメントが JSON 出力される
- inspect-document --doc-id で 1 件のドキュメントが JSON 出力される（存在しない場合はエラー出力）
- --include-related で parentDocumentId / splitInto を辿った関連ドキュメントも出力される
- 書き込みは一切行わない（`db.collection().get()` / `db.doc().get()` のみ）

## 関連

- ヘルスレポート: 2026-05-10 kanameone エラー 1 件
- 元コード: `functions/src/pdf/pdfOperations.ts:527-528` (`_r{timestamp}` 命名)、`functions/src/ocr/ocrProcessor.ts:114` (download → 404 throw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document inspection capability supporting query modes by file name or document ID.
  * New optional flag to retrieve related documents alongside inspection results.
  * Updated workflow automation to support document inspection operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/429)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->