### PR TITLE
feat(detection): Issue #432 PR-D — reverse orphan 検出 + path-extraction contract + runbook

### DIFF
--- a/docs/runbooks/orphan-storage-cleanup.md
+++ b/docs/runbooks/orphan-storage-cleanup.md
@@ -1,0 +1,118 @@
+# Orphan Storage Cleanup Runbook
+
+**対象事象**: DocSplit プロジェクトで Storage 実体は存在するが Firestore document からの参照がない孤児ファイル (reverse orphan) の発見・対応手順。
+
+**関連**: Issue #432 (PR-A safety net / PR-B docId namespace / PR-D 検出強化)
+
+---
+
+## 検出方法
+
+### 1. Cloud Logging で発生時に検知
+
+PR-B 補償処理の二段失敗 (Firestore set 失敗 → Storage delete も失敗) で発生する場合:
+
+```
+resource.type="cloud_function"
+jsonPayload.operation="splitPdf"
+jsonPayload.stage="orphanCleanup"
+jsonPayload.cleanupResult="failed"
+```
+
+このログには以下が含まれる:
+- `newDocId`: 該当する Firestore docId (未作成だが採番済)
+- `newFilePath`: Storage 上の orphan path
+- `bucket`: bucket 名
+- `manualCleanupCommand`: 直接実行可能な `gsutil rm` コマンド
+
+### 2. 定期 audit で検出 (推奨)
+
+```bash
+# GitHub Actions: Run Operations Script → audit-storage-mismatch.js → 環境選択
+# または手動:
+FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+  node scripts/audit-storage-mismatch.js --no-orphans --no-collisions
+```
+
+`reverse orphans` セクションに `processed/{docId}/...` 形式の path が列挙される。
+PR-B namespace pattern セクションは「PR-B 補償処理由来の可能性が高い候補」として hint 表示。
+
+---
+
+## 対応手順
+
+### Phase 1: 検証 (read-only)
+
+孤児ファイルが本当に Firestore から参照されていないことを再確認:
+
+```bash
+# gsutil で対象 path の metadata 確認 (作成日時、サイズ)
+gsutil stat gs://<bucket>/processed/<docId>/<fileName>
+
+# Firestore で docId を inspect (read-only)
+FIREBASE_PROJECT_ID=<project-id> node scripts/inspect-document.js <docId>
+# → "Document not found" であれば真の orphan
+```
+
+### Phase 2: 復元可能性判定
+
+孤児 PDF の内容を確認してから削除判断:
+
+```bash
+# 一時 download
+gsutil cp gs://<bucket>/processed/<docId>/<fileName> /tmp/orphan.pdf
+# 内容確認 (PDF を開く)
+open /tmp/orphan.pdf
+```
+
+判定基準:
+- **削除可**: 内容が他の processed/ doc と重複 / OCR 失敗時の不要 PDF
+- **要復元**: 失われた業務データを含み、再分割の元 PDF も存在しない
+
+### Phase 3: 削除実行 (number-authorized 必須)
+
+ユーザーから **個別 path の番号認可** (`gs://bucket/processed/XXX/YYY を削除してよい`) 取得後:
+
+```bash
+# 単一ファイル削除
+gsutil rm gs://<bucket>/processed/<docId>/<fileName>
+
+# 確認
+gsutil ls gs://<bucket>/processed/<docId>/
+```
+
+**禁止事項**:
+- `gsutil rm -r gs://<bucket>/processed/` のような prefix 一括削除は絶対禁止 (ADR-0008 教訓)
+- 認可なしの自動削除スクリプトは禁止
+
+### Phase 4: 復元 (要復元と判定された場合)
+
+元 PDF (`parentDocumentId` 起点) からの再分割を試行:
+
+1. `parentDocumentId` を孤児 path 周辺から推測 (PR-B namespace pattern なら docId が path に含まれる)
+2. Firestore で parent doc が存在し元 PDF (`original/...`) も実在することを確認
+3. 分割 UI から手動で再分割実行 → 新 docId で `processed/{newDocId}/...` に新規 save される
+4. 古い孤児 path は削除 (Phase 3)
+
+---
+
+## 予防
+
+| 対策 | 状態 |
+|---|---|
+| PR-A safety net (rotate/delete 巻き添え破壊防止) | ✅ 全環境展開済 (#434) |
+| PR-B docId namespace (新規衝突原理ゼロ化) | ✅ 全環境展開済 (#435) |
+| PR-D reverse orphan 検出 (audit-storage-mismatch.js) | ✅ 本 PR |
+| Cloud Monitoring alert policy (cleanupResult=failed) | 別 PR 候補 |
+| audit-storage-mismatch.js の定期 (cron) 実行 | 別 PR 候補 |
+
+---
+
+## 関連リソース
+
+- Issue #432 (P0 設計バグ)
+- ADR-0008 (本番データ保護)
+- `scripts/audit-storage-mismatch.js` (検出 script)
+- `scripts/inspect-document.js` (調査 script, read-only)
+- `functions/src/storage/storageDeletionGuard.ts` (PR-A safety net)
+- `functions/src/pdf/pdfOperations.ts` (PR-B docId namespace + 補償処理)

--- a/docs/runbooks/orphan-storage-cleanup.md
+++ b/docs/runbooks/orphan-storage-cleanup.md
@@ -10,6 +10,8 @@
 
 ### 1. Cloud Logging で発生時に検知
 
+**実行前**: `./scripts/switch-client.sh <env>` で対象環境を選択し、Cloud Logging Console の project 表示が一致することを確認 (マルチクライアント環境 = dev / kanameone / cocoro の取り違え防止)。
+
 PR-B 補償処理の二段失敗 (Firestore set 失敗 → Storage delete も失敗) で発生する場合:
 
 ```
@@ -35,7 +37,9 @@ FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
 ```
 
 `reverse orphans` セクションに `processed/{docId}/...` 形式の path が列挙される。
-PR-B namespace pattern セクションは「PR-B 補償処理由来の可能性が高い候補」として hint 表示。
+**docId namespace pattern** セクションは Firestore auto-ID 20 文字仕様に厳密一致 + 同 ID の doc 不在を確認した候補で、「PR-B 補償処理由来の可能性が高い」として hint 表示。
+
+**fileUrl 解析失敗 / 別 bucket 参照件数の WARN** が出ている場合、reverse orphan に false positive が混入する可能性。`gsutil rm` 前に必ず原因調査すること。
 
 ---
 
@@ -61,17 +65,29 @@ FIREBASE_PROJECT_ID=<project-id> node scripts/inspect-document.js <docId>
 ```bash
 # 一時 download
 gsutil cp gs://<bucket>/processed/<docId>/<fileName> /tmp/orphan.pdf
+
 # 内容確認 (PDF を開く)
-open /tmp/orphan.pdf
+# macOS: open /tmp/orphan.pdf
+# Linux: xdg-open /tmp/orphan.pdf   (環境により未インストールの場合あり)
+# WSL/SSH: scp <host>:/tmp/orphan.pdf ./local.pdf で手元に転送して確認
+
+# 重複確認 (任意): md5 hash で他 processed/* との同一性チェック
+md5sum /tmp/orphan.pdf
+# 同 hash のファイルが Firestore に紐づいているか inspect
+FIREBASE_PROJECT_ID=<project-id> node scripts/inspect-document.js <parent-docId-candidate>
 ```
 
 判定基準:
-- **削除可**: 内容が他の processed/ doc と重複 / OCR 失敗時の不要 PDF
+- **削除可**: 内容が他の processed/ doc と重複 (md5 hash 一致) / OCR 失敗時の不要 PDF
 - **要復元**: 失われた業務データを含み、再分割の元 PDF も存在しない
 
-### Phase 3: 削除実行 (number-authorized 必須)
+### Phase 3: 削除実行 (個別パス認可必須 = per-path explicit authorization required)
 
-ユーザーから **個別 path の番号認可** (`gs://bucket/processed/XXX/YYY を削除してよい`) 取得後:
+ユーザーから削除対象の **gs:// path を文字列単位で含む承認文** を取得後にのみ実行可。
+
+**Issue 番号や prefix 一括での認可は無効** (例: `Issue #432 全件削除してよい` / `processed/ 配下削除してよい` は不可)。各 path につき個別の認可文 (例: `gs://bucket/processed/XXX/YYY.pdf を削除してよい`) が必要。
+
+実行:
 
 ```bash
 # 単一ファイル削除
@@ -87,12 +103,27 @@ gsutil ls gs://<bucket>/processed/<docId>/
 
 ### Phase 4: 復元 (要復元と判定された場合)
 
-元 PDF (`parentDocumentId` 起点) からの再分割を試行:
+**重要**: PR-B namespace pattern `processed/{docId}/{fileName}` の `{docId}` は **未生成の子 doc ID** (splitPdf 補償処理失敗で Firestore set されなかった child)。parent ではないため path からは parent を特定できない。
 
-1. `parentDocumentId` を孤児 path 周辺から推測 (PR-B namespace pattern なら docId が path に含まれる)
-2. Firestore で parent doc が存在し元 PDF (`original/...`) も実在することを確認
-3. 分割 UI から手動で再分割実行 → 新 docId で `processed/{newDocId}/...` に新規 save される
-4. 古い孤児 path は削除 (Phase 3)
+parent (= splitPdf に渡された元 doc ID) を特定する手段:
+
+```bash
+# Cloud Logging で当該 newDocId を含む splitPdf invocation を検索
+# query 例:
+#   resource.type="cloud_function"
+#   jsonPayload.operation="splitPdf"
+#   jsonPayload.newDocId="<orphan-path から抽出した docId>"
+# → invocation の入力 documentId が parentDocumentId
+```
+
+その後の手順:
+
+1. Cloud Logging で orphan path 中の docId に対する `splitPdf` invocation を検索 → 入力 `documentId` を取得 (これが parentDocumentId)
+2. Firestore で parent doc が存在し元 PDF (`original/...` または親 fileUrl) も実在することを確認 (`inspect-document.js <parentDocumentId>`)
+3. 分割 UI から手動で再分割実行 → 新 docId で `processed/{newDocId}/...` に新規 save される (旧 path の docId とは別になる)
+4. 古い孤児 path は削除 (Phase 3、個別パス認可必須)
+
+**Cloud Logging で parent を特定できない場合** (ログ保持期間超過等): Storage `original/` prefix の手動 inspection または Gmail message id 逆引きが必要。復元不能の場合は孤児 path 単純削除を選択 (Phase 3)。
 
 ---
 
@@ -102,9 +133,11 @@ gsutil ls gs://<bucket>/processed/<docId>/
 |---|---|
 | PR-A safety net (rotate/delete 巻き添え破壊防止) | ✅ 全環境展開済 (#434) |
 | PR-B docId namespace (新規衝突原理ゼロ化) | ✅ 全環境展開済 (#435) |
-| PR-D reverse orphan 検出 (audit-storage-mismatch.js) | ✅ 本 PR |
-| Cloud Monitoring alert policy (cleanupResult=failed) | 別 PR 候補 |
-| audit-storage-mismatch.js の定期 (cron) 実行 | 別 PR 候補 |
+| PR-D reverse orphan 検出 (audit-storage-mismatch.js) | ✅ PR #436 |
+| Cloud Monitoring alert policy (`cleanupResult=failed`) | 別 PR 候補 (Issue #432 follow-up) |
+| audit-storage-mismatch.js の定期 (cron) 実行 | 別 PR 候補 (Issue #432 follow-up) |
+
+> **NOTE**: 上記表は 2026-05-11 時点。Issue #432 PR-A/PR-B/PR-D 完了状態。状況更新は本 runbook を直接編集すること。
 
 ---
 

--- a/functions/test/storagePathExtraction.test.ts
+++ b/functions/test/storagePathExtraction.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Storage path 抽出ロジックの contract test (Issue #432 PR-D, AC-B3 protect)
+ *
+ * PR-B (docId namespace) 完了後、Storage path は `processed/{fileName}` (旧) と
+ * `processed/{docId}/{fileName}` (新) の両形式が混在する。3 call sites の path
+ * 抽出ロジックが「gs://{bucket}/ 以降を任意 prefix で抽出する」設計を維持する限り、
+ * 新旧両形式で動作する (replace() / regex match 形式は両対応)。
+ *
+ * 単一セグメント抽出 (path.basename / split('/').pop()) に refactor されると
+ * 新形式 path で fileName のみが取れて bucket/path 構造が破綻し silent 破壊が
+ * 再発するため、grep contract で固定する。
+ *
+ * 対象 call sites:
+ *   - functions/src/ocr/ocrProcessor.ts (~line 111): fileUrl.replace() 形式
+ *   - functions/src/documents/deleteDocument.ts (~line 80): regex match 形式
+ *   - functions/src/pdf/pdfOperations.ts (rotatePdfPages, ~line 493): fileUrl.replace() 形式
+ */
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+// Mocha esm-utils CJS loader 推論用 (splitPdfDocIdNamespace.test.ts と同じ workaround)
+import '../src/storage/storageDeletionGuard';
+
+interface PathExtractionTarget {
+  label: string;
+  filePath: string;
+  /** path 抽出が「prefix 任意 / 末尾任意」設計であることの positive 確認パターン */
+  expectedPattern: RegExp;
+}
+
+const targets: PathExtractionTarget[] = [
+  {
+    label: 'ocrProcessor.ts',
+    filePath: 'src/ocr/ocrProcessor.ts',
+    expectedPattern: /fileUrl\.replace\(`gs:\/\/\$\{bucket\.name\}\//,
+  },
+  {
+    label: 'deleteDocument.ts',
+    filePath: 'src/documents/deleteDocument.ts',
+    expectedPattern: /match\(\/\^gs:\\\/\\\/\(\[\^\/\]\+\)\\\/\(\.\+\)\$\//,
+  },
+  {
+    label: 'pdfOperations.ts (rotatePdfPages)',
+    filePath: 'src/pdf/pdfOperations.ts',
+    // rotatePdfPages 内の filePath = fileUrl.replace(...) パターン
+    expectedPattern: /filePath = fileUrl\.replace\(`gs:\/\/\$\{bucket\.name\}\//,
+  },
+];
+
+describe('Storage path extraction contract (Issue #432 PR-D, AC-B3 protect)', () => {
+  for (const target of targets) {
+    describe(target.label, () => {
+      const fullPath = path.resolve(process.cwd(), target.filePath);
+      const content = fs.readFileSync(fullPath, 'utf-8');
+
+      it('path 抽出は prefix 任意の replace/regex 形式を維持 (新旧両 path 対応)', () => {
+        expect(content).to.match(target.expectedPattern);
+      });
+
+      it('単一セグメント抽出 path.basename(filePath) を使わない (新形式 path で破綻)', () => {
+        // path モジュールの import + basename(filePath) 呼出パターンを禁止
+        expect(content).not.to.match(/path\.basename\(\s*filePath\s*\)/);
+        expect(content).not.to.match(/basename\(\s*fileUrl\s*\)/);
+      });
+
+      it("split('/').pop() を path 末尾抽出に使わない (docId namespace 構造破壊)", () => {
+        // fileUrl/filePath を起点とした単純な末尾抽出を禁止
+        expect(content).not.to.match(/fileUrl\.split\(['"]\/['"]\)\.pop\(\)/);
+        expect(content).not.to.match(/filePath\.split\(['"]\/['"]\)\.pop\(\)/);
+      });
+    });
+  }
+});

--- a/functions/test/storagePathExtraction.test.ts
+++ b/functions/test/storagePathExtraction.test.ts
@@ -10,10 +10,17 @@
  * 新形式 path で fileName のみが取れて bucket/path 構造が破綻し silent 破壊が
  * 再発するため、grep contract で固定する。
  *
- * 対象 call sites:
- *   - functions/src/ocr/ocrProcessor.ts (~line 111): fileUrl.replace() 形式
- *   - functions/src/documents/deleteDocument.ts (~line 80): regex match 形式
- *   - functions/src/pdf/pdfOperations.ts (rotatePdfPages, ~line 493): fileUrl.replace() 形式
+ * 対象 call sites (`expectedPattern` 正規表現で検索):
+ *   - functions/src/ocr/ocrProcessor.ts: `fileUrl.replace(\`gs://${bucket.name}/\`, ...)` 形式
+ *   - functions/src/documents/deleteDocument.ts: `match(/^gs:\/\/([^/]+)\/(.+)$/)` 形式
+ *   - functions/src/pdf/pdfOperations.ts (rotatePdfPages): `fileUrl.replace(\`gs://${bucket.name}/\`, ...)` 形式
+ *     NOTE: pdfOperations.ts の splitPdf (元 PDF 読込) にも同形式の path 抽出があるが、
+ *     `rotatePdfPages` 側が新形式 path で動作することの contract を本 test で固定。
+ *     splitPdf 側のみ refactor された場合の検出は別 contract で扱う必要あり (follow-up)。
+ *
+ * 例: `path.basename(filePath)` に refactor すると新形式 `processed/{docId}/{fileName}` から
+ *     `{fileName}` のみ抽出され、`bucket.file(filePath)` が異なる object を指す
+ *     → 削除/読込が他 doc を破壊する。
  */
 
 import { expect } from 'chai';

--- a/scripts/audit-storage-mismatch.js
+++ b/scripts/audit-storage-mismatch.js
@@ -86,6 +86,20 @@ function pathFromUrl(url) {
   return m ? m[1] : null;
 }
 
+/**
+ * `gs://<bucket>/<path>` 形式の URL から path を抽出するが、bucket 名が
+ * 指定された expected bucket と一致する場合のみ返す。一致しない場合は null。
+ * 環境差 (`.appspot.com` / `.firebasestorage.app` 混在等) で別 bucket の参照
+ * を現環境の参照と誤計上する false negative を防ぐ (Issue #432 PR-D Codex 指摘)。
+ */
+function extractPathIfBucketMatches(url, expectedBucket) {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  if (m[1] !== expectedBucket) return null;
+  return m[2];
+}
+
 async function main() {
   console.log(`Project: ${projectId}`);
   console.log(`Bucket : ${bucket.name}`);
@@ -145,13 +159,55 @@ async function main() {
   }
 
   if (!skipReverseOrphans) {
+    // sanity check: Firestore docs と Storage list の整合性を verify
+    // (Issue #432 silent-failure-hunter C2 指摘: 0 件レポートが load 失敗を hide する)
+    if (targetDocs.length > 0 && storagePaths.size === 0) {
+      console.error(
+        `FATAL: Firestore に prefix="${prefix}" 参照 docs が ${targetDocs.length} 件あるが、` +
+          `Storage list は 0 件。false reverse-orphan 報告を防ぐため abort。` +
+          `bucket 名 (${bucket.name}) と IAM 権限を確認すること。`
+      );
+      await admin.app().delete();
+      process.exit(2);
+    }
+
     // Firestore documents から参照されている Storage path 集合
+    // bucket 名が一致しない fileUrl (別環境 / 旧形式 https URL 等) は除外し、解析失敗件数を記録
     const referencedPaths = new Set();
+    let fileUrlParseFailureCount = 0;
+    let fileUrlOtherBucketCount = 0;
+    let fileUrlNullOrEmptyCount = 0;
     for (const d of allDocs) {
-      const p = pathFromUrl(d.fileUrl);
-      if (p && p.startsWith(prefix)) {
+      if (d.fileUrl === undefined || d.fileUrl === null || d.fileUrl === '') {
+        fileUrlNullOrEmptyCount += 1;
+        continue;
+      }
+      // bucket 名一致確認 (false negative 防止)
+      const p = extractPathIfBucketMatches(d.fileUrl, bucket.name);
+      if (p === null) {
+        // bucket mismatch or non-gs:// URL → 解析失敗 / 別 bucket として分類
+        const looksGs = typeof d.fileUrl === 'string' && d.fileUrl.startsWith('gs://');
+        if (looksGs) {
+          fileUrlOtherBucketCount += 1;
+        } else {
+          fileUrlParseFailureCount += 1;
+          console.warn(
+            `WARN: fileUrl 解析失敗 (no-reference 扱い): docId=${d.id} status=${d.status} fileUrl=${JSON.stringify(d.fileUrl)}`
+          );
+        }
+        continue;
+      }
+      if (p.startsWith(prefix)) {
         referencedPaths.add(p);
       }
+    }
+
+    if (fileUrlParseFailureCount > 0 || fileUrlOtherBucketCount > 0) {
+      console.warn(
+        `\nWARN: fileUrl 解析失敗 ${fileUrlParseFailureCount} 件 / 別 bucket 参照 ${fileUrlOtherBucketCount} 件 / ` +
+          `null or empty ${fileUrlNullOrEmptyCount} 件。reverse orphan に false positive 含む可能性。` +
+          `gsutil rm 前に必ず原因調査すること。`
+      );
     }
 
     // Storage 実体あり Firestore 参照なし = reverse orphan
@@ -169,18 +225,26 @@ async function main() {
       console.log(`  gs://${bucket.name}/${p}`)
     );
 
-    // Issue #432 PR-B 補償処理の二段失敗で発生する想定パターンを抽出
-    // (path が processed/{docId}/ 形式で docId が 20 文字英数字)
-    const pr_b_pattern_orphans = reverseOrphans.filter((p) => {
-      const segments = p.replace(prefix, '').split('/');
-      return segments.length >= 2 && /^[A-Za-z0-9]{15,30}$/.test(segments[0]);
+    // docId namespace pattern (processed/{docId}/...) を hint 表示。
+    // Firestore auto-ID = `[A-Za-z0-9]{20}` 固定仕様に厳密一致 + 同 ID の doc が
+    // 不在であることを確認 (Issue #432 PR-D 補強: codex / silent-failure I1 指摘反映)。
+    // PR-B 補償処理二段失敗で発生する正規パターン。
+    const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+    const allDocIds = new Set(allDocs.map((d) => d.id));
+    const docIdNamespaceOrphans = reverseOrphans.filter((p) => {
+      if (!p.startsWith(normalizedPrefix)) return false;
+      const segments = p.slice(normalizedPrefix.length).split('/');
+      if (segments.length < 2) return false;
+      if (!/^[A-Za-z0-9]{20}$/.test(segments[0])) return false;
+      // 同 ID の doc が存在しない場合のみ PR-B 由来候補 (set 失敗で doc 不在のはず)
+      return !allDocIds.has(segments[0]);
     });
-    if (pr_b_pattern_orphans.length > 0) {
+    if (docIdNamespaceOrphans.length > 0) {
       console.log(
-        `\n  PR-B namespace pattern (processed/{docId}/...): ${pr_b_pattern_orphans.length}`
+        `\n  docId namespace pattern (processed/{docId}/..., doc 不在): ${docIdNamespaceOrphans.length}`
       );
       console.log(
-        '  (PR-B 補償処理二段失敗 / 手動 Storage 操作で発生する可能性が高い候補)'
+        '  (Issue #432 PR-B 補償処理二段失敗 / 手動 Storage 操作で発生する可能性が高い候補)'
       );
     }
   }

--- a/scripts/audit-storage-mismatch.js
+++ b/scripts/audit-storage-mismatch.js
@@ -7,20 +7,20 @@
  * `bucket.getFiles({prefix:'processed/'})` の再帰スキャンで検出可。
  *
  * 検出する不整合:
- *   1. fileUrl 孤児: fileUrl が指す Storage オブジェクトが存在しない
+ *   1. fileUrl 孤児: fileUrl が指す Storage オブジェクトが存在しない (Firestore→Storage 欠損)
  *   2. fileName 衝突: 複数 docs が同じ fileName を持つ（fileUrl が衝突する候補）
- *
- * NOTE: 現状は片方向 (Firestore→Storage 欠損) のみ検出。逆方向 (Storage 実体あり
- * Firestore doc なし = orphan storage、PR-B 補償処理の二段失敗で発生し得る) の検出は
- * 別 Issue で追加予定 (Issue #432 follow-up)。
+ *   3. reverse orphan: Storage 実体あり、Firestore doc から参照なし (Issue #432 PR-D)
+ *      PR-B 補償処理の二段失敗 (Firestore set 失敗 → Storage delete も失敗) や
+ *      手動 Storage 操作で発生し得る。bucket 容量の silent な消費源
  *
  * 使用方法:
  *   FIREBASE_PROJECT_ID=docsplit-kanameone node scripts/audit-storage-mismatch.js
  *
  * オプション:
- *   --prefix <path>  Storage の対象 prefix（デフォルト: processed/）
- *   --no-orphans     fileUrl 孤児チェックを省略（fileName 衝突のみ出力）
- *   --no-collisions  fileName 衝突チェックを省略
+ *   --prefix <path>          Storage の対象 prefix（デフォルト: processed/）
+ *   --no-orphans             fileUrl 孤児チェック (Firestore→Storage) を省略
+ *   --no-collisions          fileName 衝突チェックを省略
+ *   --no-reverse-orphans     reverse orphan チェック (Storage→Firestore) を省略
  */
 
 const admin = require('firebase-admin');
@@ -47,6 +47,7 @@ function getOpt(name, def = null) {
 const prefix = getOpt('--prefix', 'processed/');
 const skipOrphans = process.argv.includes('--no-orphans');
 const skipCollisions = process.argv.includes('--no-collisions');
+const skipReverseOrphans = process.argv.includes('--no-reverse-orphans');
 
 admin.initializeApp({ projectId, storageBucket });
 const db = admin.firestore();
@@ -119,8 +120,13 @@ async function main() {
   });
   console.log(`Documents with fileUrl matching prefix "${prefix}": ${targetDocs.length}\n`);
 
+  // Storage の全 path を一度だけ load (orphans / reverse orphans の両方で使う)
+  let storagePaths = null;
+  if (!skipOrphans || !skipReverseOrphans) {
+    storagePaths = await listAllStorageFiles(prefix);
+  }
+
   if (!skipOrphans) {
-    const storagePaths = await listAllStorageFiles(prefix);
     const orphans = [];
     for (const d of targetDocs) {
       const path = pathFromUrl(d.fileUrl);
@@ -136,6 +142,47 @@ async function main() {
       return acc;
     }, {});
     console.log(`\nOrphan breakdown by status: ${JSON.stringify(orphansByStatus)}`);
+  }
+
+  if (!skipReverseOrphans) {
+    // Firestore documents から参照されている Storage path 集合
+    const referencedPaths = new Set();
+    for (const d of allDocs) {
+      const p = pathFromUrl(d.fileUrl);
+      if (p && p.startsWith(prefix)) {
+        referencedPaths.add(p);
+      }
+    }
+
+    // Storage 実体あり Firestore 参照なし = reverse orphan
+    const reverseOrphans = [];
+    for (const p of storagePaths) {
+      if (!referencedPaths.has(p)) {
+        reverseOrphans.push(p);
+      }
+    }
+
+    console.log(
+      `\n=== reverse orphans (Storage 実体あり Firestore 参照なし): ${reverseOrphans.length} ===`
+    );
+    reverseOrphans.forEach((p) =>
+      console.log(`  gs://${bucket.name}/${p}`)
+    );
+
+    // Issue #432 PR-B 補償処理の二段失敗で発生する想定パターンを抽出
+    // (path が processed/{docId}/ 形式で docId が 20 文字英数字)
+    const pr_b_pattern_orphans = reverseOrphans.filter((p) => {
+      const segments = p.replace(prefix, '').split('/');
+      return segments.length >= 2 && /^[A-Za-z0-9]{15,30}$/.test(segments[0]);
+    });
+    if (pr_b_pattern_orphans.length > 0) {
+      console.log(
+        `\n  PR-B namespace pattern (processed/{docId}/...): ${pr_b_pattern_orphans.length}`
+      );
+      console.log(
+        '  (PR-B 補償処理二段失敗 / 手動 Storage 操作で発生する可能性が高い候補)'
+      );
+    }
   }
 
   if (!skipCollisions) {


### PR DESCRIPTION
## Summary

PR-B (#435) review で抽出された follow-up 3 件を統合実装する Issue #432 検出強化 PR。

## 変更内容 (3 ファイル / +248/-9)

### 1. `scripts/audit-storage-mismatch.js`: reverse orphan 検出 mode 追加
**動機 (silent-failure C1 完全対応)**: PR-B 補償処理の二段失敗 (Firestore set 失敗 → Storage delete も失敗) で発生し得る Storage 孤児を、従来の片方向 audit では検出できない。

- 逆方向 (Storage 実体あり Firestore 参照なし) を検出
- `processed/{docId}/` 形式の path を「PR-B namespace pattern」として hint 表示
- `--no-reverse-orphans` で skip 可能 (default ON)
- Storage API 呼び出しは orphans / reverseOrphans で共有 load (1 回化)

### 2. `functions/test/storagePathExtraction.test.ts`: AC-B3 contract test 新規追加
**動機 (test rating 8 指摘)**: PR-B 完了後、3 call sites の path 抽出は「prefix 任意の replace/regex 形式」だから新旧両 path 対応自動成立、と PR description で claim していたが test がなかった。

| Call site | 抽出形式 |
|---|---|
| `functions/src/ocr/ocrProcessor.ts` (~line 111) | `fileUrl.replace(\`gs://${bucket.name}/\`, '')` |
| `functions/src/documents/deleteDocument.ts` (~line 80) | `fileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/)` |
| `functions/src/pdf/pdfOperations.ts` (rotatePdfPages, ~line 493) | `fileUrl.replace(\`gs://${bucket.name}/\`, '')` |

- 各 site で expected pattern の存在を grep 確認 (positive)
- `path.basename(filePath)` / `fileUrl.split('/').pop()` への refactor を禁止 (negative)
- 計 3 sites × 3 tests = 9 件

### 3. `docs/runbooks/orphan-storage-cleanup.md`: runbook 新規追加
**動機 (silent-failure C1 補強)**: PR-B の structured log で `manualCleanupCommand` を出力するようになったが、運用側で「いつ」「何を確認して」「どう削除するか」の手順がなかった。

- 検出方法 (Cloud Logging クエリ + audit script)
- 4 phase 対応手順 (検証 / 復元可能性判定 / 削除実行 / 復元)
- ADR-0008 教訓踏襲 (prefix 一括削除禁止、認可なし自動削除禁止)

## scope 外 (別 PR 候補)

- Cloud Monitoring alert policy 設定 (GCP 操作で番号認可必要)
- ヘルスレポート 4 指標追加 (fileUrl 重複 / Storage path × docId 一意性 / parentDocumentId 関連欠損 / 回転履歴件数) — UI/機能変更で scope 拡大
- audit-storage-mismatch.js の cron 定期実行 (workflow 設計が必要)
- PR-C マイグレーション (destructive、要番号認可、別セッション)

## Test plan

- [x] 全テスト 875 件全 PASS (新規 9 件 + 既存 866 件)
- [x] `node --check scripts/audit-storage-mismatch.js` OK
- [x] tsc clean / lint 0 errors
- [ ] CI lint-build-test PASS
- [ ] CI CodeRabbit / GitGuardian PASS
- [ ] dev 反映後の動作確認:
  - GitHub Actions "Run Operations Script" → `audit-storage-mismatch` → dev 環境で実行
  - 出力に `=== reverse orphans ===` セクションが追加されていることを確認
  - dev は reverse orphan 0 件想定 (実運用データなし)
- [ ] kanameone 反映後、`audit-storage-mismatch` で reverse orphan 件数を観測 (PR-B 補償処理由来の orphan の有無を確認)
- [ ] cocoro 反映後、同様に確認

## Issue #432 修正計画への影響

| 元計画 | 状態 |
|---|---|
| PR-A safety net | ✅ merged (#434), 3 環境展開済 |
| PR-B docId namespace | ✅ merged (#435), 3 環境展開済 |
| PR-D 検出強化 (本 PR) | 🔄 review 中 |
| PR-C マイグレーション | 未着手 (信頼度付き分類 + 番号認可後実行) |

## Refs

- Issue #432
- PR #434 (PR-A safety net, merged)
- PR #435 (PR-B docId namespace, merged)
- Issue #432 follow-up 3 件 (本 PR で統合解決)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive runbook for managing orphaned storage objects, including detection methods and step-by-step remediation workflows.

* **Chores**
  * Enhanced audit script to detect additional types of storage inconsistencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/436)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->