### PR TITLE
fix(storage): Issue #432 PR-A safety net — rotate/delete で同 fileUrl 共有 doc を検出して Storage delete を skip

### DIFF
--- a/functions/src/documents/deleteDocument.ts
+++ b/functions/src/documents/deleteDocument.ts
@@ -13,6 +13,7 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { canSafelyDeleteStorageFile } from '../storage/storageDeletionGuard';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -86,8 +87,26 @@ export const deleteDocument = onCall(
 
           const [exists] = await file.exists();
           if (exists) {
-            await file.delete();
-            console.log(`Deleted storage file: ${filePath}`);
+            // Issue #432 PR-A safety net: 同 fileUrl 共有 doc がある場合は delete skip
+            const { canDelete, sharingDocCount } = await canSafelyDeleteStorageFile(
+              db,
+              fileUrl,
+              documentId
+            );
+            if (!canDelete) {
+              console.warn('Skipped storage delete: shared fileUrl detected', {
+                skippedStorageDelete: true,
+                operation: 'deleteDocument',
+                documentId,
+                fileUrl,
+                sharingDocCount,
+                reason:
+                  'Issue #432 safety net: other documents reference the same fileUrl',
+              });
+            } else {
+              await file.delete();
+              console.log(`Deleted storage file: ${filePath}`);
+            }
           } else {
             console.log(`Storage file not found (already deleted?): ${filePath}`);
           }

--- a/functions/src/documents/deleteDocument.ts
+++ b/functions/src/documents/deleteDocument.ts
@@ -87,21 +87,44 @@ export const deleteDocument = onCall(
 
           const [exists] = await file.exists();
           if (exists) {
-            // Issue #432 PR-A safety net: 同 fileUrl 共有 doc がある場合は delete skip
-            const { canDelete, sharingDocCount } = await canSafelyDeleteStorageFile(
-              db,
-              fileUrl,
-              documentId
-            );
+            // Issue #432 PR-A safety net: fail-closed で skip 理由を区別記録
+            let canDelete = false;
+            let sharingDocCountUpTo2 = 0;
+            try {
+              const guardResult = await canSafelyDeleteStorageFile(
+                db,
+                fileUrl,
+                documentId
+              );
+              canDelete = guardResult.canDelete;
+              sharingDocCountUpTo2 = guardResult.sharingDocCountUpTo2;
+            } catch (guardErr) {
+              console.error(
+                'Storage safety-net query failed; skipping delete (fail-closed)',
+                {
+                  skippedStorageDelete: true,
+                  skipReason: 'safetyNetQueryFailed',
+                  operation: 'deleteDocument',
+                  documentId,
+                  fileUrl,
+                  error:
+                    guardErr instanceof Error ? guardErr.message : String(guardErr),
+                }
+              );
+              errors.push(
+                'Storage safety-net query failed (fail-closed: delete skipped)'
+              );
+              canDelete = false;
+            }
+
             if (!canDelete) {
               console.warn('Skipped storage delete: shared fileUrl detected', {
                 skippedStorageDelete: true,
+                skipReason: 'sharedFileUrl',
                 operation: 'deleteDocument',
                 documentId,
                 fileUrl,
-                sharingDocCount,
-                reason:
-                  'Issue #432 safety net: other documents reference the same fileUrl',
+                sharingDocCountUpTo2,
               });
             } else {
               await file.delete();
@@ -113,7 +136,13 @@ export const deleteDocument = onCall(
         }
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
-        console.error('Failed to delete storage file:', errMsg);
+        console.error('Failed to delete storage file', {
+          operation: 'deleteDocument',
+          stage: 'storageDelete',
+          documentId,
+          fileUrl,
+          error: errMsg,
+        });
         errors.push(`Storage deletion failed: ${errMsg}`);
       }
     }

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -537,28 +537,51 @@ export const rotatePdfPages = onCall(
     });
     console.log('PDF uploaded to new path:', newFilePath);
 
-    // 古いファイルを削除（Issue #432 PR-A safety net: 同 fileUrl 共有 doc がある場合は skip）
+    // Issue #432 PR-A safety net: 同 fileUrl 共有 doc 検出時は旧 file delete を skip。
+    // safety net query 失敗時は fail-closed (delete しない) で構造化エラーログを残す。
+    let canDelete = false;
+    let sharingDocCountUpTo2 = 0;
     try {
-      const { canDelete, sharingDocCount } = await canSafelyDeleteStorageFile(
-        db,
+      const guardResult = await canSafelyDeleteStorageFile(db, fileUrl, documentId);
+      canDelete = guardResult.canDelete;
+      sharingDocCountUpTo2 = guardResult.sharingDocCountUpTo2;
+    } catch (guardErr) {
+      console.error('Storage safety-net query failed; skipping delete (fail-closed)', {
+        skippedStorageDelete: true,
+        skipReason: 'safetyNetQueryFailed',
+        operation: 'rotatePdfPages',
+        documentId,
         fileUrl,
-        documentId
-      );
-      if (!canDelete) {
-        console.warn('Skipped storage delete: shared fileUrl detected', {
-          skippedStorageDelete: true,
-          operation: 'rotatePdfPages',
-          documentId,
-          fileUrl,
-          sharingDocCount,
-          reason: 'Issue #432 safety net: other documents reference the same fileUrl',
-        });
-      } else {
+        error: guardErr instanceof Error ? guardErr.message : String(guardErr),
+      });
+      canDelete = false;
+    }
+
+    if (!canDelete) {
+      console.warn('Skipped storage delete: shared fileUrl detected', {
+        skippedStorageDelete: true,
+        skipReason: 'sharedFileUrl',
+        operation: 'rotatePdfPages',
+        documentId,
+        fileUrl,
+        sharingDocCountUpTo2,
+      });
+    } else {
+      // delete 失敗は許容 (旧 file 既に存在しない等のケースあり)。
+      // ただし silent failure 回避のため severity warn + 構造化ログで観測可能化。
+      try {
         await file.delete();
         console.log('Old file deleted:', filePath);
+      } catch (deleteErr) {
+        console.warn('Old file delete attempt failed (root cause not classified)', {
+          operation: 'rotatePdfPages',
+          stage: 'storageDelete',
+          documentId,
+          fileUrl,
+          filePath,
+          error: deleteErr instanceof Error ? deleteErr.message : String(deleteErr),
+        });
       }
-    } catch (deleteErr) {
-      console.log('Could not delete old file (may not exist):', deleteErr);
     }
 
     // 新しいファイルURLを構築

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -23,6 +23,7 @@ import { generateDisplayFileName } from '../../../shared/generateDisplayFileName
 import { timestampToDateString } from '../utils/timestampHelpers';
 import { loadMasterData } from '../utils/loadMasterData';
 import { sanitizeFilenameForStorage } from '../utils/fileNaming';
+import { canSafelyDeleteStorageFile } from '../storage/storageDeletionGuard';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -536,10 +537,26 @@ export const rotatePdfPages = onCall(
     });
     console.log('PDF uploaded to new path:', newFilePath);
 
-    // 古いファイルを削除（エラーは無視）
+    // 古いファイルを削除（Issue #432 PR-A safety net: 同 fileUrl 共有 doc がある場合は skip）
     try {
-      await file.delete();
-      console.log('Old file deleted:', filePath);
+      const { canDelete, sharingDocCount } = await canSafelyDeleteStorageFile(
+        db,
+        fileUrl,
+        documentId
+      );
+      if (!canDelete) {
+        console.warn('Skipped storage delete: shared fileUrl detected', {
+          skippedStorageDelete: true,
+          operation: 'rotatePdfPages',
+          documentId,
+          fileUrl,
+          sharingDocCount,
+          reason: 'Issue #432 safety net: other documents reference the same fileUrl',
+        });
+      } else {
+        await file.delete();
+        console.log('Old file deleted:', filePath);
+      }
     } catch (deleteErr) {
       console.log('Could not delete old file (may not exist):', deleteErr);
     }

--- a/functions/src/storage/storageDeletionGuard.ts
+++ b/functions/src/storage/storageDeletionGuard.ts
@@ -5,8 +5,13 @@
  * rotatePdfPages / deleteDocument での Storage file delete が
  * 他 document の実体を巻き添え破壊する設計バグへの暫定対策。
  *
- * 構造修正 (Issue #432 PR-B: docId namespace 化) 完了後も、
- * 既存旧 path doc 保護のため恒久的に有効な safety net として残す。
+ * 旧 path (docId namespace 化前に作成された document) が 1 件でも残る限り有効。
+ * Issue #432 PR-B (docId namespace 化) + 全 backfill 完了 + 旧 path 削除確認後に
+ * 再評価可。
+ *
+ * 適用範囲: 後発的な delete (rotatePdfPages 旧 file 削除 / deleteDocument)。
+ * upload-rollback (uploadPdf.ts:243) は新規 upload 直後で他 doc が参照しえないため
+ * 意図的に対象外。
  */
 
 import * as admin from 'firebase-admin';
@@ -14,7 +19,7 @@ import * as admin from 'firebase-admin';
 /**
  * 同一 fileUrl を参照する他の document が存在するかを判定。
  *
- * @param sharingDocs Firestore query 結果の document リスト (id のみ必要)
+ * @param sharingDocs 同 fileUrl を共有する document の id 配列 (limit(2) で取得済を想定)
  * @param selfDocumentId 自分自身の documentId
  * @returns true なら他 doc と共有されており delete 危険、false なら単独参照で delete 安全
  */
@@ -31,15 +36,25 @@ export function hasOtherSharingDoc(
  * Firestore で同 fileUrl を共有する document を limit(2) で検索し、
  * Storage file delete の安全性を判定する。
  *
- * limit(2) は「自分自身 + 他 1 件」を検出すれば十分のため軽量。
- * race condition は完全には防げない (query 後に別 doc 追加の可能性あり) が、
- * Issue #432 P0 の即応 safety net として実用十分。
+ * limit(2) は次の両ケースを最小コストで判定するための採用:
+ *   (a) 「自分自身 + 他 1 件」 → delete 不可
+ *   (b) 「他 2 件 (= 自分が窓外、3+ 件共有時に該当)」 → 保守的に delete 不可
+ * count() 集計より目的に合致しコストも軽量。
+ *
+ * race condition は完全には防げない。本 safety net がカバーしない代表例:
+ *   - query 後に別 doc が同 fileUrl で追加される (新規共有出現)
+ *   - 逆方向の race: concurrent rotate で両者が単独所有と判定 → 両方 delete 走行
+ *   後者は PR-B の docId namespace 化で根絶されるため、本 safety net は
+ *   既存共有資産の保護を主目的とする。
+ *
+ * 例外時の扱い: 本関数は throw する。caller は fail-closed (delete を skip) で
+ *   呼び出すこと。silent-failure 防止のため caller 側で try/catch + 構造化ログ必須。
  */
 export async function canSafelyDeleteStorageFile(
   db: admin.firestore.Firestore,
   fileUrl: string,
   selfDocumentId: string
-): Promise<{ canDelete: boolean; sharingDocCount: number }> {
+): Promise<{ canDelete: boolean; sharingDocCountUpTo2: number }> {
   const sharingQuery = await db
     .collection('documents')
     .where('fileUrl', '==', fileUrl)
@@ -49,6 +64,6 @@ export async function canSafelyDeleteStorageFile(
   const canDelete = !hasOtherSharingDoc(sharingDocs, selfDocumentId);
   return {
     canDelete,
-    sharingDocCount: sharingQuery.size,
+    sharingDocCountUpTo2: sharingQuery.size,
   };
 }

--- a/functions/src/storage/storageDeletionGuard.ts
+++ b/functions/src/storage/storageDeletionGuard.ts
@@ -1,0 +1,54 @@
+/**
+ * Storage delete safety net (Issue #432 PR-A)
+ *
+ * 同一 fileUrl を複数 document が共有している場合、
+ * rotatePdfPages / deleteDocument での Storage file delete が
+ * 他 document の実体を巻き添え破壊する設計バグへの暫定対策。
+ *
+ * 構造修正 (Issue #432 PR-B: docId namespace 化) 完了後も、
+ * 既存旧 path doc 保護のため恒久的に有効な safety net として残す。
+ */
+
+import * as admin from 'firebase-admin';
+
+/**
+ * 同一 fileUrl を参照する他の document が存在するかを判定。
+ *
+ * @param sharingDocs Firestore query 結果の document リスト (id のみ必要)
+ * @param selfDocumentId 自分自身の documentId
+ * @returns true なら他 doc と共有されており delete 危険、false なら単独参照で delete 安全
+ */
+export function hasOtherSharingDoc(
+  sharingDocs: Array<{ id: string }>,
+  selfDocumentId: string
+): boolean {
+  if (sharingDocs.length >= 2) return true;
+  if (sharingDocs.length === 1 && sharingDocs[0].id !== selfDocumentId) return true;
+  return false;
+}
+
+/**
+ * Firestore で同 fileUrl を共有する document を limit(2) で検索し、
+ * Storage file delete の安全性を判定する。
+ *
+ * limit(2) は「自分自身 + 他 1 件」を検出すれば十分のため軽量。
+ * race condition は完全には防げない (query 後に別 doc 追加の可能性あり) が、
+ * Issue #432 P0 の即応 safety net として実用十分。
+ */
+export async function canSafelyDeleteStorageFile(
+  db: admin.firestore.Firestore,
+  fileUrl: string,
+  selfDocumentId: string
+): Promise<{ canDelete: boolean; sharingDocCount: number }> {
+  const sharingQuery = await db
+    .collection('documents')
+    .where('fileUrl', '==', fileUrl)
+    .limit(2)
+    .get();
+  const sharingDocs = sharingQuery.docs.map((d) => ({ id: d.id }));
+  const canDelete = !hasOtherSharingDoc(sharingDocs, selfDocumentId);
+  return {
+    canDelete,
+    sharingDocCount: sharingQuery.size,
+  };
+}

--- a/functions/test/storageDeletionGuard.test.ts
+++ b/functions/test/storageDeletionGuard.test.ts
@@ -2,10 +2,13 @@
  * Storage delete safety net のユニットテスト (Issue #432 PR-A)
  *
  * 純粋関数 hasOtherSharingDoc の挙動分岐を検証。
- * Firestore 連携部 (canSafelyDeleteStorageFile) は emulator integration test 範囲。
+ * Firestore 連携部 (canSafelyDeleteStorageFile) は Issue #432 PR-B で
+ * emulator integration test を追加予定 (本 PR スコープ外)。
  */
 
 import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
 import { hasOtherSharingDoc } from '../src/storage/storageDeletionGuard';
 
 describe('hasOtherSharingDoc (Issue #432 PR-A safety net)', () => {
@@ -30,7 +33,7 @@ describe('hasOtherSharingDoc (Issue #432 PR-A safety net)', () => {
       ).to.be.true;
     });
 
-    it('共有 doc が 2 件で自分が含まれない → true (limit(2) 範囲外に自分があるケース)', () => {
+    it('共有 doc が 2 件で自分が含まれない → true (3+ 件共有時に limit(2) 範囲外に自分が出るケース、保守的に delete 不可)', () => {
       expect(
         hasOtherSharingDoc([{ id: 'other-1' }, { id: 'other-2' }], 'self-id')
       ).to.be.true;
@@ -46,4 +49,68 @@ describe('hasOtherSharingDoc (Issue #432 PR-A safety net)', () => {
       expect(hasOtherSharingDoc([{ id: 'other' }], '')).to.be.true;
     });
   });
+});
+
+/**
+ * 構造化ログのキー名契約テスト (Issue #432 PR-A)
+ *
+ * Cloud Logging クエリ (Test plan で監視対象) は以下のキー名に依存する:
+ *   - skippedStorageDelete: true
+ *   - skipReason: 'sharedFileUrl' | 'safetyNetQueryFailed'
+ *   - operation: 'rotatePdfPages' | 'deleteDocument'
+ *   - documentId, fileUrl
+ *
+ * 将来のリファクタでキー名が silently 変更されると kanameone 環境の監視が壊れるため、
+ * grep contract で固定する (純粋関数のテストでは検出不可能な接続部の lock-in)。
+ */
+describe('構造化ログのキー名契約 (Issue #432 PR-A Cloud Logging クエリ保護)', () => {
+  const sourceFiles = [
+    {
+      label: 'pdfOperations.ts (rotatePdfPages)',
+      filePath: path.join(__dirname, '..', 'src', 'pdf', 'pdfOperations.ts'),
+      operationName: 'rotatePdfPages',
+    },
+    {
+      label: 'deleteDocument.ts',
+      filePath: path.join(__dirname, '..', 'src', 'documents', 'deleteDocument.ts'),
+      operationName: 'deleteDocument',
+    },
+  ];
+
+  for (const { label, filePath, operationName } of sourceFiles) {
+    describe(label, () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+
+      it("skippedStorageDelete: true キーが含まれる", () => {
+        expect(content).to.match(/skippedStorageDelete:\s*true/);
+      });
+
+      it("skipReason キーが含まれる (skip 理由の識別フィールド)", () => {
+        expect(content).to.include('skipReason:');
+      });
+
+      it("skipReason に 'sharedFileUrl' リテラルが含まれる (共有検出 skip)", () => {
+        expect(content).to.match(/skipReason:\s*['"]sharedFileUrl['"]/);
+      });
+
+      it("skipReason に 'safetyNetQueryFailed' リテラルが含まれる (query 失敗 skip)", () => {
+        expect(content).to.match(/skipReason:\s*['"]safetyNetQueryFailed['"]/);
+      });
+
+      it(`operation キーに '${operationName}' が含まれる`, () => {
+        const pattern = new RegExp(
+          `operation:\\s*['"]${operationName}['"]`
+        );
+        expect(content).to.match(pattern);
+      });
+
+      it("documentId キーが含まれる (Cloud Logging filter で必須)", () => {
+        expect(content).to.match(/^\s*documentId,?\s*$/m);
+      });
+
+      it("fileUrl キーが含まれる (Cloud Logging filter で必須)", () => {
+        expect(content).to.match(/^\s*fileUrl,?\s*$/m);
+      });
+    });
+  }
 });

--- a/functions/test/storageDeletionGuard.test.ts
+++ b/functions/test/storageDeletionGuard.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Storage delete safety net のユニットテスト (Issue #432 PR-A)
+ *
+ * 純粋関数 hasOtherSharingDoc の挙動分岐を検証。
+ * Firestore 連携部 (canSafelyDeleteStorageFile) は emulator integration test 範囲。
+ */
+
+import { expect } from 'chai';
+import { hasOtherSharingDoc } from '../src/storage/storageDeletionGuard';
+
+describe('hasOtherSharingDoc (Issue #432 PR-A safety net)', () => {
+  describe('単独参照 (delete 安全)', () => {
+    it('共有 doc が 0 件 → false (他参照なし、安全)', () => {
+      expect(hasOtherSharingDoc([], 'self-id')).to.be.false;
+    });
+
+    it('共有 doc が自分自身のみ → false (他参照なし、安全)', () => {
+      expect(hasOtherSharingDoc([{ id: 'self-id' }], 'self-id')).to.be.false;
+    });
+  });
+
+  describe('共有あり (delete 危険、skip すべき)', () => {
+    it('共有 doc が他 1 件 → true (他参照あり、危険)', () => {
+      expect(hasOtherSharingDoc([{ id: 'other-id' }], 'self-id')).to.be.true;
+    });
+
+    it('共有 doc が 2 件以上 → true (他参照あり、危険)', () => {
+      expect(
+        hasOtherSharingDoc([{ id: 'self-id' }, { id: 'other-id' }], 'self-id')
+      ).to.be.true;
+    });
+
+    it('共有 doc が 2 件で自分が含まれない → true (limit(2) 範囲外に自分があるケース)', () => {
+      expect(
+        hasOtherSharingDoc([{ id: 'other-1' }, { id: 'other-2' }], 'self-id')
+      ).to.be.true;
+    });
+  });
+
+  describe('境界・異常系', () => {
+    it('selfDocumentId が空文字でも単独 doc が空文字なら false', () => {
+      expect(hasOtherSharingDoc([{ id: '' }], '')).to.be.false;
+    });
+
+    it('selfDocumentId が空文字、共有 doc が他 ID あり → true', () => {
+      expect(hasOtherSharingDoc([{ id: 'other' }], '')).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

分割PDF の fileName 衝突で複数 document が同一 Storage path を共有している状態で、`rotatePdfPages` / `deleteDocument` が旧 file delete を行うと、巻き添えで他 doc の PDF 実体が完全消失する設計バグ (Issue #432) への **即応 safety net (PR-A)**。

- 共通 helper `canSafelyDeleteStorageFile` を新規追加 (`limit(2)` 軽量 query)
- `rotatePdfPages` / `deleteDocument` で旧 file delete 前に共有チェック、共有時は構造化警告ログを出して skip
- 単独参照時は従来通り delete (後方互換)
- unit test 7 件追加 (`hasOtherSharingDoc` 純粋関数の挙動分岐)

## なぜこれが先行 PR か

Issue #432 の根治は PR-B (docId namespace 構造修正) だが、kanameone 環境では既に **silent breakage 推定 90+ 件 + 完全消失 4 件** が発生しており、進行中破壊を即停止する必要があるため、最小変更の safety net を分離 PR で先行展開する (Codex セカンドオピニオン推奨)。

PR-B 完了後も、既存旧 path doc 保護のため恒久有効。

## 設計の要点 (Codex セカンドオピニオン反映)

- `limit(2)` で軽量化 (count 集計より目的に合致)
- 共有検出時は `console.warn` で構造化ログ (`skippedStorageDelete: true`, `operation`, `documentId`, `fileUrl`, `sharingDocCount`) を出力 → 後続の orphan 候補検知に利用可
- race condition は完全には防げない (query 後に他 doc 追加の可能性) が、Issue #432 P0 即応として実用十分。完全な参照管理は将来課題

## Test plan

- [x] `npm test` (functions): **840 件全 PASS** (新規 7 件 + 既存 833 件)
- [x] `npm run lint` (functions): **0 errors** (warnings 25 は既存、本変更無関係)
- [x] `tsc --noEmit` (functions, frontend): **エラーなし**
- [ ] CI lint-build-test PASS
- [ ] CI CodeRabbit / GitGuardian PASS
- [ ] dev 反映後の動作確認 (手動 or emulator integration):
  - 同 fileUrl 共有 2 docs を投入 → rotate 実行 → 共有 file が残存することを確認 (Cloud Logging で `skippedStorageDelete: true` ログ確認)
  - 単独参照 doc を rotate 実行 → 従来通り旧 file が delete されることを確認
  - 同 fileUrl 共有 2 docs の片方を delete 実行 → 共有 file が残存することを確認
- [ ] kanameone 反映後、Cloud Logging で `skippedStorageDelete: true` ログ件数を観測 (進行中破壊の停止確認)
- [ ] cocoro 反映後、ログ確認 (被害ゼロのため skip ログ件数は 0 想定だが、設計バグ共通のため念のため)

## Refs

- Issue #432 (P0 設計バグ)
- セカンドオピニオン: 前セッション Codex MCP review + 本 PR 計画段階 Codex MCP review

🤖 Generated with [Claude Code](https://claude.com/claude-code)