### PR TITLE
fix(scripts): audit-storage-mismatch に STORAGE_BUCKET env 必須化 (PR #430 follow-up)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -130,12 +130,32 @@ jobs:
                 github.event.inputs.environment == 'dev' && secrets.GCP_SA_KEY_DEV ||
                 secrets.GCP_SA_KEY }}
 
-      - name: Resolve project ID from .firebaserc
+      - name: Resolve project ID and storage bucket
         id: resolve
+        env:
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
-          PROJECT_ID=$(node scripts/helpers/firebaserc-helper.js get-project "${{ github.event.inputs.environment }}")
+          set -euo pipefail
+          PROJECT_ID=$(node scripts/helpers/firebaserc-helper.js get-project "$ENVIRONMENT")
           echo "project_id=$PROJECT_ID" >> "$GITHUB_OUTPUT"
-          echo "Resolved: ${{ github.event.inputs.environment }} → $PROJECT_ID"
+          echo "Resolved project_id: $ENVIRONMENT → $PROJECT_ID"
+
+          # CLAUDE.md「Storage バケット名」: .appspot.com / .firebasestorage.app 混在で
+          # projectId からの推測禁止。scripts/clients/<env>.env の STORAGE_BUCKET を抽出する。
+          # ENVIRONMENT は workflow_dispatch.choice で固定 enum (dev / kanameone / cocoro)、
+          # path traversal リスクなし。
+          ENV_FILE="scripts/clients/${ENVIRONMENT}.env"
+          if [ ! -f "$ENV_FILE" ]; then
+            echo "ERROR: $ENV_FILE not found" >&2
+            exit 1
+          fi
+          STORAGE_BUCKET=$(grep -E '^STORAGE_BUCKET=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+          if [ -z "$STORAGE_BUCKET" ]; then
+            echo "ERROR: STORAGE_BUCKET not found in $ENV_FILE" >&2
+            exit 1
+          fi
+          echo "storage_bucket=$STORAGE_BUCKET" >> "$GITHUB_OUTPUT"
+          echo "Resolved storage_bucket: $STORAGE_BUCKET"
 
       - name: Parse script and args
         id: parse
@@ -183,6 +203,7 @@ jobs:
           EXPECTED_COUNT: ${{ github.event.inputs.expected_count }}
           FILE_NAME: ${{ github.event.inputs.file_name }}
           DOC_ID: ${{ github.event.inputs.doc_id }}
+          STORAGE_BUCKET: ${{ steps.resolve.outputs.storage_bucket }}
         run: |
           set -euo pipefail
           if [ -z "$PROJECT_ID" ]; then

--- a/scripts/audit-storage-mismatch.js
+++ b/scripts/audit-storage-mismatch.js
@@ -24,6 +24,14 @@ if (!projectId) {
   process.exit(1);
 }
 
+// CLAUDE.md「Storage バケット名」: .appspot.com / .firebasestorage.app の 2 形式が混在しており、
+// projectId からの推測は禁止。scripts/clients/<env>.env の STORAGE_BUCKET を必ず env 経由で渡す。
+const storageBucket = process.env.STORAGE_BUCKET;
+if (!storageBucket) {
+  console.error('STORAGE_BUCKET を設定してください (例: docsplit-kanameone.firebasestorage.app)');
+  process.exit(1);
+}
+
 function getOpt(name, def = null) {
   const i = process.argv.indexOf(name);
   return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
@@ -33,7 +41,7 @@ const prefix = getOpt('--prefix', 'processed/');
 const skipOrphans = process.argv.includes('--no-orphans');
 const skipCollisions = process.argv.includes('--no-collisions');
 
-admin.initializeApp({ projectId });
+admin.initializeApp({ projectId, storageBucket });
 const db = admin.firestore();
 const bucket = admin.storage().bucket();
 


### PR DESCRIPTION
## Summary

PR #430 merged 後に kanameone 環境で workflow_dispatch 実行 → `FirebaseError: Bucket name not specified or invalid` で fail した。`admin.initializeApp({projectId})` のみで `storageBucket` を渡していなかったため `admin.storage().bucket()` がデフォルトバケット名を取得できず Storage API 呼び出し前に throw。

CLAUDE.md「Storage バケット名」警告通り、projectId からの推測は禁止（cocoro=`.appspot.com` / kanameone+dev=`.firebasestorage.app` で混在）。`scripts/clients/<env>.env` の `STORAGE_BUCKET` を信頼源として env 経由で渡す。

## 変更内容

- **`scripts/audit-storage-mismatch.js`**: `STORAGE_BUCKET` env 必須チェック追加 + `admin.initializeApp({projectId, storageBucket})` で初期化
- **`.github/workflows/run-ops-script.yml`**:
  - resolve step を「Resolve project ID and storage bucket」にリネーム
  - `scripts/clients/${ENVIRONMENT}.env` から `STORAGE_BUCKET=...` を `grep -E '^STORAGE_BUCKET='` で抽出 → `outputs.storage_bucket`
  - Run script env: に `STORAGE_BUCKET` 追加（他スクリプトも将来 storage 参照時にそのまま使える）

`ENVIRONMENT` は `workflow_dispatch.choice` で固定 enum (dev/kanameone/cocoro)、path traversal 不可。

## Test plan

- [ ] PR merge 後、Actions → "Run Operations Script" → `environment: kanameone` / `script: audit-storage-mismatch` で再実行
- [ ] `Resolved storage_bucket: docsplit-kanameone.firebasestorage.app` がログに出る
- [ ] orphan + collisions 出力が得られる
- [ ] dev 環境でも実行（空 collection でも script 正常終了 + storage_bucket 解決）
- [ ] cocoro 環境でも実行（`.appspot.com` 形式で正しく解決）

## Acceptance Criteria

- workflow が STORAGE_BUCKET を env から正しく解決し audit-storage-mismatch.js が起動できる
- script が `STORAGE_BUCKET` 未設定時に明示的なエラーで早期 exit する
- 他既存スクリプト（cleanup-duplicates / fix-stuck-documents 等）の挙動に影響しない（env 追加のみで参照は新規スクリプトのみ）

## 関連

- PR #429 (merged): inspect-document.js
- PR #430 (merged): audit-storage-mismatch.js (本 fix の対象)

🤖 Generated with [Claude Code](https://claude.com/claude-code)