### PR TITLE
fix(scripts): Issue #432 PR-C2 — pdf-page-visual-v1 fingerprint で cross-process MatchedByHash を成立させる

### DIFF
--- a/docs/runbooks/orphan-storage-cleanup.md
+++ b/docs/runbooks/orphan-storage-cleanup.md
@@ -150,17 +150,39 @@ parent (= splitPdf に渡された元 doc ID) を特定する手段:
 - `audit-storage-mismatch.js` で被害が検出済 (衝突 group / fileUrl 孤児)
 - runbook §Phase 1〜3 で個別対応する量を超え、bulk migration が妥当と判断済
 - **freeze window (推奨)**: migration 実行中は対象環境の UI 操作 (分割 / 回転 / 削除) を停止する。進行中 splitPdf invocation との race を precondition gate で skip するが、freeze window で race 数を最小化
+- **PR-C2 で fingerprint algorithm 切替**: PR-C1 (sha256 raw bytes 比較) は pdf-lib の cross-process non-determinism により MatchedByHash が成立しないことが dev fixture で発覚 (session59 教訓)。**PR-C2 以降は `pdf-page-visual-v1` fingerprint 比較を使用**。実装: `scripts/lib/pdfPageVisualFingerprint.ts`。
+
+### fingerprint algorithm: pdf-page-visual-v1
+
+各 PDF ページの「描画同一性」を以下の構成要素で sha256 化:
+1. 各ページの **decoded Contents bytes** (正規化禁止 — whitespace / operator 順 / inline image data を保持)
+2. 各ページの **geometry**: MediaBox / CropBox / Rotate
+3. 各ページが参照する **Resources subtree**: Font / XObject / ExtGState / ColorSpace / Pattern / Shading / ProcSet を canonical digest (entries を name 文字列 sort)
+
+> **cross-process deterministic**: 別 Node プロセスで生成した PDF と同プロセス生成 PDF が同 fingerprint を返す (functions/test/pdfPageVisualFingerprint.test.ts で cross-process spawn 検証)。pdf-lib `PDFDocument.save()` のプロセス間 random `/ID` を吸収する設計。
 
 ### 5 分類と自動 action 一覧
 
 | 分類 | 判定条件 | recommendedAction | 自動実行可否 |
 |---|---|---|---|
-| **MatchedByHash** | sha256(Storage 実体) == sha256(parent + splitFromPages から再生成した期待 PDF) かつ group 内一意 | migrate-to-namespace | ✅ 自動 |
+| **MatchedByHash** | fingerprint(Storage 実体, pdf-page-visual-v1) == fingerprint(parent + splitFromPages から再生成した期待 PDF) かつ group 内一意 | migrate-to-namespace | ✅ 自動 |
 | **RepairableMissingFile** | parent + splitFromPages + 親 PDF 全て実在 | regenerate-from-parent | ✅ 自動 (敗者 doc / orphan 共通) |
-| **Ambiguous** | hash 不能 / 不一致 / 複数一致 (LikelyWinner suggestedWinner hint 含む) | manual-review | ❌ 自動禁止 |
+| **Ambiguous** | fingerprint 不能 / 不一致 / 複数一致 / unsupported-pdf-feature (LikelyWinner suggestedWinner hint 含む) | manual-review | ❌ 自動禁止 |
 | **LostOrUnrecoverable** | parent doc 不在 / splitFromPages 不在 / 親 PDF 不在 | mark-error | ✅ status:'error' のみ自動 (Storage 操作なし) |
 
 > **重要 (Codex Critical 反映)**: `rotatedAt!=null 唯一` による LikelyWinner は「離脱可能性」の手がかりに過ぎず Storage 実体の正当性証明ではない。自動 destructive action は禁止。Ambiguous の suggestedWinner hint として operator に提示する。
+
+### Ambiguous reason 細分化 (Codex Suggestion 反映)
+
+operator が manual-review 時に対処方針を即特定できるよう、Ambiguous の `reason` フィールドは以下 5 サブカテゴリ prefix で返す:
+
+| reason prefix | 意味 | operator 対処 |
+|---|---|---|
+| `content-mismatch` | fingerprint(actual storage) != fingerprint(regenerated) | parent から再生成した PDF と実体が描画的に異なる。operator が中身を比較し、勝者判定 → 手動 migrate or status='error' |
+| `multiple-fingerprint-matches` | 複数 doc が同 fingerprint (希少) | どの docId に紐付けるべきか operator が業務文脈で判定 |
+| `unsupported-pdf-feature` | encryption / acroform / optional-content / malformed | PDF 構造が自動 fingerprint 対象外。手動でファイル内容を確認し復旧可否判定 |
+| `hash-unavailable-transient` | download 一時エラー (503/403) | 数分後に再 classify、解消すれば再分類 |
+| `hash-unavailable-no-parent` | parent doc / 親 PDF / splitFromPages のいずれかが不在 | LostOrUnrecoverable 寄り。parent doc 復元できれば再分類 |
 
 ### Step 1: dev 環境で execute path を全分類検証 (本番前必須)
 
@@ -199,6 +221,7 @@ FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
   "projectId": "docsplit-kanameone",
   "bucket": "docsplit-kanameone.firebasestorage.app",
   "prefix": "processed/",
+  "hashAlgorithm": "pdf-page-visual-v1",
   "summary": {
     "totalGroups": 39,
     "totalCollisionDocs": 90,
@@ -243,13 +266,14 @@ Step 2 で出力された plan JSON 内容と各 operation の sourcePath/destPa
 }
 ```
 
-**4 重 gate (Codex セカンドオピニオン反映)**:
+**6 重 gate (Codex セカンドオピニオン反映 + PR-C2 fingerprint version gate)**:
 
 1. `approval.planId === plan.planId` (古い plan の流用防止)
 2. `operation.operationId ∈ approvedOperationIds` (operation 単位の認可)
 3. destructive action は `sourcePath / destPath ∈ approvedPaths` (per-path 文字列認可、ADR-0008 教訓)
 4. runtime env (`FIREBASE_PROJECT_ID + STORAGE_BUCKET`) が plan の `projectId / bucket` と一致 (環境取り違え防止)
 5. precondition snapshot (`expectedCurrentFileUrl + expectedStatus + expectedUpdatedAt`) が現状 doc と一致 (進行中 splitPdf invocation との race 検出 → skip)
+6. **`plan.hashAlgorithm === HASH_ALGORITHM` (PR-C2 追加 AC13)**: plan 作成時の fingerprint algorithm version と execute 側コード固定値が一致 (pdf-lib upgrade 等で algorithm が変わった古い plan を新コードで実行することを防ぐ)。PR-C1 plan (`hashAlgorithm` フィールドなし) は新 execute で gate reject される。**対応**: 古い plan を捨てて `classify-collision-docs.ts` を再実行し、新しい plan を生成すること
 
 > **禁止**: `Issue #432 全件OK` / `processed/ 配下OK` 等の prefix / 包括認可は execute script 側で reject (ADR-0008 教訓)。
 

--- a/docs/runbooks/orphan-storage-cleanup.md
+++ b/docs/runbooks/orphan-storage-cleanup.md
@@ -180,7 +180,9 @@ operator が manual-review 時に対処方針を即特定できるよう、Ambig
 |---|---|---|
 | `content-mismatch` | fingerprint(actual storage) != fingerprint(regenerated) | parent から再生成した PDF と実体が描画的に異なる。operator が中身を比較し、勝者判定 → 手動 migrate or status='error' |
 | `multiple-fingerprint-matches` | 複数 doc が同 fingerprint (希少) | どの docId に紐付けるべきか operator が業務文脈で判定 |
-| `unsupported-pdf-feature` | encryption / acroform / optional-content / malformed / **annotations** (Codex Critical 反映) / **unsupported-resource-filter** (Codex Important 反映: DCTDecode/JPXDecode 等の画像 filter) | PDF 構造が自動 fingerprint 対象外。手動でファイル内容を確認し復旧可否判定。スキャン PDF (JPEG XObject 多用) は `unsupported-resource-filter` で大半が Ambiguous に倒れる可能性あり |
+| `unsupported-pdf-feature: encryption / acroform / optional-content / malformed` | PDF 構造が自動 fingerprint 対象外 (form / 暗号化 / 構造異常) | 手動でファイル内容を確認し復旧可否判定 |
+| `unsupported-pdf-feature: annotations` (Codex Critical 反映) | page に visible annotation (Stamp/FreeText/Highlight 等) があり、Contents stream に乗らない差分があり得る | 該当 doc の PDF を Acrobat or diff-pdf で actual storage と parent regenerate 結果を visual compare → 同一なら手動で `migrate-to-namespace` 相当の更新、差異あれば `mark-error` |
+| `unsupported-pdf-feature: unsupported-resource-filter` (Codex Important 反映) | resource (画像 XObject 等) が DCTDecode/JPXDecode/Crypt 等 pdf-lib 未対応 filter | 自動 fingerprint で同一性証明できない。スキャン PDF (JPEG XObject 多用) で多発の可能性。byte 比較 + visual diff で判定、または `mark-error` で確定 |
 | `hash-unavailable-transient` | download 一時エラー (503/403) | 数分後に再 classify、解消すれば再分類 |
 | `hash-unavailable-no-parent` | parent doc / 親 PDF / splitFromPages のいずれかが不在 | LostOrUnrecoverable 寄り。parent doc 復元できれば再分類 |
 
@@ -266,7 +268,7 @@ Step 2 で出力された plan JSON 内容と各 operation の sourcePath/destPa
 }
 ```
 
-**6 重 gate (Codex セカンドオピニオン反映 + PR-C2 fingerprint version gate)**:
+**多重 gate (現在 7 種、Codex セカンドオピニオン反映 + PR-C2 で AC13 algorithm/version 追加)**:
 
 1. `approval.planId === plan.planId` (古い plan の流用防止)
 2. `operation.operationId ∈ approvedOperationIds` (operation 単位の認可)
@@ -342,7 +344,7 @@ FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
 - `scripts/audit-storage-mismatch.js` (検出 script)
 - `scripts/inspect-document.js` (調査 script, read-only)
 - `scripts/classify-collision-docs.ts` (PR-C: 5 分類 plan 出力)
-- `scripts/execute-collision-migration.ts` (PR-C: 4 重 gate + idempotent migration)
+- `scripts/execute-collision-migration.ts` (PR-C: 多重 gate + idempotent migration、PR-C2 で AC13 algorithm/version gate 追加)
 - `scripts/setup-collision-fixture.ts` (PR-C: dev 環境 fixture)
 - `scripts/lib/collisionClassifier.ts` (PR-C: 5 分類 pure function)
 - `scripts/lib/pdfRegenerator.ts` (PR-C: parent から PDF 再生成)

--- a/docs/runbooks/orphan-storage-cleanup.md
+++ b/docs/runbooks/orphan-storage-cleanup.md
@@ -180,7 +180,7 @@ operator が manual-review 時に対処方針を即特定できるよう、Ambig
 |---|---|---|
 | `content-mismatch` | fingerprint(actual storage) != fingerprint(regenerated) | parent から再生成した PDF と実体が描画的に異なる。operator が中身を比較し、勝者判定 → 手動 migrate or status='error' |
 | `multiple-fingerprint-matches` | 複数 doc が同 fingerprint (希少) | どの docId に紐付けるべきか operator が業務文脈で判定 |
-| `unsupported-pdf-feature` | encryption / acroform / optional-content / malformed | PDF 構造が自動 fingerprint 対象外。手動でファイル内容を確認し復旧可否判定 |
+| `unsupported-pdf-feature` | encryption / acroform / optional-content / malformed / **annotations** (Codex Critical 反映) / **unsupported-resource-filter** (Codex Important 反映: DCTDecode/JPXDecode 等の画像 filter) | PDF 構造が自動 fingerprint 対象外。手動でファイル内容を確認し復旧可否判定。スキャン PDF (JPEG XObject 多用) は `unsupported-resource-filter` で大半が Ambiguous に倒れる可能性あり |
 | `hash-unavailable-transient` | download 一時エラー (503/403) | 数分後に再 classify、解消すれば再分類 |
 | `hash-unavailable-no-parent` | parent doc / 親 PDF / splitFromPages のいずれかが不在 | LostOrUnrecoverable 寄り。parent doc 復元できれば再分類 |
 
@@ -274,6 +274,7 @@ Step 2 で出力された plan JSON 内容と各 operation の sourcePath/destPa
 4. runtime env (`FIREBASE_PROJECT_ID + STORAGE_BUCKET`) が plan の `projectId / bucket` と一致 (環境取り違え防止)
 5. precondition snapshot (`expectedCurrentFileUrl + expectedStatus + expectedUpdatedAt`) が現状 doc と一致 (進行中 splitPdf invocation との race 検出 → skip)
 6. **`plan.hashAlgorithm === HASH_ALGORITHM` (PR-C2 追加 AC13)**: plan 作成時の fingerprint algorithm version と execute 側コード固定値が一致 (pdf-lib upgrade 等で algorithm が変わった古い plan を新コードで実行することを防ぐ)。PR-C1 plan (`hashAlgorithm` フィールドなし) は新 execute で gate reject される。**対応**: 古い plan を捨てて `classify-collision-docs.ts` を再実行し、新しい plan を生成すること
+7. **`plan.pdfLibVersion === expectedPdfLibVersion` (PR-C2 Codex Important 反映 AC13 拡張)**: plan 作成時の pdf-lib npm version と execute 側 runtime の pdf-lib version が一致。algorithm 名は同じでも pdf-lib internal API 挙動 (decodePDFRawStream/PDFPageLeaf 等) が変わるとfingerprint 計算結果が変わるため、依存更新ごとに再 classify を要求する
 
 > **禁止**: `Issue #432 全件OK` / `processed/ 配下OK` 等の prefix / 包括認可は execute script 側で reject (ADR-0008 教訓)。
 

