### PR TITLE
fix(scripts): Issue #432 PR-C — 衝突/orphan 5 分類 migration (Codex 反映)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -53,6 +53,9 @@ on:
           - audit-storage-mismatch
           - audit-storage-mismatch --no-orphans
           - audit-storage-mismatch --no-collisions
+          - classify-collision-docs
+          - setup-collision-fixture --dev
+          - setup-collision-fixture --dev --cleanup
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false
@@ -254,10 +257,15 @@ jobs:
             NODE_PATH=./functions/node_modules \
               FIREBASE_PROJECT_ID="$PROJECT_ID" \
               node "scripts/${SCRIPT_NAME}.js" "${ARGS[@]}"
-          elif [ "$SCRIPT_NAME" = "backfill-display-filename" ]; then
+          elif [ "$SCRIPT_NAME" = "backfill-display-filename" ] || \
+               [ "$SCRIPT_NAME" = "classify-collision-docs" ] || \
+               [ "$SCRIPT_NAME" = "setup-collision-fixture" ]; then
+            # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript) に依存するため
+            # ts-node 経由で実行。STORAGE_BUCKET は resolve step で env 化済。
             cd scripts
             NODE_PATH=../functions/node_modules \
               FIREBASE_PROJECT_ID="$PROJECT_ID" \
+              STORAGE_BUCKET="$STORAGE_BUCKET" \
               npx ts-node "${SCRIPT_NAME}.ts" $SCRIPT_ARGS
           elif [ "$SCRIPT_NAME" = "inspect-document" ]; then
             # SCRIPT_ARGS は workflow_dispatch で選んだ "--file-name" / "--doc-id" / "... --include-related"

--- a/docs/runbooks/orphan-storage-cleanup.md
+++ b/docs/runbooks/orphan-storage-cleanup.md
@@ -141,11 +141,186 @@ parent (= splitPdf に渡された元 doc ID) を特定する手段:
 
 ---
 
+## PR-C 衝突 doc / orphan の信頼度付き 5 分類 migration (Issue #432 PR-C)
+
+過去被害 (kanameone 39 衝突 group + 4 fileUrl 孤児 = silent breakage 90+ docs) の復旧手順。Codex セカンドオピニオン反映後の 5 分類アルゴリズム (`MatchedByHash` / `Ambiguous` / `RepairableMissingFile` / `LostOrUnrecoverable`、LikelyWinner は Ambiguous 内 suggestedWinner hint に降格)。
+
+### 前提
+
+- `audit-storage-mismatch.js` で被害が検出済 (衝突 group / fileUrl 孤児)
+- runbook §Phase 1〜3 で個別対応する量を超え、bulk migration が妥当と判断済
+- **freeze window (推奨)**: migration 実行中は対象環境の UI 操作 (分割 / 回転 / 削除) を停止する。進行中 splitPdf invocation との race を precondition gate で skip するが、freeze window で race 数を最小化
+
+### 5 分類と自動 action 一覧
+
+| 分類 | 判定条件 | recommendedAction | 自動実行可否 |
+|---|---|---|---|
+| **MatchedByHash** | sha256(Storage 実体) == sha256(parent + splitFromPages から再生成した期待 PDF) かつ group 内一意 | migrate-to-namespace | ✅ 自動 |
+| **RepairableMissingFile** | parent + splitFromPages + 親 PDF 全て実在 | regenerate-from-parent | ✅ 自動 (敗者 doc / orphan 共通) |
+| **Ambiguous** | hash 不能 / 不一致 / 複数一致 (LikelyWinner suggestedWinner hint 含む) | manual-review | ❌ 自動禁止 |
+| **LostOrUnrecoverable** | parent doc 不在 / splitFromPages 不在 / 親 PDF 不在 | mark-error | ✅ status:'error' のみ自動 (Storage 操作なし) |
+
+> **重要 (Codex Critical 反映)**: `rotatedAt!=null 唯一` による LikelyWinner は「離脱可能性」の手がかりに過ぎず Storage 実体の正当性証明ではない。自動 destructive action は禁止。Ambiguous の suggestedWinner hint として operator に提示する。
+
+### Step 1: dev 環境で execute path を全分類検証 (本番前必須)
+
+cocoro/kanameone は被害ゼロ or 本番のため、`execute` path は dev fixture で先行検証する。
+
+```bash
+# dev 環境に 5 分類 fixture を投入 (idempotent、安全策で projectId に "dev" 含むか確認)
+./scripts/switch-client.sh dev
+FIREBASE_PROJECT_ID=doc-split-dev STORAGE_BUCKET=doc-split-dev.firebasestorage.app \
+  npx ts-node scripts/setup-collision-fixture.ts
+
+# fixture cleanup (検証完了後)
+FIREBASE_PROJECT_ID=doc-split-dev STORAGE_BUCKET=doc-split-dev.firebasestorage.app \
+  npx ts-node scripts/setup-collision-fixture.ts --cleanup
+```
+
+### Step 2: classify (read-only) で migration plan JSON 出力
+
+```bash
+# 対象環境に切替
+./scripts/switch-client.sh <env>
+
+# classify 実行 (Firestore/Storage 書き込みゼロ、JSON レポート出力)
+FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+  npx ts-node scripts/classify-collision-docs.ts \
+    --prefix processed/ --out plan-$(date +%Y%m%d-%H%M%S).json
+```
+
+出力 JSON 構造:
+
+```json
+{
+  "planId": "plan-2026-05-11T...",
+  "createdAt": "...",
+  "environment": "...",
+  "projectId": "docsplit-kanameone",
+  "bucket": "docsplit-kanameone.firebasestorage.app",
+  "prefix": "processed/",
+  "summary": {
+    "totalGroups": 39,
+    "totalCollisionDocs": 90,
+    "totalOrphans": 4,
+    "byClassification": { "MatchedByHash": ..., "Ambiguous": ..., ... },
+    "byAction": { "migrate-to-namespace": ..., ... }
+  },
+  "operations": [
+    {
+      "operationId": "op-0001",
+      "docId": "...",
+      "classification": "MatchedByHash",
+      "recommendedAction": "migrate-to-namespace",
+      "expectedCurrentFileUrl": "gs://bucket/processed/old-name.pdf",
+      "expectedStatus": "processed",
+      "expectedUpdatedAt": "...",
+      "sourcePath": "processed/old-name.pdf",
+      "destPath": "processed/<docId>/old-name.pdf",
+      ...
+    }
+  ]
+}
+```
+
+### Step 3: ユーザーへ提示 → 番号認可 (per-operation + per-path)
+
+Step 2 で出力された plan JSON 内容と各 operation の sourcePath/destPath を operator に提示し、**operationId と path を文字列単位で含む承認**を取得する。
+
+承認は別 JSON ファイルとして保存:
+
+```json
+{
+  "planId": "plan-2026-05-11T...",
+  "approvedOperationIds": [
+    "op-0001",
+    "op-0002"
+  ],
+  "approvedPaths": [
+    "gs://docsplit-kanameone.firebasestorage.app/processed/old-name-1.pdf",
+    "gs://docsplit-kanameone.firebasestorage.app/processed/<docId>/old-name-1.pdf"
+  ]
+}
+```
+
+**4 重 gate (Codex セカンドオピニオン反映)**:
+
+1. `approval.planId === plan.planId` (古い plan の流用防止)
+2. `operation.operationId ∈ approvedOperationIds` (operation 単位の認可)
+3. destructive action は `sourcePath / destPath ∈ approvedPaths` (per-path 文字列認可、ADR-0008 教訓)
+4. runtime env (`FIREBASE_PROJECT_ID + STORAGE_BUCKET`) が plan の `projectId / bucket` と一致 (環境取り違え防止)
+5. precondition snapshot (`expectedCurrentFileUrl + expectedStatus + expectedUpdatedAt`) が現状 doc と一致 (進行中 splitPdf invocation との race 検出 → skip)
+
+> **禁止**: `Issue #432 全件OK` / `processed/ 配下OK` 等の prefix / 包括認可は execute script 側で reject (ADR-0008 教訓)。
+
+### Step 4: dry-run で執行計画確認
+
+```bash
+FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+  npx ts-node scripts/execute-collision-migration.ts \
+    --plan plan-XXX.json --approval approval-XXX.json
+# (--execute なし = dry-run)
+```
+
+期待出力:
+- 全 gate 通過 operation: `📋 op-XXXX` (would execute)
+- gate 落ち: `🚫 op-XXXX` (gate-rejected)
+- precondition mismatch: `⏭️ op-XXXX` (skipped)
+
+### Step 5: 番号認可後 execute
+
+```bash
+FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+  npx ts-node scripts/execute-collision-migration.ts \
+    --plan plan-XXX.json --approval approval-XXX.json --execute
+
+# 段階実行 (operation 単位):
+FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+  npx ts-node scripts/execute-collision-migration.ts \
+    --plan plan-XXX.json --approval approval-XXX.json --execute \
+    --operations op-0001,op-0002
+```
+
+### Step 6: 中断時の再実行 (idempotency)
+
+migration 中断 (network error / kill / etc) 後の再実行は同じ plan + approval で安全:
+
+- migrate / regenerate: 新 path 存在 + Firestore fileUrl 更新済 → skip (`already migrated (idempotent)`)
+- mark-error: 既に status='error' でも再 update (副作用なし)
+
+precondition mismatch (race condition の検出) は skip + warning。再 classify で plan を作り直すか、operator が個別判断。
+
+### Step 7: post-audit で復旧確認
+
+```bash
+FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+  node scripts/audit-storage-mismatch.js
+```
+
+期待: `fileName collisions: 0 groups` / `fileUrl orphans: 0` (migration 対象として処理されたもの全て)。Ambiguous 分類で manual-review 状態のものは継続して衝突 group に表示される (operator が個別対応)。
+
+### PR-C migration スコープ外
+
+以下は本 migration では扱わない (別 PR / 手動対応):
+
+- 旧 `processed/{fileName}` 形式 → `processed/{docId}/{fileName}` の **被害なし docs** の一斉移行 (5640+ docs、本 migration は被害復旧限定)
+- `generateFileName` の timestamp 引数完全削除 (handoff session57 別 PR)
+- Cloud Monitoring alert (`cleanupResult=failed`) (handoff follow-up)
+- audit-storage-mismatch.js の cron 自動化 (handoff follow-up)
+
+---
+
 ## 関連リソース
 
 - Issue #432 (P0 設計バグ)
 - ADR-0008 (本番データ保護)
 - `scripts/audit-storage-mismatch.js` (検出 script)
 - `scripts/inspect-document.js` (調査 script, read-only)
-- `functions/src/storage/storageDeletionGuard.ts` (PR-A safety net)
+- `scripts/classify-collision-docs.ts` (PR-C: 5 分類 plan 出力)
+- `scripts/execute-collision-migration.ts` (PR-C: 4 重 gate + idempotent migration)
+- `scripts/setup-collision-fixture.ts` (PR-C: dev 環境 fixture)
+- `scripts/lib/collisionClassifier.ts` (PR-C: 5 分類 pure function)
+- `scripts/lib/pdfRegenerator.ts` (PR-C: parent から PDF 再生成)
+- `scripts/lib/storageGuard.ts` (PR-C: 削除安全性判定 helper)
+- `functions/src/storage/storageDeletionGuard.ts` (PR-A safety net、Functions 用)
 - `functions/src/pdf/pdfOperations.ts` (PR-B docId namespace + 補償処理)

--- a/functions/test/collisionClassifier.test.ts
+++ b/functions/test/collisionClassifier.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Issue #432 PR-C: collisionClassifier.ts pure function テスト
+ *
+ * Codex セカンドオピニオン (2026-05-11) 反映後の分類ロジックを固定する:
+ *   - hash matched 一意のみ MatchedByHash (自動 migrate)
+ *   - hash matched 複数 / 不能 / 不一致は Ambiguous (manual-review)
+ *   - LikelyWinner は Ambiguous 内 suggestedWinner hint に降格 (自動 destructive 禁止)
+ *   - orphan + parent + 親 PDF 在 → RepairableMissingFile (auto regenerate)
+ *   - 復元不能は LostOrUnrecoverable (status:'error' 誘導)
+ *
+ * AC カバレッジ: AC-1〜AC-4 (5 分類), AC-10 (Partial update 不変 = recommendedAction の type 固定),
+ * AC-11 (RepairableMissingFile 分類)。
+ */
+
+import { expect } from 'chai';
+import {
+  classifyCollisionGroup,
+  classifyOrphan,
+  CollisionDoc,
+  CollisionGroup,
+  DocEvidence,
+} from '../../scripts/lib/collisionClassifier';
+
+function makeDoc(overrides: Partial<CollisionDoc> = {}): CollisionDoc {
+  return {
+    id: 'docA',
+    status: 'processed',
+    fileName: '20260509_未判定_未判定_p3.pdf',
+    fileUrl: 'gs://bucket/processed/20260509_未判定_未判定_p3.pdf',
+    parentDocumentId: 'parent-1',
+    splitFromPages: { start: 3, end: 3 },
+    rotatedAt: null,
+    processedAt: '2026-05-09T00:00:00Z',
+    updatedAt: '2026-05-09T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const PARENT_OK = { exists: true as const, originalPdfExists: true as const };
+const PARENT_MISSING = { exists: false as const };
+const PARENT_NO_PDF = { exists: true as const, originalPdfExists: false as const };
+
+describe('collisionClassifier (Issue #432 PR-C)', () => {
+  describe('classifyCollisionGroup - ケース 1: hash matched 一意', () => {
+    it('1 件単独 group + hash matched → MatchedByHash 単独 (AC-2)', () => {
+      const group: CollisionGroup = {
+        fileName: 'single.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'winner' }),
+            hashEvidence: { type: 'matched', sha256: 'abc' },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      expect(results).to.have.length(1);
+      expect(results[0].docId).to.equal('winner');
+      expect(results[0].classification).to.equal('MatchedByHash');
+      expect(results[0].recommendedAction).to.equal('migrate-to-namespace');
+      expect(results[0].suggestedWinner).to.be.false;
+    });
+
+    it('hash matched 一意 + 敗者 1 件 (parent あり) → 勝者 MatchedByHash + 敗者 RepairableMissingFile', () => {
+      const group: CollisionGroup = {
+        fileName: 'collision.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'winner' }),
+            hashEvidence: { type: 'matched', sha256: 'abc' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'loser', parentDocumentId: 'parent-2' }),
+            hashEvidence: {
+              type: 'mismatched',
+              actualSha256: 'abc',
+              expectedSha256: 'xyz',
+            },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      const winner = results.find((r) => r.docId === 'winner')!;
+      const loser = results.find((r) => r.docId === 'loser')!;
+      expect(winner.classification).to.equal('MatchedByHash');
+      expect(winner.recommendedAction).to.equal('migrate-to-namespace');
+      expect(loser.classification).to.equal('RepairableMissingFile');
+      expect(loser.recommendedAction).to.equal('regenerate-from-parent');
+    });
+
+    it('hash matched 一意 + 敗者 (parent なし) → 勝者 MatchedByHash + 敗者 LostOrUnrecoverable', () => {
+      const group: CollisionGroup = {
+        fileName: 'collision-no-parent.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'winner' }),
+            hashEvidence: { type: 'matched', sha256: 'abc' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'loser', parentDocumentId: null, splitFromPages: null }),
+            hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+            parent: null,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      const loser = results.find((r) => r.docId === 'loser')!;
+      expect(loser.classification).to.equal('LostOrUnrecoverable');
+      expect(loser.recommendedAction).to.equal('mark-error');
+      expect(loser.reason).to.contain('no parentDocumentId');
+    });
+  });
+
+  describe('classifyCollisionGroup - ケース 2: hash matched 複数', () => {
+    it('hash matched 2 件 → 全員 Ambiguous (Codex Critical: 自動 destructive 禁止)', () => {
+      const group: CollisionGroup = {
+        fileName: 'multi-match.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'docA' }),
+            hashEvidence: { type: 'matched', sha256: 'abc' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'docB' }),
+            hashEvidence: { type: 'matched', sha256: 'abc' },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(r.classification).to.equal('Ambiguous');
+        expect(r.recommendedAction).to.equal('manual-review');
+        expect(r.suggestedWinner).to.be.true; // 両者 hash 一致のため両方 hint
+      });
+    });
+  });
+
+  describe('classifyCollisionGroup - ケース 3: hash matched なし', () => {
+    it('hash 不能 + 全 docs rotatedAt=null → 全件 Ambiguous (suggestedWinner なし) (AC-3)', () => {
+      const group: CollisionGroup = {
+        fileName: 'no-hint.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'docA', rotatedAt: null }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'docB', rotatedAt: null }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(r.classification).to.equal('Ambiguous');
+        expect(r.suggestedWinner).to.be.false;
+      });
+    });
+
+    it('hash 不能 + 1 件のみ rotatedAt 値あり → その doc が suggestedWinner=true (AC-4, Codex Critical: 自動 action 禁止)', () => {
+      const group: CollisionGroup = {
+        fileName: 'one-rotated.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'docA', rotatedAt: null }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'rotated-1', rotatedAt: '2026-05-10T00:00:00Z' }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      const hinted = results.find((r) => r.docId === 'rotated-1')!;
+      const other = results.find((r) => r.docId === 'docA')!;
+      expect(hinted.suggestedWinner).to.be.true;
+      expect(hinted.recommendedAction).to.equal('manual-review'); // ★ 自動 action 禁止 (Codex 反映)
+      expect(hinted.classification).to.equal('Ambiguous');
+      expect(other.suggestedWinner).to.be.false;
+    });
+
+    it('hash 不能 + 複数 rotatedAt 値あり → suggestedWinner なし (唯一でないため hint 不成立)', () => {
+      const group: CollisionGroup = {
+        fileName: 'multi-rotated.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'docA', rotatedAt: '2026-05-10T00:00:00Z' }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'docB', rotatedAt: '2026-05-11T00:00:00Z' }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(r.suggestedWinner).to.be.false;
+      });
+    });
+
+    it('hash 全件 mismatched → 全員 Ambiguous', () => {
+      const group: CollisionGroup = {
+        fileName: 'all-mismatch.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'docA' }),
+            hashEvidence: {
+              type: 'mismatched',
+              actualSha256: 'aaa',
+              expectedSha256: 'xxx',
+            },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'docB' }),
+            hashEvidence: {
+              type: 'mismatched',
+              actualSha256: 'aaa',
+              expectedSha256: 'yyy',
+            },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(r.classification).to.equal('Ambiguous');
+        expect(r.reason).to.contain('hash mismatch');
+      });
+    });
+  });
+
+  describe('classifyOrphan (fileUrl 孤児)', () => {
+    it('orphan + parent + originalPdf 在 → RepairableMissingFile (AC-11)', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'orphan-1' }),
+        hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('RepairableMissingFile');
+      expect(result.recommendedAction).to.equal('regenerate-from-parent');
+    });
+
+    it('orphan + parentDocumentId なし → LostOrUnrecoverable', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'orphan-2', parentDocumentId: null, splitFromPages: null }),
+        hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+        parent: null,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('LostOrUnrecoverable');
+      expect(result.recommendedAction).to.equal('mark-error');
+      expect(result.reason).to.contain('no parentDocumentId');
+    });
+
+    it('orphan + splitFromPages なし → LostOrUnrecoverable', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'orphan-3', splitFromPages: null }),
+        hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('LostOrUnrecoverable');
+      expect(result.reason).to.contain('no splitFromPages');
+    });
+
+    it('orphan + parent.exists=false → LostOrUnrecoverable', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'orphan-4' }),
+        hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+        parent: PARENT_MISSING,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('LostOrUnrecoverable');
+      expect(result.reason).to.contain('not found');
+    });
+
+    it('orphan + parent あり + 親 PDF なし → LostOrUnrecoverable', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'orphan-5' }),
+        hashEvidence: { type: 'unavailable', reason: 'no-parent-original-pdf' },
+        parent: PARENT_NO_PDF,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('LostOrUnrecoverable');
+      expect(result.reason).to.contain('parent original PDF not in Storage');
+    });
+  });
+
+  describe('AC-1: 5 分類混在シナリオ', () => {
+    it('1 group で MatchedByHash + RepairableMissingFile + Ambiguous + LostOrUnrecoverable が混在可能', () => {
+      const group: CollisionGroup = {
+        fileName: 'mixed.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'matched' }),
+            hashEvidence: { type: 'matched', sha256: 'abc' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'repairable', parentDocumentId: 'parent-3' }),
+            hashEvidence: {
+              type: 'mismatched',
+              actualSha256: 'abc',
+              expectedSha256: 'def',
+            },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'lost', parentDocumentId: null, splitFromPages: null }),
+            hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+            parent: null,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      const classifications = results.map((r) => r.classification).sort();
+      expect(classifications).to.deep.equal([
+        'LostOrUnrecoverable',
+        'MatchedByHash',
+        'RepairableMissingFile',
+      ]);
+    });
+  });
+
+  describe('AC-10: Partial update 不変 (recommendedAction の type 固定)', () => {
+    it('全 recommendedAction は migrate-to-namespace / regenerate-from-parent / manual-review / mark-error の 4 種のみ', () => {
+      const allowedActions = new Set([
+        'migrate-to-namespace',
+        'regenerate-from-parent',
+        'manual-review',
+        'mark-error',
+      ]);
+
+      const group: CollisionGroup = {
+        fileName: 'enum-check.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'a' }),
+            hashEvidence: { type: 'matched', sha256: 'h' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'b', parentDocumentId: null }),
+            hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+            parent: null,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(allowedActions.has(r.recommendedAction), r.recommendedAction).to.be.true;
+      });
+    });
+  });
+});

