### PR TITLE
fix(pdf): Issue #432 PR-B — splitPdf に docId namespace を導入し Storage path 衝突を根治

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -317,10 +317,10 @@ export const splitPdf = onCall(
 
       // Issue #432 PR-B: docId namespace 分離で Storage path 衝突を根治。
       // Firestore docId を Storage save 前に確定させ path に組み込む。
+      // PR-A (storageDeletionGuard) は旧 path 旧 doc 保護用に恒久有効。本 PR は新規 split のみ根治。
       const newDocRef = db.collection('documents').doc();
 
-      // ファイル名生成。timestamp は表示用 date 部分の生成に使うのみ
-      // (衝突回避は docId namespace で担保、generateFileName は責務を持たない)。
+      // ファイル名生成。
       const timestamp = Date.now();
       const fileName = generateFileName({
         customerName,
@@ -330,7 +330,9 @@ export const splitPdf = onCall(
         endPage,
       });
 
-      // Cloud Storage に保存 (Issue #432 PR-B: processed/{docId}/{fileName} で一意性保証)
+      // Cloud Storage に保存 (Issue #432 PR-B: processed/{docId}/{fileName} で一意性保証)。
+      // NOTE: 意図的に try/catch なし。Storage save 失敗は callable error として
+      // caller に surface すべき (この時点で Firestore set 未実行のため orphan 不発生)。
       const newFilePath = `processed/${newDocRef.id}/${fileName}`;
       const newFile = bucket.file(newFilePath);
       await newFile.save(Buffer.from(newPdfBytes), {
@@ -430,6 +432,17 @@ export const splitPdf = onCall(
         });
         createdDocIds.push(newDocRef.id);
       } catch (firestoreErr) {
+        // Issue #432 PR-B partial state log: segments 途中失敗で先行 N-1 docs が残る
+        // (rollback は本 PR スコープ外、別 Issue で扱う)。
+        console.error('splitPdf failed mid-loop; partial children remain in Firestore', {
+          operation: 'splitPdf',
+          stage: 'segmentsLoop',
+          parentDocumentId: documentId,
+          successfulSegments: createdDocIds.length,
+          totalSegments: segments.length,
+          failedSegmentIndex: segments.indexOf(segment),
+          partialChildIds: createdDocIds,
+        });
         console.error('Firestore set failed after Storage save; attempting orphan cleanup', {
           operation: 'splitPdf',
           stage: 'firestoreSet',
@@ -437,8 +450,14 @@ export const splitPdf = onCall(
           newFilePath,
           error: firestoreErr instanceof Error ? firestoreErr.message : String(firestoreErr),
         });
+        let cleanupErrorCaptured: unknown = null;
         try {
           await newFile.delete();
+        } catch (cleanupErr) {
+          cleanupErrorCaptured = cleanupErr;
+        }
+
+        if (cleanupErrorCaptured === null) {
           console.warn('Cleaned up orphan Storage file after Firestore set failure', {
             operation: 'splitPdf',
             stage: 'orphanCleanup',
@@ -446,18 +465,31 @@ export const splitPdf = onCall(
             newFilePath,
             cleanupResult: 'success',
           });
-        } catch (cleanupErr) {
-          console.error('Failed to cleanup orphan Storage file (manual cleanup needed)', {
-            operation: 'splitPdf',
-            stage: 'orphanCleanup',
-            newDocId: newDocRef.id,
-            newFilePath,
-            cleanupResult: 'failed',
-            cleanupError:
-              cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
-          });
+          throw firestoreErr;
         }
-        throw firestoreErr;
+
+        // 二段失敗: cleanup 自体が失敗 → Storage orphan 残存。
+        // audit-storage-mismatch.js の逆方向検出 (Storage→Firestore missing) は別 Issue で追加予定。
+        // 元例外と cleanup 失敗の両方を Error.cause で保持し、Sentry/log dedup での区別を可能に。
+        console.error('Failed to cleanup orphan Storage file (manual cleanup needed)', {
+          operation: 'splitPdf',
+          stage: 'orphanCleanup',
+          newDocId: newDocRef.id,
+          newFilePath,
+          bucket: bucket.name,
+          cleanupResult: 'failed',
+          cleanupError:
+            cleanupErrorCaptured instanceof Error
+              ? cleanupErrorCaptured.message
+              : String(cleanupErrorCaptured),
+          manualCleanupCommand: `gsutil rm gs://${bucket.name}/${newFilePath}`,
+        });
+        const wrapped = new Error(
+          `splitPdf: Firestore set failed AND orphan cleanup failed (newDocId=${newDocRef.id}, path=${newFilePath})`
+        ) as Error & { cause?: unknown; orphanLeft?: boolean };
+        wrapped.cause = firestoreErr;
+        wrapped.orphanLeft = true;
+        throw wrapped;
       }
     }
 
@@ -653,9 +685,19 @@ export const rotatePdfPages = onCall(
 // ヘルパー関数
 // ============================================
 
+/**
+ * 表示用ファイル名を生成する。
+ *
+ * Issue #432 PR-B 以降、衝突回避の責務は持たない (Storage path は呼び出し側で
+ * `processed/{docId}/{fileName}` 形式に namespace 化することで一意性を保証)。
+ *
+ * @param timestamp 表示用 date 部分の生成にのみ使用 (`{YYYYMMDD}` プレフィックス)。
+ *   Issue #432 後続 PR (PR-D 候補) で caller 修正を経て削除予定。
+ */
 function generateFileName(params: {
   customerName: string;
   documentType: string;
+  /** @deprecated Issue #432 後続 PR で削除予定。表示用 date 部分の生成にのみ使用。 */
   timestamp: number;
   startPage: number;
   endPage: number;

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -315,7 +315,12 @@ export const splitPdf = onCall(
       // PDFをバイト配列に変換
       const newPdfBytes = await newPdf.save();
 
-      // ファイル名生成
+      // Issue #432 PR-B: docId namespace 分離で Storage path 衝突を根治。
+      // Firestore docId を Storage save 前に確定させ path に組み込む。
+      const newDocRef = db.collection('documents').doc();
+
+      // ファイル名生成。timestamp は表示用 date 部分の生成に使うのみ
+      // (衝突回避は docId namespace で担保、generateFileName は責務を持たない)。
       const timestamp = Date.now();
       const fileName = generateFileName({
         customerName,
@@ -325,8 +330,8 @@ export const splitPdf = onCall(
         endPage,
       });
 
-      // Cloud Storageに保存
-      const newFilePath = `processed/${fileName}`;
+      // Cloud Storage に保存 (Issue #432 PR-B: processed/{docId}/{fileName} で一意性保証)
+      const newFilePath = `processed/${newDocRef.id}/${fileName}`;
       const newFile = bucket.file(newFilePath);
       await newFile.save(Buffer.from(newPdfBytes), {
         metadata: { contentType: 'application/pdf' },
@@ -382,48 +387,78 @@ export const splitPdf = onCall(
           docData.fileDateFormatted ?? timestampToDateString(docData.fileDate),
       });
 
-      // 新しいドキュメントをFirestoreに作成
-      // ユーザーが分割UIで選択した値は常にconfirmed=true
-      const newDocRef = db.collection('documents').doc();
+      // 新しいドキュメントを Firestore に作成 (ユーザーが分割UIで選択した値は常に confirmed=true)。
+      // Issue #432 PR-B 補償処理: Storage save 成功後の Firestore set 失敗で orphan が
+      // 残ると後続 split との path 衝突リスクが再発するため、best-effort で cleanup する。
       const splitDocFields = buildSplitDocumentData(segment);
-      await newDocRef.set({
-        ...(displayFileName ? { displayFileName } : {}),
-        id: newDocRef.id,
-        processedAt: admin.firestore.FieldValue.serverTimestamp(),
-        fileId: newDocRef.id,
-        fileName,
-        mimeType: 'application/pdf',
-        ocrResult: extractOcrResultForPages(
-          docData.pageResults || [],
-          startPage,
-          endPage
-        ),
-        // セグメントから構築したフィールド（careManager/careManagerKey含む）
-        ...splitDocFields,
-        confirmedBy: request.auth?.uid || null,
-        confirmedAt: admin.firestore.FieldValue.serverTimestamp(),
-        // 事業所確定
-        officeConfirmedBy: request.auth?.uid || null,
-        officeConfirmedAt: admin.firestore.FieldValue.serverTimestamp(),
-        // OCR抽出スナップショット
-        ocrExtraction,
-        // ページ結果（再OCR不要にするため保存）
-        pageResults: segmentPageResults.map((p: SplitPageInput, index: number) => ({
-          ...p,
-          pageNumber: index + 1, // 分割後の新しいページ番号
-          originalPageNumber: p.pageNumber, // 元のページ番号
-        })),
-        // ファイル情報
-        fileUrl: `gs://${bucket.name}/${newFilePath}`,
-        fileDate: docData.fileDate,
-        totalPages: endPage - startPage + 1,
-        targetPageNumber: 1,
-        status: 'processed',
-        parentDocumentId: documentId,
-        splitFromPages: { start: startPage, end: endPage },
-      });
-
-      createdDocIds.push(newDocRef.id);
+      try {
+        await newDocRef.set({
+          ...(displayFileName ? { displayFileName } : {}),
+          id: newDocRef.id,
+          processedAt: admin.firestore.FieldValue.serverTimestamp(),
+          fileId: newDocRef.id,
+          fileName,
+          mimeType: 'application/pdf',
+          ocrResult: extractOcrResultForPages(
+            docData.pageResults || [],
+            startPage,
+            endPage
+          ),
+          // セグメントから構築したフィールド（careManager/careManagerKey含む）
+          ...splitDocFields,
+          confirmedBy: request.auth?.uid || null,
+          confirmedAt: admin.firestore.FieldValue.serverTimestamp(),
+          // 事業所確定
+          officeConfirmedBy: request.auth?.uid || null,
+          officeConfirmedAt: admin.firestore.FieldValue.serverTimestamp(),
+          // OCR抽出スナップショット
+          ocrExtraction,
+          // ページ結果（再OCR不要にするため保存）
+          pageResults: segmentPageResults.map((p: SplitPageInput, index: number) => ({
+            ...p,
+            pageNumber: index + 1, // 分割後の新しいページ番号
+            originalPageNumber: p.pageNumber, // 元のページ番号
+          })),
+          // ファイル情報
+          fileUrl: `gs://${bucket.name}/${newFilePath}`,
+          fileDate: docData.fileDate,
+          totalPages: endPage - startPage + 1,
+          targetPageNumber: 1,
+          status: 'processed',
+          parentDocumentId: documentId,
+          splitFromPages: { start: startPage, end: endPage },
+        });
+        createdDocIds.push(newDocRef.id);
+      } catch (firestoreErr) {
+        console.error('Firestore set failed after Storage save; attempting orphan cleanup', {
+          operation: 'splitPdf',
+          stage: 'firestoreSet',
+          newDocId: newDocRef.id,
+          newFilePath,
+          error: firestoreErr instanceof Error ? firestoreErr.message : String(firestoreErr),
+        });
+        try {
+          await newFile.delete();
+          console.warn('Cleaned up orphan Storage file after Firestore set failure', {
+            operation: 'splitPdf',
+            stage: 'orphanCleanup',
+            newDocId: newDocRef.id,
+            newFilePath,
+            cleanupResult: 'success',
+          });
+        } catch (cleanupErr) {
+          console.error('Failed to cleanup orphan Storage file (manual cleanup needed)', {
+            operation: 'splitPdf',
+            stage: 'orphanCleanup',
+            newDocId: newDocRef.id,
+            newFilePath,
+            cleanupResult: 'failed',
+            cleanupError:
+              cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          });
+        }
+        throw firestoreErr;
+      }
     }
 
     // 元ドキュメントのステータスを更新（分割済みフラグ）

--- a/functions/test/splitPdfDocIdNamespace.test.ts
+++ b/functions/test/splitPdfDocIdNamespace.test.ts
@@ -1,0 +1,71 @@
+/**
+ * splitPdf docId namespace 設計の grep contract テスト (Issue #432 PR-B)
+ *
+ * Storage path 衝突を根治する docId namespace 分離 (processed/{docId}/{fileName})
+ * と、Storage save 成功 → Firestore set 失敗時の orphan cleanup 補償処理を、
+ * リファクタで silently 退化させないために grep で固定する。
+ *
+ * splitPdf は副作用が大きく (pdf-lib / Storage / Firestore) emulator + Storage
+ * emulator + pdf-lib 依存のため、純粋関数化が困難。grep contract で設計意図を保護。
+ *
+ * 実体動作の AC 検証 (path 衝突なし / 旧 path doc の rotate/delete 動作) は
+ * dev/kanameone の実環境ログで観測 (PR-A safety net 構造化ログを併用)。
+ */
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+// ローカル import を追加することで Mocha esm-utils が CJS として load する
+// (副作用ゼロの import: テスト本体は使わないが loader 推論用)
+import '../src/storage/storageDeletionGuard';
+
+const sourcePath = path.resolve(process.cwd(), 'src/pdf/pdfOperations.ts');
+const content = fs.readFileSync(sourcePath, 'utf-8');
+
+describe('splitPdf docId namespace 設計 (Issue #432 PR-B 衝突根治)', () => {
+  it('Storage path に docId namespace を含む (processed/${newDocRef.id}/${fileName} 形式)', () => {
+    expect(content).to.match(/processed\/\$\{newDocRef\.id\}\//);
+  });
+
+  it('旧 path 形式 processed/${fileName} (docId namespace なし) を直接書かない', () => {
+    // processed/${fileName} 直書きは衝突回避の責務を負わない設計欠陥のため禁止
+    expect(content).not.to.match(/['"`]processed\/\$\{fileName\}/);
+  });
+
+  it('newDocRef は Storage save 前に作成される (docId を path 採番に組み込む前提)', () => {
+    const newDocRefIdx = content.indexOf('const newDocRef = db.collection');
+    const newPathIdx = content.indexOf('processed/${newDocRef.id}/');
+    expect(newDocRefIdx).to.be.greaterThan(-1, 'newDocRef declaration not found');
+    expect(newPathIdx).to.be.greaterThan(-1, 'docId namespace path not found');
+    expect(newDocRefIdx).to.be.lessThan(
+      newPathIdx,
+      'newDocRef must be declared before Storage path uses its id'
+    );
+  });
+});
+
+describe('splitPdf orphan cleanup 補償処理 (Issue #432 PR-B Codex 補強)', () => {
+  it('Firestore set を try/catch でラップしている (補償処理の前提)', () => {
+    // 'await newDocRef.set(' が try ブロック内に存在することの近傍チェック
+    expect(content).to.match(/try\s*\{[\s\S]{0,2000}await newDocRef\.set\(/);
+  });
+
+  it('Firestore set 失敗時に Storage orphan cleanup を試行する', () => {
+    expect(content).to.include('orphanCleanup');
+    // newFile.delete() が catch ブロック内で呼ばれる (近傍チェック)
+    expect(content).to.match(/catch\s*\(firestoreErr[\s\S]{0,2000}await newFile\.delete\(\)/);
+  });
+
+  it('orphan cleanup の構造化ログキー (Cloud Logging 監視 contract)', () => {
+    expect(content).to.include("operation: 'splitPdf'");
+    expect(content).to.match(/stage:\s*['"]firestoreSet['"]/);
+    expect(content).to.match(/stage:\s*['"]orphanCleanup['"]/);
+    expect(content).to.match(/cleanupResult:\s*['"]success['"]/);
+    expect(content).to.match(/cleanupResult:\s*['"]failed['"]/);
+  });
+
+  it('Firestore set 失敗時に元の例外を caller に伝播する (silent failure 防止)', () => {
+    // catch (firestoreErr) ブロックの末尾で throw firestoreErr する
+    expect(content).to.match(/cleanupError[\s\S]{0,500}\}\);\s*\}\s*throw firestoreErr;/);
+  });
+});

--- a/functions/test/splitPdfDocIdNamespace.test.ts
+++ b/functions/test/splitPdfDocIdNamespace.test.ts
@@ -15,8 +15,11 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
-// ローカル import を追加することで Mocha esm-utils が CJS として load する
-// (副作用ゼロの import: テスト本体は使わないが loader 推論用)
+// 削除すると Mocha esm-utils がこのファイルを ESM として load し、
+// `ReferenceError: __dirname is not defined in ES module scope` で test 全体が
+// load 失敗する (NodeNext + ローカル import なし時の挙動)。
+// 副作用ゼロの local import を 1 つ追加することで CJS loader に推論させる workaround。
+// PR-A の helper を選んだ理由: 同 Issue (#432) に直接関連 + 安定実装で削除/移動リスク低。
 import '../src/storage/storageDeletionGuard';
 
 const sourcePath = path.resolve(process.cwd(), 'src/pdf/pdfOperations.ts');
@@ -42,6 +45,22 @@ describe('splitPdf docId namespace 設計 (Issue #432 PR-B 衝突根治)', () =>
       'newDocRef must be declared before Storage path uses its id'
     );
   });
+
+  it('newDocRef は for-loop 内で宣言される (segment ごとに独立した docId 確保)', () => {
+    // hoist されると全 segment が同 docId → 同 path を共有 → 衝突再発 (#432 回帰)
+    const loopIdx = content.indexOf('for (const segment of segments)');
+    const newDocRefIdx = content.indexOf('const newDocRef = db.collection');
+    expect(loopIdx).to.be.greaterThan(-1, 'segments loop not found');
+    expect(newDocRefIdx).to.be.greaterThan(
+      loopIdx,
+      'newDocRef must be declared inside the segment loop, not hoisted'
+    );
+  });
+
+  it('Firestore fileUrl は newFilePath 変数から構築される (path の二重定義による silent 不整合を防ぐ)', () => {
+    // gs://bucket/processed/{fileName} 等を直接 fileUrl に書くと Storage save path と乖離して silent 破壊
+    expect(content).to.match(/fileUrl:\s*`gs:\/\/\$\{bucket\.name\}\/\$\{newFilePath\}`/);
+  });
 });
 
 describe('splitPdf orphan cleanup 補償処理 (Issue #432 PR-B Codex 補強)', () => {
@@ -65,7 +84,28 @@ describe('splitPdf orphan cleanup 補償処理 (Issue #432 PR-B Codex 補強)', 
   });
 
   it('Firestore set 失敗時に元の例外を caller に伝播する (silent failure 防止)', () => {
-    // catch (firestoreErr) ブロックの末尾で throw firestoreErr する
-    expect(content).to.match(/cleanupError[\s\S]{0,500}\}\);\s*\}\s*throw firestoreErr;/);
+    // 補償処理経路の終端で必ず throw が発生 (success → throw firestoreErr / failure → throw wrapped)
+    expect(content).to.match(/throw firestoreErr;/);
+    expect(content).to.match(/throw wrapped;/);
+  });
+
+  it('createdDocIds.push は try ブロック内 (Firestore set 成功時のみ実行)', () => {
+    // try 外に出ると失敗時にも push されて splitInto に orphan id が混入
+    expect(content).to.match(/await newDocRef\.set\([\s\S]{0,3000}createdDocIds\.push/);
+    expect(content).not.to.match(/\}\s*finally\s*\{[\s\S]{0,500}createdDocIds\.push/);
+  });
+
+  it('二段失敗時は Error.cause で元例外を保持し orphanLeft マーカーを付与する (Sentry/log dedup での区別)', () => {
+    // wrapped.cause = firestoreErr; wrapped.orphanLeft = true; の存在を contract 化
+    expect(content).to.match(/wrapped\.cause\s*=\s*firestoreErr/);
+    expect(content).to.match(/wrapped\.orphanLeft\s*=\s*true/);
+    expect(content).to.include('manualCleanupCommand');
+  });
+
+  it('segments 途中失敗時に partial state 概要ログを出力する (運用 triage 支援)', () => {
+    expect(content).to.match(/stage:\s*['"]segmentsLoop['"]/);
+    expect(content).to.include('partialChildIds');
+    expect(content).to.include('successfulSegments');
+    expect(content).to.include('failedSegmentIndex');
   });
 });

--- a/scripts/audit-storage-mismatch.js
+++ b/scripts/audit-storage-mismatch.js
@@ -3,9 +3,16 @@
  * Firestore documents.fileUrl と Storage 実体の整合性監査スクリプト（read-only）
  *
  * documents コレクションを全件スキャンし、Storage `processed/` の実ファイル一覧と
- * 突合する。検出する不整合:
+ * 突合する。Issue #432 PR-B 以降の `processed/{docId}/{fileName}` 形式も
+ * `bucket.getFiles({prefix:'processed/'})` の再帰スキャンで検出可。
+ *
+ * 検出する不整合:
  *   1. fileUrl 孤児: fileUrl が指す Storage オブジェクトが存在しない
  *   2. fileName 衝突: 複数 docs が同じ fileName を持つ（fileUrl が衝突する候補）
+ *
+ * NOTE: 現状は片方向 (Firestore→Storage 欠損) のみ検出。逆方向 (Storage 実体あり
+ * Firestore doc なし = orphan storage、PR-B 補償処理の二段失敗で発生し得る) の検出は
+ * 別 Issue で追加予定 (Issue #432 follow-up)。
  *
  * 使用方法:
  *   FIREBASE_PROJECT_ID=docsplit-kanameone node scripts/audit-storage-mismatch.js


### PR DESCRIPTION
## Summary

分割PDF の Storage path を `processed/{fileName}` → **`processed/{docId}/{fileName}`** に変更し、Issue #432 の fileName 衝突による silent 破壊を構造的に根治する (Codex セカンドオピニオンで B 案推奨)。

Firestore docId は一意な自動採番のため衝突原理的に発生しない。

## 主要変更

- `splitPdf` 内で `newDocRef` を Storage save 前に作成し path に組み込む
- **補償処理 (Codex 補強)**: Storage save 成功 → Firestore set 失敗時に best-effort で Storage delete + 構造化ログ。orphan が残ると後続 split との path 衝突リスクが再発するため必須
- 構造化ログ: `operation='splitPdf'`, `stage='firestoreSet'|'orphanCleanup'`, `cleanupResult='success'|'failed'` (Cloud Logging 監視 contract)
- Firestore set 失敗は元例外を caller に伝播 (silent failure 防止)
- `generateFileName` の責務不変 (timestamp は表示用 date 部分のみ生成、衝突回避は docId namespace で担保)

## 互換性

| 既存資産 | 動作 | 根拠 |
|---|---|---|
| 既存 `processed/{fileName}` 旧 doc | 触らない | PR-A safety net で rotate/delete 巻き添え破壊を防御 (恒久有効) |
| 旧 doc の rotate/delete | 新旧両形式で動作 | fileUrl 任意 prefix を `replace` で path 抽出する実装 (`ocrProcessor.ts:111`, `deleteDocument.ts:80`, `pdfOperations.ts:493`) |
| `audit-storage-mismatch.js` | 新形式も自動検出 | `bucket.getFiles({prefix:'processed/'})` で再帰スキャン |

## なぜ root cause 修正なのか

PR-A は進行中破壊を **停止** する safety net (recurring damage を skip するだけ)。PR-B が **新規分割の path 衝突を原理的に発生させない** 設計修正。これで Issue #432 の根因 1-3 (`generateFileName` 衝突回避なし / `bucket.file().save()` 衝突検査なし / `rotatePdfPages` の delete 副作用) のうち根因 1-2 を根治する (3 は PR-A safety net で停止済)。

PR-B 完了で **新規発生はゼロ**、過去被害の復旧は PR-C マイグレーションへ。

## Test plan

- [x] 全テスト 861 件全 PASS (新規 7 件 grep contract + 既存 854 件)
- [x] tsc clean / lint 0 errors
- [ ] CI lint-build-test PASS
- [ ] CI CodeRabbit / GitGuardian PASS
- [ ] dev 反映後の動作確認:
  - 同一書類で 2 回分割 → 2 doc が異なる path (`processed/{docId1}/...` と `processed/{docId2}/...`) を持つことを Firestore で確認
  - Cloud Logging で `splitPdf` 実行時に従来通りログが出ることを確認 (補償処理が誤発火しないこと)
- [ ] kanameone 反映後、新規分割で `processed/{docId}/` 形式の path が採用されることを Firestore で確認
- [ ] cocoro 反映後、同様に確認

## 未対応 (別 PR)

- PR-C マイグレーション: 既存 211 processed/ docs (kanameone) の path 移動 + 衝突 39 group の復元可能性 4 分類 (Codex セカンドオピニオンで信頼度付き分類へ変更)
- PR-D 検出強化: ヘルスレポート 4 指標追加 + audit-storage-mismatch 日次化
- generateFileName timestamp 引数の完全削除 (caller 全箇所修正後に別 PR、Codex 推奨で deprecated 段階を踏む)
- canSafelyDeleteStorageFile emulator integration test (PR-A review S2)

## 設計上の判断

- **「全成功 or 全失敗」のトランザクション化は本 PR スコープ外**。Storage と Firestore は単一トランザクションにできず、現状は per-segment の補償処理 + 元例外伝播で realistic な完全性を担保。完全な状態管理は別 PR (segments 全体の rollback / status 二段階化等)
- **同 PR で `generateFileName` timestamp 完全削除は危険** (Codex 推奨)。caller が test/scripts に散在する可能性 + TypeScript で全 caller 検出後に削除する方が安全

## Refs

- Issue #432 (P0 設計バグ)
- Codex セカンドオピニオン (前セッション + 本セッション impl-plan 段階)
- 前 PR #434 (PR-A safety net、merged 2026-05-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved storage path collision issues during PDF splitting operations
  * Improved error handling with automatic cleanup when Firestore writes fail during PDF splitting

* **Tests**
  * Added validation tests for PDF splitting path namespace and error recovery behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/435)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->