--- a/functions/test/collisionClassifier.test.ts
+++ b/functions/test/collisionClassifier.test.ts
@@ -48,7 +48,7 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
         evidences: [
           {
             doc: makeDoc({ id: 'winner' }),
-            hashEvidence: { type: 'matched', sha256: 'abc' },
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
         ],
@@ -67,15 +67,16 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
         evidences: [
           {
             doc: makeDoc({ id: 'winner' }),
-            hashEvidence: { type: 'matched', sha256: 'abc' },
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
           {
             doc: makeDoc({ id: 'loser', parentDocumentId: 'parent-2' }),
             hashEvidence: {
               type: 'mismatched',
-              actualSha256: 'abc',
-              expectedSha256: 'xyz',
+              algorithm: 'pdf-page-visual-v1',
+              actualFingerprint: 'abc',
+              expectedFingerprint: 'xyz',
             },
             parent: PARENT_OK,
           },
@@ -96,7 +97,7 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
         evidences: [
           {
             doc: makeDoc({ id: 'winner' }),
-            hashEvidence: { type: 'matched', sha256: 'abc' },
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
           {
@@ -121,12 +122,12 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
         evidences: [
           {
             doc: makeDoc({ id: 'docA' }),
-            hashEvidence: { type: 'matched', sha256: 'abc' },
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
           {
             doc: makeDoc({ id: 'docB' }),
-            hashEvidence: { type: 'matched', sha256: 'abc' },
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
         ],
@@ -219,8 +220,9 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
             doc: makeDoc({ id: 'docA' }),
             hashEvidence: {
               type: 'mismatched',
-              actualSha256: 'aaa',
-              expectedSha256: 'xxx',
+              algorithm: 'pdf-page-visual-v1',
+              actualFingerprint: 'aaa',
+              expectedFingerprint: 'xxx',
             },
             parent: PARENT_OK,
           },
@@ -228,8 +230,9 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
             doc: makeDoc({ id: 'docB' }),
             hashEvidence: {
               type: 'mismatched',
-              actualSha256: 'aaa',
-              expectedSha256: 'yyy',
+              algorithm: 'pdf-page-visual-v1',
+              actualFingerprint: 'aaa',
+              expectedFingerprint: 'yyy',
             },
             parent: PARENT_OK,
           },
@@ -238,7 +241,8 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
       const results = classifyCollisionGroup(group);
       results.forEach((r) => {
         expect(r.classification).to.equal('Ambiguous');
-        expect(r.reason).to.contain('hash mismatch');
+        // PR-C2: reason は細分化されて 'content-mismatch:' prefix を持つ
+        expect(r.reason).to.contain('content-mismatch');
       });
     });
   });
@@ -308,15 +312,16 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
         evidences: [
           {
             doc: makeDoc({ id: 'matched' }),
-            hashEvidence: { type: 'matched', sha256: 'abc' },
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
           {
             doc: makeDoc({ id: 'repairable', parentDocumentId: 'parent-3' }),
             hashEvidence: {
               type: 'mismatched',
-              actualSha256: 'abc',
-              expectedSha256: 'def',
+              algorithm: 'pdf-page-visual-v1',
+              actualFingerprint: 'abc',
+              expectedFingerprint: 'def',
             },
             parent: PARENT_OK,
           },
@@ -351,7 +356,7 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
         evidences: [
           {
             doc: makeDoc({ id: 'a' }),
-            hashEvidence: { type: 'matched', sha256: 'h' },
+            hashEvidence: { type: 'matched', fingerprint: 'h', algorithm: 'pdf-page-visual-v1' },
             parent: PARENT_OK,
           },
           {
@@ -364,6 +369,157 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
       const results = classifyCollisionGroup(group);
       results.forEach((r) => {
         expect(allowedActions.has(r.recommendedAction), r.recommendedAction).to.be.true;
+      });
+    });
+  });
+
+  describe('PR-C2: unsupported PDF feature (encryption/acroform/optional-content/malformed)', () => {
+    it('orphan + hashEvidence.type=unsupported (encryption) → Ambiguous + manual-review', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'enc-doc' }),
+        hashEvidence: {
+          type: 'unsupported',
+          reason: 'encryption',
+          detail: '/Encrypt entry present in trailer',
+          algorithm: 'pdf-page-visual-v1',
+        },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('Ambiguous');
+      expect(result.recommendedAction).to.equal('manual-review');
+      expect(result.reason).to.contain('unsupported-pdf-feature');
+      expect(result.reason).to.contain('encryption');
+    });
+
+    it('orphan + hashEvidence.type=unsupported (acroform) → Ambiguous (parent 在でも Repairable に降格しない)', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'form-doc' }),
+        hashEvidence: {
+          type: 'unsupported',
+          reason: 'acroform',
+          detail: '/AcroForm present in catalog',
+          algorithm: 'pdf-page-visual-v1',
+        },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('Ambiguous');
+      expect(result.recommendedAction).to.equal('manual-review');
+      expect(result.reason).to.contain('acroform');
+    });
+
+    it('orphan + hashEvidence.type=unsupported (optional-content) → Ambiguous', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'oc-doc' }),
+        hashEvidence: {
+          type: 'unsupported',
+          reason: 'optional-content',
+          detail: '/OCProperties present',
+          algorithm: 'pdf-page-visual-v1',
+        },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('Ambiguous');
+      expect(result.reason).to.contain('optional-content');
+    });
+
+    it('collision group loser + hashEvidence.type=unsupported (malformed) → Ambiguous (Repairable 経路から降格)', () => {
+      const group: CollisionGroup = {
+        fileName: 'unsupported-loser.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'winner' }),
+            hashEvidence: { type: 'matched', fingerprint: 'abc', algorithm: 'pdf-page-visual-v1' },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'loser' }),
+            hashEvidence: {
+              type: 'unsupported',
+              reason: 'malformed',
+              detail: 'page 0 content stream decode failed',
+              algorithm: 'pdf-page-visual-v1',
+            },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      const winner = results.find((r) => r.docId === 'winner')!;
+      const loser = results.find((r) => r.docId === 'loser')!;
+      expect(winner.classification).to.equal('MatchedByHash');
+      expect(loser.classification).to.equal('Ambiguous');
+      expect(loser.reason).to.contain('collision group loser');
+      expect(loser.reason).to.contain('unsupported-pdf-feature');
+      expect(loser.reason).to.contain('malformed');
+    });
+  });
+
+  describe('PR-C2 Codex Suggestion: Ambiguous reason 細分化', () => {
+    it('content-mismatch: fingerprint mismatch の reason に "content-mismatch" prefix', () => {
+      const group: CollisionGroup = {
+        fileName: 'mm.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'a' }),
+            hashEvidence: {
+              type: 'mismatched',
+              algorithm: 'pdf-page-visual-v1',
+              actualFingerprint: 'x',
+              expectedFingerprint: 'y',
+            },
+            parent: PARENT_OK,
+          },
+          {
+            doc: makeDoc({ id: 'b' }),
+            hashEvidence: {
+              type: 'mismatched',
+              algorithm: 'pdf-page-visual-v1',
+              actualFingerprint: 'x',
+              expectedFingerprint: 'z',
+            },
+            parent: PARENT_OK,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(r.reason).to.match(/^content-mismatch/);
+      });
+    });
+
+    it('hash-unavailable-transient: computation-error の reason は "hash-unavailable-transient"', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'tr' }),
+        hashEvidence: { type: 'unavailable', reason: 'computation-error' },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('Ambiguous');
+      expect(result.reason).to.contain('hash-unavailable-transient');
+    });
+
+    it('hash-unavailable-no-parent: unavailable reason="no-parent" は "hash-unavailable-no-parent"', () => {
+      const group: CollisionGroup = {
+        fileName: 'np.pdf',
+        evidences: [
+          {
+            doc: makeDoc({ id: 'doc' }),
+            hashEvidence: { type: 'unavailable', reason: 'no-parent' },
+            parent: null,
+          },
+          {
+            doc: makeDoc({ id: 'doc2' }),
+            hashEvidence: { type: 'unavailable', reason: 'no-storage-actual' },
+            parent: null,
+          },
+        ],
+      };
+      const results = classifyCollisionGroup(group);
+      results.forEach((r) => {
+        expect(r.reason).to.contain('hash-unavailable-no-parent');
       });
     });
   });

--- a/functions/test/collisionClassifier.test.ts
+++ b/functions/test/collisionClassifier.test.ts
@@ -425,6 +425,38 @@ describe('collisionClassifier (Issue #432 PR-C)', () => {
       expect(result.reason).to.contain('optional-content');
     });
 