--- a/functions/test/executeMigrationOps.test.ts
+++ b/functions/test/executeMigrationOps.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Issue #432 PR-C: scripts/lib/executeMigrationOps.ts pure function テスト (F-D2)
+ *
+ * CLAUDE.md MUST: 「DBにPartial Updateする関数を追加/変更 → テストに『更新対象外フィールドの
+ * 値が変化しないこと』を含める」を pure-function ベースで担保する。
+ *
+ * 各 build*UpdatePayload は Firestore update() に渡す key set を固定する責務。
+ * これらの key set が仕様通り (migrate=[fileUrl], regenerate=[fileUrl,status,lastErrorMessage],
+ * markError=[status,lastErrorMessage]) であることを test で lock-in する。
+ *
+ * Note: admin.firestore.FieldValue.delete() は internal sentinel object で構造比較不可のため、
+ * lastErrorMessage キーの存在のみ検証する。実際の delete 動作は Firestore emulator integration
+ * test で別途確認 (本 PR スコープ外、PR-C2 で dev fixture 経由で動作確認)。
+ */
+
+import { expect } from 'chai';
+import * as admin from 'firebase-admin';
+import {
+  buildMigrateUpdatePayload,
+  buildRegenerateUpdatePayload,
+  buildMarkErrorUpdatePayload,
+  EXPECTED_UPDATE_KEYS,
+} from '../../scripts/lib/executeMigrationOps';
+
+describe('executeMigrationOps Partial update 不変 (Issue #432 PR-C, F-D2, CLAUDE.md MUST)', () => {
+  describe('buildMigrateUpdatePayload', () => {
+    it('fileUrl 1 キーのみを返す (他フィールド不変)', () => {
+      const payload = buildMigrateUpdatePayload('gs://bucket/processed/abc/file.pdf');
+      const keys = Object.keys(payload).sort();
+      expect(keys).to.deep.equal([...EXPECTED_UPDATE_KEYS.migrate].sort());
+    });
+
+    it('fileUrl の値は引数そのまま', () => {
+      const url = 'gs://docsplit-kanameone.firebasestorage.app/processed/xyz/test.pdf';
+      const payload = buildMigrateUpdatePayload(url);
+      expect(payload.fileUrl).to.equal(url);
+    });
+
+    it('fileName / parentDocumentId / status / ocrExtraction 等は payload に含まれない', () => {
+      const payload = buildMigrateUpdatePayload('gs://bucket/path');
+      expect(payload).to.not.have.property('fileName');
+      expect(payload).to.not.have.property('parentDocumentId');
+      expect(payload).to.not.have.property('status');
+      expect(payload).to.not.have.property('ocrExtraction');
+      expect(payload).to.not.have.property('updatedAt');
+      expect(payload).to.not.have.property('processedAt');
+      expect(payload).to.not.have.property('rotatedAt');
+    });
+  });
+
+  describe('buildRegenerateUpdatePayload', () => {
+    it('fileUrl + status + lastErrorMessage 3 キーのみを返す', () => {
+      const payload = buildRegenerateUpdatePayload('gs://bucket/processed/abc/file.pdf');
+      const keys = Object.keys(payload).sort();
+      expect(keys).to.deep.equal([...EXPECTED_UPDATE_KEYS.regenerate].sort());
+    });
+
+    it('status は processed に戻す (orphan 由来 error からの回復)', () => {
+      const payload = buildRegenerateUpdatePayload('gs://bucket/path');
+      expect(payload.status).to.equal('processed');
+    });
+
+    it('lastErrorMessage は FieldValue.delete() (sentinel) で削除', () => {
+      const payload = buildRegenerateUpdatePayload('gs://bucket/path');
+      expect(payload.lastErrorMessage).to.be.instanceOf(
+        admin.firestore.FieldValue.delete().constructor
+      );
+    });
+
+    it('fileName / parentDocumentId / ocrExtraction 等は payload に含まれない', () => {
+      const payload = buildRegenerateUpdatePayload('gs://bucket/path');
+      expect(payload).to.not.have.property('fileName');
+      expect(payload).to.not.have.property('parentDocumentId');
+      expect(payload).to.not.have.property('ocrExtraction');
+      expect(payload).to.not.have.property('splitFromPages');
+      expect(payload).to.not.have.property('updatedAt');
+    });
+  });
+
+  describe('buildMarkErrorUpdatePayload', () => {
+    it('status + lastErrorMessage 2 キーのみを返す (Storage 操作なし)', () => {
+      const payload = buildMarkErrorUpdatePayload('test reason');
+      const keys = Object.keys(payload).sort();
+      expect(keys).to.deep.equal([...EXPECTED_UPDATE_KEYS.markError].sort());
+    });
+
+    it('status は error に固定', () => {
+      const payload = buildMarkErrorUpdatePayload('test reason');
+      expect(payload.status).to.equal('error');
+    });
+
+    it('lastErrorMessage に Issue #432 PR-C migration prefix + reason を含む', () => {
+      const reason = 'no parentDocumentId; cannot regenerate';
+      const payload = buildMarkErrorUpdatePayload(reason);
+      expect(payload.lastErrorMessage).to.contain('Issue #432 PR-C migration');
+      expect(payload.lastErrorMessage).to.contain(reason);
+    });
+
+    it('fileUrl / fileName / parentDocumentId 等は payload に含まれない', () => {
+      const payload = buildMarkErrorUpdatePayload('test');
+      expect(payload).to.not.have.property('fileUrl');
+      expect(payload).to.not.have.property('fileName');
+      expect(payload).to.not.have.property('parentDocumentId');
+      expect(payload).to.not.have.property('updatedAt');
+    });
+  });
+
+  describe('EXPECTED_UPDATE_KEYS (regression lock)', () => {
+    it('migrate は fileUrl 1 キーのみであることをドキュメント化', () => {
+      expect(EXPECTED_UPDATE_KEYS.migrate).to.deep.equal(['fileUrl']);
+    });
+
+    it('regenerate は fileUrl/status/lastErrorMessage 3 キーのみ', () => {
+      expect([...EXPECTED_UPDATE_KEYS.regenerate].sort()).to.deep.equal(
+        ['fileUrl', 'lastErrorMessage', 'status']
+      );
+    });
+
+    it('markError は status/lastErrorMessage 2 キーのみ', () => {
+      expect([...EXPECTED_UPDATE_KEYS.markError].sort()).to.deep.equal(
+        ['lastErrorMessage', 'status']
+      );
+    });
+  });
+});

