### PR TITLE
feat(scripts): audit-storage-mismatch — Firestore↔Storage 整合性監査

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -50,6 +50,9 @@ on:
           - inspect-document --file-name --include-related
           - inspect-document --doc-id
           - inspect-document --doc-id --include-related
+          - audit-storage-mismatch
+          - audit-storage-mismatch --no-orphans
+          - audit-storage-mismatch --no-collisions
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false

--- a/scripts/audit-storage-mismatch.js
+++ b/scripts/audit-storage-mismatch.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Firestore documents.fileUrl と Storage 実体の整合性監査スクリプト（read-only）
+ *
+ * documents コレクションを全件スキャンし、Storage `processed/` の実ファイル一覧と
+ * 突合する。検出する不整合:
+ *   1. fileUrl 孤児: fileUrl が指す Storage オブジェクトが存在しない
+ *   2. fileName 衝突: 複数 docs が同じ fileName を持つ（fileUrl が衝突する候補）
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=docsplit-kanameone node scripts/audit-storage-mismatch.js
+ *
+ * オプション:
+ *   --prefix <path>  Storage の対象 prefix（デフォルト: processed/）
+ *   --no-orphans     fileUrl 孤児チェックを省略（fileName 衝突のみ出力）
+ *   --no-collisions  fileName 衝突チェックを省略
+ */
+
+const admin = require('firebase-admin');
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+
+function getOpt(name, def = null) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+
+const prefix = getOpt('--prefix', 'processed/');
+const skipOrphans = process.argv.includes('--no-orphans');
+const skipCollisions = process.argv.includes('--no-collisions');
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+const bucket = admin.storage().bucket();
+
+function tsToIso(ts) {
+  if (!ts) return null;
+  if (typeof ts.toDate === 'function') return ts.toDate().toISOString();
+  return String(ts);
+}
+
+async function listAllStorageFiles(prefixPath) {
+  const all = new Set();
+  let token;
+  let page = 0;
+  do {
+    const [files, nextQuery] = await bucket.getFiles({
+      prefix: prefixPath,
+      maxResults: 1000,
+      pageToken: token,
+      autoPaginate: false,
+    });
+    files.forEach((f) => all.add(f.name));
+    page += 1;
+    token = nextQuery && nextQuery.pageToken;
+  } while (token);
+  console.log(
+    `Storage list complete: prefix="${prefixPath}", pages=${page}, files=${all.size}`,
+  );
+  return all;
+}
+
+function pathFromUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(/^gs:\/\/[^/]+\/(.+)$/);
+  return m ? m[1] : null;
+}
+
+async function main() {
+  console.log(`Project: ${projectId}`);
+  console.log(`Bucket : ${bucket.name}`);
+  console.log(`Prefix : ${prefix}\n`);
+
+  console.log('Loading documents collection...');
+  const snap = await db.collection('documents').get();
+  console.log(`Total documents: ${snap.size}`);
+
+  const allDocs = [];
+  snap.forEach((doc) => {
+    const data = doc.data();
+    allDocs.push({
+      id: doc.id,
+      status: data.status,
+      fileName: data.fileName,
+      displayFileName: data.displayFileName,
+      fileUrl: data.fileUrl,
+      parentDocumentId: data.parentDocumentId,
+      splitInto: data.splitInto,
+      isSplitSource: data.isSplitSource,
+      rotatedAt: tsToIso(data.rotatedAt),
+      processedAt: tsToIso(data.processedAt),
+      updatedAt: tsToIso(data.updatedAt),
+      lastErrorMessage: data.lastErrorMessage,
+    });
+  });
+
+  const targetDocs = allDocs.filter((d) => {
+    const path = pathFromUrl(d.fileUrl);
+    return path && path.startsWith(prefix);
+  });
+  console.log(`Documents with fileUrl matching prefix "${prefix}": ${targetDocs.length}\n`);
+
+  if (!skipOrphans) {
+    const storagePaths = await listAllStorageFiles(prefix);
+    const orphans = [];
+    for (const d of targetDocs) {
+      const path = pathFromUrl(d.fileUrl);
+      if (!storagePaths.has(path)) {
+        orphans.push(d);
+      }
+    }
+    console.log(`\n=== fileUrl orphans (Storage 実体なし): ${orphans.length} ===`);
+    orphans.forEach((o) => console.log(JSON.stringify(o)));
+
+    const orphansByStatus = orphans.reduce((acc, o) => {
+      acc[o.status || 'unknown'] = (acc[o.status || 'unknown'] || 0) + 1;
+      return acc;
+    }, {});
+    console.log(`\nOrphan breakdown by status: ${JSON.stringify(orphansByStatus)}`);
+  }
+
+  if (!skipCollisions) {
+    const byFileName = new Map();
+    for (const d of targetDocs) {
+      if (!d.fileName) continue;
+      if (!byFileName.has(d.fileName)) byFileName.set(d.fileName, []);
+      byFileName.get(d.fileName).push(d);
+    }
+    const collisions = [...byFileName.entries()].filter(([, v]) => v.length > 1);
+    console.log(`\n=== fileName collisions (複数 docs が同名): ${collisions.length} groups ===`);
+    for (const [fileName, docs] of collisions) {
+      console.log(`\n-- ${fileName} (${docs.length} docs) --`);
+      for (const d of docs) {
+        console.log(`  ${d.id} | status=${d.status} | rotatedAt=${d.rotatedAt} | fileUrl=${d.fileUrl}`);
+      }
+    }
+  }
+
+  await admin.app().delete();
+}
+
+main().catch((err) => {
+  console.error('Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR #429 inspect-document の調査で kanameone 環境の **fileName 衝突 + rotatePdfPages delete 副作用による silent failure** を発見した（同名 fileName を持つ 3 docs のうち、status:processed のまま実体が消失していた件あり）。網羅的に被害を把握するため、documents 全件と Storage 実体を突合する read-only 監査スクリプトを追加。

## 背景（PR #429 で判明した事実）

`fileName: 20260509_未判定_未判定_p3.pdf` を持つ docs が 3 件存在:

| docId | status | fileUrl | parentDocumentId |
|---|---|---|---|
| 0ZuExP... | processed | `..._p3_r1778340000575.pdf` (回転後) | lqoU... |
| M7i4Nx... | **error** | `..._p3.pdf` (旧、Storage に無し) | EkZ6... |
| U4Lf5Z... | **processed** | `..._p3.pdf` (旧、Storage に無し、silent failure) | FIGb... |

`generateFileName` (`functions/src/pdf/pdfOperations.ts:581-595`) は `{date}_{customer}_{docType}_{pageRange}` で命名し timestamp 等の衝突回避要素を持たない。同日に「未判定_未判定_p3」が複数出ると同一パスに上書き save される。さらに `rotatePdfPages` が古ファイルを delete するため、同パスを共有する他 docs が silent に破壊される。

## 検出する不整合

1. **fileUrl 孤児**: Firestore documents.fileUrl が指す Storage オブジェクトが存在しない
2. **fileName 衝突**: 複数 docs が同じ fileName を持つ（fileUrl 衝突候補）

## 実装方針

- Storage 一覧は `bucket.getFiles({prefix, autoPaginate:false})` でページング取得し Set 化
- 各 doc の fileUrl path を O(1) lookup で照合（5640+ docs / 多数 Storage オブジェクトでも `exists()` の N 回 RPC 回避）
- read-only（`db.collection().get()` / `bucket.getFiles()` のみ）

## Test plan

- [ ] PR merge 後、Actions → "Run Operations Script" → `environment: kanameone` / `script: audit-storage-mismatch` で実行
- [ ] 出力された orphan 件数 + status breakdown を確認
- [ ] fileName 衝突 group の中身を確認、被害の網羅性を判断
- [ ] dev 環境でも実行（空 collection でも script が正常終了することを確認）
- [ ] cocoro 環境でも同様に実行（同種 silent failure の有無を確認）

## Acceptance Criteria

- documents 全件と Storage `processed/` 全ファイルを突合し、不整合 docs を JSON 1 行/件で出力する
- fileName 衝突 group を出力する（人間判読しやすい indented フォーマット）
- 書き込み API（set/update/delete）の呼び出しは一切なし
- Storage list の RPC コストが O(N/1000) ページング（N 回ではない）

## 関連

- PR #429 (merged): inspect-document.js 追加
- 設計バグ本体: `functions/src/pdf/pdfOperations.ts:581-595` (generateFileName) / `527-545` (rotatePdfPages delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)