+    it('orphan + hashEvidence.type=unsupported (annotations, Codex Critical 反映) → Ambiguous', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'anno-doc' }),
+        hashEvidence: {
+          type: 'unsupported',
+          reason: 'annotations',
+          detail: 'page 0 has 1 annotation(s)',
+          algorithm: 'pdf-page-visual-v1',
+        },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('Ambiguous');
+      expect(result.reason).to.contain('annotations');
+    });
+
+    it('orphan + hashEvidence.type=unsupported (unsupported-resource-filter, Codex Important 反映) → Ambiguous', () => {
+      const evidence: DocEvidence = {
+        doc: makeDoc({ id: 'filter-doc' }),
+        hashEvidence: {
+          type: 'unsupported',
+          reason: 'unsupported-resource-filter',
+          detail: 'page 0 resources canonical digest: UnsupportedEncodingError DCTDecode',
+          algorithm: 'pdf-page-visual-v1',
+        },
+        parent: PARENT_OK,
+      };
+      const result = classifyOrphan(evidence);
+      expect(result.classification).to.equal('Ambiguous');
+      expect(result.reason).to.contain('unsupported-resource-filter');
+    });
+
     it('collision group loser + hashEvidence.type=unsupported (malformed) → Ambiguous (Repairable 経路から降格)', () => {
       const group: CollisionGroup = {
         fileName: 'unsupported-loser.pdf',

--- a/functions/test/executeCollisionMigrationGate.test.ts
+++ b/functions/test/executeCollisionMigrationGate.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Issue #432 PR-C2: execute-collision-migration.ts の AC13 gate
+ * (hashAlgorithm + pdfLibVersion) を subprocess 経由で検証する。
+ *
+ * pr-test-analyzer (PR #441 review) Critical C2 反映:
+ *   AC13 gate は本 migration の silent-breakage 防止の最重要 gate (PR-C1 plan を新
+ *   コードで黙って実行する / pdf-lib upgrade 後に古い plan を実行する を防ぐ)。
+ *   gate ロジック自体を unit test しないと、エンジニアリング変更で gate が壊れたとき
+ *   CI が検知できない。
+ *
+ * 検証戦略:
+ *   - 一時 plan.json を作って `npx ts-node scripts/execute-collision-migration.ts ...`
+ *     を spawnSync で起動する
+ *   - `process.exit(2)` (gate reject) になるパターン:
+ *     - hashAlgorithm undefined (PR-C1 plan)
+ *     - hashAlgorithm が無効
+ *     - pdfLibVersion 不一致
+ *   - `process.exit(2)` 以外になるパターンは現状 setup なしでは到達しないので skip
+ *
+ * 注意: ts-node 起動コストが大きいので test 数を絞り timeout を 20s に設定。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { PDFDocument } from 'pdf-lib';
+
+// pdf-lib version を runtime で取得。ESM mode の test loader でも動作させるため、
+// __dirname / require / package.json import attribute すべて使わず、pdf-lib の
+// PDFDocument prototype 由来情報や、相対パス無しで cwd ベースの fs アクセスを行う。
+// (cwd は mocha 起動 dir = functions/、よって 1 階層上の node_modules を見る)
+function readPdfLibVersion(): string {
+  const candidates = [
+    'node_modules/pdf-lib/package.json',
+    '../node_modules/pdf-lib/package.json',
+  ];
+  for (const rel of candidates) {
+    try {
+      const json = JSON.parse(fs.readFileSync(rel, 'utf-8')) as {
+        version: string;
+      };
+      return json.version;
+    } catch {
+      // try next
+    }
+  }
+  throw new Error('pdf-lib/package.json not found via cwd-relative paths');
+}
+const pdfLibVersion: string = readPdfLibVersion();
+// PDFDocument を 1 度参照することで pdf-lib resolve 失敗時の early failure を担保
+void PDFDocument;
+
+// __dirname を回避 (mocha + ts-node が ESM mode で動くケース対策)。
+// cwd は mocha 起動 dir (= functions/)、よって project root は ../ 相対。
+const PROJECT_ROOT = path.resolve(process.cwd(), '..');
+const SCRIPT_PATH = path.join(
+  PROJECT_ROOT,
+  'scripts/execute-collision-migration.ts'
+);
+
+interface PlanFixture {
+  planId: string;
+  createdAt: string;
+  environment: string;
+  projectId: string;
+  bucket: string;
+  prefix: string;
+  hashAlgorithm?: string;
+  pdfLibVersion?: string;
+  summary: Record<string, unknown>;
+  operations: unknown[];
+}
+
+function makePlan(overrides: Partial<PlanFixture> = {}): PlanFixture {
+  return {
+    planId: 'plan-test-' + crypto.randomBytes(2).toString('hex'),
+    createdAt: '2026-05-12T00:00:00.000Z',
+    environment: 'test',
+    projectId: 'test-project',
+    bucket: 'test-bucket',
+    prefix: 'processed/',
+    hashAlgorithm: 'pdf-page-visual-v1',
+    pdfLibVersion,
+    summary: {},
+    operations: [],
+    ...overrides,
+  };
+}
+
+function makeApproval(planId: string): Record<string, unknown> {
+  return {
+    planId,
+    approvedOperationIds: [],
+    approvedPaths: [],
+  };
+}
+
+function writeTmpJson(obj: unknown, label: string): string {
+  const p = path.join(
+    os.tmpdir(),
+    `gate-${label}-${crypto.randomBytes(4).toString('hex')}.json`
+  );
+  fs.writeFileSync(p, JSON.stringify(obj));
+  return p;
+}
+
+interface GateResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * execute-collision-migration.ts を ts-node 経由で spawnSync 実行し、
+ * gate の reject (exit 2) または通過 (それ以外) を判定する。
+ */
+function runExecuteScript(
+  plan: PlanFixture,
+  envOverride: { projectId?: string; bucket?: string } = {}
+): GateResult {
+  const planPath = writeTmpJson(plan, 'plan');
+  const approvalPath = writeTmpJson(makeApproval(plan.planId), 'approval');
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--require',
+        'ts-node/register',
+        SCRIPT_PATH,
+        '--plan',
+        planPath,
+        '--approval',
+        approvalPath,
+      ],
+      {
+        encoding: 'utf-8',
+        timeout: 30000,
+        cwd: PROJECT_ROOT,
+        env: {
+          ...process.env,
+          // 既定では plan と一致させ、特定 gate を検証するときだけ envOverride で
+          // 意図的に不一致を作る
+          FIREBASE_PROJECT_ID: envOverride.projectId ?? plan.projectId,
+          STORAGE_BUCKET: envOverride.bucket ?? plan.bucket,
+          // 子 ts-node に scripts/tsconfig.json を使わせる
+          // (resolveJsonModule: true が必要 for pdf-lib/package.json import)
+          TS_NODE_PROJECT: path.join(PROJECT_ROOT, 'scripts/tsconfig.json'),
+        },
+      }
+    );
+    return {
+      status: result.status,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    };
+  } finally {
+    for (const p of [planPath, approvalPath]) {
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+describe('execute-collision-migration AC13 gate (Issue #432 PR-C2, pr-test-analyzer C2 反映)', function () {
+  this.timeout(60000);
+
+  it('Critical: plan.hashAlgorithm が undefined (PR-C1 旧 plan) → exit 2', () => {
+    const plan = makePlan({ hashAlgorithm: undefined });
+    const result = runExecuteScript(plan);
+    expect(result.status).to.equal(2);
+    expect(result.stderr).to.match(/plan\.hashAlgorithm.*missing|hashAlgorithm/);
+  });
+
+  it('Critical: plan.hashAlgorithm が現行 HASH_ALGORITHM と不一致 → exit 2', () => {
+    const plan = makePlan({ hashAlgorithm: 'pdf-page-visual-v0-FAKE' });
+    const result = runExecuteScript(plan);
+    expect(result.status).to.equal(2);
+    expect(result.stderr).to.contain('hashAlgorithm');
+  });
+
+  it('Critical: plan.pdfLibVersion が undefined → exit 2', () => {
+    const plan = makePlan({ pdfLibVersion: undefined });
+    const result = runExecuteScript(plan);
+    expect(result.status).to.equal(2);
+    expect(result.stderr).to.contain('pdfLibVersion');
+  });
+
+  it('Critical: plan.pdfLibVersion が runtime version と不一致 → exit 2', () => {
+    const plan = makePlan({ pdfLibVersion: '0.0.0-FAKE' });
+    const result = runExecuteScript(plan);
+    expect(result.status).to.equal(2);
+    expect(result.stderr).to.contain('pdfLibVersion');
+  });
+
+  it('Important: plan.projectId が runtime FIREBASE_PROJECT_ID と不一致 → exit 2 (Gate 4)', () => {
+    const plan = makePlan(); // plan.projectId = 'test-project'
+    // env を意図的に別 project に設定 (本番取り違え再現)
+    const result = runExecuteScript(plan, { projectId: 'wrong-runtime-project' });
+    expect(result.status).to.equal(2);
+    expect(result.stderr).to.contain('plan.projectId');
+  });
+});

--- a/functions/test/pdfPageVisualFingerprint.test.ts
+++ b/functions/test/pdfPageVisualFingerprint.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Issue #432 PR-C2: pdfPageVisualFingerprint cross-process deterministic test.
+ *
+ * PR-C1 では `regenerateChildPdf` の deterministic 性を「同一プロセス内 2 回呼出し」
+ * のみで検証し、pdf-lib の `PDFDocument.save()` がプロセス間で異なる bytes を出力する
+ * 性質を見落として MatchedByHash 分類が dev fixture で 0 件になった (session59 で発覚)。
+ *
+ * 本テストでは:
+ *   1. cross-process deterministic: 別 Node プロセスで生成した PDF と同一プロセスで
+ *      生成した PDF が visual fingerprint で一致することを検証する (主目的)
+ *   2. 偽陽性防止 (AC9-12): XObject 差分 / font 差分 / Rotate 差分 / CropBox 差分
+ *      で fingerprint が変化することを検証
+ *   3. unsupported features: 暗号化 PDF (loadOptions) / AcroForm 入り PDF で
+ *      kind='unsupported' が返ること
+ *   4. internal API lock (AC14): pdf-lib の internal exports が想定の形で存在
+ *      していること (decodePDFRawStream / PDFRawStream 等)
+ *
+ * 失敗時の意味:
+ *   - cross-process determinism 失敗 → PR-C2 修正方針が根本から成立せず、本番展開不可
+ *   - 偽陽性防止失敗 → MatchedByHash で異なる描画を「同一」と誤認する重大バグ
+ *   - lock test 失敗 → pdf-lib upgrade で内部 API 仕様変化、再 review 必要
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import {
+  PDFArray,
+  PDFDict,
+  PDFDocument,
+  PDFObject,
+  PDFRawStream,
+  PDFRef,
+  decodePDFRawStream,
+  degrees,
+} from 'pdf-lib';
+import {
+  HASH_ALGORITHM,
+  computePdfPageVisualFingerprint,
+  canonicalDigest,
+} from '../../scripts/lib/pdfPageVisualFingerprint';
+import { regenerateChildPdf } from '../../scripts/lib/pdfRegenerator';
+
+const FINGERPRINT_MODULE = path.resolve(
+  __dirname,
+  '../../scripts/lib/pdfPageVisualFingerprint'
+);
+const REGENERATOR_MODULE = path.resolve(
+  __dirname,
+  '../../scripts/lib/pdfRegenerator'
+);
+
+interface FingerprintOk {
+  kind: 'ok';
+  hex: string;
+}
+
+interface FingerprintUnsupported {
+  kind: 'unsupported';
+  reason: string;
+  detail: string;
+}
+
+/**
+ * 別 Node プロセスを spawn して fingerprint を計算する。
+ * 親プロセスの内部状態 (random seed / module state) を完全に切り離すため、
+ * 必ず deterministic な結果を要求できる。
+ */
+function fingerprintInChildProcess(
+  parentPdfPath: string,
+  startPage: number,
+  endPage: number
+): FingerprintOk | FingerprintUnsupported {
+  const script = `
+    const { regenerateChildPdf } = require(${JSON.stringify(REGENERATOR_MODULE)});
+    const { computePdfPageVisualFingerprint } = require(${JSON.stringify(
+      FINGERPRINT_MODULE
+    )});
+    const fs = require('fs');
+    (async () => {
+      const buf = fs.readFileSync(${JSON.stringify(parentPdfPath)});
+      const child = await regenerateChildPdf(buf, ${startPage}, ${endPage});
+      const fp = await computePdfPageVisualFingerprint(child);
+      process.stdout.write(JSON.stringify(fp));
+    })().catch((err) => {
+      process.stderr.write(err.stack || err.message);
+      process.exit(1);
+    });
+  `;
+  const scriptPath = path.join(
+    os.tmpdir(),
+    `fp-child-${crypto.randomBytes(4).toString('hex')}.js`
+  );
+  fs.writeFileSync(scriptPath, script);
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--require', 'ts-node/register', scriptPath],
+      {
+        encoding: 'utf-8',
+        timeout: 30000,
+        // 親 (mocha) は functions/ で実行されるが、子の require 解決を doc-split root に
+        // 寄せて scripts/* と pdf-lib どちらにも到達できるようにする
+        cwd: path.resolve(__dirname, '../../'),
+      }
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `child process exit=${result.status}: stderr=${result.stderr}`
+      );
+    }
+    const out = JSON.parse(result.stdout) as
+      | FingerprintOk
+      | FingerprintUnsupported;
+    return out;
+  } finally {
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function makeNPagePdf(n: number, seed = 0): Promise<Buffer> {
+  const pdf = await PDFDocument.create();
+  for (let i = 0; i < n; i++) {
+    const page = pdf.addPage([200, 200]);
+    page.drawRectangle({
+      x: 10 + i * 3 + seed,
+      y: 10 + i * 3 + seed,
+      width: 30,
+      height: 30,
+    });
+  }
+  return Buffer.from(await pdf.save());
+}
+
+function writeTmpPdf(buf: Buffer): string {
+  const p = path.join(
+    os.tmpdir(),
+    `fp-parent-${crypto.randomBytes(4).toString('hex')}.pdf`
+  );
+  fs.writeFileSync(p, buf);
+  return p;
+}
+
+describe('pdfPageVisualFingerprint (Issue #432 PR-C2)', () => {
+  describe('★ cross-process deterministic (PR-C1 設計欠陥の根本対策)', () => {
+    let parentPath: string;
+    before(async () => {
+      const parent = await makeNPagePdf(5, 0);
+      parentPath = writeTmpPdf(parent);
+    });
+    after(() => {
+      try {
+        fs.unlinkSync(parentPath);
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('別プロセスで生成 → 同プロセスで生成、両者の fingerprint が一致', async () => {
+      const parent = fs.readFileSync(parentPath);
+      const inProcChild = await regenerateChildPdf(parent, 2, 3);
+      const inProcFp = await computePdfPageVisualFingerprint(inProcChild);
+      const crossFp = fingerprintInChildProcess(parentPath, 2, 3);
+
+      expect(inProcFp.kind).to.equal('ok');
+      expect(crossFp.kind).to.equal('ok');
+      if (inProcFp.kind === 'ok' && crossFp.kind === 'ok') {
+        expect(crossFp.hex).to.equal(inProcFp.hex);
+      }
+    });
+
+    it('同 parent + 同 range で 2 つの別プロセス同士の fingerprint も一致', () => {
+      const a = fingerprintInChildProcess(parentPath, 1, 2);
+      const b = fingerprintInChildProcess(parentPath, 1, 2);
+      expect(a.kind).to.equal('ok');
+      expect(b.kind).to.equal('ok');
+      if (a.kind === 'ok' && b.kind === 'ok') expect(a.hex).to.equal(b.hex);
+    });
+
+    it('異なる page range なら fingerprint も異なる (cross-process)', () => {
+      const a = fingerprintInChildProcess(parentPath, 1, 1);
+      const b = fingerprintInChildProcess(parentPath, 2, 2);
+      expect(a.kind).to.equal('ok');
+      expect(b.kind).to.equal('ok');
+      if (a.kind === 'ok' && b.kind === 'ok') expect(a.hex).to.not.equal(b.hex);
+    });
+  });
+
+  describe('正常系: 同一描画の同プロセス deterministic', () => {
+    it('同入力で 2 回計算 → 同じ hex', async () => {
+      const pdf = await makeNPagePdf(3);
+      const fp1 = await computePdfPageVisualFingerprint(pdf);
+      const fp2 = await computePdfPageVisualFingerprint(pdf);
+      expect(fp1.kind).to.equal('ok');
+      expect(fp2.kind).to.equal('ok');
+      if (fp1.kind === 'ok' && fp2.kind === 'ok') {
+        expect(fp1.hex).to.equal(fp2.hex);
+        expect(fp1.pageCount).to.equal(3);
+      }
+    });
+
+    it('algorithm version が "pdf-page-visual-v1" を返す', async () => {
+      const pdf = await makeNPagePdf(1);
+      const fp = await computePdfPageVisualFingerprint(pdf);
+      expect(fp.algorithm).to.equal(HASH_ALGORITHM);
+      expect(HASH_ALGORITHM).to.equal('pdf-page-visual-v1');
+    });
+  });
+
+  describe('AC9-12: 偽陽性防止 (描画差異が fingerprint に反映される)', () => {
+    it('AC9: 描画内容が異なる (rectangle 位置差) → fingerprint が異なる', async () => {
+      const a = await makeNPagePdf(2, 0);
+      const b = await makeNPagePdf(2, 7); // seed 差で content stream の数値リテラル変化
+      const fpA = await computePdfPageVisualFingerprint(a);
+      const fpB = await computePdfPageVisualFingerprint(b);
+      expect(fpA.kind).to.equal('ok');
+      expect(fpB.kind).to.equal('ok');
+      if (fpA.kind === 'ok' && fpB.kind === 'ok') {
+        expect(fpA.hex).to.not.equal(fpB.hex);
+      }
+    });
+
+    it('AC10: Rotate 差分 → fingerprint が異なる', async () => {
+      const base = await PDFDocument.create();
+      const p1 = base.addPage([200, 200]);
+      p1.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      const aBuf = Buffer.from(await base.save());
+
+      const rotated = await PDFDocument.create();
+      const p2 = rotated.addPage([200, 200]);
+      p2.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      p2.setRotation(degrees(90));
+      const bBuf = Buffer.from(await rotated.save());
+
+      const fpA = await computePdfPageVisualFingerprint(aBuf);
+      const fpB = await computePdfPageVisualFingerprint(bBuf);
+      expect(fpA.kind).to.equal('ok');
+      expect(fpB.kind).to.equal('ok');
+      if (fpA.kind === 'ok' && fpB.kind === 'ok') {
+        expect(fpA.hex).to.not.equal(fpB.hex);
+      }
+    });
+
+    it('AC11: MediaBox/CropBox 差分 → fingerprint が異なる', async () => {
+      const smaller = await PDFDocument.create();
+      const sp = smaller.addPage([100, 100]);
+      sp.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      const smallBuf = Buffer.from(await smaller.save());
+
+      const bigger = await PDFDocument.create();
+      const bp = bigger.addPage([200, 200]);
+      bp.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      const bigBuf = Buffer.from(await bigger.save());
+
+      const fpA = await computePdfPageVisualFingerprint(smallBuf);
+      const fpB = await computePdfPageVisualFingerprint(bigBuf);
+      expect(fpA.kind).to.equal('ok');
+      expect(fpB.kind).to.equal('ok');
+      if (fpA.kind === 'ok' && fpB.kind === 'ok') {
+        expect(fpA.hex).to.not.equal(fpB.hex);
+      }
+    });
+
+    it('AC12: ページ数差分 → fingerprint が異なる', async () => {
+      const onePage = await makeNPagePdf(1);
+      const twoPage = await makeNPagePdf(2);
+      const fp1 = await computePdfPageVisualFingerprint(onePage);
+      const fp2 = await computePdfPageVisualFingerprint(twoPage);
+      expect(fp1.kind).to.equal('ok');
+      expect(fp2.kind).to.equal('ok');
+      if (fp1.kind === 'ok' && fp2.kind === 'ok') {
+        expect(fp1.hex).to.not.equal(fp2.hex);
+        expect(fp1.pageCount).to.equal(1);
+        expect(fp2.pageCount).to.equal(2);
+      }
+    });
+
+    it('AC9 拡張: Resources (font 入替) → fingerprint が異なる', async () => {
+      // helvetica + 文字列描画
+      const a = await PDFDocument.create();
+      const pa = a.addPage([300, 200]);
+      const fontA = await a.embedFont('Helvetica');
+      pa.drawText('hello', { x: 50, y: 100, size: 20, font: fontA });
+      const aBuf = Buffer.from(await a.save());
+
+      // times + 文字列描画 (font が異なる resources subtree を生む)
+      const b = await PDFDocument.create();
+      const pb = b.addPage([300, 200]);
+      const fontB = await b.embedFont('Times-Roman');
+      pb.drawText('hello', { x: 50, y: 100, size: 20, font: fontB });
+      const bBuf = Buffer.from(await b.save());
+
+      const fpA = await computePdfPageVisualFingerprint(aBuf);
+      const fpB = await computePdfPageVisualFingerprint(bBuf);
+      expect(fpA.kind).to.equal('ok');
+      expect(fpB.kind).to.equal('ok');
+      if (fpA.kind === 'ok' && fpB.kind === 'ok') {
+        expect(fpA.hex).to.not.equal(fpB.hex);
+      }
+    });
+  });
+
+  describe('AC + Codex Suggestion: unsupported features は kind=unsupported を返す', () => {
+    it('malformed PDF (空 buffer) → kind=unsupported, reason=malformed', async () => {
+      const fp = await computePdfPageVisualFingerprint(Buffer.from([]));
+      expect(fp.kind).to.equal('unsupported');
+      if (fp.kind === 'unsupported') {
+        expect(fp.reason).to.equal('malformed');
+      }
+    });
+
+    it('AcroForm 入り PDF → kind=unsupported, reason=acroform', async () => {
+      const pdf = await PDFDocument.create();
+      const page = pdf.addPage([300, 200]);
+      page.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      const form = pdf.getForm();
+      form.createTextField('input1');
+      const buf = Buffer.from(await pdf.save());
+
+      const fp = await computePdfPageVisualFingerprint(buf);
+      expect(fp.kind).to.equal('unsupported');
+      if (fp.kind === 'unsupported') {
+        expect(fp.reason).to.equal('acroform');
+      }
+    });
+  });
+
+  describe('AC14: pdf-lib internal API lock', () => {
+    it('decodePDFRawStream は named export かつ function', () => {
+      expect(typeof decodePDFRawStream).to.equal('function');
+    });
+
+    it('PDFRawStream は named export かつ parser 経由で実体化される', async () => {
+      // parser 経由で読み込んだ PDF の content stream が PDFRawStream であることを確認
+      // (PDFArray 要素は通常 PDFRef なので context.lookup() で resolve してから判定)
+      const pdf = await makeNPagePdf(1);
+      const reloaded = await PDFDocument.load(pdf);
+      const contents = reloaded.getPage(0).node.Contents();
+      let rawStreamCount = 0;
+      const resolveAndCount = (obj: PDFObject): void => {
+        const resolved =
+          obj instanceof PDFRef ? reloaded.context.lookup(obj) : obj;
+        if (resolved instanceof PDFRawStream) rawStreamCount += 1;
+      };
+      if (contents instanceof PDFArray) {
+        for (let i = 0; i < contents.size(); i++) resolveAndCount(contents.get(i));
+      } else if (contents !== undefined) {
+        resolveAndCount(contents);
+      }
+      expect(rawStreamCount).to.be.greaterThan(0);
+    });
+
+    it('PDFPageLeaf.Contents/Resources/MediaBox/CropBox/Rotate methods が存在', async () => {
+      const pdf = await makeNPagePdf(1);
+      const reloaded = await PDFDocument.load(pdf);
+      const node = reloaded.getPage(0).node;
+      expect(typeof node.Contents).to.equal('function');
+      expect(typeof node.Resources).to.equal('function');
+      expect(typeof node.MediaBox).to.equal('function');
+      expect(typeof node.CropBox).to.equal('function');
+      expect(typeof node.Rotate).to.equal('function');
+    });
+
+    it('PDFDict.entries() は [PDFName, PDFObject] tuples を返す', async () => {
+      const pdf = await makeNPagePdf(1);
+      const reloaded = await PDFDocument.load(pdf);
+      const dict = reloaded.getPage(0).node;
+      const entries = dict.entries();
+      expect(entries).to.be.an('array');
+      expect(entries.length).to.be.greaterThan(0);
+    });
+
+    it('canonicalDigest は PDFDict に対して deterministic な Buffer を返す', async () => {
+      const pdf = await makeNPagePdf(1);
+      const reloaded = await PDFDocument.load(pdf);
+      const dict = reloaded.getPage(0).node;
+      const d1 = canonicalDigest(dict as PDFDict, reloaded.context);
+      const d2 = canonicalDigest(dict as PDFDict, reloaded.context);
+      expect(d1).to.be.instanceOf(Buffer);
+      expect(d1.equals(d2)).to.equal(true);
+    });
+  });
+});

--- a/functions/test/pdfPageVisualFingerprint.test.ts
+++ b/functions/test/pdfPageVisualFingerprint.test.ts
@@ -110,6 +110,18 @@ function fingerprintInChildProcess(
         cwd: path.resolve(__dirname, '../../'),
       }
     );
+    // Critical (silent-failure-hunter PR #441 review): spawn 失敗 / signal kill /
+    // exit !== 0 を区別して握りつぶさない (debug 性 + test の偽 PASS 防止)
+    if (result.error) {
+      throw new Error(
+        `child process spawn failed: ${result.error.message} (signal=${result.signal ?? '<none>'})`
+      );
+    }
+    if (result.signal) {
+      throw new Error(
+        `child process killed by signal=${result.signal} stderr=${result.stderr}`
+      );
+    }
     if (result.status !== 0) {
       throw new Error(
         `child process exit=${result.status}: stderr=${result.stderr}`
@@ -477,6 +489,59 @@ describe('pdfPageVisualFingerprint (Issue #432 PR-C2)', () => {
       expect(fp2.kind).to.equal('ok');
       if (fp1.kind === 'ok' && fp2.kind === 'ok') {
         expect(fp1.hex).to.not.equal(fp2.hex);
+      }
+    });
+  });
+
+  describe('5 並列 review 反映 (PR #441 post-review v1.2)', () => {
+    it('Critical (code-reviewer): cross-locale 子プロセス間で同 PDF → 同 fingerprint hex (byte-order sort 担保)', async () => {
+      const parent = await makeNPagePdf(3, 0);
+      const parentPath = writeTmpPdf(parent);
+      try {
+        // 2 つの子プロセスを異なる LANG/LC_ALL で起動。byte-order sort 化により
+        // どちらの locale でも同じ canonical digest を返すことを担保。
+        const fpInLocale = (lang: string): FingerprintOk | FingerprintUnsupported => {
+          const script = `
+            const { regenerateChildPdf } = require(${JSON.stringify(REGENERATOR_MODULE)});
+            const { computePdfPageVisualFingerprint } = require(${JSON.stringify(FINGERPRINT_MODULE)});
+            const fs = require('fs');
+            (async () => {
+              const buf = fs.readFileSync(${JSON.stringify(parentPath)});
+              const child = await regenerateChildPdf(buf, 1, 2);
+              const fp = await computePdfPageVisualFingerprint(child);
+              process.stdout.write(JSON.stringify(fp));
+            })().catch((err) => { process.stderr.write(err.stack || err.message); process.exit(1); });
+          `;
+          const sp = path.join(os.tmpdir(), `loc-${crypto.randomBytes(4).toString('hex')}.js`);
+          fs.writeFileSync(sp, script);
+          try {
+            const result = spawnSync(
+              process.execPath,
+              ['--require', 'ts-node/register', sp],
+              {
+                encoding: 'utf-8',
+                timeout: 30000,
+                cwd: path.resolve(__dirname, '../../'),
+                env: { ...process.env, LANG: lang, LC_ALL: lang },
+              }
+            );
+            if (result.status !== 0) {
+              throw new Error(`child exit=${result.status} stderr=${result.stderr}`);
+            }
+            return JSON.parse(result.stdout);
+          } finally {
+            try { fs.unlinkSync(sp); } catch { /* ignore */ }
+          }
+        };
+        const fpC = fpInLocale('C.UTF-8');
+        const fpJa = fpInLocale('ja_JP.UTF-8');
+        expect(fpC.kind).to.equal('ok');
+        expect(fpJa.kind).to.equal('ok');
+        if (fpC.kind === 'ok' && fpJa.kind === 'ok') {
+          expect(fpJa.hex).to.equal(fpC.hex);
+        }
+      } finally {
+        try { fs.unlinkSync(parentPath); } catch { /* ignore */ }
       }
     });
   });

--- a/functions/test/pdfPageVisualFingerprint.test.ts
+++ b/functions/test/pdfPageVisualFingerprint.test.ts
@@ -31,9 +31,12 @@ import {
   PDFArray,
   PDFDict,
   PDFDocument,
+  PDFName,
+  PDFNumber,
   PDFObject,
   PDFRawStream,
   PDFRef,
+  PDFString,
   decodePDFRawStream,
   degrees,
 } from 'pdf-lib';
@@ -385,6 +388,96 @@ describe('pdfPageVisualFingerprint (Issue #432 PR-C2)', () => {
       const d2 = canonicalDigest(dict as PDFDict, reloaded.context);
       expect(d1).to.be.instanceOf(Buffer);
       expect(d1.equals(d2)).to.equal(true);
+    });
+  });
+
+  describe('Codex review (PR #441 post-review) 反映 v1.1', () => {
+    it('Critical: visible annotation 入り page → unsupported.annotations', async () => {
+      const pdf = await PDFDocument.create();
+      const page = pdf.addPage([200, 200]);
+      page.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+
+      // 手動で Text annotation を 1 件追加 (form field ではないので AcroForm 経路を踏まない)
+      const annotDict = pdf.context.obj({
+        Type: 'Annot',
+        Subtype: 'Text',
+        Rect: [50, 50, 100, 100],
+        Contents: PDFString.of('codex review annotation test'),
+      });
+      const annotRef = pdf.context.register(annotDict);
+      page.node.addAnnot(annotRef);
+
+      const buf = Buffer.from(await pdf.save());
+      const fp = await computePdfPageVisualFingerprint(buf);
+      expect(fp.kind).to.equal('unsupported');
+      if (fp.kind === 'unsupported') {
+        expect(fp.reason).to.equal('annotations');
+      }
+    });
+
+    it('Suggestion: CropBox absent == CropBox 明示 (MediaBox 同値) → 同 fingerprint', async () => {
+      // pdf1: CropBox なし (PDF spec で MediaBox にフォールバック)
+      const pdf1 = await PDFDocument.create();
+      const p1 = pdf1.addPage([200, 200]);
+      p1.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      const buf1 = Buffer.from(await pdf1.save());
+
+      // pdf2: CropBox を MediaBox と同じ値で明示
+      const pdf2 = await PDFDocument.create();
+      const p2 = pdf2.addPage([200, 200]);
+      p2.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+      const cropArr = pdf2.context.obj([0, 0, 200, 200]);
+      p2.node.set(PDFName.of('CropBox'), cropArr);
+      const buf2 = Buffer.from(await pdf2.save());
+
+      const fp1 = await computePdfPageVisualFingerprint(buf1);
+      const fp2 = await computePdfPageVisualFingerprint(buf2);
+      expect(fp1.kind).to.equal('ok');
+      expect(fp2.kind).to.equal('ok');
+      if (fp1.kind === 'ok' && fp2.kind === 'ok') {
+        // 表示同一性は等価 → effective fallback で同 fingerprint
+        expect(fp1.hex).to.equal(fp2.hex);
+      }
+    });
+
+    it('Important: UserUnit 差分 → fingerprint が異なる', async () => {
+      const build = async (unit: number) => {
+        const pdf = await PDFDocument.create();
+        const p = pdf.addPage([200, 200]);
+        p.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+        p.node.set(PDFName.of('UserUnit'), PDFNumber.of(unit));
+        return Buffer.from(await pdf.save());
+      };
+      const fp1 = await computePdfPageVisualFingerprint(await build(1));
+      const fp2 = await computePdfPageVisualFingerprint(await build(2));
+      expect(fp1.kind).to.equal('ok');
+      expect(fp2.kind).to.equal('ok');
+      if (fp1.kind === 'ok' && fp2.kind === 'ok') {
+        expect(fp1.hex).to.not.equal(fp2.hex);
+      }
+    });
+
+    it('Important: /Group 差分 → fingerprint が異なる', async () => {
+      const build = async (cs: string) => {
+        const pdf = await PDFDocument.create();
+        const p = pdf.addPage([200, 200]);
+        p.drawRectangle({ x: 5, y: 5, width: 20, height: 20 });
+        // page-level /Group (transparency group dict) の CS (color space) 差分
+        const group = pdf.context.obj({
+          Type: 'Group',
+          S: 'Transparency',
+          CS: cs,
+        });
+        p.node.set(PDFName.of('Group'), group);
+        return Buffer.from(await pdf.save());
+      };
+      const fp1 = await computePdfPageVisualFingerprint(await build('DeviceRGB'));
+      const fp2 = await computePdfPageVisualFingerprint(await build('DeviceCMYK'));
+      expect(fp1.kind).to.equal('ok');
+      expect(fp2.kind).to.equal('ok');
+      if (fp1.kind === 'ok' && fp2.kind === 'ok') {
+        expect(fp1.hex).to.not.equal(fp2.hex);
+      }
     });
   });
 });

--- a/scripts/classify-collision-docs.ts
+++ b/scripts/classify-collision-docs.ts
@@ -30,6 +30,9 @@ import {
   HASH_ALGORITHM,
   computePdfPageVisualFingerprint,
 } from './lib/pdfPageVisualFingerprint';
+// AC13 拡張 (Codex Important): plan に pdf-lib version も記録。dependency 更新で
+// internal API 挙動が変わったときに古い plan が新コードで黙って通るのを防ぐ。
+import { version as pdfLibVersion } from 'pdf-lib/package.json';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const storageBucket = process.env.STORAGE_BUCKET;
@@ -572,6 +575,7 @@ async function main(): Promise<void> {
     bucket: bucket.name,
     prefix,
     hashAlgorithm,
+    pdfLibVersion,
     summary,
     operations,
   };

--- a/scripts/classify-collision-docs.ts
+++ b/scripts/classify-collision-docs.ts
@@ -6,7 +6,7 @@
  * parent context を gather し scripts/lib/collisionClassifier に渡す。
  *
  * 出力 JSON は execute-collision-migration.ts (T7) の入力となる migration plan。
- * planId / env / bucket / precondition snapshot を含み、4 重 gate (T7 実装) で照合される。
+ * planId / env / bucket / precondition snapshot を含み、多重 gate (T7 実装) で照合される。
  *
  * 使用方法:
  *   FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
@@ -96,8 +96,6 @@ function extractPathIfBucketMatches(
   return m[2];
 }
 
-// sha256() は PR-C1 で使われていたが、PR-C2 で visual fingerprint 比較に切り替えたため削除。
-// 必要であれば crypto.createHash('sha256') を直接利用。
 
 /**
  * Storage の指定 path が実在するか個別 exists() で確認する (cache 付き)。
@@ -388,10 +386,23 @@ async function buildDocEvidence(
       parent,
     };
   } catch (err) {
-    console.warn(`hash computation failed for doc ${doc.id}: ${(err as Error).message}`);
+    // silent-failure-hunter I2 反映: 残った throw は regenerateChildPdf 系の permanent
+    // failure (parent PDF malformed / page range out-of-bounds / pdf-lib copyPages 失敗)
+    // が支配的。computation-error (transient) に流すと operator が永久に retry し続ける
+    // silent retry loop になる。unsupported.malformed に倒し、Ambiguous + manual-review
+    // 経路 (classifyOrphan / classifyLoserForRegeneration 共通) に確実に到達させる。
+    const msg = (err as Error).message;
+    console.error(
+      `PERMANENT hash failure docId=${doc.id} parentId=${doc.parentDocumentId} msg=${msg}`
+    );
     return {
       doc,
-      hashEvidence: { type: 'unavailable', reason: 'computation-error' },
+      hashEvidence: {
+        type: 'unsupported',
+        reason: 'malformed',
+        detail: `regenerate/fingerprint failure: ${msg}`,
+        algorithm: HASH_ALGORITHM,
+      },
       parent,
     };
   }
@@ -404,7 +415,7 @@ interface MigrationOperation {
   recommendedAction: ClassificationResult['recommendedAction'];
   reason: string;
   suggestedWinner: boolean;
-  // precondition snapshot (T7 4 重 gate で照合)
+  // precondition snapshot (T7 多重 gate で照合)
   expectedCurrentFileUrl: string | null;
   expectedStatus: string;
   expectedUpdatedAt: string | null;

--- a/scripts/classify-collision-docs.ts
+++ b/scripts/classify-collision-docs.ts
@@ -23,8 +23,13 @@ import {
   CollisionGroup,
   ClassificationResult,
   DocEvidence,
+  FingerprintAlgorithm,
 } from './lib/collisionClassifier';
 import { regenerateChildPdf } from './lib/pdfRegenerator';
+import {
+  HASH_ALGORITHM,
+  computePdfPageVisualFingerprint,
+} from './lib/pdfPageVisualFingerprint';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const storageBucket = process.env.STORAGE_BUCKET;
@@ -88,9 +93,8 @@ function extractPathIfBucketMatches(
   return m[2];
 }
 
-function sha256(buf: Buffer): string {
-  return crypto.createHash('sha256').update(buf).digest('hex');
-}
+// sha256() は PR-C1 で使われていたが、PR-C2 で visual fingerprint 比較に切り替えたため削除。
+// 必要であれば crypto.createHash('sha256') を直接利用。
 
 /**
  * Storage の指定 path が実在するか個別 exists() で確認する (cache 付き)。
@@ -321,18 +325,63 @@ async function buildDocEvidence(
       doc.splitFromPages.start,
       doc.splitFromPages.end
     );
-    const actualHash = sha256(actualBuf);
-    const expectedHash = sha256(expectedBuf);
-    if (actualHash === expectedHash) {
-      return { doc, hashEvidence: { type: 'matched', sha256: actualHash }, parent };
+    // PR-C2: cross-process deterministic visual fingerprint で比較 (pdf-page-visual-v1)
+    const actualFp = await computePdfPageVisualFingerprint(actualBuf);
+    const expectedFp = await computePdfPageVisualFingerprint(expectedBuf);
+
+    // どちらかが unsupported (encryption/acroform/optional-content/malformed) なら
+    // Ambiguous に倒すための unsupported evidence を返す (両方の状態を 1 つに集約)
+    if (actualFp.kind === 'unsupported' || expectedFp.kind === 'unsupported') {
+      const target = actualFp.kind === 'unsupported' ? actualFp : expectedFp;
+      // type narrowing
+      if (target.kind === 'unsupported') {
+        return {
+          doc,
+          hashEvidence: {
+            type: 'unsupported',
+            reason: target.reason,
+            detail:
+              actualFp.kind === 'unsupported' && expectedFp.kind === 'unsupported'
+                ? `actual+expected: ${target.detail}`
+                : `${actualFp.kind === 'unsupported' ? 'actual' : 'expected'}: ${target.detail}`,
+            algorithm: HASH_ALGORITHM,
+          },
+          parent,
+        };
+      }
     }
+
+    if (
+      actualFp.kind === 'ok' &&
+      expectedFp.kind === 'ok' &&
+      actualFp.hex === expectedFp.hex
+    ) {
+      return {
+        doc,
+        hashEvidence: {
+          type: 'matched',
+          fingerprint: actualFp.hex,
+          algorithm: HASH_ALGORITHM,
+        },
+        parent,
+      };
+    }
+    if (actualFp.kind === 'ok' && expectedFp.kind === 'ok') {
+      return {
+        doc,
+        hashEvidence: {
+          type: 'mismatched',
+          actualFingerprint: actualFp.hex,
+          expectedFingerprint: expectedFp.hex,
+          algorithm: HASH_ALGORITHM,
+        },
+        parent,
+      };
+    }
+    // ここに到達するのは defensive case (両方 unsupported かつ最初の分岐から抜けた等)
     return {
       doc,
-      hashEvidence: {
-        type: 'mismatched',
-        actualSha256: actualHash,
-        expectedSha256: expectedHash,
-      },
+      hashEvidence: { type: 'unavailable', reason: 'computation-error' },
       parent,
     };
   } catch (err) {
@@ -510,6 +559,11 @@ async function main(): Promise<void> {
     summary.byAction[result.recommendedAction] += 1;
   }
 
+  // AC13: plan に fingerprint algorithm version を記録。execute 側で固定値と照合し、
+  // mismatch なら gate reject (pdf-lib upgrade 等で algorithm が変わった古い plan を
+  // 新コードで実行することを防ぐ)。
+  const hashAlgorithm: FingerprintAlgorithm = HASH_ALGORITHM;
+
   const plan = {
     planId,
     createdAt: new Date().toISOString(),
@@ -517,6 +571,7 @@ async function main(): Promise<void> {
     projectId,
     bucket: bucket.name,
     prefix,
+    hashAlgorithm,
     summary,
     operations,
   };

--- a/scripts/execute-collision-migration.ts
+++ b/scripts/execute-collision-migration.ts
@@ -2,12 +2,15 @@
 /**
  * Issue #432 PR-C: classify-collision-docs.ts が出力した migration plan を実行
  *
- * 4 重 gate (Codex セカンドオピニオン反映):
+ * 多重 gate (現在 7 種、Codex セカンドオピニオン反映 + PR-C2 で AC13 algorithm/version 追加):
  *   1. approval.planId === plan.planId
  *   2. operation.operationId が approval.approvedOperationIds に含まれる
  *   3. (destructive 時) operation の sourcePath/destPath が approval.approvedPaths に含まれる
  *   4. runtime env (projectId / storageBucket) が plan の projectId / bucket と一致
  *   5. precondition (expectedCurrentFileUrl / expectedStatus / expectedUpdatedAt) が現状 doc と一致
+ *   6. plan.hashAlgorithm === HASH_ALGORITHM (AC13)
+ *   7. plan.pdfLibVersion === expectedPdfLibVersion (AC13 拡張 / Codex Important 反映)
+ * Gate 0 (defense-in-depth): Ambiguous + suggestedWinner=true の destructive action を reject
  *
  * idempotency: 各 operation は再実行可能。既に完了状態 (新 path 存在 + fileUrl 更新済) なら skip。
  * Storage delete は scripts/lib/storageGuard 経由で同 fileUrl 共有 doc が残存しないことを確認。

--- a/scripts/execute-collision-migration.ts
+++ b/scripts/execute-collision-migration.ts
@@ -33,8 +33,10 @@ import {
 // F-C3: classifier の型を import して二重定義 (drift リスク) を解消
 import type {
   Classification,
+  FingerprintAlgorithm,
   RecommendedAction,
 } from './lib/collisionClassifier';
+import { HASH_ALGORITHM } from './lib/pdfPageVisualFingerprint';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const storageBucket = process.env.STORAGE_BUCKET;
@@ -89,6 +91,12 @@ interface Plan {
   projectId: string;
   bucket: string;
   prefix: string;
+  /**
+   * AC13: fingerprint algorithm version。execute 側コード固定値と一致しない plan は
+   * gate reject (pdf-lib upgrade 等で algorithm が変わった古い plan を新コードで実行
+   * することを防ぐ)。PR-C1 plan (pre v1) には存在しないので undefined で gate を弾く。
+   */
+  hashAlgorithm?: FingerprintAlgorithm;
   summary: unknown;
   operations: Operation[];
 }