--- a/functions/test/pdfRegenerator.test.ts
+++ b/functions/test/pdfRegenerator.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Issue #432 PR-C: scripts/lib/pdfRegenerator.ts pure function テスト (F-D1)
+ *
+ * 目的:
+ *   - 正常系 (page range 抽出が pdf-lib 仕様通り)
+ *   - 境界値 (1 ページ / 全ページ / 範囲外)
+ *   - 異常系 (不正 PDF buffer / page range 不正)
+ *   - deterministic 性 (同入力 → 同 sha256) ★ MatchedByHash 判定の信頼性根拠
+ *
+ * MatchedByHash classifier は「sha256(actual storage) == sha256(regenerated from parent)」で
+ * 勝者を確定する設計のため、regenerateChildPdf が deterministic でなければ classifier
+ * の根本前提が崩れる。本テストはそこをロック。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import { PDFDocument } from 'pdf-lib';
+import { regenerateChildPdf } from '../../scripts/lib/pdfRegenerator';
+
+async function makeNPagePdf(n: number, seed: number = 0): Promise<Buffer> {
+  const pdf = await PDFDocument.create();
+  for (let i = 0; i < n; i++) {
+    const page = pdf.addPage([100, 100]);
+    page.drawRectangle({ x: 5 + i * 3 + seed, y: 5 + i * 3 + seed, width: 20, height: 20 });
+  }
+  return Buffer.from(await pdf.save());
+}
+
+function sha256(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+describe('pdfRegenerator.regenerateChildPdf (Issue #432 PR-C, F-D1)', () => {
+  describe('正常系: page range 抽出', () => {
+    it('5 ページ親 + start=2 end=3 → 2 ページ child', async () => {
+      const parent = await makeNPagePdf(5);
+      const child = await regenerateChildPdf(parent, 2, 3);
+      const childPdf = await PDFDocument.load(child);
+      expect(childPdf.getPageCount()).to.equal(2);
+    });
+
+    it('境界: start=1 end=1 (単一ページ)', async () => {
+      const parent = await makeNPagePdf(5);
+      const child = await regenerateChildPdf(parent, 1, 1);
+      const childPdf = await PDFDocument.load(child);
+      expect(childPdf.getPageCount()).to.equal(1);
+    });
+
+    it('境界: start=1 end=N (全ページ)', async () => {
+      const parent = await makeNPagePdf(5);
+      const child = await regenerateChildPdf(parent, 1, 5);
+      const childPdf = await PDFDocument.load(child);
+      expect(childPdf.getPageCount()).to.equal(5);
+    });
+  });
+
+  describe('異常系: page range 不正', () => {
+    it('startPage=0 → throw', async () => {
+      const parent = await makeNPagePdf(5);
+      try {
+        await regenerateChildPdf(parent, 0, 1);
+        expect.fail('expected throw');
+      } catch (err) {
+        expect((err as Error).message).to.contain('invalid page range');
+      }
+    });
+
+    it('startPage > endPage → throw', async () => {
+      const parent = await makeNPagePdf(5);
+      try {
+        await regenerateChildPdf(parent, 3, 2);
+        expect.fail('expected throw');
+      } catch (err) {
+        expect((err as Error).message).to.contain('invalid page range');
+      }
+    });
+
+    it('endPage > totalPages → throw', async () => {
+      const parent = await makeNPagePdf(3);
+      try {
+        await regenerateChildPdf(parent, 1, 10);
+        expect.fail('expected throw');
+      } catch (err) {
+        expect((err as Error).message).to.contain('out of bounds');
+      }
+    });
+
+    it('不正 PDF buffer (空 buffer) → pdf-lib エラーが伝播', async () => {
+      try {
+        await regenerateChildPdf(Buffer.from([]), 1, 1);
+        expect.fail('expected throw');
+      } catch (err) {
+        // pdf-lib のエラー型に依存しない汎用検証 (load 失敗)
+        expect(err).to.be.instanceOf(Error);
+      }
+    });
+  });
+
+  describe('★ deterministic 性 (MatchedByHash classifier の信頼性根拠)', () => {
+    it('同入力 + 同 page range で 2 回生成 → sha256 が完全一致', async () => {
+      const parent = await makeNPagePdf(5);
+      const child1 = await regenerateChildPdf(parent, 2, 3);
+      const child2 = await regenerateChildPdf(parent, 2, 3);
+      expect(sha256(child1)).to.equal(sha256(child2));
+    });
+
+    it('異なる page range なら sha256 が異なる', async () => {
+      const parent = await makeNPagePdf(5);
+      const child1 = await regenerateChildPdf(parent, 1, 1);
+      const child2 = await regenerateChildPdf(parent, 2, 2);
+      expect(sha256(child1)).to.not.equal(sha256(child2));
+    });
+
+    it('異なる parent (page 1 の内容が異なる) なら同 page range でも sha256 が異なる', async () => {
+      const parent1 = await makeNPagePdf(5, 0);
+      const parent2 = await makeNPagePdf(5, 7); // seed 差で page 1 の rectangle 位置が変わる
+      const child1 = await regenerateChildPdf(parent1, 1, 1);
+      const child2 = await regenerateChildPdf(parent2, 1, 1);
+      expect(sha256(child1)).to.not.equal(sha256(child2));
+    });
+  });
+});

--- a/functions/test/storageGuard.test.ts
+++ b/functions/test/storageGuard.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Issue #432 PR-C: scripts/lib/storageGuard.ts pure function テスト
+ *
+ * evaluatePathSafety: Firestore mock 不要の pure function 部分のみテスト。
+ * 統合系 (findDocsReferencingFileUrl / isPathSafeToDeleteAfterExcluding) は
+ * dev fixture 経由で動作確認 (T6)。
+ */
+
+import { expect } from 'chai';
+import { evaluatePathSafety } from '../../scripts/lib/storageGuard';
+
+describe('storageGuard.evaluatePathSafety (Issue #432 PR-C)', () => {
+  it('共有 doc なし → safe=true / residual=空', () => {
+    const result = evaluatePathSafety([], ['docX']);
+    expect(result.safe).to.be.true;
+    expect(result.residualDocIds).to.deep.equal([]);
+  });
+
+  it('除外 IDs が共有者全員をカバー → safe=true', () => {
+    const result = evaluatePathSafety(['doc1', 'doc2'], ['doc1', 'doc2']);
+    expect(result.safe).to.be.true;
+    expect(result.residualDocIds).to.deep.equal([]);
+  });
+
+  it('除外されない共有者が 1 件残る → safe=false / residual=その doc', () => {
+    const result = evaluatePathSafety(['doc1', 'doc2', 'doc3'], ['doc1', 'doc2']);
+    expect(result.safe).to.be.false;
+    expect(result.residualDocIds).to.deep.equal(['doc3']);
+  });
+
+  it('除外 IDs に含まれない無関係 doc が複数残存 → safe=false', () => {
+    const result = evaluatePathSafety(['a', 'b', 'c'], ['z']);
+    expect(result.safe).to.be.false;
+    expect(result.residualDocIds.sort()).to.deep.equal(['a', 'b', 'c']);
+  });
+
+  it('除外 IDs 空配列 + 共有者あり → safe=false (= 全員残存)', () => {
+    const result = evaluatePathSafety(['doc1'], []);
+    expect(result.safe).to.be.false;
+    expect(result.residualDocIds).to.deep.equal(['doc1']);
+  });
+});

--- a/scripts/classify-collision-docs.ts
+++ b/scripts/classify-collision-docs.ts
@@ -63,12 +63,20 @@ function tsToIso(ts: unknown): string | null {
   return String(ts);
 }
 
+/**
+ * gs://<bucket>/<path> の <path> 部分を返す。bucket 一致確認なし。
+ * F-B4 後は呼び出し元を狭く保つため、参照箇所を最小化している。
+ */
 function pathFromUrl(url: string | null | undefined): string | null {
   if (!url || typeof url !== 'string') return null;
   const m = url.match(/^gs:\/\/[^/]+\/(.+)$/);
   return m ? m[1] : null;
 }
 
+/**
+ * bucket 一致確認付き (PR-D 同等、F-B4 反映)。マルチクライアント環境で別 bucket
+ * 参照を本環境の参照と誤計上する false negative を防ぐ。
+ */
 function extractPathIfBucketMatches(
   url: string | null | undefined,
   expectedBucket: string
@@ -82,6 +90,24 @@ function extractPathIfBucketMatches(
 
 function sha256(buf: Buffer): string {
   return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Storage の指定 path が実在するか個別 exists() で確認する (cache 付き)。
+ * F-A1: parent PDF は `processed/` に限定されない (通常 `original/...`) ため
+ * Storage 一覧 (prefix 限定) には載らない。`bucket.file(p).exists()` で個別確認。
+ */
+async function makeStorageExistenceChecker(): Promise<
+  (path: string) => Promise<boolean>
+> {
+  const cache = new Map<string, boolean>();
+  return async (path: string): Promise<boolean> => {
+    const cached = cache.get(path);
+    if (cached !== undefined) return cached;
+    const [exists] = await bucket.file(path).exists();
+    cache.set(path, exists);
+    return exists;
+  };
 }
 
 async function loadAllDocs(): Promise<RawDoc[]> {
@@ -121,19 +147,40 @@ async function listStorageFiles(prefixPath: string): Promise<Set<string>> {
   return all;
 }
 
-async function downloadIfExists(path: string): Promise<Buffer | null> {
+/**
+ * F-B3: catch-all で transient 503/403 を「ファイルなし」と誤分類する silent
+ * failure を防ぐ。404 のみ absent、それ以外は error として hashEvidence 側で
+ * computation-error 扱いにする (LostOrUnrecoverable に流さない)。
+ */
+type DownloadResult =
+  | { kind: 'ok'; buf: Buffer }
+  | { kind: 'absent' }
+  | { kind: 'error'; message: string };
+
+async function downloadIfExists(path: string): Promise<DownloadResult> {
   try {
     const [buf] = await bucket.file(path).download();
-    return buf;
-  } catch {
-    return null;
+    return { kind: 'ok', buf };
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === 404) return { kind: 'absent' };
+    return { kind: 'error', message: (err as Error).message };
   }
 }
 
-/** doc 1 件分の hash evidence + parent context を gather (Firestore/Storage I/O) */
+/**
+ * doc 1 件分の hash evidence + parent context を gather (Firestore/Storage I/O)
+ *
+ * F-A1 反映: parent PDF は通常 `original/...` 配下にあり `processed/` Storage 一覧には
+ *   載らない。`storageExists(parentPath)` で個別確認 + cache する。
+ * F-B3 反映: download の transient error (403/503) は hashEvidence: unavailable +
+ *   reason: 'computation-error' として返し、LostOrUnrecoverable に降格させない。
+ * F-B4 反映: bucket 不一致の fileUrl は本環境の path として扱わず、
+ *   reason: 'bucket-mismatch' で hash 比較不能として返す。
+ */
 async function buildDocEvidence(
   doc: CollisionDoc,
-  storagePaths: Set<string>,
+  storageExists: (path: string) => Promise<boolean>,
   parentCache: Map<string, RawDoc | null>,
   parentBufferCache: Map<string, Buffer | null>
 ): Promise<DocEvidence> {
@@ -166,15 +213,25 @@ async function buildDocEvidence(
     if (parentDoc === null) {
       parent = { exists: false };
     } else {
-      const parentPath = pathFromUrl(parentDoc.fileUrl);
-      const parentPdfExists = parentPath !== null && storagePaths.has(parentPath);
+      // F-B4: bucket 一致確認、不一致の parent は本環境の参照として扱わない
+      const parentPath = extractPathIfBucketMatches(parentDoc.fileUrl, bucket.name);
+      const parentPdfExists = parentPath !== null && (await storageExists(parentPath));
       parent = { exists: true, originalPdfExists: parentPdfExists };
     }
   }
 
   // hash evidence (Storage 実体 sha256 vs 親から再生成した期待 sha256)
-  const docPath = pathFromUrl(doc.fileUrl);
-  if (docPath === null || !storagePaths.has(docPath)) {
+  // F-B4: bucket mismatch は本環境の path として扱わず unavailable
+  const docPath = extractPathIfBucketMatches(doc.fileUrl, bucket.name);
+  if (docPath === null) {
+    return {
+      doc,
+      hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+      parent,
+    };
+  }
+  const docPathExists = await storageExists(docPath);
+  if (!docPathExists) {
     return {
       doc,
       hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
@@ -204,20 +261,51 @@ async function buildDocEvidence(
   }
 
   try {
-    const actualBuf = await downloadIfExists(docPath);
-    if (actualBuf === null) {
+    const actualResult = await downloadIfExists(docPath);
+    if (actualResult.kind === 'absent') {
       return {
         doc,
         hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
         parent,
       };
     }
+    if (actualResult.kind === 'error') {
+      console.warn(
+        `WARN: actual download failed (transient?) docId=${doc.id} path=${docPath}: ${actualResult.message}`
+      );
+      return {
+        doc,
+        hashEvidence: { type: 'unavailable', reason: 'computation-error' },
+        parent,
+      };
+    }
+    const actualBuf = actualResult.buf;
 
     let parentBuf = parentBufferCache.get(doc.parentDocumentId);
     if (parentBuf === undefined) {
       const parentDoc = parentCache.get(doc.parentDocumentId)!;
-      const parentPath = pathFromUrl(parentDoc!.fileUrl);
-      parentBuf = parentPath ? await downloadIfExists(parentPath) : null;
+      // F-B4: parent path も bucket 一致確認
+      const parentPath = extractPathIfBucketMatches(parentDoc!.fileUrl, bucket.name);
+      if (parentPath === null) {
+        parentBuf = null;
+      } else {
+        const parentResult = await downloadIfExists(parentPath);
+        if (parentResult.kind === 'ok') {
+          parentBuf = parentResult.buf;
+        } else if (parentResult.kind === 'error') {
+          console.warn(
+            `WARN: parent download failed (transient?) parentId=${doc.parentDocumentId} path=${parentPath}: ${parentResult.message}`
+          );
+          parentBufferCache.set(doc.parentDocumentId, null);
+          return {
+            doc,
+            hashEvidence: { type: 'unavailable', reason: 'computation-error' },
+            parent,
+          };
+        } else {
+          parentBuf = null;
+        }
+      }
       parentBufferCache.set(doc.parentDocumentId, parentBuf);
     }
     if (parentBuf === null) {
@@ -321,12 +409,13 @@ async function main(): Promise<void> {
   const allDocs = await loadAllDocs();
   console.log(`Total documents: ${allDocs.length}`);
 
+  // F-B4: bucket 一致確認付きで target 抽出 (別 bucket 参照を本環境に誤計上しない)
   const targetDocs = allDocs.filter((d) => {
-    const path = pathFromUrl(d.fileUrl);
-    return path && path.startsWith(prefix);
+    const path = extractPathIfBucketMatches(d.fileUrl, bucket.name);
+    return path !== null && path.startsWith(prefix);
   });
   console.log(
-    `Documents with fileUrl matching prefix "${prefix}": ${targetDocs.length}\n`
+    `Documents with fileUrl matching prefix "${prefix}" in bucket "${bucket.name}": ${targetDocs.length}\n`
   );
 
   console.log(`Listing Storage files under prefix "${prefix}"...`);
@@ -342,13 +431,14 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  // 衝突 group + orphan を分離
+  // F-A2: 衝突 group + orphan を排他的に分離 (orphan を byFileName に push しない)
   const byFileName = new Map<string, RawDoc[]>();
   const orphanDocs: RawDoc[] = [];
   for (const d of targetDocs) {
-    const path = pathFromUrl(d.fileUrl);
-    if (path && !storagePaths.has(path)) {
+    const path = extractPathIfBucketMatches(d.fileUrl, bucket.name);
+    if (path !== null && !storagePaths.has(path)) {
       orphanDocs.push(d);
+      continue; // ★ orphan は collision group 集計から除外 (二重登録防止)
     }
     if (!d.fileName) continue;
     if (!byFileName.has(d.fileName)) byFileName.set(d.fileName, []);
@@ -360,6 +450,9 @@ async function main(): Promise<void> {
   console.log(
     `Collision groups: ${collisionGroups.length} | fileUrl orphans: ${orphanDocs.length}\n`
   );
+
+  // F-A1: parent PDF 個別 exists() checker (`original/` 配下も含めて検出可能)
+  const storageExists = await makeStorageExistenceChecker();
 
   const parentCache = new Map<string, RawDoc | null>();
   const parentBufferCache = new Map<string, Buffer | null>();
@@ -393,7 +486,7 @@ async function main(): Promise<void> {
     }
     const evidences: DocEvidence[] = [];
     for (const d of docs) {
-      evidences.push(await buildDocEvidence(d, storagePaths, parentCache, parentBufferCache));
+      evidences.push(await buildDocEvidence(d, storageExists, parentCache, parentBufferCache));
     }
     const group: CollisionGroup = { fileName, evidences };
     const results = classifyCollisionGroup(group);
@@ -409,7 +502,7 @@ async function main(): Promise<void> {
   // orphan の classify
   console.log(`\nClassifying ${orphanDocs.length} orphans...`);
   for (const d of orphanDocs) {
-    const evidence = await buildDocEvidence(d, storagePaths, parentCache, parentBufferCache);
+    const evidence = await buildDocEvidence(d, storageExists, parentCache, parentBufferCache);
     const result = classifyOrphan(evidence);
     const op = buildOperation(d, result, opCounter);
     operations.push(op);

--- a/scripts/classify-collision-docs.ts
+++ b/scripts/classify-collision-docs.ts
@@ -1,0 +1,457 @@
+#!/usr/bin/env ts-node
+/**
+ * Issue #432 PR-C: 衝突 doc / fileUrl 孤児を 5 分類して JSON レポート出力 (read-only)
+ *
+ * 既存 scripts/audit-storage-mismatch.js (検出のみ) を発展させ、各 doc に hash evidence +
+ * parent context を gather し scripts/lib/collisionClassifier に渡す。
+ *
+ * 出力 JSON は execute-collision-migration.ts (T7) の入力となる migration plan。
+ * planId / env / bucket / precondition snapshot を含み、4 重 gate (T7 実装) で照合される。
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+ *     npx ts-node scripts/classify-collision-docs.ts [--prefix processed/] [--out plan.json]
+ */
+
+import * as admin from 'firebase-admin';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import {
+  classifyCollisionGroup,
+  classifyOrphan,
+  CollisionDoc,
+  CollisionGroup,
+  ClassificationResult,
+  DocEvidence,
+} from './lib/collisionClassifier';
+import { regenerateChildPdf } from './lib/pdfRegenerator';
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const storageBucket = process.env.STORAGE_BUCKET;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+if (!storageBucket) {
+  console.error(
+    'STORAGE_BUCKET を設定してください (例: docsplit-kanameone.firebasestorage.app)'
+  );
+  process.exit(1);
+}
+
+function getOpt(name: string, def: string | null = null): string | null {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+
+const prefix = getOpt('--prefix', 'processed/')!;
+const outFile = getOpt('--out', null);
+
+admin.initializeApp({ projectId, storageBucket });
+const db = admin.firestore();
+const bucket = admin.storage().bucket();
+
+interface RawDoc extends CollisionDoc {
+  _raw: admin.firestore.DocumentData;
+}
+
+function tsToIso(ts: unknown): string | null {
+  if (!ts) return null;
+  if (typeof ts === 'object' && ts !== null && 'toDate' in ts) {
+    return (ts as { toDate(): Date }).toDate().toISOString();
+  }
+  return String(ts);
+}
+
+function pathFromUrl(url: string | null | undefined): string | null {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(/^gs:\/\/[^/]+\/(.+)$/);
+  return m ? m[1] : null;
+}
+
+function extractPathIfBucketMatches(
+  url: string | null | undefined,
+  expectedBucket: string
+): string | null {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  if (m[1] !== expectedBucket) return null;
+  return m[2];
+}
+
+function sha256(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+async function loadAllDocs(): Promise<RawDoc[]> {
+  const snap = await db.collection('documents').get();
+  const all: RawDoc[] = [];
+  snap.forEach((doc) => {
+    const data = doc.data();
+    all.push({
+      id: doc.id,
+      status: data.status,
+      fileName: data.fileName,
+      fileUrl: data.fileUrl ?? null,
+      parentDocumentId: data.parentDocumentId ?? null,
+      splitFromPages: data.splitFromPages ?? null,
+      rotatedAt: tsToIso(data.rotatedAt),
+      processedAt: tsToIso(data.processedAt),
+      updatedAt: tsToIso(data.updatedAt),
+      _raw: data,
+    });
+  });
+  return all;
+}
+
+async function listStorageFiles(prefixPath: string): Promise<Set<string>> {
+  const all = new Set<string>();
+  let token: string | undefined;
+  do {
+    const [files, nextQuery] = await bucket.getFiles({
+      prefix: prefixPath,
+      maxResults: 1000,
+      pageToken: token,
+      autoPaginate: false,
+    });
+    files.forEach((f) => all.add(f.name));
+    token = (nextQuery as { pageToken?: string } | undefined)?.pageToken;
+  } while (token);
+  return all;
+}
+
+async function downloadIfExists(path: string): Promise<Buffer | null> {
+  try {
+    const [buf] = await bucket.file(path).download();
+    return buf;
+  } catch {
+    return null;
+  }
+}
+
+/** doc 1 件分の hash evidence + parent context を gather (Firestore/Storage I/O) */
+async function buildDocEvidence(
+  doc: CollisionDoc,
+  storagePaths: Set<string>,
+  parentCache: Map<string, RawDoc | null>,
+  parentBufferCache: Map<string, Buffer | null>
+): Promise<DocEvidence> {
+  // parent context
+  let parent: DocEvidence['parent'] = null;
+  if (doc.parentDocumentId !== null) {
+    let parentDoc = parentCache.get(doc.parentDocumentId);
+    if (parentDoc === undefined) {
+      const snap = await db.doc(`documents/${doc.parentDocumentId}`).get();
+      if (snap.exists) {
+        const data = snap.data()!;
+        parentDoc = {
+          id: snap.id,
+          status: data.status,
+          fileName: data.fileName,
+          fileUrl: data.fileUrl ?? null,
+          parentDocumentId: data.parentDocumentId ?? null,
+          splitFromPages: data.splitFromPages ?? null,
+          rotatedAt: tsToIso(data.rotatedAt),
+          processedAt: tsToIso(data.processedAt),
+          updatedAt: tsToIso(data.updatedAt),
+          _raw: data,
+        };
+      } else {
+        parentDoc = null;
+      }
+      parentCache.set(doc.parentDocumentId, parentDoc);
+    }
+
+    if (parentDoc === null) {
+      parent = { exists: false };
+    } else {
+      const parentPath = pathFromUrl(parentDoc.fileUrl);
+      const parentPdfExists = parentPath !== null && storagePaths.has(parentPath);
+      parent = { exists: true, originalPdfExists: parentPdfExists };
+    }
+  }
+
+  // hash evidence (Storage 実体 sha256 vs 親から再生成した期待 sha256)
+  const docPath = pathFromUrl(doc.fileUrl);
+  if (docPath === null || !storagePaths.has(docPath)) {
+    return {
+      doc,
+      hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+      parent,
+    };
+  }
+  if (doc.parentDocumentId === null || doc.splitFromPages === null) {
+    return {
+      doc,
+      hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+      parent,
+    };
+  }
+  if (parent === null || !parent.exists) {
+    return {
+      doc,
+      hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+      parent,
+    };
+  }
+  if (!parent.originalPdfExists) {
+    return {
+      doc,
+      hashEvidence: { type: 'unavailable', reason: 'no-parent-original-pdf' },
+      parent,
+    };
+  }
+
+  try {
+    const actualBuf = await downloadIfExists(docPath);
+    if (actualBuf === null) {
+      return {
+        doc,
+        hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+        parent,
+      };
+    }
+
+    let parentBuf = parentBufferCache.get(doc.parentDocumentId);
+    if (parentBuf === undefined) {
+      const parentDoc = parentCache.get(doc.parentDocumentId)!;
+      const parentPath = pathFromUrl(parentDoc!.fileUrl);
+      parentBuf = parentPath ? await downloadIfExists(parentPath) : null;
+      parentBufferCache.set(doc.parentDocumentId, parentBuf);
+    }
+    if (parentBuf === null) {
+      return {
+        doc,
+        hashEvidence: { type: 'unavailable', reason: 'no-parent-original-pdf' },
+        parent,
+      };
+    }
+
+    const expectedBuf = await regenerateChildPdf(
+      parentBuf,
+      doc.splitFromPages.start,
+      doc.splitFromPages.end
+    );
+    const actualHash = sha256(actualBuf);
+    const expectedHash = sha256(expectedBuf);
+    if (actualHash === expectedHash) {
+      return { doc, hashEvidence: { type: 'matched', sha256: actualHash }, parent };
+    }
+    return {
+      doc,
+      hashEvidence: {
+        type: 'mismatched',
+        actualSha256: actualHash,
+        expectedSha256: expectedHash,
+      },
+      parent,
+    };
+  } catch (err) {
+    console.warn(`hash computation failed for doc ${doc.id}: ${(err as Error).message}`);
+    return {
+      doc,
+      hashEvidence: { type: 'unavailable', reason: 'computation-error' },
+      parent,
+    };
+  }
+}
+
+interface MigrationOperation {
+  operationId: string;
+  docId: string;
+  classification: ClassificationResult['classification'];
+  recommendedAction: ClassificationResult['recommendedAction'];
+  reason: string;
+  suggestedWinner: boolean;
+  // precondition snapshot (T7 4 重 gate で照合)
+  expectedCurrentFileUrl: string | null;
+  expectedStatus: string;
+  expectedUpdatedAt: string | null;
+  // path 情報
+  sourcePath: string | null;
+  destPath: string | null;
+  // 親情報 (regenerate-from-parent 時に必要)
+  parentDocumentId: string | null;
+  splitFromPages: { start: number; end: number } | null;
+  fileName: string;
+}
+
+function buildOperation(
+  doc: CollisionDoc,
+  result: ClassificationResult,
+  opCounter: { n: number }
+): MigrationOperation {
+  const sourcePath = pathFromUrl(doc.fileUrl);
+  const destPath =
+    result.recommendedAction === 'migrate-to-namespace' ||
+    result.recommendedAction === 'regenerate-from-parent'
+      ? `${prefix}${doc.id}/${doc.fileName}`
+      : null;
+
+  opCounter.n += 1;
+  return {
+    operationId: `op-${String(opCounter.n).padStart(4, '0')}`,
+    docId: doc.id,
+    classification: result.classification,
+    recommendedAction: result.recommendedAction,
+    reason: result.reason,
+    suggestedWinner: result.suggestedWinner,
+    expectedCurrentFileUrl: doc.fileUrl,
+    expectedStatus: doc.status,
+    expectedUpdatedAt: doc.updatedAt,
+    sourcePath,
+    destPath,
+    parentDocumentId: doc.parentDocumentId,
+    splitFromPages: doc.splitFromPages,
+    fileName: doc.fileName,
+  };
+}
+
+async function main(): Promise<void> {
+  console.log(`Project: ${projectId}`);
+  console.log(`Bucket : ${bucket.name}`);
+  console.log(`Prefix : ${prefix}\n`);
+
+  const planId = `plan-${new Date().toISOString().replace(/[:.]/g, '-')}-${crypto
+    .randomBytes(4)
+    .toString('hex')}`;
+
+  console.log('Loading documents collection...');
+  const allDocs = await loadAllDocs();
+  console.log(`Total documents: ${allDocs.length}`);
+
+  const targetDocs = allDocs.filter((d) => {
+    const path = pathFromUrl(d.fileUrl);
+    return path && path.startsWith(prefix);
+  });
+  console.log(
+    `Documents with fileUrl matching prefix "${prefix}": ${targetDocs.length}\n`
+  );
+
+  console.log(`Listing Storage files under prefix "${prefix}"...`);
+  const storagePaths = await listStorageFiles(prefix);
+  console.log(`Storage files: ${storagePaths.size}\n`);
+
+  // sanity check (audit-storage-mismatch.js と同じ false negative 防止)
+  if (targetDocs.length > 0 && storagePaths.size === 0) {
+    console.error(
+      `FATAL: ${targetDocs.length} docs reference prefix="${prefix}" but Storage list is empty. Aborting to prevent false LostOrUnrecoverable classification.`
+    );
+    await admin.app().delete();
+    process.exit(2);
+  }
+
+  // 衝突 group + orphan を分離
+  const byFileName = new Map<string, RawDoc[]>();
+  const orphanDocs: RawDoc[] = [];
+  for (const d of targetDocs) {
+    const path = pathFromUrl(d.fileUrl);
+    if (path && !storagePaths.has(path)) {
+      orphanDocs.push(d);
+    }
+    if (!d.fileName) continue;
+    if (!byFileName.has(d.fileName)) byFileName.set(d.fileName, []);
+    byFileName.get(d.fileName)!.push(d);
+  }
+  const collisionGroups = [...byFileName.entries()].filter(
+    ([, docs]) => docs.length > 1
+  );
+  console.log(
+    `Collision groups: ${collisionGroups.length} | fileUrl orphans: ${orphanDocs.length}\n`
+  );
+
+  const parentCache = new Map<string, RawDoc | null>();
+  const parentBufferCache = new Map<string, Buffer | null>();
+  const opCounter = { n: 0 };
+  const operations: MigrationOperation[] = [];
+  const summary = {
+    totalGroups: collisionGroups.length,
+    totalCollisionDocs: collisionGroups.reduce((sum, [, docs]) => sum + docs.length, 0),
+    totalOrphans: orphanDocs.length,
+    byClassification: {
+      MatchedByHash: 0,
+      Ambiguous: 0,
+      RepairableMissingFile: 0,
+      LostOrUnrecoverable: 0,
+    },
+    byAction: {
+      'migrate-to-namespace': 0,
+      'regenerate-from-parent': 0,
+      'manual-review': 0,
+      'mark-error': 0,
+    },
+  };
+
+  // 衝突 group の classify
+  console.log('Classifying collision groups...');
+  let groupIdx = 0;
+  for (const [fileName, docs] of collisionGroups) {
+    groupIdx += 1;
+    if (groupIdx % 10 === 0) {
+      console.log(`  ${groupIdx}/${collisionGroups.length} groups processed`);
+    }
+    const evidences: DocEvidence[] = [];
+    for (const d of docs) {
+      evidences.push(await buildDocEvidence(d, storagePaths, parentCache, parentBufferCache));
+    }
+    const group: CollisionGroup = { fileName, evidences };
+    const results = classifyCollisionGroup(group);
+    for (const r of results) {
+      const doc = docs.find((d) => d.id === r.docId)!;
+      const op = buildOperation(doc, r, opCounter);
+      operations.push(op);
+      summary.byClassification[r.classification] += 1;
+      summary.byAction[r.recommendedAction] += 1;
+    }
+  }
+
+  // orphan の classify
+  console.log(`\nClassifying ${orphanDocs.length} orphans...`);
+  for (const d of orphanDocs) {
+    const evidence = await buildDocEvidence(d, storagePaths, parentCache, parentBufferCache);
+    const result = classifyOrphan(evidence);
+    const op = buildOperation(d, result, opCounter);
+    operations.push(op);
+    summary.byClassification[result.classification] += 1;
+    summary.byAction[result.recommendedAction] += 1;
+  }
+
+  const plan = {
+    planId,
+    createdAt: new Date().toISOString(),
+    environment: process.env.ENVIRONMENT_LABEL ?? projectId, // CI 経由で渡される環境 label (optional)
+    projectId,
+    bucket: bucket.name,
+    prefix,
+    summary,
+    operations,
+  };
+
+  const json = JSON.stringify(plan, null, 2);
+  if (outFile) {
+    fs.writeFileSync(outFile, json);
+    console.log(`\nPlan written to: ${outFile}`);
+  }
+  console.log('\n=== Plan summary ===');
+  console.log(JSON.stringify(summary, null, 2));
+  console.log(`planId: ${planId}`);
+  console.log(`operations: ${operations.length}`);
+
+  if (!outFile) {
+    console.log('\n--- Plan JSON (use --out <file> to save) ---');
+    console.log(json);
+  }
+
+  await admin.app().delete();
+}
+
+main().catch(async (err) => {
+  console.error('Failed:', err);
+  try {
+    await admin.app().delete();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/scripts/execute-collision-migration.ts
+++ b/scripts/execute-collision-migration.ts
@@ -25,6 +25,16 @@ import * as admin from 'firebase-admin';
 import * as fs from 'fs';
 import { isPathSafeToDeleteAfterExcluding } from './lib/storageGuard';
 import { regenerateChildPdf } from './lib/pdfRegenerator';
+import {
+  buildMigrateUpdatePayload,
+  buildRegenerateUpdatePayload,
+  buildMarkErrorUpdatePayload,
+} from './lib/executeMigrationOps';
+// F-C3: classifier の型を import して二重定義 (drift リスク) を解消
+import type {
+  Classification,
+  RecommendedAction,
+} from './lib/collisionClassifier';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const storageBucket = process.env.STORAGE_BUCKET;
@@ -58,12 +68,8 @@ if (!planFile || !approvalFile) {
 interface Operation {
   operationId: string;
   docId: string;
-  classification: 'MatchedByHash' | 'Ambiguous' | 'RepairableMissingFile' | 'LostOrUnrecoverable';
-  recommendedAction:
-    | 'migrate-to-namespace'
-    | 'regenerate-from-parent'
-    | 'manual-review'
-    | 'mark-error';
+  classification: Classification;
+  recommendedAction: RecommendedAction;
   reason: string;
   suggestedWinner: boolean;
   expectedCurrentFileUrl: string | null;
@@ -182,6 +188,27 @@ async function isAlreadyMigrated(op: Operation): Promise<boolean> {
   return exists;
 }
 
+/**
+ * F-B2: Storage delete を 404 のみ silent skip し、それ以外は構造化結果として返す。
+ * caller は outcome.details.oldDeleteOutcome を見て operator に伝達できる。
+ * Issue #432 silent breakage の再演 (delete 失敗の握りつぶし) を防ぐ。
+ */
+type OldDeleteResult =
+  | { outcome: 'deleted' }
+  | { outcome: 'already-absent' }
+  | { outcome: 'failed'; error: string };
+
+async function deleteStorageSelective(path: string): Promise<OldDeleteResult> {
+  try {
+    await bucket.file(path).delete();
+    return { outcome: 'deleted' };
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === 404) return { outcome: 'already-absent' };
+    return { outcome: 'failed', error: (err as Error).message };
+  }
+}
+
 async function executeMigrate(op: Operation): Promise<OperationOutcome> {
   // migrate-to-namespace: 旧 Storage path → 新 docId namespace path に copy → Firestore fileUrl 更新 → 旧 path delete
   if (op.sourcePath === null || op.destPath === null) {
@@ -203,8 +230,8 @@ async function executeMigrate(op: Operation): Promise<OperationOutcome> {
     await bucket.file(op.sourcePath).copy(bucket.file(op.destPath));
   }
 
-  // Firestore: fileUrl 更新 (Partial update 不変 = fileUrl のみ)
-  await db.doc(`documents/${op.docId}`).update({ fileUrl: newFileUrl });
+  // Firestore: fileUrl 更新 (Partial update 不変 = fileUrl のみ、F-D2 で testable 化)
+  await db.doc(`documents/${op.docId}`).update(buildMigrateUpdatePayload(newFileUrl));
 
   // 旧 path delete (storageGuard で同 fileUrl 共有 doc 残存確認)
   // 今回更新した自分自身は新 fileUrl になっているため共有者から外れる
@@ -219,21 +246,35 @@ async function executeMigrate(op: Operation): Promise<OperationOutcome> {
       details: {
         newFileUrl,
         oldFileUrl,
+        oldDeleteOutcome: 'skipped-sharing',
         residualDocIds: guard.residualDocIds,
       },
     };
   }
 
-  await bucket.file(op.sourcePath).delete().catch(() => {
-    /* idempotent: 既に削除済みなら無視 */
-  });
+  // F-B2: 404 以外の delete 失敗を silent に握り潰さず outcome に残す
+  const deleteResult = await deleteStorageSelective(op.sourcePath);
+  if (deleteResult.outcome === 'failed') {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: `migrated but old path delete failed: ${deleteResult.error}`,
+      details: { newFileUrl, oldFileUrl, oldDeleteOutcome: 'failed', oldDeleteError: deleteResult.error },
+    };
+  }
+
   return {
     operationId: op.operationId,
     docId: op.docId,
     action: op.recommendedAction,
     status: 'executed',
-    reason: 'migrated to docId namespace, old path deleted',
-    details: { newFileUrl, oldFileUrl },
+    reason:
+      deleteResult.outcome === 'deleted'
+        ? 'migrated to docId namespace, old path deleted'
+        : 'migrated to docId namespace, old path was already absent',
+    details: { newFileUrl, oldFileUrl, oldDeleteOutcome: deleteResult.outcome },
   };
 }
 
@@ -259,8 +300,28 @@ async function executeRegenerate(op: Operation): Promise<OperationOutcome> {
       reason: 'parent doc disappeared since plan creation',
     };
   }
-  const parentFileUrl = parentSnap.data()!.fileUrl as string;
-  const parentPath = parentFileUrl.replace(`gs://${storageBucket}/`, '');
+  const parentFileUrl = parentSnap.data()?.fileUrl;
+  if (typeof parentFileUrl !== 'string') {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: 'parent fileUrl is missing or not a string',
+    };
+  }
+  // F-B4: parent fileUrl が runtime bucket と一致することを検証 (`.appspot.com` ↔ `.firebasestorage.app` 取り違え防止)
+  const parentMatch = parentFileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!parentMatch || parentMatch[1] !== storageBucket) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: `parent fileUrl bucket mismatch: ${parentFileUrl} (expected bucket=${storageBucket})`,
+    };
+  }
+  const parentPath = parentMatch[2];
   const [parentBuf] = await bucket.file(parentPath).download();
 
   const childBuf = await regenerateChildPdf(
@@ -277,19 +338,39 @@ async function executeRegenerate(op: Operation): Promise<OperationOutcome> {
   const newFileUrl = `gs://${storageBucket}/${op.destPath}`;
 
   // Firestore: fileUrl 更新 + status を processed に戻す (元々 processed だった想定だが orphan 由来で error 化したケースも回復)
-  // Partial update 不変: fileUrl + status + lastErrorMessage の deleteField のみ
-  await db.doc(`documents/${op.docId}`).update({
-    fileUrl: newFileUrl,
-    status: 'processed',
-    lastErrorMessage: admin.firestore.FieldValue.delete(),
-  });
+  // Partial update 不変: fileUrl + status + lastErrorMessage の deleteField のみ (F-D2)
+  await db.doc(`documents/${op.docId}`).update(buildRegenerateUpdatePayload(newFileUrl));
 
   // 旧 path 後始末 (collision group 敗者の場合): storageGuard で安全確認
+  // F-B2: 404 以外の delete 失敗を outcome details に残す (silent failure 防止)
+  let oldDeleteRecord: { outcome: string; error?: string; residualDocIds?: string[] } | undefined;
   if (op.sourcePath !== null && op.sourcePath !== op.destPath) {
     const oldFileUrl = `gs://${storageBucket}/${op.sourcePath}`;
     const guard = await isPathSafeToDeleteAfterExcluding(db, oldFileUrl, [op.docId]);
-    if (guard.safe) {
-      await bucket.file(op.sourcePath).delete().catch(() => undefined);
+    if (!guard.safe) {
+      oldDeleteRecord = {
+        outcome: 'skipped-sharing',
+        residualDocIds: guard.residualDocIds,
+      };
+    } else {
+      const deleteResult = await deleteStorageSelective(op.sourcePath);
+      oldDeleteRecord = deleteResult.outcome === 'failed'
+        ? { outcome: 'failed', error: deleteResult.error }
+        : { outcome: deleteResult.outcome };
+      if (deleteResult.outcome === 'failed') {
+        return {
+          operationId: op.operationId,
+          docId: op.docId,
+          action: op.recommendedAction,
+          status: 'error',
+          reason: `regenerated but old path delete failed: ${deleteResult.error}`,
+          details: {
+            newFileUrl,
+            regeneratedBytes: childBuf.length,
+            oldDeleteOutcome: oldDeleteRecord,
+          },
+        };
+      }
     }
   }
 
@@ -302,16 +383,14 @@ async function executeRegenerate(op: Operation): Promise<OperationOutcome> {
     details: {
       newFileUrl,
       regeneratedBytes: childBuf.length,
+      ...(oldDeleteRecord ? { oldDeleteOutcome: oldDeleteRecord } : {}),
     },
   };
 }
 
 async function executeMarkError(op: Operation): Promise<OperationOutcome> {
-  // Partial update 不変 (CLAUDE.md MUST): status + lastErrorMessage のみ更新、他フィールド不変
-  await db.doc(`documents/${op.docId}`).update({
-    status: 'error',
-    lastErrorMessage: `Issue #432 PR-C migration: ${op.reason}`,
-  });
+  // Partial update 不変 (CLAUDE.md MUST): status + lastErrorMessage のみ更新、他フィールド不変 (F-D2)
+  await db.doc(`documents/${op.docId}`).update(buildMarkErrorUpdatePayload(op.reason));
   return {
     operationId: op.operationId,
     docId: op.docId,
@@ -335,12 +414,51 @@ function isPathApproved(op: Operation): { ok: boolean; reason: string } {
     if (op.destPath && !approvedPaths.has(`gs://${storageBucket}/${op.destPath}`)) {
       return { ok: false, reason: `destPath not in approvedPaths: gs://${storageBucket}/${op.destPath}` };
     }
+    // F-B1: executeRegenerate は op.sourcePath !== destPath の場合 sourcePath を delete し得る。
+    // ADR-0008 教訓「per-path 個別認可必須」を守るため、sourcePath も approvedPaths にあることを要求。
+    if (
+      op.sourcePath &&
+      op.sourcePath !== op.destPath &&
+      !approvedPaths.has(`gs://${storageBucket}/${op.sourcePath}`)
+    ) {
+      return {
+        ok: false,
+        reason: `sourcePath (regenerate-from-parent will delete this) not in approvedPaths: gs://${storageBucket}/${op.sourcePath}`,
+      };
+    }
   }
   // mark-error は Storage 触らないため path 認可不要 (operationId 認可のみで通す)
   return { ok: true, reason: 'path approved' };
 }
 
 async function processOperation(op: Operation): Promise<OperationOutcome> {
+  // Gate 0 (defense in depth, F-B5): Codex セカンドオピニオンの Critical を裏付けゲート化。
+  // Ambiguous classification は manual-review action 以外で実行不可、suggestedWinner hint は
+  // 自動 destructive action の根拠にしない (rotatedAt!=null 唯一は Storage 実体正当性証明ではない)。
+  if (op.classification === 'Ambiguous' && op.recommendedAction !== 'manual-review') {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'gate-rejected',
+      reason: `defense-in-depth: Ambiguous classification must use manual-review (got ${op.recommendedAction})`,
+    };
+  }
+  if (
+    op.suggestedWinner &&
+    (op.recommendedAction === 'migrate-to-namespace' ||
+      op.recommendedAction === 'regenerate-from-parent')
+  ) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'gate-rejected',
+      reason:
+        'defense-in-depth: suggestedWinner hint must not trigger automatic destructive action (Codex Critical)',
+    };
+  }
+
   // Gate 2: operationId 認可
   if (!approvedOpIds.has(op.operationId)) {
     return {
@@ -375,19 +493,11 @@ async function processOperation(op: Operation): Promise<OperationOutcome> {
     };
   }
 
-  // Gate 5: precondition snapshot
-  const pre = await checkPrecondition(op);
-  if (!pre.ok) {
-    return {
-      operationId: op.operationId,
-      docId: op.docId,
-      action: op.recommendedAction,
-      status: 'skipped',
-      reason: `precondition mismatch: ${pre.reason}`,
-    };
-  }
-
-  // idempotency: migrate / regenerate で既に完了済 → skip
+  // F-A3: idempotency を precondition より前に評価。
+  // copy 成功 → Firestore update 失敗 → 再実行のシナリオで、precondition は旧 fileUrl を期待し
+  // 現状は新 fileUrl になっている (もしくはその逆) のドリフト検出になる。idempotency check が
+  // 「完了状態 (新 path 存在 + Firestore fileUrl 更新済)」を先に判定することで、
+  // 完了済 op は precondition mismatch にせず安全に skip する。
   if (
     (op.recommendedAction === 'migrate-to-namespace' ||
       op.recommendedAction === 'regenerate-from-parent') &&
@@ -399,6 +509,18 @@ async function processOperation(op: Operation): Promise<OperationOutcome> {
       action: op.recommendedAction,
       status: 'skipped',
       reason: 'already migrated (idempotent)',
+    };
+  }
+
+  // Gate 5: precondition snapshot (idempotency check 通過後に実行)
+  const pre = await checkPrecondition(op);
+  if (!pre.ok) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'skipped',
+      reason: `precondition mismatch: ${pre.reason}`,
     };
   }
 

--- a/scripts/execute-collision-migration.ts
+++ b/scripts/execute-collision-migration.ts
@@ -1,0 +1,502 @@
+#!/usr/bin/env ts-node
+/**
+ * Issue #432 PR-C: classify-collision-docs.ts が出力した migration plan を実行
+ *
+ * 4 重 gate (Codex セカンドオピニオン反映):
+ *   1. approval.planId === plan.planId
+ *   2. operation.operationId が approval.approvedOperationIds に含まれる
+ *   3. (destructive 時) operation の sourcePath/destPath が approval.approvedPaths に含まれる
+ *   4. runtime env (projectId / storageBucket) が plan の projectId / bucket と一致
+ *   5. precondition (expectedCurrentFileUrl / expectedStatus / expectedUpdatedAt) が現状 doc と一致
+ *
+ * idempotency: 各 operation は再実行可能。既に完了状態 (新 path 存在 + fileUrl 更新済) なら skip。
+ * Storage delete は scripts/lib/storageGuard 経由で同 fileUrl 共有 doc が残存しないことを確認。
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+ *     npx ts-node scripts/execute-collision-migration.ts \
+ *       --plan plan.json --approval approval.json [--execute] [--operations op-0001,op-0002]
+ *
+ *   --execute なし: dry-run (Firestore/Storage 書き込みゼロ、執行計画 JSON 出力のみ)
+ *   --operations: 個別 operation 限定 (テスト/段階実行)
+ */
+
+import * as admin from 'firebase-admin';
+import * as fs from 'fs';
+import { isPathSafeToDeleteAfterExcluding } from './lib/storageGuard';
+import { regenerateChildPdf } from './lib/pdfRegenerator';
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const storageBucket = process.env.STORAGE_BUCKET;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+if (!storageBucket) {
+  console.error('STORAGE_BUCKET を設定してください');
+  process.exit(1);
+}
+
+function getOpt(name: string): string | null {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+
+const planFile = getOpt('--plan');
+const approvalFile = getOpt('--approval');
+const operationsFilterRaw = getOpt('--operations');
+const operationsFilter = operationsFilterRaw
+  ? new Set(operationsFilterRaw.split(',').map((s) => s.trim()))
+  : null;
+const execute = process.argv.includes('--execute');
+
+if (!planFile || !approvalFile) {
+  console.error('--plan <plan.json> と --approval <approval.json> は必須です');
+  process.exit(1);
+}
+
+interface Operation {
+  operationId: string;
+  docId: string;
+  classification: 'MatchedByHash' | 'Ambiguous' | 'RepairableMissingFile' | 'LostOrUnrecoverable';
+  recommendedAction:
+    | 'migrate-to-namespace'
+    | 'regenerate-from-parent'
+    | 'manual-review'
+    | 'mark-error';
+  reason: string;
+  suggestedWinner: boolean;
+  expectedCurrentFileUrl: string | null;
+  expectedStatus: string;
+  expectedUpdatedAt: string | null;
+  sourcePath: string | null;
+  destPath: string | null;
+  parentDocumentId: string | null;
+  splitFromPages: { start: number; end: number } | null;
+  fileName: string;
+}
+
+interface Plan {
+  planId: string;
+  createdAt: string;
+  environment: string;
+  projectId: string;
+  bucket: string;
+  prefix: string;
+  summary: unknown;
+  operations: Operation[];
+}
+
+interface Approval {
+  planId: string;
+  approvedOperationIds: string[];
+  approvedPaths: string[];
+}
+
+const plan: Plan = JSON.parse(fs.readFileSync(planFile, 'utf8'));
+const approval: Approval = JSON.parse(fs.readFileSync(approvalFile, 'utf8'));
+
+// === Gate 1+4: planId + runtime env 一致 ===
+if (approval.planId !== plan.planId) {
+  console.error(
+    `FATAL: approval.planId (${approval.planId}) !== plan.planId (${plan.planId})`
+  );
+  process.exit(2);
+}
+if (plan.projectId !== projectId) {
+  console.error(
+    `FATAL: plan.projectId (${plan.projectId}) !== runtime FIREBASE_PROJECT_ID (${projectId})`
+  );
+  process.exit(2);
+}
+if (plan.bucket !== storageBucket) {
+  console.error(
+    `FATAL: plan.bucket (${plan.bucket}) !== runtime STORAGE_BUCKET (${storageBucket})`
+  );
+  process.exit(2);
+}
+
+const approvedOpIds = new Set(approval.approvedOperationIds);
+const approvedPaths = new Set(approval.approvedPaths);
+
+admin.initializeApp({ projectId, storageBucket });
+const db = admin.firestore();
+const bucket = admin.storage().bucket();
+
+function tsToIso(ts: unknown): string | null {
+  if (!ts) return null;
+  if (typeof ts === 'object' && ts !== null && 'toDate' in ts) {
+    return (ts as { toDate(): Date }).toDate().toISOString();
+  }
+  return String(ts);
+}
+
+interface OperationOutcome {
+  operationId: string;
+  docId: string;
+  action: Operation['recommendedAction'];
+  status: 'executed' | 'dry-run' | 'skipped' | 'gate-rejected' | 'error';
+  reason: string;
+  details?: Record<string, unknown>;
+}
+
+async function checkPrecondition(op: Operation): Promise<{ ok: boolean; reason: string }> {
+  const snap = await db.doc(`documents/${op.docId}`).get();
+  if (!snap.exists) {
+    return { ok: false, reason: 'doc no longer exists' };
+  }
+  const data = snap.data()!;
+  const currentFileUrl = (data.fileUrl as string | undefined) ?? null;
+  const currentStatus = data.status as string;
+  const currentUpdatedAt = tsToIso(data.updatedAt);
+
+  if (currentFileUrl !== op.expectedCurrentFileUrl) {
+    return {
+      ok: false,
+      reason: `fileUrl drift: expected=${op.expectedCurrentFileUrl} actual=${currentFileUrl}`,
+    };
+  }
+  if (currentStatus !== op.expectedStatus) {
+    return {
+      ok: false,
+      reason: `status drift: expected=${op.expectedStatus} actual=${currentStatus}`,
+    };
+  }
+  if (currentUpdatedAt !== op.expectedUpdatedAt) {
+    return {
+      ok: false,
+      reason: `updatedAt drift: expected=${op.expectedUpdatedAt} actual=${currentUpdatedAt}`,
+    };
+  }
+  return { ok: true, reason: 'precondition matched' };
+}
+
+async function isAlreadyMigrated(op: Operation): Promise<boolean> {
+  // idempotency: 新 path に実体ありかつ Firestore fileUrl が新 path 指す → 完了済
+  if (op.destPath === null) return false;
+  const snap = await db.doc(`documents/${op.docId}`).get();
+  if (!snap.exists) return false;
+  const expectedNewFileUrl = `gs://${storageBucket}/${op.destPath}`;
+  if (snap.data()!.fileUrl !== expectedNewFileUrl) return false;
+  const [exists] = await bucket.file(op.destPath).exists();
+  return exists;
+}
+
+async function executeMigrate(op: Operation): Promise<OperationOutcome> {
+  // migrate-to-namespace: 旧 Storage path → 新 docId namespace path に copy → Firestore fileUrl 更新 → 旧 path delete
+  if (op.sourcePath === null || op.destPath === null) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: 'sourcePath or destPath is null',
+    };
+  }
+
+  const newFileUrl = `gs://${storageBucket}/${op.destPath}`;
+  const oldFileUrl = `gs://${storageBucket}/${op.sourcePath}`;
+
+  // 旧 → 新 copy (idempotent: copy 失敗時は再実行可)
+  const [destExists] = await bucket.file(op.destPath).exists();
+  if (!destExists) {
+    await bucket.file(op.sourcePath).copy(bucket.file(op.destPath));
+  }
+
+  // Firestore: fileUrl 更新 (Partial update 不変 = fileUrl のみ)
+  await db.doc(`documents/${op.docId}`).update({ fileUrl: newFileUrl });
+
+  // 旧 path delete (storageGuard で同 fileUrl 共有 doc 残存確認)
+  // 今回更新した自分自身は新 fileUrl になっているため共有者から外れる
+  const guard = await isPathSafeToDeleteAfterExcluding(db, oldFileUrl, [op.docId]);
+  if (!guard.safe) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'executed',
+      reason: 'copied + Firestore updated; old path delete skipped (sharing docs remain)',
+      details: {
+        newFileUrl,
+        oldFileUrl,
+        residualDocIds: guard.residualDocIds,
+      },
+    };
+  }
+
+  await bucket.file(op.sourcePath).delete().catch(() => {
+    /* idempotent: 既に削除済みなら無視 */
+  });
+  return {
+    operationId: op.operationId,
+    docId: op.docId,
+    action: op.recommendedAction,
+    status: 'executed',
+    reason: 'migrated to docId namespace, old path deleted',
+    details: { newFileUrl, oldFileUrl },
+  };
+}
+
+async function executeRegenerate(op: Operation): Promise<OperationOutcome> {
+  if (op.parentDocumentId === null || op.splitFromPages === null || op.destPath === null) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: 'missing parentDocumentId / splitFromPages / destPath',
+    };
+  }
+
+  // parent PDF download
+  const parentSnap = await db.doc(`documents/${op.parentDocumentId}`).get();
+  if (!parentSnap.exists) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: 'parent doc disappeared since plan creation',
+    };
+  }
+  const parentFileUrl = parentSnap.data()!.fileUrl as string;
+  const parentPath = parentFileUrl.replace(`gs://${storageBucket}/`, '');
+  const [parentBuf] = await bucket.file(parentPath).download();
+
+  const childBuf = await regenerateChildPdf(
+    parentBuf,
+    op.splitFromPages.start,
+    op.splitFromPages.end
+  );
+
+  // 新 path に upload (idempotent: 既存 destPath は overwrite)
+  await bucket.file(op.destPath).save(childBuf, {
+    metadata: { contentType: 'application/pdf' },
+  });
+
+  const newFileUrl = `gs://${storageBucket}/${op.destPath}`;
+
+  // Firestore: fileUrl 更新 + status を processed に戻す (元々 processed だった想定だが orphan 由来で error 化したケースも回復)
+  // Partial update 不変: fileUrl + status + lastErrorMessage の deleteField のみ
+  await db.doc(`documents/${op.docId}`).update({
+    fileUrl: newFileUrl,
+    status: 'processed',
+    lastErrorMessage: admin.firestore.FieldValue.delete(),
+  });
+
+  // 旧 path 後始末 (collision group 敗者の場合): storageGuard で安全確認
+  if (op.sourcePath !== null && op.sourcePath !== op.destPath) {
+    const oldFileUrl = `gs://${storageBucket}/${op.sourcePath}`;
+    const guard = await isPathSafeToDeleteAfterExcluding(db, oldFileUrl, [op.docId]);
+    if (guard.safe) {
+      await bucket.file(op.sourcePath).delete().catch(() => undefined);
+    }
+  }
+
+  return {
+    operationId: op.operationId,
+    docId: op.docId,
+    action: op.recommendedAction,
+    status: 'executed',
+    reason: 'regenerated from parent and saved to docId namespace',
+    details: {
+      newFileUrl,
+      regeneratedBytes: childBuf.length,
+    },
+  };
+}
+
+async function executeMarkError(op: Operation): Promise<OperationOutcome> {
+  // Partial update 不変 (CLAUDE.md MUST): status + lastErrorMessage のみ更新、他フィールド不変
+  await db.doc(`documents/${op.docId}`).update({
+    status: 'error',
+    lastErrorMessage: `Issue #432 PR-C migration: ${op.reason}`,
+  });
+  return {
+    operationId: op.operationId,
+    docId: op.docId,
+    action: op.recommendedAction,
+    status: 'executed',
+    reason: 'marked as error for manual repair',
+  };
+}
+
+function isPathApproved(op: Operation): { ok: boolean; reason: string } {
+  // Gate 3: destructive action は path 認可必須
+  if (op.recommendedAction === 'migrate-to-namespace') {
+    if (op.sourcePath && !approvedPaths.has(`gs://${storageBucket}/${op.sourcePath}`)) {
+      return { ok: false, reason: `sourcePath not in approvedPaths: gs://${storageBucket}/${op.sourcePath}` };
+    }
+    if (op.destPath && !approvedPaths.has(`gs://${storageBucket}/${op.destPath}`)) {
+      return { ok: false, reason: `destPath not in approvedPaths: gs://${storageBucket}/${op.destPath}` };
+    }
+  }
+  if (op.recommendedAction === 'regenerate-from-parent') {
+    if (op.destPath && !approvedPaths.has(`gs://${storageBucket}/${op.destPath}`)) {
+      return { ok: false, reason: `destPath not in approvedPaths: gs://${storageBucket}/${op.destPath}` };
+    }
+  }
+  // mark-error は Storage 触らないため path 認可不要 (operationId 認可のみで通す)
+  return { ok: true, reason: 'path approved' };
+}
+
+async function processOperation(op: Operation): Promise<OperationOutcome> {
+  // Gate 2: operationId 認可
+  if (!approvedOpIds.has(op.operationId)) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'gate-rejected',
+      reason: 'operationId not in approvedOperationIds',
+    };
+  }
+
+  // manual-review はそもそも何もしない
+  if (op.recommendedAction === 'manual-review') {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'skipped',
+      reason: 'manual-review action: no automated execution',
+    };
+  }
+
+  // Gate 3: path 認可 (destructive のみ)
+  const pathGate = isPathApproved(op);
+  if (!pathGate.ok) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'gate-rejected',
+      reason: pathGate.reason,
+    };
+  }
+
+  // Gate 5: precondition snapshot
+  const pre = await checkPrecondition(op);
+  if (!pre.ok) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'skipped',
+      reason: `precondition mismatch: ${pre.reason}`,
+    };
+  }
+
+  // idempotency: migrate / regenerate で既に完了済 → skip
+  if (
+    (op.recommendedAction === 'migrate-to-namespace' ||
+      op.recommendedAction === 'regenerate-from-parent') &&
+    (await isAlreadyMigrated(op))
+  ) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'skipped',
+      reason: 'already migrated (idempotent)',
+    };
+  }
+
+  if (!execute) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'dry-run',
+      reason: 'all gates passed; would execute',
+      details: { sourcePath: op.sourcePath, destPath: op.destPath },
+    };
+  }
+
+  // 実行
+  try {
+    switch (op.recommendedAction) {
+      case 'migrate-to-namespace':
+        return await executeMigrate(op);
+      case 'regenerate-from-parent':
+        return await executeRegenerate(op);
+      case 'mark-error':
+        return await executeMarkError(op);
+      default:
+        return {
+          operationId: op.operationId,
+          docId: op.docId,
+          action: op.recommendedAction,
+          status: 'error',
+          reason: `unhandled action: ${op.recommendedAction}`,
+        };
+    }
+  } catch (err) {
+    return {
+      operationId: op.operationId,
+      docId: op.docId,
+      action: op.recommendedAction,
+      status: 'error',
+      reason: (err as Error).message,
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`Project: ${projectId}`);
+  console.log(`Bucket : ${storageBucket}`);
+  console.log(`Plan   : ${planFile} (planId=${plan.planId})`);
+  console.log(`Approval: ${approvalFile}`);
+  console.log(`Mode   : ${execute ? 'EXECUTE' : 'DRY-RUN'}`);
+  if (operationsFilter) {
+    console.log(`Filter : ${[...operationsFilter].join(', ')}`);
+  }
+  console.log('');
+
+  const ops = operationsFilter
+    ? plan.operations.filter((op) => operationsFilter.has(op.operationId))
+    : plan.operations;
+
+  console.log(`Processing ${ops.length}/${plan.operations.length} operations...\n`);
+
+  const outcomes: OperationOutcome[] = [];
+  for (const op of ops) {
+    const outcome = await processOperation(op);
+    outcomes.push(outcome);
+    const symbol = {
+      executed: '✅',
+      'dry-run': '📋',
+      skipped: '⏭️ ',
+      'gate-rejected': '🚫',
+      error: '❌',
+    }[outcome.status];
+    console.log(`${symbol} ${outcome.operationId} ${outcome.docId} (${outcome.action}): ${outcome.reason}`);
+  }
+
+  const summary = outcomes.reduce(
+    (acc, o) => {
+      acc[o.status] = (acc[o.status] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+  console.log('\n=== Summary ===');
+  console.log(JSON.stringify(summary, null, 2));
+
+  await admin.app().delete();
+
+  // gate-rejected / error がある場合は exit 1 (operator が確認しやすいように)
+  if ((summary['gate-rejected'] ?? 0) > 0 || (summary['error'] ?? 0) > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch(async (err) => {
+  console.error('Failed:', err);
+  try {
+    await admin.app().delete();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/scripts/lib/collisionClassifier.ts
+++ b/scripts/lib/collisionClassifier.ts
@@ -1,0 +1,247 @@
+/**
+ * Issue #432 PR-C: 衝突 doc / fileUrl 孤児の信頼度付き 4 分類 (pure function)
+ *
+ * 設計判断 (Codex セカンドオピニオン 2026-05-11 反映):
+ *   - hash 一致確定のみ自動移行 (MatchedByHash)
+ *   - rotatedAt!=null 唯一による LikelyWinner 自動移行は禁止 (silent breakage 偽装復旧の再演リスク)
+ *     → Ambiguous 内 suggestedWinner hint に降格
+ *   - hash 不能 / 不一致 / 複数一致は全て Ambiguous (manual-review)
+ *   - orphan + parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile (auto regenerate)
+ *   - 復元不能は LostOrUnrecoverable (status:'error' + lastErrorMessage で manual repair 誘導)
+ *
+ * Partial update 不変 (CLAUDE.md MUST): mark-error action は status / lastErrorMessage のみ更新、
+ * 他フィールド (fileName, parentDocumentId, ocrExtraction 等) は不変。
+ */
+
+export interface CollisionDoc {
+  id: string;
+  status: string;
+  fileName: string;
+  fileUrl: string | null;
+  parentDocumentId: string | null;
+  splitFromPages: { start: number; end: number } | null;
+  rotatedAt: string | null;
+  processedAt: string | null;
+  updatedAt: string | null;
+}
+
+/**
+ * doc 1 件分の事前評価結果。caller (classify-collision-docs.ts) が:
+ *   - hashEvidence: Storage 実体 sha256 と「親 PDF + splitFromPages から再生成した期待 sha256」の比較結果
+ *   - parent: parentDocumentId の有無 + 親 doc 存在 + 元 PDF 実在
+ * を Firestore / Storage アクセスで埋め、本 classifier (pure) に渡す。
+ */
+export interface DocEvidence {
+  doc: CollisionDoc;
+  hashEvidence:
+    | { type: 'matched'; sha256: string }
+    | { type: 'mismatched'; actualSha256: string; expectedSha256: string }
+    | {
+        type: 'unavailable';
+        reason:
+          | 'no-parent'
+          | 'no-parent-original-pdf'
+          | 'no-storage-actual'
+          | 'computation-error';
+      };
+  parent:
+    | { exists: true; originalPdfExists: boolean }
+    | { exists: false }
+    | null;
+}
+
+/**
+ * 衝突 group: 同 fileName を共有する doc 群 (1 件単独 group も含む)。
+ * orphan (Storage 実体なし) は別経路 classifyOrphan で扱う。
+ */
+export interface CollisionGroup {
+  fileName: string;
+  evidences: DocEvidence[];
+}
+
+export type Classification =
+  | 'MatchedByHash'
+  | 'Ambiguous'
+  | 'RepairableMissingFile'
+  | 'LostOrUnrecoverable';
+
+export type RecommendedAction =
+  | 'migrate-to-namespace'
+  | 'regenerate-from-parent'
+  | 'manual-review'
+  | 'mark-error';
+
+export interface ClassificationResult {
+  docId: string;
+  classification: Classification;
+  reason: string;
+  /**
+   * Ambiguous 内で「勝者候補」を示す低信頼 hint (rotatedAt!=null 唯一など)。
+   * recommendedAction は manual-review 固定で、自動 destructive action には使わない。
+   */
+  suggestedWinner: boolean;
+  recommendedAction: RecommendedAction;
+}
+
+/**
+ * 衝突 group 内の各 doc を分類する。
+ *
+ * ロジック:
+ *   1. hash matched が group 内で一意 → その doc を MatchedByHash + migrate-to-namespace
+ *   2. hash matched が複数 → 全員 Ambiguous (どれが正しい page bytes か断定不能)
+ *   3. hash matched なし → 全員 Ambiguous + suggestedWinner hint (rotatedAt 唯一性で 1 件 hint)
+ *   4. hash mismatched / unavailable のみの group → 上記 3 と同じ
+ *
+ * 1 件単独 group (collision なし) でも本関数を通せる。
+ */
+export function classifyCollisionGroup(
+  group: CollisionGroup
+): ClassificationResult[] {
+  const matchedDocIds = group.evidences
+    .filter((e) => e.hashEvidence.type === 'matched')
+    .map((e) => e.doc.id);
+
+  // ケース 1: hash matched が一意 → 自動 migrate
+  if (matchedDocIds.length === 1) {
+    const winnerId = matchedDocIds[0];
+    return group.evidences.map((e) =>
+      e.doc.id === winnerId
+        ? {
+            docId: e.doc.id,
+            classification: 'MatchedByHash' as const,
+            reason: 'sha256(actual storage bytes) == sha256(regenerated from parent + splitFromPages)',
+            suggestedWinner: false,
+            recommendedAction: 'migrate-to-namespace' as const,
+          }
+        : classifyLoserOrAmbiguous(e, group, /* hasUniqueWinner */ true)
+    );
+  }
+
+  // ケース 2: hash matched が複数 → 全員 Ambiguous (どれを勝者とすべきか断定不能)
+  if (matchedDocIds.length >= 2) {
+    return group.evidences.map((e) => ({
+      docId: e.doc.id,
+      classification: 'Ambiguous' as const,
+      reason: `multiple hash matches in group (${matchedDocIds.length} docs claim ownership of same storage bytes)`,
+      suggestedWinner: e.hashEvidence.type === 'matched',
+      recommendedAction: 'manual-review' as const,
+    }));
+  }
+
+  // ケース 3: hash matched なし (mismatched / unavailable のみ)
+  // → 全員 Ambiguous、rotatedAt!=null 唯一 doc には suggestedWinner hint (低信頼)
+  const rotatedDocs = group.evidences.filter((e) => e.doc.rotatedAt !== null);
+  const hasUniqueRotatedHint = rotatedDocs.length === 1;
+  const suggestedHintDocId = hasUniqueRotatedHint ? rotatedDocs[0].doc.id : null;
+
+  return group.evidences.map((e) => ({
+    docId: e.doc.id,
+    classification: 'Ambiguous' as const,
+    reason: buildAmbiguousReason(e),
+    suggestedWinner: e.doc.id === suggestedHintDocId,
+    recommendedAction: 'manual-review' as const,
+  }));
+}
+
+/**
+ * fileUrl 孤児 (Storage 実体なし) を分類する。
+ *
+ * - parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile + regenerate-from-parent
+ * - 上記以外 → LostOrUnrecoverable + mark-error (status:'error' 誘導)
+ */
+export function classifyOrphan(evidence: DocEvidence): ClassificationResult {
+  const { doc, parent } = evidence;
+
+  if (
+    doc.parentDocumentId !== null &&
+    doc.splitFromPages !== null &&
+    parent !== null &&
+    parent.exists &&
+    parent.originalPdfExists
+  ) {
+    return {
+      docId: doc.id,
+      classification: 'RepairableMissingFile',
+      reason: 'fileUrl orphan; parent doc + splitFromPages + parent original PDF all available',
+      suggestedWinner: false,
+      recommendedAction: 'regenerate-from-parent',
+    };
+  }
+
+  return {
+    docId: doc.id,
+    classification: 'LostOrUnrecoverable',
+    reason: buildLostReason(doc, parent),
+    suggestedWinner: false,
+    recommendedAction: 'mark-error',
+  };
+}
+
+// 衝突 group 内の「勝者以外」doc の分類: hash 一致 winner と異なる実体を保持しうるため
+// Ambiguous (manual-review) 扱い。Codex 指摘反映: pending 化は OCR 再処理キューを壊すため不可。
+function classifyLoserOrAmbiguous(
+  evidence: DocEvidence,
+  group: CollisionGroup,
+  hasUniqueWinner: boolean
+): ClassificationResult {
+  // 勝者 doc 確定後の他 doc は repair 候補だが、本 PR-C スコープでは
+  // 「敗者 doc も orphan と同じく親から再生成可能なら RepairableMissingFile」を試みる。
+  // (Codex 推奨: 敗者 doc の自動再生成で復旧率最大化)
+  if (
+    evidence.doc.parentDocumentId !== null &&
+    evidence.doc.splitFromPages !== null &&
+    evidence.parent !== null &&
+    evidence.parent.exists &&
+    evidence.parent.originalPdfExists
+  ) {
+    return {
+      docId: evidence.doc.id,
+      classification: 'RepairableMissingFile',
+      reason: hasUniqueWinner
+        ? 'collision group loser; winner identified by hash, this doc has different content; parent + original PDF available for regeneration'
+        : 'collision group; parent + original PDF available for regeneration',
+      suggestedWinner: false,
+      recommendedAction: 'regenerate-from-parent',
+    };
+  }
+
+  // 親なし / 親 PDF なし → 復元不能
+  return {
+    docId: evidence.doc.id,
+    classification: 'LostOrUnrecoverable',
+    reason: buildLostReason(evidence.doc, evidence.parent),
+    suggestedWinner: false,
+    recommendedAction: 'mark-error',
+  };
+}
+
+function buildAmbiguousReason(evidence: DocEvidence): string {
+  switch (evidence.hashEvidence.type) {
+    case 'mismatched':
+      return `hash mismatch: actual storage bytes != regenerated from parent + splitFromPages`;
+    case 'unavailable':
+      return `hash comparison unavailable: ${evidence.hashEvidence.reason}`;
+    case 'matched':
+      // この path は ケース 2 (multiple matches) でのみ到達するが defensive に
+      return 'hash matched but multiple winners in group';
+  }
+}
+
+function buildLostReason(
+  doc: CollisionDoc,
+  parent: DocEvidence['parent']
+): string {
+  if (doc.parentDocumentId === null) {
+    return 'no parentDocumentId; cannot regenerate from split source';
+  }
+  if (doc.splitFromPages === null) {
+    return 'no splitFromPages; cannot determine page range to regenerate';
+  }
+  if (parent === null || !parent.exists) {
+    return `parent doc (${doc.parentDocumentId}) not found; cannot regenerate`;
+  }
+  if (!parent.originalPdfExists) {
+    return `parent doc exists but parent original PDF not in Storage; cannot regenerate`;
+  }
+  return 'unknown lost reason';
+}

--- a/scripts/lib/collisionClassifier.ts
+++ b/scripts/lib/collisionClassifier.ts
@@ -1,5 +1,8 @@
 /**
- * Issue #432 PR-C: 衝突 doc / fileUrl 孤児の信頼度付き 4 分類 (pure function)
+ * Issue #432 PR-C: 衝突 doc / fileUrl 孤児の信頼度付き 4 分類 pure function
+ *
+ * 4 分類: MatchedByHash / Ambiguous / RepairableMissingFile / LostOrUnrecoverable
+ * (LikelyWinner は Ambiguous 内 suggestedWinner hint に降格 = 設計案からの統合)。
  *
  * 設計判断 (Codex セカンドオピニオン 2026-05-11 反映):
  *   - hash 一致確定のみ自動移行 (MatchedByHash)
@@ -7,6 +10,9 @@
  *     → Ambiguous 内 suggestedWinner hint に降格
  *   - hash 不能 / 不一致 / 複数一致は全て Ambiguous (manual-review)
  *   - orphan + parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile (auto regenerate)
+ *   - 衝突 group 内の「敗者」doc も同条件で RepairableMissingFile に分類 (Codex 推奨: 復旧率最大化)
+ *   - hash unavailable.reason='computation-error' (transient 503/403) は parent 在でも
+ *     RepairableMissingFile / LostOrUnrecoverable に降格させず Ambiguous に留める (F-B3)
  *   - 復元不能は LostOrUnrecoverable (status:'error' + lastErrorMessage で manual repair 誘導)
  *
  * Partial update 不変 (CLAUDE.md MUST): mark-error action は status / lastErrorMessage のみ更新、
@@ -86,10 +92,15 @@ export interface ClassificationResult {
 /**
  * 衝突 group 内の各 doc を分類する。
  *
- * ロジック:
- *   1. hash matched が group 内で一意 → その doc を MatchedByHash + migrate-to-namespace
- *   2. hash matched が複数 → 全員 Ambiguous (どれが正しい page bytes か断定不能)
- *   3. hash matched なし → 全員 Ambiguous + suggestedWinner hint (rotatedAt 唯一性で 1 件 hint)
+ * ロジック (各 doc の戻り値 classification + recommendedAction):
+ *   1. hash matched が group 内で一意:
+ *      - 勝者 → MatchedByHash + migrate-to-namespace (自動 Storage move)
+ *      - 敗者 → 親 + splitFromPages + 親 PDF 実在なら RepairableMissingFile + regenerate-from-parent
+ *               (= 親から再生成、敗者の Storage 実体は勝者と別物のため上書き再生成で復旧)、
+ *               不能なら LostOrUnrecoverable + mark-error
+ *   2. hash matched が複数 → 全員 Ambiguous + manual-review (どれが正しい page bytes か断定不能)
+ *   3. hash matched なし → 全員 Ambiguous + manual-review (rotatedAt 唯一性で 1 件 suggestedWinner hint、
+ *      ただし hint は operator 参考情報であり自動 destructive action には使わない = Codex Critical)
  *   4. hash mismatched / unavailable のみの group → 上記 3 と同じ
  *
  * 1 件単独 group (collision なし) でも本関数を通せる。
@@ -101,7 +112,7 @@ export function classifyCollisionGroup(
     .filter((e) => e.hashEvidence.type === 'matched')
     .map((e) => e.doc.id);
 
-  // ケース 1: hash matched が一意 → 自動 migrate
+  // ケース 1: hash matched が一意 → 自動 migrate (敗者は再生成 or LostOrUnrecoverable)
   if (matchedDocIds.length === 1) {
     const winnerId = matchedDocIds[0];
     return group.evidences.map((e) =>
@@ -113,7 +124,7 @@ export function classifyCollisionGroup(
             suggestedWinner: false,
             recommendedAction: 'migrate-to-namespace' as const,
           }
-        : classifyLoserOrAmbiguous(e, group, /* hasUniqueWinner */ true)
+        : classifyLoserForRegeneration(e, /* hasUniqueWinner */ true)
     );
   }
 
@@ -146,11 +157,24 @@ export function classifyCollisionGroup(
 /**
  * fileUrl 孤児 (Storage 実体なし) を分類する。
  *
+ * - hash unavailable.reason='computation-error' (transient 503/403): parent 在でも
+ *   一旦 Ambiguous + manual-review に留める (F-B3 反映、actual 取得失敗を Lost に流さない)
  * - parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile + regenerate-from-parent
  * - 上記以外 → LostOrUnrecoverable + mark-error (status:'error' 誘導)
  */
 export function classifyOrphan(evidence: DocEvidence): ClassificationResult {
   const { doc, parent } = evidence;
+
+  // F-B3: transient error (computation-error) は Lost に降格させず Ambiguous に留める
+  if (isComputationError(evidence)) {
+    return {
+      docId: doc.id,
+      classification: 'Ambiguous',
+      reason: 'hash comparison unavailable due to transient error; defer to manual-review',
+      suggestedWinner: false,
+      recommendedAction: 'manual-review',
+    };
+  }
 
   if (
     doc.parentDocumentId !== null &&
@@ -177,16 +201,33 @@ export function classifyOrphan(evidence: DocEvidence): ClassificationResult {
   };
 }
 
-// 衝突 group 内の「勝者以外」doc の分類: hash 一致 winner と異なる実体を保持しうるため
-// Ambiguous (manual-review) 扱い。Codex 指摘反映: pending 化は OCR 再処理キューを壊すため不可。
-function classifyLoserOrAmbiguous(
+/**
+ * 衝突 group 内の「勝者以外」doc を分類する (Codex 推奨: 復旧率最大化のため敗者も自動再生成).
+ *
+ * - hash unavailable.reason='computation-error' は Ambiguous に留める (F-B3、Lost に流さない)
+ * - parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile + regenerate-from-parent
+ *   (敗者の Storage 実体は勝者と別物のため、親から再生成して上書き)
+ * - 不能 → LostOrUnrecoverable + mark-error
+ *
+ * 注意: pending 化は OCR 再処理キューを壊す (processOCR が pending を拾う) ため、
+ * 敗者 doc の status は 'processed' のまま fileUrl のみ新 docId namespace path に
+ * 切り替える (regenerate-from-parent action 内で実装)。
+ */
+function classifyLoserForRegeneration(
   evidence: DocEvidence,
-  group: CollisionGroup,
   hasUniqueWinner: boolean
 ): ClassificationResult {
-  // 勝者 doc 確定後の他 doc は repair 候補だが、本 PR-C スコープでは
-  // 「敗者 doc も orphan と同じく親から再生成可能なら RepairableMissingFile」を試みる。
-  // (Codex 推奨: 敗者 doc の自動再生成で復旧率最大化)
+  // F-B3: transient error は Lost に降格させない
+  if (isComputationError(evidence)) {
+    return {
+      docId: evidence.doc.id,
+      classification: 'Ambiguous',
+      reason: 'collision group loser; hash comparison unavailable due to transient error; defer to manual-review',
+      suggestedWinner: false,
+      recommendedAction: 'manual-review',
+    };
+  }
+
   if (
     evidence.doc.parentDocumentId !== null &&
     evidence.doc.splitFromPages !== null &&
@@ -205,7 +246,6 @@ function classifyLoserOrAmbiguous(
     };
   }
 
-  // 親なし / 親 PDF なし → 復元不能
   return {
     docId: evidence.doc.id,
     classification: 'LostOrUnrecoverable',
@@ -213,6 +253,13 @@ function classifyLoserOrAmbiguous(
     suggestedWinner: false,
     recommendedAction: 'mark-error',
   };
+}
+
+function isComputationError(evidence: DocEvidence): boolean {
+  return (
+    evidence.hashEvidence.type === 'unavailable' &&
+    evidence.hashEvidence.reason === 'computation-error'
+  );
 }
 
 function buildAmbiguousReason(evidence: DocEvidence): string {

--- a/scripts/lib/executeMigrationOps.ts
+++ b/scripts/lib/executeMigrationOps.ts
@@ -1,0 +1,49 @@
+/**
+ * Issue #432 PR-C: execute-collision-migration.ts の update field 構築を pure 関数化 (F-D2)
+ *
+ * Partial update 不変 (CLAUDE.md MUST) を testable にするため、各 execute action の
+ * Firestore update payload 構築をここに集約。caller (execute-collision-migration.ts) は
+ * `db.doc(...).update(buildMigrateUpdatePayload(...))` の形で呼ぶことで、update key set が
+ * 仕様通り (fileUrl のみ / fileUrl + status + lastErrorMessage / status + lastErrorMessage)
+ * であることを test で固定できる。
+ */
+
+import * as admin from 'firebase-admin';
+
+/** migrate-to-namespace: fileUrl のみ更新 (他フィールド不変) */
+export function buildMigrateUpdatePayload(
+  newFileUrl: string
+): Record<string, string> {
+  return { fileUrl: newFileUrl };
+}
+
+/**
+ * regenerate-from-parent: fileUrl + status + lastErrorMessage 削除
+ * (orphan 由来で error 化した doc も processed に回復)
+ */
+export function buildRegenerateUpdatePayload(
+  newFileUrl: string
+): Record<string, string | admin.firestore.FieldValue> {
+  return {
+    fileUrl: newFileUrl,
+    status: 'processed',
+    lastErrorMessage: admin.firestore.FieldValue.delete(),
+  };
+}
+
+/** mark-error: status + lastErrorMessage のみ (Storage 触らない、最小 partial update) */
+export function buildMarkErrorUpdatePayload(
+  reason: string
+): Record<string, string> {
+  return {
+    status: 'error',
+    lastErrorMessage: `Issue #432 PR-C migration: ${reason}`,
+  };
+}
+
+/** Partial update 不変検証用の expected key set (CLAUDE.md MUST 準拠) */
+export const EXPECTED_UPDATE_KEYS = {
+  migrate: ['fileUrl'] as const,
+  regenerate: ['fileUrl', 'status', 'lastErrorMessage'] as const,
+  markError: ['status', 'lastErrorMessage'] as const,
+};

--- a/scripts/lib/pdfRegenerator.ts
+++ b/scripts/lib/pdfRegenerator.ts
@@ -1,0 +1,52 @@
+/**
+ * Issue #432 PR-C: parent PDF + splitFromPages から child PDF を再生成
+ *
+ * functions/src/pdf/pdfOperations.ts:307-316 splitPdf の partial copy ロジックを
+ * scripts 用に独立実装 (Functions 変更ゼロ制約)。
+ *
+ * 重要: 親 PDF が rotate 後形式 (`_r{timestamp}.pdf`) の場合、再生成された child は
+ * 「事故当時の child bytes」とは byte-for-byte 一致しない可能性がある (rotate 後ページが入る)。
+ * この点は runbook の repair policy で明示し、operator が承知の上で repair する設計。
+ */
+
+import { PDFDocument } from 'pdf-lib';
+
+/**
+ * parent PDF buffer + page range から child PDF buffer を生成する。
+ *
+ * @param parentPdfBuffer parent doc の現在 fileUrl が指す PDF bytes (rotate 済みなら rotate 後)
+ * @param startPage 1-indexed inclusive
+ * @param endPage 1-indexed inclusive
+ * @returns child PDF bytes
+ */
+export async function regenerateChildPdf(
+  parentPdfBuffer: Buffer,
+  startPage: number,
+  endPage: number
+): Promise<Buffer> {
+  if (startPage < 1 || endPage < startPage) {
+    throw new Error(
+      `invalid page range: startPage=${startPage}, endPage=${endPage}`
+    );
+  }
+
+  const parentPdf = await PDFDocument.load(parentPdfBuffer);
+  const totalPages = parentPdf.getPageCount();
+
+  if (endPage > totalPages) {
+    throw new Error(
+      `page range out of bounds: endPage=${endPage} > parent totalPages=${totalPages}`
+    );
+  }
+
+  const newPdf = await PDFDocument.create();
+  const pageIndices = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage - 1 + i
+  );
+  const copiedPages = await newPdf.copyPages(parentPdf, pageIndices);
+  copiedPages.forEach((page) => newPdf.addPage(page));
+
+  const newPdfBytes = await newPdf.save();
+  return Buffer.from(newPdfBytes);
+}

--- a/scripts/lib/storageGuard.ts
+++ b/scripts/lib/storageGuard.ts
@@ -1,0 +1,67 @@
+/**
+ * Storage path 削除安全性判定 (Issue #432 PR-C migration 用)
+ *
+ * functions/src/storage/storageDeletionGuard.ts (canSafelyDeleteStorageFile) の
+ * scripts 版。Functions 変更ゼロ制約のため独立実装する。
+ *
+ * Functions 版との API 差:
+ *   - Functions 版: 「自分以外」の共有 doc を判定 (limit(2) 単独参照判定)
+ *   - 本 scripts 版: 「除外 docIds リスト以外」の共有 doc を判定 (migration で
+ *     複数の敗者 doc を一括除外しつつ「他に共有者が居ないか」確認するため)
+ *
+ * race condition: query 後の新規共有出現は防げない。caller は execute 直前に
+ *   再 query するか、precondition snapshot との不一致 reject で対応すること。
+ */
+
+import * as admin from 'firebase-admin';
+
+/**
+ * 同一 fileUrl を参照する全ての document id を返す。
+ *
+ * limit を付けない理由: migration では「除外 IDs を全部弾いた後の残存」を
+ * 数える必要があり、Functions 版の limit(2) 最適化は使えない。kanameone の
+ * 衝突 group 最大が 6 docs であるため、limit なし全件取得でも実用的なコスト。
+ */
+export async function findDocsReferencingFileUrl(
+  db: admin.firestore.Firestore,
+  fileUrl: string
+): Promise<string[]> {
+  const snap = await db
+    .collection('documents')
+    .where('fileUrl', '==', fileUrl)
+    .get();
+  return snap.docs.map((d) => d.id);
+}
+
+/**
+ * pure: 共有 doc id 一覧と除外 id 一覧から削除安全性を判定。
+ *
+ * - safe=true: 除外 IDs 以外に共有 doc がない (= 削除しても孤児化しない)
+ * - safe=false: 残存 (residualDocIds) があり、削除すれば残存 doc を巻き添えに
+ *   する。caller は skip + warning で対応。
+ *
+ * 単体テスト用に async から分離した pure function。Firestore mock 不要。
+ */
+export function evaluatePathSafety(
+  referencingDocIds: readonly string[],
+  excludeDocIds: readonly string[]
+): { safe: boolean; residualDocIds: string[] } {
+  const excludeSet = new Set(excludeDocIds);
+  const residualDocIds = referencingDocIds.filter((id) => !excludeSet.has(id));
+  return { safe: residualDocIds.length === 0, residualDocIds };
+}
+
+/**
+ * 同 fileUrl を共有する doc 群から除外 IDs を弾き、残存ゼロ時のみ delete 安全。
+ *
+ * @param excludeDocIds 削除/更新で fileUrl 参照を外す予定の docIds (敗者 doc 群)
+ * @returns safe=true なら delete 実行可、false なら residualDocIds があり skip 必須
+ */
+export async function isPathSafeToDeleteAfterExcluding(
+  db: admin.firestore.Firestore,
+  fileUrl: string,
+  excludeDocIds: readonly string[]
+): Promise<{ safe: boolean; residualDocIds: string[] }> {
+  const referencingDocIds = await findDocsReferencingFileUrl(db, fileUrl);
+  return evaluatePathSafety(referencingDocIds, excludeDocIds);
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@google-cloud/logging": "^11.2.1",
-    "firebase-admin": "^12.7.0"
+    "firebase-admin": "^12.7.0",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/scripts/setup-collision-fixture.ts
+++ b/scripts/setup-collision-fixture.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env ts-node
+/**
+ * Issue #432 PR-C: dev 環境に 5 分類網羅 fixture を投入 (idempotent)
+ *
+ * 目的 (Codex Critical 反映): cocoro 環境は被害ゼロ (0 件 no-op) のため
+ * execute-collision-migration.ts の execute path が kanameone 本番で初動するリスク。
+ * dev に意図的な衝突 + orphan を作り、execute path を全分類で実環境前検証する。
+ *
+ * 投入内容 (planId が `pr-c-fixture-*` 固定で識別可能):
+ *   - parent doc (5 page) + Storage 実体
+ *   - MatchedByHash 衝突 group: 2 child docs 同 fileName, 1 件は hash 一致 PDF (parent から再生成),
+ *     1 件は hash 不一致 PDF を upload
+ *   - Ambiguous group: 2 child docs 同 fileName, 両方とも hash 不一致 (rotatedAt は片方 set)
+ *   - RepairableMissingFile orphan: child doc with parent 在 + splitFromPages 在, Storage upload なし
+ *   - LostOrUnrecoverable orphan: child doc with parentDocumentId=null
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=doc-split-dev STORAGE_BUCKET=doc-split-dev.firebasestorage.app \
+ *     npx ts-node scripts/setup-collision-fixture.ts [--cleanup]
+ *
+ * --cleanup: fixture を削除する (再投入前のリセット用)
+ */
+
+import * as admin from 'firebase-admin';
+import { PDFDocument } from 'pdf-lib';
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const storageBucket = process.env.STORAGE_BUCKET;
+
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+if (!storageBucket) {
+  console.error('STORAGE_BUCKET を設定してください');
+  process.exit(1);
+}
+
+// 安全策: fixture は dev 環境専用 (本番事故防止)
+if (!projectId.includes('dev')) {
+  console.error(
+    `FATAL: setup-collision-fixture は dev 環境専用です。projectId=${projectId} は dev を含みません。`
+  );
+  process.exit(2);
+}
+
+const cleanup = process.argv.includes('--cleanup');
+
+admin.initializeApp({ projectId, storageBucket });
+const db = admin.firestore();
+const bucket = admin.storage().bucket();
+
+const FIXTURE_PREFIX = 'processed/';
+const PARENT_DOC_ID = 'pr-c-fixture-parent';
+const FIXTURE_DOC_IDS = {
+  PARENT: PARENT_DOC_ID,
+  MATCHED_WINNER: 'pr-c-fixture-matched-winner',
+  MATCHED_LOSER: 'pr-c-fixture-matched-loser',
+  AMBIGUOUS_A: 'pr-c-fixture-ambiguous-a',
+  AMBIGUOUS_B: 'pr-c-fixture-ambiguous-b',
+  REPAIRABLE_ORPHAN: 'pr-c-fixture-repairable-orphan',
+  LOST_ORPHAN: 'pr-c-fixture-lost-orphan',
+};
+const COLLISION_FILENAME = '20260101_fixture_未判定_未判定_p1.pdf';
+const AMBIGUOUS_FILENAME = '20260102_fixture_未判定_未判定_p2.pdf';
+const REPAIRABLE_FILENAME = '20260103_fixture_未判定_未判定_p3.pdf';
+const LOST_FILENAME = '20260104_fixture_未判定_未判定_p4.pdf';
+
+// parent PDF: 5 pages, content をページ番号で区別 (hash 比較対象として必要)
+async function makeParentPdf(): Promise<Buffer> {
+  const pdf = await PDFDocument.create();
+  for (let i = 0; i < 5; i++) {
+    const page = pdf.addPage([100, 100]);
+    // 各ページに違う矩形を描画して hash 区別を確保 (font 不要)
+    page.drawRectangle({ x: 10 + i * 5, y: 10 + i * 5, width: 30, height: 30 });
+  }
+  return Buffer.from(await pdf.save());
+}
+
+// 別 PDF (mismatched 用): 全く異なる構造
+async function makeUnrelatedPdf(seed: number): Promise<Buffer> {
+  const pdf = await PDFDocument.create();
+  const page = pdf.addPage([200, 200]);
+  page.drawRectangle({
+    x: seed * 10,
+    y: seed * 10,
+    width: 50,
+    height: 50,
+  });
+  return Buffer.from(await pdf.save());
+}
+
+// parent から特定 page range を抽出 (regenerateChildPdf と同等ロジック = hash matched 保証)
+async function extractFromParent(
+  parentBuf: Buffer,
+  startPage: number,
+  endPage: number
+): Promise<Buffer> {
+  const parent = await PDFDocument.load(parentBuf);
+  const pdf = await PDFDocument.create();
+  const indices = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage - 1 + i
+  );
+  const pages = await pdf.copyPages(parent, indices);
+  pages.forEach((p) => pdf.addPage(p));
+  return Buffer.from(await pdf.save());
+}
+
+async function uploadPdf(path: string, buf: Buffer): Promise<void> {
+  await bucket.file(path).save(buf, {
+    metadata: { contentType: 'application/pdf' },
+  });
+}
+
+async function setDoc(
+  id: string,
+  data: admin.firestore.DocumentData
+): Promise<void> {
+  await db.doc(`documents/${id}`).set(data);
+}
+
+async function deleteDocIfExists(id: string): Promise<void> {
+  const ref = db.doc(`documents/${id}`);
+  const snap = await ref.get();
+  if (snap.exists) await ref.delete();
+}
+
+async function deleteFileIfExists(path: string): Promise<void> {
+  try {
+    await bucket.file(path).delete();
+  } catch {
+    /* ignore not-found */
+  }
+}
+
+async function doCleanup(): Promise<void> {
+  console.log('Cleaning up fixture...');
+  for (const id of Object.values(FIXTURE_DOC_IDS)) {
+    await deleteDocIfExists(id);
+  }
+  // Storage cleanup: parent + collision + ambiguous (orphan は元々なし)
+  // 旧 path (= 旧 fileUrl 形式) と新 docId namespace 形式の両方掃除
+  const pathsToDelete = [
+    `${FIXTURE_PREFIX}${PARENT_DOC_ID}.pdf`,
+    `${FIXTURE_PREFIX}${COLLISION_FILENAME}`, // 旧形式 (collision)
+    `${FIXTURE_PREFIX}${AMBIGUOUS_FILENAME}`, // 旧形式 (ambiguous)
+    `${FIXTURE_PREFIX}${FIXTURE_DOC_IDS.MATCHED_WINNER}/${COLLISION_FILENAME}`,
+    `${FIXTURE_PREFIX}${FIXTURE_DOC_IDS.MATCHED_LOSER}/${COLLISION_FILENAME}`,
+    `${FIXTURE_PREFIX}${FIXTURE_DOC_IDS.AMBIGUOUS_A}/${AMBIGUOUS_FILENAME}`,
+    `${FIXTURE_PREFIX}${FIXTURE_DOC_IDS.AMBIGUOUS_B}/${AMBIGUOUS_FILENAME}`,
+    `${FIXTURE_PREFIX}${FIXTURE_DOC_IDS.REPAIRABLE_ORPHAN}/${REPAIRABLE_FILENAME}`,
+  ];
+  for (const path of pathsToDelete) {
+    await deleteFileIfExists(path);
+  }
+  console.log('Cleanup complete.');
+}
+
+async function main(): Promise<void> {
+  console.log(`Project: ${projectId}`);
+  console.log(`Bucket : ${storageBucket}`);
+
+  if (cleanup) {
+    await doCleanup();
+    await admin.app().delete();
+    return;
+  }
+
+  // 既存 fixture を削除してから再投入 (idempotent)
+  await doCleanup();
+
+  console.log('\nGenerating parent PDF...');
+  const parentBuf = await makeParentPdf();
+  const parentPath = `${FIXTURE_PREFIX}${PARENT_DOC_ID}.pdf`;
+  await uploadPdf(parentPath, parentBuf);
+  await setDoc(PARENT_DOC_ID, {
+    id: PARENT_DOC_ID,
+    status: 'split',
+    fileName: 'pr-c-fixture-parent.pdf',
+    fileUrl: `gs://${storageBucket}/${parentPath}`,
+    isSplitSource: true,
+    splitInto: [
+      FIXTURE_DOC_IDS.MATCHED_WINNER,
+      FIXTURE_DOC_IDS.MATCHED_LOSER,
+      FIXTURE_DOC_IDS.AMBIGUOUS_A,
+      FIXTURE_DOC_IDS.AMBIGUOUS_B,
+      FIXTURE_DOC_IDS.REPAIRABLE_ORPHAN,
+    ],
+    totalPages: 5,
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  // ── MatchedByHash group ──
+  // 旧形式 fileUrl で衝突: 両 child docs が `processed/{COLLISION_FILENAME}` を指す
+  // Storage には MATCHED_WINNER の期待 hash と一致する PDF を 1 つだけ upload
+  console.log('Setting up MatchedByHash collision group...');
+  const winnerExpectedBuf = await extractFromParent(parentBuf, 1, 1);
+  const collisionPath = `${FIXTURE_PREFIX}${COLLISION_FILENAME}`;
+  await uploadPdf(collisionPath, winnerExpectedBuf);
+  const collisionFileUrl = `gs://${storageBucket}/${collisionPath}`;
+  await setDoc(FIXTURE_DOC_IDS.MATCHED_WINNER, {
+    id: FIXTURE_DOC_IDS.MATCHED_WINNER,
+    status: 'processed',
+    fileName: COLLISION_FILENAME,
+    fileUrl: collisionFileUrl,
+    parentDocumentId: PARENT_DOC_ID,
+    splitFromPages: { start: 1, end: 1 },
+    totalPages: 1,
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  // loser doc は別 page range (hash mismatched) を主張するが Storage は winner 内容
+  await setDoc(FIXTURE_DOC_IDS.MATCHED_LOSER, {
+    id: FIXTURE_DOC_IDS.MATCHED_LOSER,
+    status: 'processed',
+    fileName: COLLISION_FILENAME,
+    fileUrl: collisionFileUrl,
+    parentDocumentId: PARENT_DOC_ID,
+    splitFromPages: { start: 2, end: 2 }, // 期待 hash != Storage 実体
+    totalPages: 1,
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  // ── Ambiguous group ──
+  // 両 child docs とも別 page を主張、Storage は無関係 PDF (両者 hash 不一致)
+  console.log('Setting up Ambiguous collision group...');
+  const ambiguousPath = `${FIXTURE_PREFIX}${AMBIGUOUS_FILENAME}`;
+  await uploadPdf(ambiguousPath, await makeUnrelatedPdf(7));
+  const ambiguousFileUrl = `gs://${storageBucket}/${ambiguousPath}`;
+  await setDoc(FIXTURE_DOC_IDS.AMBIGUOUS_A, {
+    id: FIXTURE_DOC_IDS.AMBIGUOUS_A,
+    status: 'processed',
+    fileName: AMBIGUOUS_FILENAME,
+    fileUrl: ambiguousFileUrl,
+    parentDocumentId: PARENT_DOC_ID,
+    splitFromPages: { start: 3, end: 3 },
+    totalPages: 1,
+    rotatedAt: admin.firestore.FieldValue.serverTimestamp(), // suggestedWinner hint
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  await setDoc(FIXTURE_DOC_IDS.AMBIGUOUS_B, {
+    id: FIXTURE_DOC_IDS.AMBIGUOUS_B,
+    status: 'processed',
+    fileName: AMBIGUOUS_FILENAME,
+    fileUrl: ambiguousFileUrl,
+    parentDocumentId: PARENT_DOC_ID,
+    splitFromPages: { start: 4, end: 4 },
+    totalPages: 1,
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  // ── RepairableMissingFile orphan ──
+  console.log('Setting up RepairableMissingFile orphan...');
+  const repairablePath = `${FIXTURE_PREFIX}${REPAIRABLE_FILENAME}`;
+  // Storage には upload しない (orphan)
+  await setDoc(FIXTURE_DOC_IDS.REPAIRABLE_ORPHAN, {
+    id: FIXTURE_DOC_IDS.REPAIRABLE_ORPHAN,
+    status: 'processed',
+    fileName: REPAIRABLE_FILENAME,
+    fileUrl: `gs://${storageBucket}/${repairablePath}`,
+    parentDocumentId: PARENT_DOC_ID,
+    splitFromPages: { start: 5, end: 5 },
+    totalPages: 1,
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  // ── LostOrUnrecoverable orphan ──
+  console.log('Setting up LostOrUnrecoverable orphan...');
+  await setDoc(FIXTURE_DOC_IDS.LOST_ORPHAN, {
+    id: FIXTURE_DOC_IDS.LOST_ORPHAN,
+    status: 'processed',
+    fileName: LOST_FILENAME,
+    fileUrl: `gs://${storageBucket}/${FIXTURE_PREFIX}${LOST_FILENAME}`,
+    // parentDocumentId なし (orphan with no recovery path)
+    parentDocumentId: null,
+    splitFromPages: null,
+    totalPages: 1,
+    processedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  console.log('\n✅ Fixture setup complete. 5 docs (excl. parent) covering 4 classifications.');
+  console.log('Run: npx ts-node scripts/classify-collision-docs.ts');
+
+  await admin.app().delete();
+}
+
+main().catch(async (err) => {
+  console.error('Failed:', err);
+  try {
+    await admin.app().delete();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/scripts/setup-collision-fixture.ts
+++ b/scripts/setup-collision-fixture.ts
@@ -51,6 +51,9 @@ const db = admin.firestore();
 const bucket = admin.storage().bucket();
 
 const FIXTURE_PREFIX = 'processed/';
+// F-A1: parent PDF は実環境同様 `original/` 配下に置く (旧版は processed/ に置いていて
+// classify が parent 不在を見落とす欠陥を隠蔽していた)。
+const PARENT_PREFIX = 'original/';
 const PARENT_DOC_ID = 'pr-c-fixture-parent';
 const FIXTURE_DOC_IDS = {
   PARENT: PARENT_DOC_ID,
@@ -142,7 +145,8 @@ async function doCleanup(): Promise<void> {
   // Storage cleanup: parent + collision + ambiguous (orphan は元々なし)
   // 旧 path (= 旧 fileUrl 形式) と新 docId namespace 形式の両方掃除
   const pathsToDelete = [
-    `${FIXTURE_PREFIX}${PARENT_DOC_ID}.pdf`,
+    `${PARENT_PREFIX}${PARENT_DOC_ID}.pdf`, // F-A1: parent は original/ 配下
+    `${FIXTURE_PREFIX}${PARENT_DOC_ID}.pdf`, // 旧 fixture 残存 (互換 cleanup)
     `${FIXTURE_PREFIX}${COLLISION_FILENAME}`, // 旧形式 (collision)
     `${FIXTURE_PREFIX}${AMBIGUOUS_FILENAME}`, // 旧形式 (ambiguous)
     `${FIXTURE_PREFIX}${FIXTURE_DOC_IDS.MATCHED_WINNER}/${COLLISION_FILENAME}`,
@@ -172,7 +176,9 @@ async function main(): Promise<void> {
 
   console.log('\nGenerating parent PDF...');
   const parentBuf = await makeParentPdf();
-  const parentPath = `${FIXTURE_PREFIX}${PARENT_DOC_ID}.pdf`;
+  // F-A1: parent は original/ 配下 (実環境同様)。classify-collision-docs.ts が `processed/`
+  // Storage 一覧だけで parent 不在判定する欠陥を再発見させない。
+  const parentPath = `${PARENT_PREFIX}${PARENT_DOC_ID}.pdf`;
   await uploadPdf(parentPath, parentBuf);
   await setDoc(PARENT_DOC_ID, {
     id: PARENT_DOC_ID,


### PR DESCRIPTION
## Summary

Issue #432 過去被害 (kanameone 39 衝突 group + 4 fileUrl 孤児 = silent breakage 90+ docs) の復旧用 destructive migration script 群。**Codex セカンドオピニオン (2026-05-11) で Critical 2 + Important 6 を反映後に実装**。

- Critical: LikelyWinner 自動 destructive 禁止 / 「敗者 doc を pending + fileUrl クリア」禁止
- Important: sha256 比較必須 / 4 重 gate / idempotency / dev fixture / storageGuard 共有 / freeze window

## 5 分類アルゴリズム

| 分類 | 判定条件 | recommendedAction |
|---|---|---|
| MatchedByHash | sha256 一致が group 内一意 | migrate-to-namespace |
| RepairableMissingFile | parent + splitFromPages + 親 PDF 在 | regenerate-from-parent |
| Ambiguous | hash 不能 / 不一致 / 複数一致 (LikelyWinner は suggestedWinner hint) | manual-review |
| LostOrUnrecoverable | parent / 親 PDF 不在 | mark-error |

## 4 重 gate (execute-collision-migration.ts)

1. \`approval.planId === plan.planId\`
2. \`operation.operationId ∈ approvedOperationIds\`
3. destructive action は \`sourcePath / destPath ∈ approvedPaths\`
4. runtime env (\`FIREBASE_PROJECT_ID + STORAGE_BUCKET\`) が plan の \`projectId / bucket\` と一致
5. precondition snapshot (\`expectedCurrentFileUrl + expectedStatus + expectedUpdatedAt\`) が現状 doc と一致

idempotency: 完了済 operation は \`already migrated\` で skip、中断後の再実行可。

## ファイル

| ファイル | 役割 |
|---|---|
| scripts/lib/collisionClassifier.ts | 5 分類 pure function |
| scripts/lib/storageGuard.ts | 削除安全性判定 (除外 IDs 対応) |
| scripts/lib/pdfRegenerator.ts | parent から child PDF 再生成 |
| scripts/classify-collision-docs.ts | read-only スキャン → plan JSON 出力 |
| scripts/execute-collision-migration.ts | 4 重 gate + idempotent execute |
| scripts/setup-collision-fixture.ts | dev 環境 5 分類 fixture (idempotent) |
| functions/test/collisionClassifier.test.ts | 15 unit test |
| functions/test/storageGuard.test.ts | 5 unit test |
| docs/runbooks/orphan-storage-cleanup.md | PR-C 手順 + freeze window |
| .github/workflows/run-ops-script.yml | script choice + ts-node 分岐追加 |

## スコープ外 (handoff session57「次のアクション」別 PR)

- 旧 \`processed/{fileName}\` → \`processed/{docId}/{fileName}\` の **被害なし** 5640+ docs 一斉移行
- \`generateFileName\` timestamp 引数完全削除
- Cloud Monitoring alert + cron 自動化

## Test plan

- [x] \`functions/test/collisionClassifier.test.ts\` 15 tests passing (AC-1〜AC-4 + AC-10 + AC-11)
- [x] \`functions/test/storageGuard.test.ts\` 5 tests passing (evaluatePathSafety pure)
- [x] scripts tsc 0 errors
- [x] functions lint 0 errors
- [ ] dev 環境で \`setup-collision-fixture.ts\` 投入 → \`classify-collision-docs.ts\` → \`execute-collision-migration.ts --dry-run\` → \`--execute\` で全 5 分類 execute path 動作確認 (PR-C2 で実行)
- [ ] cocoro 環境で classify dry-run → 0 件レポート確認 (PR-C2)
- [ ] kanameone 環境で classify dry-run → 39 group + 4 orphan 分類レポート提示 → 番号認可 → execute (PR-C2 別 PR)
- [ ] 復旧後 audit-storage-mismatch.js で衝突 group 0 / orphan 0 確認 (PR-C2)

## Critical な特記事項

- **本 PR は Functions 変更ゼロ** (scripts + test + docs + workflow のみ)
- **destructive 実行は本 PR には含まれない** (PR-C2 で番号認可付き実行ログとして別 PR)
- **dev fixture は projectId に \"dev\" 含む環境のみ動作** (本番事故防止)

Refs #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collision document classification and migration workflow to resolve storage conflicts
  
* **Documentation**
  * Added runbook for orphan storage cleanup procedures with detailed classification categories and approved action steps

* **Tests**
  * Added comprehensive test suites for collision classification logic, migration operations, PDF regeneration, and storage safety evaluation

* **Chores**
  * Updated CI/CD workflow to support collision-related operations
  * Added PDF processing library dependency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->