@@ -118,6 +126,16 @@ if (plan.projectId !== projectId) {
 if (plan.bucket !== storageBucket) {
   console.error(
     `FATAL: plan.bucket (${plan.bucket}) !== runtime STORAGE_BUCKET (${storageBucket})`
+  );
+  process.exit(2);
+}
+
+// === AC13: fingerprint algorithm version gate (PR-C2) ===
+// PR-C1 plan は hashAlgorithm を持たないため undefined で reject。
+// pdf-lib upgrade で algorithm が変わった旧 plan を新コードで実行するシナリオも reject。
+if (plan.hashAlgorithm !== HASH_ALGORITHM) {
+  console.error(
+    `FATAL: plan.hashAlgorithm (${plan.hashAlgorithm ?? '<missing>'}) !== execute code's HASH_ALGORITHM (${HASH_ALGORITHM}). Re-run classify-collision-docs.ts to regenerate the plan with the current fingerprint algorithm.`
   );
   process.exit(2);
 }

--- a/scripts/execute-collision-migration.ts
+++ b/scripts/execute-collision-migration.ts
@@ -37,6 +37,8 @@ import type {
   RecommendedAction,
 } from './lib/collisionClassifier';
 import { HASH_ALGORITHM } from './lib/pdfPageVisualFingerprint';
+// AC13 拡張 (Codex Important): plan.pdfLibVersion と execute 側 pdf-lib version の照合
+import { version as expectedPdfLibVersion } from 'pdf-lib/package.json';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const storageBucket = process.env.STORAGE_BUCKET;
@@ -97,6 +99,11 @@ interface Plan {
    * することを防ぐ)。PR-C1 plan (pre v1) には存在しないので undefined で gate を弾く。
    */
   hashAlgorithm?: FingerprintAlgorithm;
+  /**
+   * AC13 拡張 (Codex Important): pdf-lib npm package の version 文字列。algorithm 名は
+   * 同じでも pdf-lib internal API 変更で fingerprint 計算結果が変わるリスクを検出する。
+   */
+  pdfLibVersion?: string;
   summary: unknown;
   operations: Operation[];
 }
@@ -136,6 +143,14 @@ if (plan.bucket !== storageBucket) {
 if (plan.hashAlgorithm !== HASH_ALGORITHM) {
   console.error(
     `FATAL: plan.hashAlgorithm (${plan.hashAlgorithm ?? '<missing>'}) !== execute code's HASH_ALGORITHM (${HASH_ALGORITHM}). Re-run classify-collision-docs.ts to regenerate the plan with the current fingerprint algorithm.`
+  );
+  process.exit(2);
+}
+// AC13 拡張 (Codex Important): pdf-lib version mismatch も reject。algorithm 名は
+// 同じでも pdf-lib internal API 挙動が変わると fingerprint 計算結果が変わるため。
+if (plan.pdfLibVersion !== expectedPdfLibVersion) {
+  console.error(
+    `FATAL: plan.pdfLibVersion (${plan.pdfLibVersion ?? '<missing>'}) !== execute runtime pdf-lib version (${expectedPdfLibVersion}). Re-run classify-collision-docs.ts after package version sync.`
   );
   process.exit(2);
 }

--- a/scripts/lib/collisionClassifier.ts
+++ b/scripts/lib/collisionClassifier.ts
@@ -4,15 +4,27 @@
  * 4 分類: MatchedByHash / Ambiguous / RepairableMissingFile / LostOrUnrecoverable
  * (LikelyWinner は Ambiguous 内 suggestedWinner hint に降格 = 設計案からの統合)。
  *
- * 設計判断 (Codex セカンドオピニオン 2026-05-11 反映):
- *   - hash 一致確定のみ自動移行 (MatchedByHash)
+ * PR-C2 (2026-05-12, session60 着手): hash 比較を `sha256(raw PDF bytes)` から
+ * `pdf-page-visual-v1` fingerprint 比較に変更 (pdf-lib `PDFDocument.save()` の
+ * cross-process non-determinism を回避)。実装は scripts/lib/pdfPageVisualFingerprint.ts。
+ *   - DocEvidence.hashEvidence.type='matched' → fingerprint hex が一致 (algorithm 明示)
+ *   - DocEvidence.hashEvidence.type='mismatched' → fingerprint hex が異なる
+ *   - DocEvidence.hashEvidence.type='unsupported' → PDF が暗号化 / AcroForm 等で fingerprint
+ *     算出不能 (PR-C2 で追加)。Ambiguous + manual-review に倒す
+ *   - DocEvidence.hashEvidence.type='unavailable' → parent 在不在等で fingerprint 比較に
+ *     至らなかった (既存)
+ *
+ * 設計判断 (Codex セカンドオピニオン 2026-05-11/2026-05-12 反映):
+ *   - fingerprint 一致確定のみ自動移行 (MatchedByHash)
  *   - rotatedAt!=null 唯一による LikelyWinner 自動移行は禁止 (silent breakage 偽装復旧の再演リスク)
  *     → Ambiguous 内 suggestedWinner hint に降格
- *   - hash 不能 / 不一致 / 複数一致は全て Ambiguous (manual-review)
+ *   - fingerprint 不能 / 不一致 / 複数一致 / unsupported は全て Ambiguous (manual-review)
  *   - orphan + parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile (auto regenerate)
  *   - 衝突 group 内の「敗者」doc も同条件で RepairableMissingFile に分類 (Codex 推奨: 復旧率最大化)
  *   - hash unavailable.reason='computation-error' (transient 503/403) は parent 在でも
  *     RepairableMissingFile / LostOrUnrecoverable に降格させず Ambiguous に留める (F-B3)
+ *   - hashEvidence.type='unsupported' (PR-C2 追加) も同様に Ambiguous に留める (自動再生成
+ *     しても fingerprint 比較不能なので gate 通せない)
  *   - 復元不能は LostOrUnrecoverable (status:'error' + lastErrorMessage で manual repair 誘導)
  *
  * Partial update 不変 (CLAUDE.md MUST): mark-error action は status / lastErrorMessage のみ更新、
@@ -33,15 +45,40 @@ export interface CollisionDoc {
 
 /**
  * doc 1 件分の事前評価結果。caller (classify-collision-docs.ts) が:
- *   - hashEvidence: Storage 実体 sha256 と「親 PDF + splitFromPages から再生成した期待 sha256」の比較結果
+ *   - hashEvidence: Storage 実体の visual fingerprint と「親 PDF + splitFromPages から
+ *     再生成した PDF の visual fingerprint」の比較結果 (PR-C2 で sha256(raw bytes) から
+ *     visual fingerprint 比較に変更、cross-process determinism を担保)
  *   - parent: parentDocumentId の有無 + 親 doc 存在 + 元 PDF 実在
  * を Firestore / Storage アクセスで埋め、本 classifier (pure) に渡す。
+ *
+ * `algorithm` は fingerprint アルゴリズムバージョン (例 'pdf-page-visual-v1')。
+ * plan JSON の precondition snapshot に記録し、execute 側で固定値と照合して mismatch
+ * なら gate reject する (AC13)。
  */
+export type FingerprintAlgorithm = 'pdf-page-visual-v1';
+
+export type UnsupportedReason =
+  | 'encryption'
+  | 'acroform'
+  | 'optional-content'
+  | 'malformed';
+
 export interface DocEvidence {
   doc: CollisionDoc;
   hashEvidence:
-    | { type: 'matched'; sha256: string }
-    | { type: 'mismatched'; actualSha256: string; expectedSha256: string }
+    | { type: 'matched'; fingerprint: string; algorithm: FingerprintAlgorithm }
+    | {
+        type: 'mismatched';
+        actualFingerprint: string;
+        expectedFingerprint: string;
+        algorithm: FingerprintAlgorithm;
+      }
+    | {
+        type: 'unsupported';
+        reason: UnsupportedReason;
+        detail: string;
+        algorithm: FingerprintAlgorithm;
+      }
     | {
         type: 'unavailable';
         reason:
@@ -120,7 +157,8 @@ export function classifyCollisionGroup(
         ? {
             docId: e.doc.id,
             classification: 'MatchedByHash' as const,
-            reason: 'sha256(actual storage bytes) == sha256(regenerated from parent + splitFromPages)',
+            reason:
+              'fingerprint(actual storage, pdf-page-visual-v1) == fingerprint(regenerated from parent + splitFromPages)',
             suggestedWinner: false,
             recommendedAction: 'migrate-to-namespace' as const,
           }
@@ -133,7 +171,7 @@ export function classifyCollisionGroup(
     return group.evidences.map((e) => ({
       docId: e.doc.id,
       classification: 'Ambiguous' as const,
-      reason: `multiple hash matches in group (${matchedDocIds.length} docs claim ownership of same storage bytes)`,
+      reason: `multiple fingerprint matches in group (${matchedDocIds.length} docs share the same visual fingerprint with the regenerated PDF)`,
       suggestedWinner: e.hashEvidence.type === 'matched',
       recommendedAction: 'manual-review' as const,
     }));
@@ -159,6 +197,8 @@ export function classifyCollisionGroup(
  *
  * - hash unavailable.reason='computation-error' (transient 503/403): parent 在でも
  *   一旦 Ambiguous + manual-review に留める (F-B3 反映、actual 取得失敗を Lost に流さない)
+ * - hashEvidence.type='unsupported' (encryption / acroform / optional-content / malformed,
+ *   PR-C2 追加): 同じく Ambiguous + manual-review (PDF 構造ベースの自動復旧不可)
  * - parent + splitFromPages + 親 PDF 実在 → RepairableMissingFile + regenerate-from-parent
  * - 上記以外 → LostOrUnrecoverable + mark-error (status:'error' 誘導)
  */
@@ -170,7 +210,19 @@ export function classifyOrphan(evidence: DocEvidence): ClassificationResult {
     return {
       docId: doc.id,
       classification: 'Ambiguous',
-      reason: 'hash comparison unavailable due to transient error; defer to manual-review',
+      reason: buildUnavailableReason('hash-unavailable-transient'),
+      suggestedWinner: false,
+      recommendedAction: 'manual-review',
+    };
+  }
+
+  // PR-C2: unsupported PDF feature (encryption / acroform / optional-content / malformed) も
+  // Ambiguous に倒す (fingerprint 比較不能のため自動復旧 gate を通せない)
+  if (isUnsupported(evidence)) {
+    return {
+      docId: doc.id,
+      classification: 'Ambiguous',
+      reason: buildUnsupportedReason(evidence),
       suggestedWinner: false,
       recommendedAction: 'manual-review',
     };
@@ -222,7 +274,18 @@ function classifyLoserForRegeneration(
     return {
       docId: evidence.doc.id,
       classification: 'Ambiguous',
-      reason: 'collision group loser; hash comparison unavailable due to transient error; defer to manual-review',
+      reason: `collision group loser; ${buildUnavailableReason('hash-unavailable-transient')}`,
+      suggestedWinner: false,
+      recommendedAction: 'manual-review',
+    };
+  }
+
+  // PR-C2: unsupported は Ambiguous に倒す (fingerprint 比較不能)
+  if (isUnsupported(evidence)) {
+    return {
+      docId: evidence.doc.id,
+      classification: 'Ambiguous',
+      reason: `collision group loser; ${buildUnsupportedReason(evidence)}`,
       suggestedWinner: false,
       recommendedAction: 'manual-review',
     };
@@ -262,16 +325,51 @@ function isComputationError(evidence: DocEvidence): boolean {
   );
 }
 
+function isUnsupported(evidence: DocEvidence): boolean {
+  return evidence.hashEvidence.type === 'unsupported';
+}
+
+/**
+ * Codex Suggestion 反映: Ambiguous reason 細分化。operator が manual review 時に
+ * 「なぜ Ambiguous か」を即特定できるよう、5 種類のサブカテゴリで返す:
+ *   - content-mismatch: actual storage bytes と regenerated の visual fingerprint が異なる
+ *   - unsupported-pdf-feature: encryption/acroform/optional-content/malformed
+ *   - hash-unavailable-transient: 一時的な download エラー (再試行候補)
+ *   - hash-unavailable-no-parent: parent doc または original PDF が見つからない
+ *   - multiple-fingerprint-matches: 複数 doc が同じ fingerprint を持つ (希少)
+ */
+export type AmbiguousReasonKind =
+  | 'content-mismatch'
+  | 'unsupported-pdf-feature'
+  | 'hash-unavailable-transient'
+  | 'hash-unavailable-no-parent';
+
 function buildAmbiguousReason(evidence: DocEvidence): string {
   switch (evidence.hashEvidence.type) {
     case 'mismatched':
-      return `hash mismatch: actual storage bytes != regenerated from parent + splitFromPages`;
+      return 'content-mismatch: visual fingerprint(actual storage) != visual fingerprint(regenerated from parent + splitFromPages)';
+    case 'unsupported':
+      return buildUnsupportedReason(evidence);
     case 'unavailable':
-      return `hash comparison unavailable: ${evidence.hashEvidence.reason}`;
+      if (evidence.hashEvidence.reason === 'computation-error') {
+        return buildUnavailableReason('hash-unavailable-transient');
+      }
+      return buildUnavailableReason('hash-unavailable-no-parent', evidence.hashEvidence.reason);
     case 'matched':
       // この path は ケース 2 (multiple matches) でのみ到達するが defensive に
-      return 'hash matched but multiple winners in group';
+      return 'multiple-fingerprint-matches: fingerprint matched but multiple winners in group';
   }
+}
+
+function buildUnsupportedReason(evidence: DocEvidence): string {
+  if (evidence.hashEvidence.type !== 'unsupported') {
+    return 'unsupported-pdf-feature: <unexpected hashEvidence type>';
+  }
+  return `unsupported-pdf-feature: ${evidence.hashEvidence.reason} (${evidence.hashEvidence.detail})`;
+}
+
+function buildUnavailableReason(kind: AmbiguousReasonKind, detail?: string): string {
+  return detail ? `${kind}: ${detail}` : kind;
 }
 
 function buildLostReason(

--- a/scripts/lib/collisionClassifier.ts
+++ b/scripts/lib/collisionClassifier.ts
@@ -57,11 +57,9 @@ export interface CollisionDoc {
  */
 export type FingerprintAlgorithm = 'pdf-page-visual-v1';
 
-export type UnsupportedReason =
-  | 'encryption'
-  | 'acroform'
-  | 'optional-content'
-  | 'malformed';
+// drift 防止のため pdfPageVisualFingerprint で定義した UnsupportedReason を re-export
+import type { UnsupportedReason as FingerprintUnsupportedReason } from './pdfPageVisualFingerprint';
+export type UnsupportedReason = FingerprintUnsupportedReason;
 
 export interface DocEvidence {
   doc: CollisionDoc;
@@ -171,7 +169,7 @@ export function classifyCollisionGroup(
     return group.evidences.map((e) => ({
       docId: e.doc.id,
       classification: 'Ambiguous' as const,
-      reason: `multiple fingerprint matches in group (${matchedDocIds.length} docs share the same visual fingerprint with the regenerated PDF)`,
+      reason: `multiple-fingerprint-matches: ${matchedDocIds.length} docs share the same visual fingerprint with the regenerated PDF`,
       suggestedWinner: e.hashEvidence.type === 'matched',
       recommendedAction: 'manual-review' as const,
     }));
@@ -342,7 +340,8 @@ export type AmbiguousReasonKind =
   | 'content-mismatch'
   | 'unsupported-pdf-feature'
   | 'hash-unavailable-transient'
-  | 'hash-unavailable-no-parent';
+  | 'hash-unavailable-no-parent'
+  | 'multiple-fingerprint-matches';
 
 function buildAmbiguousReason(evidence: DocEvidence): string {
   switch (evidence.hashEvidence.type) {
@@ -357,7 +356,7 @@ function buildAmbiguousReason(evidence: DocEvidence): string {
       return buildUnavailableReason('hash-unavailable-no-parent', evidence.hashEvidence.reason);
     case 'matched':
       // この path は ケース 2 (multiple matches) でのみ到達するが defensive に
-      return 'multiple-fingerprint-matches: fingerprint matched but multiple winners in group';
+      return 'multiple-fingerprint-matches: defensive fallback for matched evidence';
   }
 }
 

--- a/scripts/lib/collisionClassifier.ts
+++ b/scripts/lib/collisionClassifier.ts
@@ -343,7 +343,17 @@ export type AmbiguousReasonKind =
   | 'hash-unavailable-no-parent'
   | 'multiple-fingerprint-matches';
 
-function buildAmbiguousReason(evidence: DocEvidence): string {
+/**
+ * type-design-analyzer (PR #441 review) 反映: Ambiguous の reason 文字列を
+ * `${AmbiguousReasonKind}` または `${AmbiguousReasonKind}: ${string}` の template
+ * literal で型強制し、build*Reason 関数群と AmbiguousReasonKind の drift を
+ * compile error 化する。
+ */
+export type AmbiguousReasonString =
+  | `${AmbiguousReasonKind}`
+  | `${AmbiguousReasonKind}: ${string}`;
+
+function buildAmbiguousReason(evidence: DocEvidence): AmbiguousReasonString {
   switch (evidence.hashEvidence.type) {
     case 'mismatched':
       return 'content-mismatch: visual fingerprint(actual storage) != visual fingerprint(regenerated from parent + splitFromPages)';
@@ -360,14 +370,17 @@ function buildAmbiguousReason(evidence: DocEvidence): string {
   }
 }
 
-function buildUnsupportedReason(evidence: DocEvidence): string {
+function buildUnsupportedReason(evidence: DocEvidence): AmbiguousReasonString {
   if (evidence.hashEvidence.type !== 'unsupported') {
     return 'unsupported-pdf-feature: <unexpected hashEvidence type>';
   }
   return `unsupported-pdf-feature: ${evidence.hashEvidence.reason} (${evidence.hashEvidence.detail})`;
 }
 
-function buildUnavailableReason(kind: AmbiguousReasonKind, detail?: string): string {
+function buildUnavailableReason(
+  kind: AmbiguousReasonKind,
+  detail?: string
+): AmbiguousReasonString {
   return detail ? `${kind}: ${detail}` : kind;
 }
 

--- a/scripts/lib/pdfPageVisualFingerprint.ts
+++ b/scripts/lib/pdfPageVisualFingerprint.ts
@@ -61,7 +61,13 @@ export type UnsupportedReason =
   | 'encryption'
   | 'acroform'
   | 'optional-content'
-  | 'malformed';
+  | 'malformed'
+  /** Codex Critical 反映: visible annotations は描画に影響するが Contents stream に
+   *  乗らない (別 dict / appearance stream)。安全側で自動復旧対象外に倒す。 */
+  | 'annotations'
+  /** Codex Important 反映: DCTDecode/JPXDecode 等 pdf-lib decodePDFRawStream 未対応の
+   *  filter で resources subtree が decode できない場合に降格させる reason。 */
+  | 'unsupported-resource-filter';
 
 export type Fingerprint =
   | {
@@ -138,15 +144,40 @@ export async function computePdfPageVisualFingerprint(
   for (let i = 0; i < pageCount; i++) {
     const node = pdf.getPage(i).node;
 
+    // Codex Critical 反映: visible annotations は描画に影響するが Contents stream に
+    // 乗らない (separate /Annots 配列 + appearance stream)。同 Contents/Resources で
+    // annotation のみ違う PDF が偽 MatchedByHash になるリスクを排除するため unsupported。
+    const annots = node.Annots();
+    if (annots !== undefined && annots.size() > 0) {
+      return {
+        kind: 'unsupported',
+        reason: 'annotations',
+        detail: `page ${i} has ${annots.size()} annotation(s); cannot prove visual equivalence via fingerprint`,
+        algorithm: HASH_ALGORITHM,
+      };
+    }
+
     // 1. decoded Contents bytes (正規化禁止)
     let contentBytes: Uint8Array;
     try {
       contentBytes = collectDecodedContentBytes(node.Contents(), pdf.context);
     } catch (err) {
+      // Codex Important 反映: 画像 stream の decode 失敗 (DCTDecode/JPXDecode 等
+      // pdf-lib 1.17.1 未対応 filter) は malformed ではなく unsupported-resource-filter
+      // に降格させる。catch-all で computation-error にすると transient と誤分類される。
+      const msg = (err as Error).message;
+      if (isUnsupportedFilterError(msg)) {
+        return {
+          kind: 'unsupported',
+          reason: 'unsupported-resource-filter',
+          detail: `page ${i} content stream uses unsupported filter: ${msg}`,
+          algorithm: HASH_ALGORITHM,
+        };
+      }
       return {
         kind: 'unsupported',
         reason: 'malformed',
-        detail: `page ${i} content stream: ${(err as Error).message}`,
+        detail: `page ${i} content stream: ${msg}`,
         algorithm: HASH_ALGORITHM,
       };
     }
@@ -154,14 +185,48 @@ export async function computePdfPageVisualFingerprint(
     top.update(Buffer.from(contentBytes));
 
     // 2. geometry
+    // Codex Suggestion 反映: CropBox absent は PDF spec 上 MediaBox にフォールバックする。
+    // absent と「CropBox==MediaBox 明示」は表示同一なので、effective crop を hash する。
     top.update('|media=');
     top.update(encodeRect(node.MediaBox(), pdf.context));
     const cropBox = node.CropBox();
-    top.update('|crop=');
-    top.update(cropBox === undefined ? '<absent>' : encodeRect(cropBox, pdf.context));
+    const effectiveCrop = cropBox ?? node.MediaBox();
+    top.update('|effectiveCrop=');
+    top.update(encodeRect(effectiveCrop, pdf.context));
     const rotate = node.Rotate();
     const rotateValue = rotate === undefined ? 0 : rotate.asNumber();
     top.update(`|rotate=${rotateValue}`);
+
+    // Codex Important 反映: page-level visual entries の追加 /UserUnit, /Group。
+    // /UserUnit は page size の実寸 (1.0 default), /Group は transparency blending。
+    const userUnit = node.lookup(PDFName.of('UserUnit'));
+    if (userUnit === undefined) {
+      top.update('|userUnit=<absent>');
+    } else if (userUnit instanceof PDFNumber) {
+      top.update(`|userUnit=${userUnit.asNumber()}`);
+    } else {
+      top.update(`|userUnit=<unexpected:${userUnit.constructor.name}>`);
+    }
+    top.update('|group=');
+    const group = node.lookup(PDFName.of('Group'));
+    if (group === undefined) {
+      top.update('<absent>');
+    } else {
+      try {
+        top.update(canonicalDigest(group, pdf.context));
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (isUnsupportedFilterError(msg)) {
+          return {
+            kind: 'unsupported',
+            reason: 'unsupported-resource-filter',
+            detail: `page ${i} /Group canonical digest: ${msg}`,
+            algorithm: HASH_ALGORITHM,
+          };
+        }
+        throw err;
+      }
+    }
 
     // 3. Resources canonical digest
     top.update('|resources=');
@@ -169,8 +234,23 @@ export async function computePdfPageVisualFingerprint(
     if (resources === undefined) {
       top.update('<absent>');
     } else {
-      const resourcesDigest = canonicalDigest(resources, pdf.context);
-      top.update(resourcesDigest);
+      try {
+        const resourcesDigest = canonicalDigest(resources, pdf.context);
+        top.update(resourcesDigest);
+      } catch (err) {
+        // Codex Important 反映: resources subtree 内の image XObject 等の decode 失敗を
+        // unsupported-resource-filter に降格 (transient computation-error にしない)
+        const msg = (err as Error).message;
+        if (isUnsupportedFilterError(msg)) {
+          return {
+            kind: 'unsupported',
+            reason: 'unsupported-resource-filter',
+            detail: `page ${i} resources canonical digest: ${msg}`,
+            algorithm: HASH_ALGORITHM,
+          };
+        }
+        throw err;
+      }
     }
   }
 
@@ -180,6 +260,24 @@ export async function computePdfPageVisualFingerprint(
     pageCount,
     algorithm: HASH_ALGORITHM,
   };
+}
+
+/**
+ * pdf-lib `decodePDFRawStream` が UnsupportedEncodingError を投げるパターンを判定する。
+ * DCTDecode / JPXDecode / CCITTFaxDecode / JBIG2Decode 等の画像 filter のほか、不明
+ * filter も含む。本判定は pdf-lib 内部メッセージに依存するため lock test で固定する。
+ */
+function isUnsupportedFilterError(message: string): boolean {
+  return (
+    message.includes('UnsupportedEncoding') ||
+    message.includes('DCTDecode') ||
+    message.includes('JPXDecode') ||
+    message.includes('CCITTFaxDecode') ||
+    message.includes('JBIG2Decode') ||
+    message.includes('Crypt') ||
+    message.includes('unknown filter') ||
+    message.includes('Unknown filter')
+  );
 }
 
 /**
@@ -257,12 +355,12 @@ function encodeRect(arr: PDFArray, context: PDFContext): Buffer {
  *
  * - PDFDict: entries を name 文字列 sort してから recurse (V8 iteration order 差吸収)
  * - PDFArray: 順序保持して recurse (PDF semantically order-sensitive)
- * - PDFRef: 循環防止 + lookup して resolve した先を recurse
- * - PDFStream: dict subtree + decoded bytes
+ * - PDFRef: recursion stack 上の循環のみ cycle marker、stack 外の共有参照は通常 recurse
+ *   (Codex Important 反映: 旧版は traversal 全体共有 Set だったため、sibling 経由の共有参照
+ *    で object number が hash に混入 → cross-process determinism が弱くなっていた)
+ * - PDFStream: dict subtree + decoded bytes (filter 不可なら caller に throw、上位で
+ *   unsupported-resource-filter に降格)
  * - その他 scalar: 型 prefix + 値 string
- *
- * 循環 ref を visited で検出 (PDFRef は pdf-lib 側で同一識別子を共有 instance に
- * 解決される設計のため Set<PDFRef> で識別可能)。
  */
 export function canonicalDigest(obj: PDFObject, context: PDFContext): Buffer {
   const sha = crypto.createHash('sha256');
@@ -274,20 +372,27 @@ function walk(
   sha: crypto.Hash,
   obj: PDFObject,
   context: PDFContext,
-  visited: Set<PDFRef>
+  recursionStack: Set<PDFRef>
 ): void {
   if (obj instanceof PDFRef) {
-    if (visited.has(obj)) {
-      sha.update(`ref-cycle|${obj.objectNumber}|${obj.generationNumber}`);
+    if (recursionStack.has(obj)) {
+      // 真の循環参照のみ stable cycle marker (object number は意図的に含めない =
+      // cross-process determinism のため)
+      sha.update('ref-cycle');
       return;
     }
-    visited.add(obj);
-    const resolved = context.lookup(obj);
-    sha.update('ref|');
-    if (resolved === undefined) {
-      sha.update('<undefined>');
-    } else {
-      walk(sha, resolved, context, visited);
+    recursionStack.add(obj);
+    try {
+      const resolved = context.lookup(obj);
+      sha.update('ref|');
+      if (resolved === undefined) {
+        sha.update('<undefined>');
+      } else {
+        walk(sha, resolved, context, recursionStack);
+      }
+    } finally {
+      // recursion stack から外し、sibling 経由で同 ref が再出現したら通常 recurse
+      recursionStack.delete(obj);
     }
     return;
   }
@@ -299,7 +404,7 @@ function walk(
       sha.update('|key=');
       sha.update(k.asString());
       sha.update('|val=');
-      walk(sha, v, context, visited);
+      walk(sha, v, context, recursionStack);
     }
     return;
   }
@@ -308,13 +413,13 @@ function walk(
     sha.update(`array|size=${size}`);
     for (let i = 0; i < size; i++) {
       sha.update('|');
-      walk(sha, obj.get(i), context, visited);
+      walk(sha, obj.get(i), context, recursionStack);
     }
     return;
   }
   if (obj instanceof PDFStream) {
     sha.update('stream|dict=');
-    walk(sha, obj.dict, context, visited);
+    walk(sha, obj.dict, context, recursionStack);
     const bytes = decodeStreamBytes(obj);
     sha.update(`|bytes_len=${bytes.length}|bytes=`);
     sha.update(Buffer.from(bytes));

--- a/scripts/lib/pdfPageVisualFingerprint.ts
+++ b/scripts/lib/pdfPageVisualFingerprint.ts
@@ -215,16 +215,15 @@ export async function computePdfPageVisualFingerprint(
       try {
         top.update(canonicalDigest(group, pdf.context));
       } catch (err) {
+        // silent-failure-hunter I1 反映: canonical digest 失敗は構造解析失敗 = malformed
+        // 等価で扱う (transient computation-error に流すと operator が retry し続ける)
         const msg = (err as Error).message;
-        if (isUnsupportedFilterError(msg)) {
-          return {
-            kind: 'unsupported',
-            reason: 'unsupported-resource-filter',
-            detail: `page ${i} /Group canonical digest: ${msg}`,
-            algorithm: HASH_ALGORITHM,
-          };
-        }
-        throw err;
+        return {
+          kind: 'unsupported',
+          reason: isUnsupportedFilterError(msg) ? 'unsupported-resource-filter' : 'malformed',
+          detail: `page ${i} /Group canonical digest failed: ${msg}`,
+          algorithm: HASH_ALGORITHM,
+        };
       }
     }
 
@@ -238,18 +237,16 @@ export async function computePdfPageVisualFingerprint(
         const resourcesDigest = canonicalDigest(resources, pdf.context);
         top.update(resourcesDigest);
       } catch (err) {
-        // Codex Important 反映: resources subtree 内の image XObject 等の decode 失敗を
-        // unsupported-resource-filter に降格 (transient computation-error にしない)
+        // silent-failure-hunter I1 + Codex Important 反映: resources subtree の decode
+        // 失敗 (image XObject の DCTDecode 等) は unsupported-resource-filter、その他の
+        // 構造解析失敗は malformed として returning unsupported (catch-all 不発防止)。
         const msg = (err as Error).message;
-        if (isUnsupportedFilterError(msg)) {
-          return {
-            kind: 'unsupported',
-            reason: 'unsupported-resource-filter',
-            detail: `page ${i} resources canonical digest: ${msg}`,
-            algorithm: HASH_ALGORITHM,
-          };
-        }
-        throw err;
+        return {
+          kind: 'unsupported',
+          reason: isUnsupportedFilterError(msg) ? 'unsupported-resource-filter' : 'malformed',
+          detail: `page ${i} resources canonical digest failed: ${msg}`,
+          algorithm: HASH_ALGORITHM,
+        };
       }
     }
   }
@@ -398,7 +395,14 @@ function walk(
   }
   if (obj instanceof PDFDict) {
     const entries = [...obj.entries()];
-    entries.sort((a, b) => a[0].asString().localeCompare(b[0].asString()));
+    // Critical (code-reviewer PR #441 review): localeCompare は OS locale / ICU データ版
+    // 依存で cross-machine non-deterministic。byte-order 比較に置換して classify
+    // (e.g. ja_JP な開発機) と execute (e.g. C な GitHub Actions) で同 hex を保証。
+    entries.sort((a, b) => {
+      const sa = a[0].asString();
+      const sb = b[0].asString();
+      return sa < sb ? -1 : sa > sb ? 1 : 0;
+    });
     sha.update(`dict|size=${entries.length}`);
     for (const [k, v] of entries) {
       sha.update('|key=');

--- a/scripts/lib/pdfPageVisualFingerprint.ts
+++ b/scripts/lib/pdfPageVisualFingerprint.ts
@@ -1,0 +1,354 @@
+/**
+ * Issue #432 PR-C2: PDF page visual fingerprint (cross-process deterministic).
+ *
+ * pdf-lib `PDFDocument.save()` は同一プロセス内 deterministic だがプロセス間で
+ * 非決定 (PDF `/ID` random、internal metadata) のため、sha256(raw bytes) 比較は
+ * MatchedByHash を成立させない (PR-C1 session59 で発覚)。本モジュールは PDF の
+ * 「描画同一性」を以下の要素で表現する fingerprint hex を返す:
+ *   1. 各ページの decoded Contents bytes (正規化禁止、Codex Critical 2 反映)
+ *   2. 各ページの geometry (MediaBox / CropBox / Rotate)
+ *   3. 各ページが参照する Resources (Font / XObject / ExtGState / ColorSpace
+ *      / Pattern / Shading / ProcSet) の canonical digest
+ *
+ * Codex Critical (PR-C2 v2 計画):
+ *   - PDFPage.node.normalizedEntries() は副作用 (push/pop graphics state stream
+ *     追加 + Resources/Annots 補完) のため使用禁止 → page.node.Contents() 直接読み
+ *     + PDFArray / PDFStream / PDFRawStream 明示処理
+ *   - whitespace / operator 順 / 数値表記 を正規化しない (inline image data 破壊
+ *     リスク + graphics state 順序依存 = 偽陽性増加)
+ *   - PDFDict entries は name 文字列 sort で V8 iteration order 差を吸収
+ *
+ * Unsupported features (Ambiguous フォールバック):
+ *   - /Encrypt → unsupported.encryption
+ *   - /AcroForm → unsupported.acroform
+ *   - /OCProperties → unsupported.optional-content
+ *   - 復元不能 PDF load 例外 → unsupported.malformed
+ *
+ * Algorithm version: 'pdf-page-visual-v1'。precondition snapshot + execute 側
+ * 固定値で照合し、mismatch なら gate reject (AC13)。
+ *
+ * Internal API lock (AC14): pdf-lib の以下を直接利用しているため、test で
+ * 存在をアサートする:
+ *   - decodePDFRawStream (named export)
+ *   - PDFRawStream (named export, instanceof check 用)
+ *   - PDFPageLeaf.Contents() / Resources() / MediaBox() / CropBox() / Rotate()
+ *   - PDFDict.entries()
+ *   - PDFContext.lookup()
+ */
+
+import {
+  PDFArray,
+  PDFBool,
+  PDFContext,
+  PDFDict,
+  PDFDocument,
+  PDFHexString,
+  PDFName,
+  PDFNull,
+  PDFNumber,
+  PDFObject,
+  PDFRawStream,
+  PDFRef,
+  PDFStream,
+  PDFString,
+  decodePDFRawStream,
+} from 'pdf-lib';
+import * as crypto from 'crypto';
+
+export const HASH_ALGORITHM = 'pdf-page-visual-v1';
+
+export type UnsupportedReason =
+  | 'encryption'
+  | 'acroform'
+  | 'optional-content'
+  | 'malformed';
+
+export type Fingerprint =
+  | {
+      kind: 'ok';
+      hex: string;
+      pageCount: number;
+      algorithm: typeof HASH_ALGORITHM;
+    }
+  | {
+      kind: 'unsupported';
+      reason: UnsupportedReason;
+      detail: string;
+      algorithm: typeof HASH_ALGORITHM;
+    };
+
+/**
+ * 1 つの PDF buffer から visual fingerprint を計算する。
+ *
+ * 同一プロセス内で 2 回呼んでも、別プロセスで生成して比較しても、
+ * 描画同一の PDF からは同じ hex を返す (cross-process deterministic)。
+ *
+ * 異なる描画 (XObject 入替 / font 差替 / Rotate 変化 / CropBox 変化 / 同 operator
+ * 列でも inline image data 差分) では異なる hex を返す (AC9-12 偽陽性防止)。
+ */
+export async function computePdfPageVisualFingerprint(
+  pdfBuffer: Buffer
+): Promise<Fingerprint> {
+  let pdf: PDFDocument;
+  try {
+    pdf = await PDFDocument.load(pdfBuffer, {
+      throwOnInvalidObject: false,
+      ignoreEncryption: true,
+    });
+  } catch (err) {
+    return {
+      kind: 'unsupported',
+      reason: 'malformed',
+      detail: `PDFDocument.load failed: ${(err as Error).message}`,
+      algorithm: HASH_ALGORITHM,
+    };
+  }
+
+  if (pdf.isEncrypted) {
+    return {
+      kind: 'unsupported',
+      reason: 'encryption',
+      detail: '/Encrypt entry present in trailer',
+      algorithm: HASH_ALGORITHM,
+    };
+  }
+
+  if (pdf.catalog.AcroForm() !== undefined) {
+    return {
+      kind: 'unsupported',
+      reason: 'acroform',
+      detail: '/AcroForm present in catalog (interactive form, repair requires manual review)',
+      algorithm: HASH_ALGORITHM,
+    };
+  }
+
+  if (pdf.catalog.get(PDFName.of('OCProperties')) !== undefined) {
+    return {
+      kind: 'unsupported',
+      reason: 'optional-content',
+      detail: '/OCProperties present in catalog (optional content / layers)',
+      algorithm: HASH_ALGORITHM,
+    };
+  }
+
+  const pageCount = pdf.getPageCount();
+  const top = crypto.createHash('sha256');
+  top.update(`alg=${HASH_ALGORITHM}|pages=${pageCount}`);
+
+  for (let i = 0; i < pageCount; i++) {
+    const node = pdf.getPage(i).node;
+
+    // 1. decoded Contents bytes (正規化禁止)
+    let contentBytes: Uint8Array;
+    try {
+      contentBytes = collectDecodedContentBytes(node.Contents(), pdf.context);
+    } catch (err) {
+      return {
+        kind: 'unsupported',
+        reason: 'malformed',
+        detail: `page ${i} content stream: ${(err as Error).message}`,
+        algorithm: HASH_ALGORITHM,
+      };
+    }
+    top.update(`|page=${i}|content_len=${contentBytes.length}|content=`);
+    top.update(Buffer.from(contentBytes));
+
+    // 2. geometry
+    top.update('|media=');
+    top.update(encodeRect(node.MediaBox(), pdf.context));
+    const cropBox = node.CropBox();
+    top.update('|crop=');
+    top.update(cropBox === undefined ? '<absent>' : encodeRect(cropBox, pdf.context));
+    const rotate = node.Rotate();
+    const rotateValue = rotate === undefined ? 0 : rotate.asNumber();
+    top.update(`|rotate=${rotateValue}`);
+
+    // 3. Resources canonical digest
+    top.update('|resources=');
+    const resources = node.Resources();
+    if (resources === undefined) {
+      top.update('<absent>');
+    } else {
+      const resourcesDigest = canonicalDigest(resources, pdf.context);
+      top.update(resourcesDigest);
+    }
+  }
+
+  return {
+    kind: 'ok',
+    hex: top.digest('hex'),
+    pageCount,
+    algorithm: HASH_ALGORITHM,
+  };
+}
+
+/**
+ * page.node.Contents() の戻り (PDFStream | PDFArray | undefined) を decoded bytes
+ * の連結に変換する。PDFArray の場合は各要素を 0x0a で区切る (PDF spec の content
+ * stream concat と等価)。
+ */
+function collectDecodedContentBytes(
+  contents: PDFStream | PDFArray | undefined,
+  context: PDFContext
+): Uint8Array {
+  if (contents === undefined) return new Uint8Array(0);
+  if (contents instanceof PDFArray) {
+    const parts: Buffer[] = [];
+    const size = contents.size();
+    for (let i = 0; i < size; i++) {
+      const elem = contents.get(i);
+      const resolved = resolveStream(elem, context);
+      parts.push(Buffer.from(decodeStreamBytes(resolved)));
+      if (i + 1 < size) parts.push(Buffer.from([0x0a]));
+    }
+    return Buffer.concat(parts);
+  }
+  if (contents instanceof PDFStream) {
+    return decodeStreamBytes(contents);
+  }
+  throw new Error(
+    `unexpected Contents type: ${(contents as PDFObject).constructor.name}`
+  );
+}
+
+function resolveStream(obj: PDFObject, context: PDFContext): PDFStream {
+  const resolved = obj instanceof PDFRef ? context.lookup(obj) : obj;
+  if (!(resolved instanceof PDFStream)) {
+    throw new Error(
+      `expected PDFStream, got ${resolved?.constructor.name ?? 'undefined'}`
+    );
+  }
+  return resolved;
+}
+
+function decodeStreamBytes(stream: PDFStream): Uint8Array {
+  if (stream instanceof PDFRawStream) {
+    // decodePDFRawStream は StreamType を返す。decode() で filter 解除後の bytes を取り出す。
+    return decodePDFRawStream(stream).decode();
+  }
+  // PDFFlateStream 等 (新規生成側) は内部で encoded bytes を保持しており getContents() は
+  // filter 適用後の raw bytes を返す。decoded 表現で比較したいので無変換のまま使う
+  // (生成側の content stream は uncompressed のため filter 解除は同値).
+  return stream.getContents();
+}
+
+/**
+ * MediaBox / CropBox 等の rectangle PDFArray を bytes に変換する。
+ * indirect ref を含む可能性に備えて resolve しつつ、数値の文字列化は元の
+ * decimal 表現を尊重 (PDFNumber.asNumber() は number、文字列化は toString)。
+ */
+function encodeRect(arr: PDFArray, context: PDFContext): Buffer {
+  const parts: string[] = [];
+  const size = arr.size();
+  for (let i = 0; i < size; i++) {
+    const elem = arr.get(i);
+    const resolved = elem instanceof PDFRef ? context.lookup(elem) : elem;
+    if (resolved instanceof PDFNumber) {
+      parts.push(String(resolved.asNumber()));
+    } else {
+      parts.push(`<${resolved?.constructor.name ?? 'undefined'}>`);
+    }
+  }
+  return Buffer.from(parts.join(','));
+}
+
+/**
+ * PDFObject の canonical digest を返す。Resources subtree 等を再帰的に hash 化。
+ *
+ * - PDFDict: entries を name 文字列 sort してから recurse (V8 iteration order 差吸収)
+ * - PDFArray: 順序保持して recurse (PDF semantically order-sensitive)
+ * - PDFRef: 循環防止 + lookup して resolve した先を recurse
+ * - PDFStream: dict subtree + decoded bytes
+ * - その他 scalar: 型 prefix + 値 string
+ *
+ * 循環 ref を visited で検出 (PDFRef は pdf-lib 側で同一識別子を共有 instance に
+ * 解決される設計のため Set<PDFRef> で識別可能)。
+ */
+export function canonicalDigest(obj: PDFObject, context: PDFContext): Buffer {
+  const sha = crypto.createHash('sha256');
+  walk(sha, obj, context, new Set<PDFRef>());
+  return sha.digest();
+}
+
+function walk(
+  sha: crypto.Hash,
+  obj: PDFObject,
+  context: PDFContext,
+  visited: Set<PDFRef>
+): void {
+  if (obj instanceof PDFRef) {
+    if (visited.has(obj)) {
+      sha.update(`ref-cycle|${obj.objectNumber}|${obj.generationNumber}`);
+      return;
+    }
+    visited.add(obj);
+    const resolved = context.lookup(obj);
+    sha.update('ref|');
+    if (resolved === undefined) {
+      sha.update('<undefined>');
+    } else {
+      walk(sha, resolved, context, visited);
+    }
+    return;
+  }
+  if (obj instanceof PDFDict) {
+    const entries = [...obj.entries()];
+    entries.sort((a, b) => a[0].asString().localeCompare(b[0].asString()));
+    sha.update(`dict|size=${entries.length}`);
+    for (const [k, v] of entries) {
+      sha.update('|key=');
+      sha.update(k.asString());
+      sha.update('|val=');
+      walk(sha, v, context, visited);
+    }
+    return;
+  }
+  if (obj instanceof PDFArray) {
+    const size = obj.size();
+    sha.update(`array|size=${size}`);
+    for (let i = 0; i < size; i++) {
+      sha.update('|');
+      walk(sha, obj.get(i), context, visited);
+    }
+    return;
+  }
+  if (obj instanceof PDFStream) {
+    sha.update('stream|dict=');
+    walk(sha, obj.dict, context, visited);
+    const bytes = decodeStreamBytes(obj);
+    sha.update(`|bytes_len=${bytes.length}|bytes=`);
+    sha.update(Buffer.from(bytes));
+    return;
+  }
+  if (obj instanceof PDFName) {
+    sha.update('name|');
+    sha.update(obj.asString());
+    return;
+  }
+  if (obj instanceof PDFNumber) {
+    sha.update('num|');
+    sha.update(String(obj.asNumber()));
+    return;
+  }
+  if (obj instanceof PDFString) {
+    sha.update('str|');
+    sha.update(obj.asString());
+    return;
+  }
+  if (obj instanceof PDFHexString) {
+    sha.update('hex|');
+    sha.update(Buffer.from(obj.asBytes()));
+    return;
+  }
+  if (obj instanceof PDFBool) {
+    sha.update('bool|');
+    sha.update(obj.asBoolean() ? '1' : '0');
+    return;
+  }
+  if ((obj as unknown) === (PDFNull as unknown)) {
+    sha.update('null');
+    return;
+  }
+  sha.update('unknown|');
+  sha.update(obj.constructor.name);
+}

--- a/scripts/setup-collision-fixture.ts
+++ b/scripts/setup-collision-fixture.ts
@@ -148,18 +148,45 @@ function regenerateChildPdfInOtherProcess(
         cwd: path.resolve(__dirname, '../'),
       }
     );
-    if (result.status !== 0) {
+    // Critical (silent-failure-hunter PR #441 review): spawn 自体の失敗 (ENOENT 等) /
+    // signal kill (SIGTERM by timeout) / outTmp 未書き込み を握りつぶすと、壊れた or
+    // 古い winner PDF を MatchedByHash fixture として upload してしまい、本番条件
+    // (cross-process MatchedByHash 成立) を fixture で破る silent failure になる。
+    if (result.error) {
       throw new Error(
-        `cross-process regenerate failed (exit=${result.status}): ${result.stderr}`
+        `cross-process regenerate spawn failed: ${result.error.message} (signal=${result.signal ?? '<none>'})`
       );
     }
-    return fs.readFileSync(outTmp);
+    if (result.signal) {
+      throw new Error(
+        `cross-process regenerate killed by signal=${result.signal} stderr=${result.stderr}`
+      );
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `cross-process regenerate exit=${result.status} stderr=${result.stderr}`
+      );
+    }
+    if (!fs.existsSync(outTmp)) {
+      throw new Error(
+        `cross-process regenerate reported success (status=0) but outTmp was not written: ${outTmp}`
+      );
+    }
+    const buf = fs.readFileSync(outTmp);
+    if (buf.length === 0) {
+      throw new Error(`cross-process regenerate produced empty file: ${outTmp}`);
+    }
+    return buf;
   } finally {
+    // ENOENT 以外の cleanup 失敗は log だけ残す (disk full 等の検知)
     for (const p of [parentTmp, outTmp, scriptTmp]) {
       try {
         fs.unlinkSync(p);
-      } catch {
-        /* ignore */
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code !== 'ENOENT') {
+          console.warn(`tmp cleanup failed path=${p} code=${code}: ${(err as Error).message}`);
+        }
       }
     }
   }

--- a/scripts/setup-collision-fixture.ts
+++ b/scripts/setup-collision-fixture.ts
@@ -22,6 +22,11 @@
  */
 
 import * as admin from 'firebase-admin';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
 import { PDFDocument } from 'pdf-lib';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
@@ -93,21 +98,71 @@ async function makeUnrelatedPdf(seed: number): Promise<Buffer> {
   return Buffer.from(await pdf.save());
 }
 
-// parent から特定 page range を抽出 (regenerateChildPdf と同等ロジック = hash matched 保証)
-async function extractFromParent(
-  parentBuf: Buffer,
+/**
+ * PR-C2: 別 Node プロセスを spawn して `regenerateChildPdf(parent, start, end)` を
+ * 実行し、その bytes を Storage upload 用に取り出す。setup プロセスと classify プロセスが
+ * 別 process である本番条件を fixture でも再現することで、「visual fingerprint が
+ * cross-process で一致する」ことを fixture 検証で実証する (Codex Important 反映)。
+ *
+ * 失敗時は throw して setup を中止する。
+ */
+function regenerateChildPdfInOtherProcess(
+  parentPdfBuffer: Buffer,
   startPage: number,
   endPage: number
-): Promise<Buffer> {
-  const parent = await PDFDocument.load(parentBuf);
-  const pdf = await PDFDocument.create();
-  const indices = Array.from(
-    { length: endPage - startPage + 1 },
-    (_, i) => startPage - 1 + i
+): Buffer {
+  const parentTmp = path.join(
+    os.tmpdir(),
+    `fixture-parent-${crypto.randomBytes(4).toString('hex')}.pdf`
   );
-  const pages = await pdf.copyPages(parent, indices);
-  pages.forEach((p) => pdf.addPage(p));
-  return Buffer.from(await pdf.save());
+  const outTmp = path.join(
+    os.tmpdir(),
+    `fixture-child-${crypto.randomBytes(4).toString('hex')}.pdf`
+  );
+  const regenModule = path.resolve(__dirname, './lib/pdfRegenerator');
+  const script = `
+    const fs = require('fs');
+    const { regenerateChildPdf } = require(${JSON.stringify(regenModule)});
+    (async () => {
+      const parent = fs.readFileSync(${JSON.stringify(parentTmp)});
+      const child = await regenerateChildPdf(parent, ${startPage}, ${endPage});
+      fs.writeFileSync(${JSON.stringify(outTmp)}, child);
+    })().catch((err) => {
+      process.stderr.write(err.stack || err.message);
+      process.exit(1);
+    });
+  `;
+  const scriptTmp = path.join(
+    os.tmpdir(),
+    `fixture-spawn-${crypto.randomBytes(4).toString('hex')}.js`
+  );
+  fs.writeFileSync(parentTmp, parentPdfBuffer);
+  fs.writeFileSync(scriptTmp, script);
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--require', 'ts-node/register', scriptTmp],
+      {
+        encoding: 'utf-8',
+        timeout: 30000,
+        cwd: path.resolve(__dirname, '../'),
+      }
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `cross-process regenerate failed (exit=${result.status}): ${result.stderr}`
+      );
+    }
+    return fs.readFileSync(outTmp);
+  } finally {
+    for (const p of [parentTmp, outTmp, scriptTmp]) {
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
 }
 
 async function uploadPdf(path: string, buf: Buffer): Promise<void> {
@@ -200,9 +255,15 @@ async function main(): Promise<void> {
 
   // ── MatchedByHash group ──
   // 旧形式 fileUrl で衝突: 両 child docs が `processed/{COLLISION_FILENAME}` を指す
-  // Storage には MATCHED_WINNER の期待 hash と一致する PDF を 1 つだけ upload
-  console.log('Setting up MatchedByHash collision group...');
-  const winnerExpectedBuf = await extractFromParent(parentBuf, 1, 1);
+  // Storage には MATCHED_WINNER の期待 fingerprint と一致する PDF を 1 つだけ upload。
+  //
+  // PR-C2 (Codex Important 反映): winner PDF は **別 Node プロセス** で生成する。
+  // 同プロセス生成だと PR-C1 で見落とした「sha256(raw bytes) は一致するが、別プロセスで
+  // 生成された raw bytes とは異なる」リスクが再発する可能性があるため、本番条件 (setup
+  // と classify が別プロセス) を fixture で再現する。
+  // visual fingerprint は cross-process で一致する設計のため、これでも MatchedByHash 成立。
+  console.log('Setting up MatchedByHash collision group (cross-process generation)...');
+  const winnerExpectedBuf = regenerateChildPdfInOtherProcess(parentBuf, 1, 1);
   const collisionPath = `${FIXTURE_PREFIX}${COLLISION_FILENAME}`;
   await uploadPdf(collisionPath, winnerExpectedBuf);
   const collisionFileUrl = `gs://${storageBucket}/${collisionPath}`;


### PR DESCRIPTION
## Summary

Issue #432 PR-C1 (PR #438 / `3d88fdb`) は `sha256(raw PDF bytes)` で MatchedByHash 判定する設計だったが、pdf-lib `PDFDocument.save()` がプロセス間で異なる bytes を返す non-determinism (PDF `/ID` random + internal metadata) を見落としていた。dev fixture 検証で MatchedByHash 0 件 (期待 2 件) となり kanameone 90+ docs の自動復旧が成立しないことが発覚 (session59)。

本 PR は hash 比較を **`pdf-page-visual-v1` visual fingerprint** に置き換え、cross-process でも MatchedByHash が確定的に成立する設計に修正する。

## 反映 review 履歴 (3 commits)

1. **PR-C2 v2 計画反映** (`0a06d82`): session59 で取得済の Codex セカンドオピニオン Critical 3 + Important 5 + Suggestion 4 を実装に反映
2. **Codex MCP post-review 反映 v1.1** (`1e5988f`): PR #441 作成後 `/codex review` で発見した Critical 1 (visible annotations) + Important 4 (DCTDecode/visited stack/UserUnit-Group/pdfLibVersion) + Suggestion 3 (CropBox fallback / AmbiguousReasonKind drift / UnsupportedReason re-export) を反映
3. **5 並列 review 反映 v1.2** (`6829932`): `/review-pr all parallel` で 5 専門 agent (code-reviewer / pr-test-analyzer / silent-failure-hunter / type-design-analyzer / comment-analyzer) を並列実行し発見:
   - **Critical (本番展開ブロッカー) ×2**:
     - localeCompare による cross-machine 非決定性 → byte-order sort
     - spawnSync の error/signal/missing outTmp/empty buffer を握りつぶし → 明示 throw
   - **Important ×5**: canonicalDigest catch-all を malformed/unsupported-resource-filter に分類、buildDocEvidence catch-all を permanent unsupported.malformed に降格、AC13 gate の unit test 5 件追加、gate 数表記統一、AmbiguousReasonString を template literal type で型強制
   - **Suggestion**: runbook の Ambiguous reason 表を annotations / unsupported-resource-filter 別行に分割

## fingerprint algorithm (pdf-page-visual-v1)

各 PDF ページの「描画同一性」を以下の構成要素で sha256 化:
1. **decoded Contents bytes** (正規化禁止 — whitespace/operator 順/inline image data を保持)
2. **page-level visual entries**: MediaBox / **effective CropBox (absent==MediaBox fallback)** / Rotate / **UserUnit** (v1.1) / **Group** (v1.1)
3. **Resources subtree canonical digest**: Font / XObject / ExtGState / ColorSpace / Pattern / Shading / ProcSet を recursion stack ベースで recurse、**PDFDict entries は byte-order sort** (v1.2: locale 非依存)
4. **visible annotations あり**: page.node.Annots() 非空 → `unsupported.annotations` に降格 (偽陽性回避、v1.1)
5. **unsupported features**: encryption / acroform / optional-content / malformed / **annotations** / **unsupported-resource-filter** (DCTDecode/JPXDecode 等)

> **cross-process deterministic 検証**: 別 Node プロセスで生成した PDF と同プロセス生成 PDF が同 fingerprint を返す (functions/test/pdfPageVisualFingerprint.test.ts で cross-process spawn + cross-locale spawn 検証)。

## 6+1 重 gate (AC13 拡張)

`execute-collision-migration.ts` の 多重 gate (現在 7 種):
1. `approval.planId === plan.planId`
2. `operation.operationId ∈ approvedOperationIds`
3. destructive action は `sourcePath/destPath ∈ approvedPaths`
4. runtime env `(FIREBASE_PROJECT_ID + STORAGE_BUCKET)` が plan の `(projectId + bucket)` と一致
5. precondition snapshot (expectedCurrentFileUrl + expectedStatus + expectedUpdatedAt) と現状 doc が一致
6. **`plan.hashAlgorithm === HASH_ALGORITHM`** (AC13, PR-C2)
7. **`plan.pdfLibVersion === expectedPdfLibVersion`** (AC13 拡張, v1.1 Codex Important 反映)

Gate 0 (defense-in-depth): Ambiguous + suggestedWinner=true の destructive action を reject

## 変更ファイル (9 files, +1858/-93 行)

| 種別 | ファイル | 行数 |
|---|---|---|
| 新規 | `scripts/lib/pdfPageVisualFingerprint.ts` | ~470 行 |
| 新規 | `functions/test/pdfPageVisualFingerprint.test.ts` | ~410 行 |
| 新規 | `functions/test/executeCollisionMigrationGate.test.ts` | ~180 行 (v1.2) |
| 変更 | `scripts/lib/collisionClassifier.ts` | +135/-19 |
| 変更 | `scripts/classify-collision-docs.ts` | +95/-32 |
| 変更 | `scripts/execute-collision-migration.ts` | +35/-3 |
| 変更 | `scripts/setup-collision-fixture.ts` | +135/-22 |
| 変更 | `functions/test/collisionClassifier.test.ts` | +207/-12 |
| 変更 | `docs/runbooks/orphan-storage-cleanup.md` | +43/-6 |

## Test plan

- [x] `cd functions && npm test` → **955 passing** (cross-process + cross-locale + AC13 gate test 全件)
- [x] `cd scripts && npx tsc --noEmit` → PASS
- [x] `cd functions && npm run type-check:test` → PASS
- [x] `/codex review` MCP セカンドオピニオン → Critical 1 + Important 4 + Suggestion 3 反映済 (commit 1e5988f)
- [x] `/review-pr all parallel` (5 並列 review) → Critical 2 + Important 5 + Suggestion 1 反映済 (commit 6829932)
- [x] **dev 環境通し検証** (merge 前必須、[結果コメント](https://github.com/yasushi-honda/doc-split/pull/441#issuecomment-4426066508)): MatchedByHash=1 / Ambiguous=2 / RepairableMissingFile=2 / LostOrUnrecoverable=1 で 5 分類成立確認 ✅

## Acceptance Criteria

- AC1-AC8: PR-C1 から継続 (5 分類 + idempotent execute + Partial update 不変 + gate + dev fixture + ADR-0008 遵守)
- AC9-12: 偽陽性防止 (XObject/font/Rotate/CropBox/UserUnit/Group/annotations の差分検出)
- AC13: hashAlgorithm + pdfLibVersion version gate (unit test 5 件で gate reject の exit 2 確認)
- AC14: pdf-lib internal API lock test (decodePDFRawStream / PDFRawStream / PDFPageLeaf 等)

## 残作業 (後続 PR 候補)

- per-record `hashEvidence.algorithm` cross-check at execute time
- JPEG/PNG XObject 偽陽性防止 test (実 image XObject fixture)
- Form XObject 偽陽性防止 test
- encryption / optional-content の fingerprint 関数側 test
- `setup-collision-fixture` の dynamic prefix 列挙 cleanup
- `--outcomes <out.json>` オプションで gate-rejected / error operationId を永続化

## Refs

- Issue #432
- session59 handoff: `docs/handoff/LATEST.md` §session59
- 教訓 memory: `~/.claude/memory/feedback_deterministic_cross_process.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)