### PR TITLE
feat(splitPdf): Issue #445 PR-D2 — provenance 10 fields 必須 + concurrent write 検出 + atomic batch

### DIFF
--- a/docs/context/data-model.md
+++ b/docs/context/data-model.md
@@ -680,6 +680,19 @@ interface DocumentProvenance {
 - `fileName` / `displayFileName` は引き続き UI 表示・ソート・検索用、`derivedObjectPath` を Storage identity / path construction / Firestore lookup key として使い分ける（ADR-0014 + ADR-0016 SHOULD 3 / MUST 4）。
 - `createdAt` は audit / トレース用途のみで、PR-C3c（PR #452）の自動復旧 gate（6-field provenance）と混同しない（Codex MCP Low 1 指摘）。
 
+### 実装注釈（PR-D2 splitPdf 改修時の運用ルール）
+
+PR-D2（`splitPdf` 改修、Issue #445）以降、provenance の書込は以下のパターンで実装する：
+
+| 項目 | 実装上の選択 | 理由 |
+|------|------------|------|
+| `createdAt` の生成 | `Timestamp.now()`（`firebase-admin/firestore` の admin Timestamp、`provenance.ts` factory が自動付与） | factory で 10 fields 完備を保証するため、`FieldValue.serverTimestamp()` sentinel ではなく具体値の Timestamp を使う。runtime 検証 + lowercase 正規化 + 省略時 default を 1 箇所にカプセル化（`createSplitProvenance()`）。`processedAt` 等の他 audit field は引き続き `serverTimestamp()` を使用（書込タイミングが Firestore commit 側に委譲できる場合）。 |
+| `sourceSha256` / `derivedSha256` の計算 | `crypto.createHash('sha256').update(buffer).digest('hex')` で **書込/読込した buffer から compute** | GCS metadata は `md5Hash` / `crc32c` のみ提供し sha256 を含まない。MUST 5（同一 read snapshot 整合）保証のため、download / save に使った実 buffer から計算する。 |
+| `source*` 5 fields の取得タイミング | `acquireSourceSnapshot()` helper で **`getMetadata() → download() → getMetadata()`** 3-stage 一致確認 | download 中の親 PDF 上書き（concurrent write）を検出。`generation` + `metageneration` 両方が一致するときのみ snapshot として採用。不一致は `SourceDriftError` で retry / abort（Codex H1 / H2 反映）。 |
+| `derived*` 4 fields の取得タイミング | `file.save()` resolve 直後の `file.getMetadata()` で取得、sha256 は同時に compute | GCS は object write 後の metadata read を strongly consistent に保証。eventual consistency による不正値リスクなし。 |
+| Firestore 書込の atomicity | 全 segments を accumulate → 最終 drift check 通過後に **`db.batch().commit()`** で原子書込 | 個別 `newDocRef.set()` 中失敗による partial child docs を構造的に排除（Codex H3 反映）。Storage の cleanup は別途 best-effort（`ifGenerationMatch` precondition 付き）。 |
+| `provenance.sourcePath` のフォーマット | GCS **object name のみ**（`gs://` prefix を含まない） | `parseGcsUri()` で fileUrl から bucket + objectName を分離、bucket mismatch は `failed-precondition` で abort。factory の runtime 検証で `gs://` 始まりを reject。 |
+
 ---
 
 ## 定数（ビジネスロジック設定値）

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -263,6 +263,9 @@ export function getReprocessClearFields() {
     pageResults: df,
     // 表示用ファイル名（#178 displayFileName自動生成）
     displayFileName: df,
+    // 分割 PDF provenance (#445 ADR-0016): 再処理時に古い snapshot を残すと
+    // derivedObjectPath と実 Storage state が不整合になるため必ずクリアする
+    provenance: df,
     // メタ情報
     customerName: df,
     customerId: df,

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -330,6 +330,15 @@ export const splitPdf = onCall(
     if (!Array.isArray(segments) || segments.length === 0) {
       throw new HttpsError('invalid-argument', 'segments must be a non-empty array');
     }
+    // Codex post-impl review Low 1 反映: Firestore batch.commit() は 500 writes の hard limit。
+    // batch 内訳は child set × N + parent update × 1 = N+1 ≤ 500 → N ≤ 499 が安全な上限。
+    // 実運用で 500 segment 分割は非現実的だが明示的に弾く (UI / API 双方への防御線)。
+    if (segments.length > 499) {
+      throw new HttpsError(
+        'invalid-argument',
+        `segments.length=${segments.length} exceeds Firestore batch write limit (max 499 to allow 1 parent update in same commit)`
+      );
+    }
     for (let i = 0; i < segments.length; i++) {
       const seg = segments[i];
       if (

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -430,6 +430,18 @@ export const splitPdf = onCall(
       // PDF を読み込み
       const pdfDoc = await PDFDocument.load(buffer);
 
+      // Evaluator LOW 3 反映: endPage が実 PDF ページ数を超えると pdf-lib copyPages が
+      // raw Error を throw し、Cloud Functions INTERNAL エラーで client に伝播してデバッグ
+      // 困難になる。invalid-argument として早期 abort し、原因を明示する。
+      const totalSourcePages = pdfDoc.getPageCount();
+      const outOfRange = segments.find((s) => s.endPage > totalSourcePages);
+      if (outOfRange) {
+        throw new HttpsError(
+          'invalid-argument',
+          `segment endPage=${outOfRange.endPage} exceeds source PDF totalPages=${totalSourcePages}`
+        );
+      }
+
       // segments を accumulate (Firestore set はまだ実行しない)
       // Codex High 3: Firestore は最後に batch.commit で原子書込、partial state を消す
       const accumulated: AccumulatedSegment[] = [];

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -11,8 +11,8 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
-import * as crypto from 'crypto';
 import { PDFDocument, degrees } from 'pdf-lib';
+import { sha256Hex } from '../utils/hash';
 import {
   analyzePdf,
   generateSplitSummary,
@@ -384,11 +384,10 @@ export const splitPdf = onCall(
       try {
         const snap = await acquireSourceSnapshot(file);
         buffer = snap.buffer;
-        const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
         sourceSnapshot = {
           generation: snap.generation,
           metageneration: snap.metageneration,
-          sha256,
+          sha256: sha256Hex(buffer),
         };
       } catch (err) {
         if (err instanceof SourceDriftError) {
@@ -459,8 +458,9 @@ export const splitPdf = onCall(
           const newFilePath = `processed/${newDocRef.id}/${fileName}`;
           const newFile = bucket.file(newFilePath);
 
-          // Storage save (失敗は callable error として surface)
-          await newFile.save(Buffer.from(newPdfBytes), {
+          // Storage save (失敗は callable error として surface)。
+          // pdf-lib の Uint8Array を直接渡し、sha256 と共用して Buffer.from 二重 allocation を回避。
+          await newFile.save(newPdfBytes, {
             metadata: { contentType: 'application/pdf' },
           });
 
@@ -474,10 +474,7 @@ export const splitPdf = onCall(
               `Failed to retrieve derived metadata for ${newFilePath} (gen=${derivedGeneration}, meta=${derivedMetageneration})`
             );
           }
-          const derivedSha256 = crypto
-            .createHash('sha256')
-            .update(Buffer.from(newPdfBytes))
-            .digest('hex');
+          const derivedSha256 = sha256Hex(newPdfBytes);
 
           // 分割後のページ結果を抽出
           const segmentPageResults = (docData.pageResults || []).filter(

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -11,6 +11,7 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import * as crypto from 'crypto';
 import { PDFDocument, degrees } from 'pdf-lib';
 import {
   analyzePdf,
@@ -24,6 +25,15 @@ import { timestampToDateString } from '../utils/timestampHelpers';
 import { loadMasterData } from '../utils/loadMasterData';
 import { sanitizeFilenameForStorage } from '../utils/fileNaming';
 import { canSafelyDeleteStorageFile } from '../storage/storageDeletionGuard';
+import { createSplitProvenance } from './provenance';
+import {
+  SourceDriftError,
+  acquireSourceSnapshot,
+  backoffSleep,
+  parseGcsUri,
+  verifyFinalDrift,
+  verifySnapshotConsistency,
+} from './splitSnapshot';
 
 const db = admin.firestore();
 const storage = admin.storage();
@@ -242,6 +252,53 @@ interface SplitRequest {
 /**
  * PDFを分割して新しいドキュメントを作成
  */
+// ============================================
+// splitPdf 内部: drift 時に cleanup する Storage file の最小 shape
+// (Codex Medium 3: ifGenerationMatch precondition で誤削除防止)
+// ============================================
+
+interface CleanableStorageFile {
+  delete(options?: { ifGenerationMatch?: string | number }): Promise<unknown>;
+}
+
+interface AccumulatedSegment {
+  newDocRef: FirebaseFirestore.DocumentReference;
+  newFile: CleanableStorageFile;
+  newFilePath: string;
+  fileName: string;
+  derivedGeneration: string;
+  payload: Record<string, unknown>;
+}
+
+async function cleanupAccumulatedStorageFiles(
+  accumulated: AccumulatedSegment[],
+  stage: string,
+  parentDocumentId: string
+): Promise<void> {
+  if (accumulated.length === 0) return;
+  const results = await Promise.allSettled(
+    accumulated.map((item) =>
+      item.newFile.delete({ ifGenerationMatch: item.derivedGeneration })
+    )
+  );
+  const failed = results.filter((r) => r.status === 'rejected');
+  if (failed.length > 0) {
+    console.error('splitPdf: failed to cleanup some accumulated Storage files', {
+      operation: 'splitPdf',
+      stage,
+      parentDocumentId,
+      totalCount: accumulated.length,
+      failedCount: failed.length,
+      failedPaths: accumulated
+        .map((item, idx) =>
+          results[idx].status === 'rejected' ? item.newFilePath : null
+        )
+        .filter((p): p is string => p !== null),
+      manualCleanupHint: 'gsutil rm gs://<bucket>/<path> for each failed path',
+    });
+  }
+}
+
 export const splitPdf = onCall(
   {
     region: 'asia-northeast1',
@@ -263,6 +320,26 @@ export const splitPdf = onCall(
     if (!documentId || !splitPoints || !segments) {
       throw new HttpsError('invalid-argument', 'Missing required fields');
     }
+    // Codex Low 2: segments の page 範囲を runtime 検証 (UI を信用しすぎない)
+    if (!Array.isArray(segments) || segments.length === 0) {
+      throw new HttpsError('invalid-argument', 'segments must be a non-empty array');
+    }
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      if (
+        typeof seg.startPage !== 'number' ||
+        typeof seg.endPage !== 'number' ||
+        !Number.isInteger(seg.startPage) ||
+        !Number.isInteger(seg.endPage) ||
+        seg.startPage < 1 ||
+        seg.endPage < seg.startPage
+      ) {
+        throw new HttpsError(
+          'invalid-argument',
+          `segments[${i}] has invalid page range: start=${seg.startPage}, end=${seg.endPage}`
+        );
+      }
+    }
 
     // 元ドキュメント取得
     const docRef = db.doc(`documents/${documentId}`);
@@ -275,235 +352,348 @@ export const splitPdf = onCall(
     const docData = docSnapshot.data()!;
     const fileUrl = docData.fileUrl as string;
 
-    // PDFファイルをダウンロード
+    // Codex Medium 1: gs:// URI parser + bucket mismatch を failed-precondition で abort
     const bucket = storage.bucket();
-    const filePath = fileUrl.replace(`gs://${bucket.name}/`, '');
-    const file = bucket.file(filePath);
-    const [buffer] = await file.download();
-
-    // PDFを読み込み
-    const pdfDoc = await PDFDocument.load(buffer);
-
-    const createdDocIds: string[] = [];
-
-    // 各セグメントを分割
-    for (const segment of segments) {
-      const {
-        startPage,
-        endPage,
-        documentType,
-        customerName,
-        customerId,
-        officeName,
-        officeId,
-        customerCandidates,
-        officeCandidates,
-        // needsManualCustomerSelection, needsManualOfficeSelectionは
-        // 分割UIで選択済みのため常にfalseになる
-        // isDuplicateCustomer, careManagerName は buildSplitDocumentData(segment) で処理
-      } = segment;
-
-      // 新しいPDFを作成
-      const newPdf = await PDFDocument.create();
-      const pageIndices = Array.from(
-        { length: endPage - startPage + 1 },
-        (_, i) => startPage - 1 + i
+    let sourceObjectName: string;
+    try {
+      const parsed = parseGcsUri(fileUrl, bucket.name);
+      sourceObjectName = parsed.objectName;
+    } catch (err) {
+      throw new HttpsError(
+        'failed-precondition',
+        `Source fileUrl is not a valid gs:// URI in bucket "${bucket.name}": ${
+          err instanceof Error ? err.message : String(err)
+        }`
       );
-      const copiedPages = await newPdf.copyPages(pdfDoc, pageIndices);
-      copiedPages.forEach((page) => newPdf.addPage(page));
+    }
+    const file = bucket.file(sourceObjectName);
 
-      // PDFをバイト配列に変換
-      const newPdfBytes = await newPdf.save();
+    const MAX_RETRIES = 2; // 合計 3 attempts
+    let lastDriftError: SourceDriftError | null = null;
 
-      // Issue #432 PR-B: docId namespace 分離で Storage path 衝突を根治。
-      // Firestore docId を Storage save 前に確定させ path に組み込む。
-      // PR-A (storageDeletionGuard) は旧 path 旧 doc 保護用に恒久有効。本 PR は新規 split のみ根治。
-      const newDocRef = db.collection('documents').doc();
-
-      // ファイル名生成。
-      const timestamp = Date.now();
-      const fileName = generateFileName({
-        customerName,
-        documentType,
-        timestamp,
-        startPage,
-        endPage,
-      });
-
-      // Cloud Storage に保存 (Issue #432 PR-B: processed/{docId}/{fileName} で一意性保証)。
-      // NOTE: 意図的に try/catch なし。Storage save 失敗は callable error として
-      // caller に surface すべき (この時点で Firestore set 未実行のため orphan 不発生)。
-      const newFilePath = `processed/${newDocRef.id}/${fileName}`;
-      const newFile = bucket.file(newFilePath);
-      await newFile.save(Buffer.from(newPdfBytes), {
-        metadata: { contentType: 'application/pdf' },
-      });
-
-      // 分割後のページ結果を抽出
-      const segmentPageResults = (docData.pageResults || []).filter(
-        (p: SplitPageInput) => p.pageNumber >= startPage && p.pageNumber <= endPage
-      );
-
-      // ocrExtractionスナップショットを構築
-      // 元ドキュメントのocrExtractionがあれば継承、なければsplit-legacyとして生成
-      const parentOcrExtraction = docData.ocrExtraction;
-      const ocrExtraction = parentOcrExtraction
-        ? {
-            ...parentOcrExtraction,
-            splitFrom: {
-              documentId,
-              pages: { start: startPage, end: endPage },
-            },
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      // T1: 3-stage metadata-download-metadata snapshot
+      // (Codex High 1/H2: download 中の上書きを generation + metageneration 両方で検出)
+      // 純粋 orchestration は splitSnapshot.ts に抽出済 (Codex M4 対応の unit test 可能化)
+      let buffer: Buffer;
+      let sourceSnapshot: {
+        generation: string;
+        metageneration: string;
+        sha256: string;
+      };
+      try {
+        const snap = await acquireSourceSnapshot(file);
+        buffer = snap.buffer;
+        const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
+        sourceSnapshot = {
+          generation: snap.generation,
+          metageneration: snap.metageneration,
+          sha256,
+        };
+      } catch (err) {
+        if (err instanceof SourceDriftError) {
+          console.warn('splitPdf: source drift detected during snapshot acquisition', {
+            operation: 'splitPdf',
+            stage: 'sourceSnapshot',
+            attempt,
+            parentDocumentId: documentId,
+            before: err.before,
+            after: err.after,
+          });
+          lastDriftError = err;
+          if (attempt < MAX_RETRIES) {
+            await backoffSleep(attempt);
+            continue;
           }
-        : {
-            version: 'split-legacy',
-            extractedAt: admin.firestore.FieldValue.serverTimestamp(),
-            customer: {
-              name: customerName,
-              id: customerId || null,
-              candidates: customerCandidates || [],
-            },
-            office: {
-              name: officeName,
-              id: officeId || null,
-              candidates: officeCandidates || [],
-            },
-            documentType: {
-              name: documentType,
-            },
-            splitFrom: {
-              documentId,
-              pages: { start: startPage, end: endPage },
-            },
+          throw new HttpsError(
+            'aborted',
+            `splitPdf aborted: source concurrent write detected after ${attempt + 1} attempts (${err.message})`
+          );
+        }
+        throw err;
+      }
+
+      // PDF を読み込み
+      const pdfDoc = await PDFDocument.load(buffer);
+
+      // segments を accumulate (Firestore set はまだ実行しない)
+      // Codex High 3: Firestore は最後に batch.commit で原子書込、partial state を消す
+      const accumulated: AccumulatedSegment[] = [];
+
+      try {
+        for (const segment of segments) {
+          const {
+            startPage,
+            endPage,
+            documentType,
+            customerName,
+            customerId,
+            officeName,
+            officeId,
+            customerCandidates,
+            officeCandidates,
+            // needsManualCustomerSelection, needsManualOfficeSelection は
+            // 分割UIで選択済みのため常に false。
+            // isDuplicateCustomer, careManagerName は buildSplitDocumentData(segment) で処理。
+          } = segment;
+
+          const newPdf = await PDFDocument.create();
+          const pageIndices = Array.from(
+            { length: endPage - startPage + 1 },
+            (_, i) => startPage - 1 + i
+          );
+          const copiedPages = await newPdf.copyPages(pdfDoc, pageIndices);
+          copiedPages.forEach((page) => newPdf.addPage(page));
+          const newPdfBytes = await newPdf.save();
+
+          // Issue #432 PR-B: docId namespace 分離で Storage path 衝突を根治
+          const newDocRef = db.collection('documents').doc();
+          const timestamp = Date.now();
+          const fileName = generateFileName({
+            customerName,
+            documentType,
+            timestamp,
+            startPage,
+            endPage,
+          });
+          const newFilePath = `processed/${newDocRef.id}/${fileName}`;
+          const newFile = bucket.file(newFilePath);
+
+          // Storage save (失敗は callable error として surface)
+          await newFile.save(Buffer.from(newPdfBytes), {
+            metadata: { contentType: 'application/pdf' },
+          });
+
+          // T2: file.save() 直後に derived* を取得 (GCS は object metadata strongly consistent)
+          const [derivedMeta] = await newFile.getMetadata();
+          const derivedGeneration = String(derivedMeta.generation ?? '');
+          const derivedMetageneration = String(derivedMeta.metageneration ?? '');
+          if (!derivedGeneration || !derivedMetageneration) {
+            throw new HttpsError(
+              'internal',
+              `Failed to retrieve derived metadata for ${newFilePath} (gen=${derivedGeneration}, meta=${derivedMetageneration})`
+            );
+          }
+          const derivedSha256 = crypto
+            .createHash('sha256')
+            .update(Buffer.from(newPdfBytes))
+            .digest('hex');
+
+          // 分割後のページ結果を抽出
+          const segmentPageResults = (docData.pageResults || []).filter(
+            (p: SplitPageInput) =>
+              p.pageNumber >= startPage && p.pageNumber <= endPage
+          );
+
+          // ocrExtraction スナップショット
+          const parentOcrExtraction = docData.ocrExtraction;
+          const ocrExtraction = parentOcrExtraction
+            ? {
+                ...parentOcrExtraction,
+                splitFrom: {
+                  documentId,
+                  pages: { start: startPage, end: endPage },
+                },
+              }
+            : {
+                version: 'split-legacy',
+                extractedAt: admin.firestore.FieldValue.serverTimestamp(),
+                customer: {
+                  name: customerName,
+                  id: customerId || null,
+                  candidates: customerCandidates || [],
+                },
+                office: {
+                  name: officeName,
+                  id: officeId || null,
+                  candidates: officeCandidates || [],
+                },
+                documentType: { name: documentType },
+                splitFrom: {
+                  documentId,
+                  pages: { start: startPage, end: endPage },
+                },
+              };
+
+          // displayFileName 生成 (#178 Stage 2 / #182 fallback)
+          const displayFileName = generateDisplayFileName({
+            documentType,
+            customerName,
+            officeName,
+            fileDate:
+              docData.fileDateFormatted ?? timestampToDateString(docData.fileDate),
+          });
+
+          // T4: provenance を factory で構築 (10 fields を runtime 検証)
+          const provenance = createSplitProvenance({
+            sourceGeneration: sourceSnapshot.generation,
+            sourceMetageneration: sourceSnapshot.metageneration,
+            sourceSha256: sourceSnapshot.sha256,
+            sourcePath: sourceObjectName,
+            sourceBucket: bucket.name,
+            derivedObjectPath: newFilePath,
+            derivedGeneration,
+            derivedMetageneration,
+            derivedSha256,
+          });
+
+          const splitDocFields = buildSplitDocumentData(segment);
+          const payload: Record<string, unknown> = {
+            ...(displayFileName ? { displayFileName } : {}),
+            id: newDocRef.id,
+            processedAt: admin.firestore.FieldValue.serverTimestamp(),
+            fileId: newDocRef.id,
+            fileName,
+            mimeType: 'application/pdf',
+            ocrResult: extractOcrResultForPages(
+              docData.pageResults || [],
+              startPage,
+              endPage
+            ),
+            // セグメントから構築したフィールド (careManager/careManagerKey 含む)
+            ...splitDocFields,
+            confirmedBy: request.auth?.uid || null,
+            confirmedAt: admin.firestore.FieldValue.serverTimestamp(),
+            officeConfirmedBy: request.auth?.uid || null,
+            officeConfirmedAt: admin.firestore.FieldValue.serverTimestamp(),
+            ocrExtraction,
+            pageResults: segmentPageResults.map(
+              (p: SplitPageInput, index: number) => ({
+                ...p,
+                pageNumber: index + 1,
+                originalPageNumber: p.pageNumber,
+              })
+            ),
+            fileUrl: `gs://${bucket.name}/${newFilePath}`,
+            fileDate: docData.fileDate,
+            totalPages: endPage - startPage + 1,
+            targetPageNumber: 1,
+            status: 'processed',
+            parentDocumentId: documentId,
+            splitFromPages: { start: startPage, end: endPage },
+            provenance,
           };
 
-      // displayFileName 生成 (#178 Stage 2)
-      // #182 fallback: fileDateFormatted は OCR 完了時にのみ設定される派生フィールド。
-      // 旧ドキュメントや手動登録等で未設定の場合は fileDate (Timestamp) から YYYY/MM/DD を
-      // 導出して日付パート欠落を防ぐ。fileDate も null なら日付パートが省略される。
-      const displayFileName = generateDisplayFileName({
-        documentType,
-        customerName,
-        officeName,
-        fileDate:
-          docData.fileDateFormatted ?? timestampToDateString(docData.fileDate),
-      });
-
-      // 新しいドキュメントを Firestore に作成 (ユーザーが分割UIで選択した値は常に confirmed=true)。
-      // Issue #432 PR-B 補償処理: Storage save 成功後の Firestore set 失敗で orphan が
-      // 残ると後続 split との path 衝突リスクが再発するため、best-effort で cleanup する。
-      const splitDocFields = buildSplitDocumentData(segment);
-      try {
-        await newDocRef.set({
-          ...(displayFileName ? { displayFileName } : {}),
-          id: newDocRef.id,
-          processedAt: admin.firestore.FieldValue.serverTimestamp(),
-          fileId: newDocRef.id,
-          fileName,
-          mimeType: 'application/pdf',
-          ocrResult: extractOcrResultForPages(
-            docData.pageResults || [],
-            startPage,
-            endPage
-          ),
-          // セグメントから構築したフィールド（careManager/careManagerKey含む）
-          ...splitDocFields,
-          confirmedBy: request.auth?.uid || null,
-          confirmedAt: admin.firestore.FieldValue.serverTimestamp(),
-          // 事業所確定
-          officeConfirmedBy: request.auth?.uid || null,
-          officeConfirmedAt: admin.firestore.FieldValue.serverTimestamp(),
-          // OCR抽出スナップショット
-          ocrExtraction,
-          // ページ結果（再OCR不要にするため保存）
-          pageResults: segmentPageResults.map((p: SplitPageInput, index: number) => ({
-            ...p,
-            pageNumber: index + 1, // 分割後の新しいページ番号
-            originalPageNumber: p.pageNumber, // 元のページ番号
-          })),
-          // ファイル情報
-          fileUrl: `gs://${bucket.name}/${newFilePath}`,
-          fileDate: docData.fileDate,
-          totalPages: endPage - startPage + 1,
-          targetPageNumber: 1,
-          status: 'processed',
-          parentDocumentId: documentId,
-          splitFromPages: { start: startPage, end: endPage },
-        });
-        createdDocIds.push(newDocRef.id);
-      } catch (firestoreErr) {
-        // Issue #432 PR-B partial state log: segments 途中失敗で先行 N-1 docs が残る
-        // (rollback は本 PR スコープ外、別 Issue で扱う)。
-        console.error('splitPdf failed mid-loop; partial children remain in Firestore', {
+          accumulated.push({
+            newDocRef,
+            newFile,
+            newFilePath,
+            fileName,
+            derivedGeneration,
+            payload,
+          });
+        }
+      } catch (err) {
+        // segment 内 PDF 生成 / Storage save / derived metadata / provenance factory 失敗。
+        // 既に accumulate された Storage files を best-effort cleanup する。
+        console.error('splitPdf: segment processing failed, cleaning up accumulated', {
           operation: 'splitPdf',
           stage: 'segmentsLoop',
+          attempt,
           parentDocumentId: documentId,
-          successfulSegments: createdDocIds.length,
+          accumulatedCount: accumulated.length,
           totalSegments: segments.length,
-          failedSegmentIndex: segments.indexOf(segment),
-          partialChildIds: createdDocIds,
+          error: err instanceof Error ? err.message : String(err),
         });
-        console.error('Firestore set failed after Storage save; attempting orphan cleanup', {
-          operation: 'splitPdf',
-          stage: 'firestoreSet',
-          newDocId: newDocRef.id,
-          newFilePath,
-          error: firestoreErr instanceof Error ? firestoreErr.message : String(firestoreErr),
-        });
-        let cleanupErrorCaptured: unknown = null;
-        try {
-          await newFile.delete();
-        } catch (cleanupErr) {
-          cleanupErrorCaptured = cleanupErr;
-        }
+        await cleanupAccumulatedStorageFiles(accumulated, 'segmentsLoop', documentId);
+        throw err;
+      }
 
-        if (cleanupErrorCaptured === null) {
-          console.warn('Cleaned up orphan Storage file after Firestore set failure', {
+      // T3: Final drift check (Codex High 1/H2: generation + metageneration 両方比較)
+      try {
+        const [finalMeta] = await file.getMetadata();
+        verifyFinalDrift(
+          {
+            generation: sourceSnapshot.generation,
+            metageneration: sourceSnapshot.metageneration,
+          },
+          finalMeta
+        );
+      } catch (err) {
+        if (err instanceof SourceDriftError) {
+          console.warn('splitPdf: source drift detected at final check', {
             operation: 'splitPdf',
-            stage: 'orphanCleanup',
-            newDocId: newDocRef.id,
-            newFilePath,
-            cleanupResult: 'success',
+            stage: 'finalDrift',
+            attempt,
+            parentDocumentId: documentId,
+            before: err.before,
+            after: err.after,
+            accumulatedCount: accumulated.length,
           });
-          throw firestoreErr;
+          await cleanupAccumulatedStorageFiles(
+            accumulated,
+            'finalDrift',
+            documentId
+          );
+          lastDriftError = err;
+          if (attempt < MAX_RETRIES) {
+            await backoffSleep(attempt);
+            continue;
+          }
+          throw new HttpsError(
+            'aborted',
+            `splitPdf aborted: source concurrent write detected after ${attempt + 1} attempts (${err.message})`
+          );
         }
+        throw err;
+      }
 
-        // 二段失敗: cleanup 自体が失敗 → Storage orphan 残存。
-        // audit-storage-mismatch.js の逆方向検出 (Storage→Firestore missing) は別 Issue で追加予定。
-        // 元例外と cleanup 失敗の両方を Error.cause で保持し、Sentry/log dedup での区別を可能に。
-        console.error('Failed to cleanup orphan Storage file (manual cleanup needed)', {
-          operation: 'splitPdf',
-          stage: 'orphanCleanup',
-          newDocId: newDocRef.id,
-          newFilePath,
-          bucket: bucket.name,
-          cleanupResult: 'failed',
-          cleanupError:
-            cleanupErrorCaptured instanceof Error
-              ? cleanupErrorCaptured.message
-              : String(cleanupErrorCaptured),
-          manualCleanupCommand: `gsutil rm gs://${bucket.name}/${newFilePath}`,
-        });
+      // T4: Atomic Firestore batch write (Codex High 3: partial state を消す)
+      const batch = db.batch();
+      for (const item of accumulated) {
+        batch.set(item.newDocRef, item.payload);
+      }
+      try {
+        await batch.commit();
+      } catch (firestoreErr) {
+        console.error(
+          'splitPdf: Firestore batch commit failed; cleaning up Storage orphans',
+          {
+            operation: 'splitPdf',
+            stage: 'firestoreBatch',
+            attempt,
+            parentDocumentId: documentId,
+            accumulatedCount: accumulated.length,
+            error:
+              firestoreErr instanceof Error
+                ? firestoreErr.message
+                : String(firestoreErr),
+          }
+        );
+        await cleanupAccumulatedStorageFiles(
+          accumulated,
+          'firestoreBatch',
+          documentId
+        );
         const wrapped = new Error(
-          `splitPdf: Firestore set failed AND orphan cleanup failed (newDocId=${newDocRef.id}, path=${newFilePath})`
-        ) as Error & { cause?: unknown; orphanLeft?: boolean };
+          `splitPdf: Firestore batch commit failed (parent=${documentId}, segments=${accumulated.length})`
+        ) as Error & { cause?: unknown };
         wrapped.cause = firestoreErr;
-        wrapped.orphanLeft = true;
         throw wrapped;
       }
+
+      const createdDocIds = accumulated.map((item) => item.newDocRef.id);
+
+      // 元ドキュメントのステータスを更新 (分割済みフラグ)
+      await docRef.update({
+        splitInto: createdDocIds,
+        status: 'split',
+        isSplitSource: true,
+      });
+
+      return {
+        success: true,
+        createdDocuments: createdDocIds,
+      };
     }
 
-    // 元ドキュメントのステータスを更新（分割済みフラグ）
-    await docRef.update({
-      splitInto: createdDocIds,
-      status: 'split',
-      isSplitSource: true,
-    });
-
-    return {
-      success: true,
-      createdDocuments: createdDocIds,
-    };
+    // 全 attempts drift で失敗 (上記 throw でほぼ到達しないが安全網)
+    throw new HttpsError(
+      'aborted',
+      `splitPdf aborted: source concurrent write detected (${
+        lastDriftError?.message ?? 'unknown drift'
+      })`
+    );
   }
 );
 

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -562,7 +562,7 @@ export const splitPdf = onCall(
               docData.fileDateFormatted ?? timestampToDateString(docData.fileDate),
           });
 
-          // T4: provenance を factory で構築 (10 fields を runtime 検証)
+          // T2-3: provenance を factory で構築 (10 fields を runtime 検証)
           const provenance = createSplitProvenance({
             sourceGeneration: sourceSnapshot.generation,
             sourceMetageneration: sourceSnapshot.metageneration,
@@ -628,7 +628,22 @@ export const splitPdf = onCall(
           error: err instanceof Error ? err.message : String(err),
         });
         await cleanupAccumulatedStorageFiles(accumulated, 'segmentsLoop', documentId);
-        throw err;
+        // /review-pr silent-failure-hunter C2 反映: HttpsError 以外を rethrow すると
+        // Firebase Functions v2 が INTERNAL に潰すため明示的にラップする。
+        // pdf-lib parse error / GCS getMetadata 失敗 / provenance validation 等を
+        // 全て internal でラップし、原因 message を client へ伝える。
+        if (err instanceof HttpsError) throw err;
+        throw new HttpsError(
+          'internal',
+          `splitPdf segment processing failed at attempt ${attempt}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          {
+            stage: 'segmentsLoop',
+            parentDocumentId: documentId,
+            accumulatedCount: accumulated.length,
+          }
+        );
       }
 
       // T3: Final drift check (Codex High 1/H2: generation + metageneration 両方比較)
@@ -667,7 +682,16 @@ export const splitPdf = onCall(
             `splitPdf aborted: source concurrent write detected after ${attempt + 1} attempts (${err.message})`
           );
         }
-        throw err;
+        // /review-pr silent-failure-hunter I-6: verifyFinalDrift の "Missing generation"
+        // 系 raw Error が INTERNAL に潰れないよう明示ラップ
+        if (err instanceof HttpsError) throw err;
+        throw new HttpsError(
+          'internal',
+          `splitPdf final drift check failed at attempt ${attempt}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { stage: 'finalDrift', parentDocumentId: documentId }
+        );
       }
 
       // T4: Atomic Firestore batch write (Codex High 3 + post-impl High: child + parent
@@ -705,11 +729,22 @@ export const splitPdf = onCall(
           'firestoreBatch',
           documentId
         );
-        const wrapped = new Error(
-          `splitPdf: Firestore batch commit failed (parent=${documentId}, segments=${accumulated.length})`
-        ) as Error & { cause?: unknown };
-        wrapped.cause = firestoreErr;
-        throw wrapped;
+        // /review-pr silent-failure-hunter C1: Firebase Functions v2 は非 HttpsError を
+        // INTERNAL (message: "INTERNAL") に潰す。明示的に internal でラップして
+        // 原因 message + structured details を client / 監視ログへ surface する。
+        throw new HttpsError(
+          'internal',
+          `splitPdf Firestore batch commit failed (parent=${documentId}, segments=${accumulated.length}): ${
+            firestoreErr instanceof Error
+              ? firestoreErr.message
+              : String(firestoreErr)
+          }`,
+          {
+            stage: 'firestoreBatch',
+            parentDocumentId: documentId,
+            accumulatedCount: accumulated.length,
+          }
+        );
       }
 
       return {
@@ -718,12 +753,22 @@ export const splitPdf = onCall(
       };
     }
 
-    // 全 attempts drift で失敗 (上記 throw でほぼ到達しないが安全網)
+    // 通常は到達不能 (retry loop 内 throw で 100% return / throw する)。
+    // 到達したら retry loop の制御フローが壊れている = bug。
+    // /review-pr silent-failure-hunter I-4 反映: 'aborted' は drift retry exhausted を意味し、
+    // この時点では「retry loop が return せず throw もせず抜けた」状態のため 'internal' が正確。
+    console.error('splitPdf: retry loop exited without explicit throw/return (logic bug)', {
+      operation: 'splitPdf',
+      stage: 'retryLoopExit',
+      parentDocumentId: documentId,
+      lastDriftError: lastDriftError?.message ?? null,
+    });
     throw new HttpsError(
-      'aborted',
-      `splitPdf aborted: source concurrent write detected (${
-        lastDriftError?.message ?? 'unknown drift'
-      })`
+      'internal',
+      `splitPdf: retry loop exited unexpectedly (parent=${documentId}, lastDrift=${
+        lastDriftError?.message ?? 'none'
+      })`,
+      { stage: 'retryLoopExit', parentDocumentId: documentId }
     );
   }
 );

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -32,7 +32,6 @@ import {
   backoffSleep,
   parseGcsUri,
   verifyFinalDrift,
-  verifySnapshotConsistency,
 } from './splitSnapshot';
 
 const db = admin.firestore();
@@ -276,9 +275,16 @@ async function cleanupAccumulatedStorageFiles(
   parentDocumentId: string
 ): Promise<void> {
   if (accumulated.length === 0) return;
+  // derivedGeneration が空 = `newFile.save()` 直後・`getMetadata()` 前に失敗した entry。
+  // 自分が生成した newDocRef 配下の新規 path のため、他 process が割込む可能性はない
+  // (newDocRef.id は fresh random で外部公開前)。precondition なしの delete を使う。
   const results = await Promise.allSettled(
     accumulated.map((item) =>
-      item.newFile.delete({ ifGenerationMatch: item.derivedGeneration })
+      item.newFile.delete(
+        item.derivedGeneration
+          ? { ifGenerationMatch: item.derivedGeneration }
+          : undefined
+      )
     )
   );
   const failed = results.filter((r) => r.status === 'rejected');
@@ -464,6 +470,19 @@ export const splitPdf = onCall(
             metadata: { contentType: 'application/pdf' },
           });
 
+          // Codex post-impl review Medium 1 反映: save 直後・metadata 取得前に失敗しても
+          // cleanup 対象になるよう、partial entry を即 accumulated に登録する。
+          // derivedGeneration / payload は後段で fill in。
+          const inflightEntry: AccumulatedSegment = {
+            newDocRef,
+            newFile,
+            newFilePath,
+            fileName,
+            derivedGeneration: '',
+            payload: {},
+          };
+          accumulated.push(inflightEntry);
+
           // T2: file.save() 直後に derived* を取得 (GCS は object metadata strongly consistent)
           const [derivedMeta] = await newFile.getMetadata();
           const derivedGeneration = String(derivedMeta.generation ?? '');
@@ -474,6 +493,7 @@ export const splitPdf = onCall(
               `Failed to retrieve derived metadata for ${newFilePath} (gen=${derivedGeneration}, meta=${derivedMetageneration})`
             );
           }
+          inflightEntry.derivedGeneration = derivedGeneration;
           const derivedSha256 = sha256Hex(newPdfBytes);
 
           // 分割後のページ結果を抽出
@@ -571,14 +591,8 @@ export const splitPdf = onCall(
             provenance,
           };
 
-          accumulated.push({
-            newDocRef,
-            newFile,
-            newFilePath,
-            fileName,
-            derivedGeneration,
-            payload,
-          });
+          // payload を完成させ inflightEntry に書込む (push 済なので別に push しない)
+          inflightEntry.payload = payload;
         }
       } catch (err) {
         // segment 内 PDF 生成 / Storage save / derived metadata / provenance factory 失敗。
@@ -635,11 +649,19 @@ export const splitPdf = onCall(
         throw err;
       }
 
-      // T4: Atomic Firestore batch write (Codex High 3: partial state を消す)
+      // T4: Atomic Firestore batch write (Codex High 3 + post-impl High: child + parent
+      // を同一 batch にまとめて 1 commit にし、「子作成済み・親未 split」状態を構造的に排除)
+      const createdDocIds = accumulated.map((item) => item.newDocRef.id);
       const batch = db.batch();
       for (const item of accumulated) {
         batch.set(item.newDocRef, item.payload);
       }
+      // 元ドキュメントのステータスを更新 (分割済みフラグ) — child set と同一 batch
+      batch.update(docRef, {
+        splitInto: createdDocIds,
+        status: 'split',
+        isSplitSource: true,
+      });
       try {
         await batch.commit();
       } catch (firestoreErr) {
@@ -668,15 +690,6 @@ export const splitPdf = onCall(
         wrapped.cause = firestoreErr;
         throw wrapped;
       }
-
-      const createdDocIds = accumulated.map((item) => item.newDocRef.id);
-
-      // 元ドキュメントのステータスを更新 (分割済みフラグ)
-      await docRef.update({
-        splitInto: createdDocIds,
-        status: 'split',
-        isSplitSource: true,
-      });
 
       return {
         success: true,

--- a/functions/src/pdf/provenance.ts
+++ b/functions/src/pdf/provenance.ts
@@ -1,0 +1,133 @@
+/**
+ * 分割 PDF Provenance Factory + Runtime Validation
+ *
+ * ADR-0016 MUST 2 (10 fields) / MUST 5 (read snapshot 整合) を実装する factory。
+ * sha256 hex 長さ・generation 数値文字列・path 非空を runtime 検証する。
+ *
+ * Issue #445 PR-D2 (splitPdf 改修) で利用。
+ *
+ * 詳細: docs/adr/0016-document-identity-and-provenance.md
+ */
+
+import { Timestamp } from 'firebase-admin/firestore';
+import type { DocumentProvenance } from '../../../shared/types';
+
+const SHA256_HEX_RE = /^[0-9a-fA-F]{64}$/;
+const NUMERIC_STRING_RE = /^[0-9]+$/;
+
+/**
+ * createSplitProvenance() の入力型。createdAt は audit field のため省略可
+ * (省略時は Timestamp.now() を採用)。
+ */
+export interface CreateSplitProvenanceInput {
+  sourceGeneration: string;
+  sourceMetageneration: string;
+  sourceSha256: string;
+  sourcePath: string;
+  sourceBucket: string;
+  derivedObjectPath: string;
+  derivedGeneration: string;
+  derivedMetageneration: string;
+  derivedSha256: string;
+  createdAt?: Timestamp;
+}
+
+export class ProvenanceValidationError extends Error {
+  constructor(public readonly field: string, public readonly reason: string) {
+    super(`Invalid provenance field "${field}": ${reason}`);
+    this.name = 'ProvenanceValidationError';
+  }
+}
+
+function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ProvenanceValidationError(
+      field,
+      `expected non-empty string, got ${typeof value === 'string' ? '""' : typeof value}`
+    );
+  }
+}
+
+function assertSha256Hex(value: unknown, field: string): asserts value is string {
+  assertNonEmptyString(value, field);
+  if (!SHA256_HEX_RE.test(value)) {
+    throw new ProvenanceValidationError(
+      field,
+      `expected 64-char hex string, got length ${value.length}`
+    );
+  }
+}
+
+function assertNumericString(value: unknown, field: string): asserts value is string {
+  assertNonEmptyString(value, field);
+  if (!NUMERIC_STRING_RE.test(value)) {
+    throw new ProvenanceValidationError(
+      field,
+      `expected numeric digit string, got "${value}"`
+    );
+  }
+}
+
+function assertObjectName(value: unknown, field: string): asserts value is string {
+  assertNonEmptyString(value, field);
+  if (value.startsWith('gs://')) {
+    throw new ProvenanceValidationError(
+      field,
+      'expected GCS object name (no "gs://" prefix), got URI'
+    );
+  }
+}
+
+/**
+ * 入力 10 fields 全てを runtime 検証する。失敗時は ProvenanceValidationError を throw。
+ *
+ * 検証規則 (ADR-0016 MUST 2):
+ * - sourceGeneration / sourceMetageneration / derivedGeneration / derivedMetageneration: 数値文字列 (GCS metadata 仕様)
+ * - sourceSha256 / derivedSha256: 64 桁 hex (大小文字許容)
+ * - sourcePath / derivedObjectPath: 非空 + "gs://" prefix 禁止 (object name のみ受け取る)
+ * - sourceBucket: 非空
+ */
+export function assertValidProvenanceInput(input: CreateSplitProvenanceInput): void {
+  assertNumericString(input.sourceGeneration, 'sourceGeneration');
+  assertNumericString(input.sourceMetageneration, 'sourceMetageneration');
+  assertSha256Hex(input.sourceSha256, 'sourceSha256');
+  assertObjectName(input.sourcePath, 'sourcePath');
+  assertNonEmptyString(input.sourceBucket, 'sourceBucket');
+  assertObjectName(input.derivedObjectPath, 'derivedObjectPath');
+  assertNumericString(input.derivedGeneration, 'derivedGeneration');
+  assertNumericString(input.derivedMetageneration, 'derivedMetageneration');
+  assertSha256Hex(input.derivedSha256, 'derivedSha256');
+}
+
+/**
+ * DocumentProvenance を構築する factory。runtime 検証 + sha256 を lowercase 正規化する。
+ *
+ * - createdAt 省略時は Timestamp.now() を採用
+ * - sha256 は lowercase に正規化 (大文字小文字の混在で照合失敗を防ぐ)
+ * - 入力検証 NG 時は ProvenanceValidationError を throw (caller が segment ループを abort できる)
+ *
+ * 戻り値のキャストについて: shared/types.ts の DocumentProvenance.createdAt は
+ * `firebase/firestore` (client SDK) の Timestamp 型を参照しているが、本ファイルでは
+ * `firebase-admin/firestore` の Timestamp を生成する。両者は runtime 互換 (seconds/
+ * nanoseconds/toDate/toMillis/isEqual 同一) だが `toJSON` の有無で TS 型が一致しないため、
+ * 既存パターン (searchIndexer.ts L104 等の admin Timestamp 直書込) と整合させるために
+ * factory 境界で 1 箇所キャストする。
+ */
+export function createSplitProvenance(
+  input: CreateSplitProvenanceInput
+): DocumentProvenance {
+  assertValidProvenanceInput(input);
+  const provenance = {
+    sourceGeneration: input.sourceGeneration,
+    sourceMetageneration: input.sourceMetageneration,
+    sourceSha256: input.sourceSha256.toLowerCase(),
+    sourcePath: input.sourcePath,
+    sourceBucket: input.sourceBucket,
+    derivedObjectPath: input.derivedObjectPath,
+    derivedGeneration: input.derivedGeneration,
+    derivedMetageneration: input.derivedMetageneration,
+    derivedSha256: input.derivedSha256.toLowerCase(),
+    createdAt: input.createdAt ?? Timestamp.now(),
+  };
+  return provenance as unknown as DocumentProvenance;
+}

--- a/functions/src/pdf/splitSnapshot.ts
+++ b/functions/src/pdf/splitSnapshot.ts
@@ -1,0 +1,175 @@
+/**
+ * 分割 PDF Source Snapshot 取得 / Drift 検出 / GCS URI parsing
+ *
+ * ADR-0016 MUST 5 (同一 read snapshot で source\* を取得 + concurrent write 検出) を
+ * 純粋関数で実装する。Codex MCP セカンドオピニオン thread `019e231a-...` の High 1/H2
+ * 指摘を反映した「3-stage metadata-download-metadata 一致確認」パターン。
+ *
+ * Issue #445 PR-D2 (splitPdf 改修) で利用。
+ *
+ * 詳細: docs/adr/0016-document-identity-and-provenance.md
+ */
+
+/**
+ * Source snapshot drift / GCS URI 不整合 検出時に throw されるエラー型。
+ * splitPdf の retry ループで「再試行可能 = drift」と「即 fail = それ以外」を区別するために
+ * instanceof でカテゴリ判定する。
+ */
+export class SourceDriftError extends Error {
+  constructor(
+    message: string,
+    public readonly before: { generation: string; metageneration: string },
+    public readonly after: { generation: string; metageneration: string }
+  ) {
+    super(message);
+    this.name = 'SourceDriftError';
+  }
+}
+
+/**
+ * `gs://bucket/path/to/object` 形式の URI を bucket と object name に分解する。
+ *
+ * - 不正形式 / 別 bucket / 空 object name は throw する (caller は failed-precondition で abort)
+ * - `gs://` prefix を含まない単純 path や、別 prefix (例: `https://`) も拒否
+ *
+ * 期待 bucket を渡すと bucket mismatch も検出する。
+ *
+ * Codex Medium 1 指摘 (fileUrl.replace の脆弱性) への対応。
+ */
+export function parseGcsUri(
+  uri: string,
+  expectedBucket?: string
+): { bucket: string; objectName: string } {
+  if (typeof uri !== 'string' || uri.length === 0) {
+    throw new Error(`Invalid GCS URI: expected non-empty string, got ${typeof uri}`);
+  }
+  const match = uri.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!match) {
+    throw new Error(`Invalid GCS URI: expected "gs://bucket/object", got "${uri}"`);
+  }
+  const [, bucket, objectName] = match;
+  if (expectedBucket !== undefined && bucket !== expectedBucket) {
+    throw new Error(
+      `GCS bucket mismatch: expected "${expectedBucket}", got "${bucket}" in URI "${uri}"`
+    );
+  }
+  return { bucket, objectName };
+}
+
+/**
+ * `getMetadata()` の戻り値 2 件を比較し、generation と metageneration の両方が
+ * 一致しているか検証する pure function。
+ *
+ * - 一致 → snapshot として採用可能 (戻り値 = consistent snapshot)
+ * - 不一致 → SourceDriftError を throw (caller が retry or abort を判断)
+ *
+ * Codex High 1 (snapshot 一致確認) + High 2 (metageneration も必須) 反映。
+ */
+export function verifySnapshotConsistency(
+  before: { generation?: string | number; metageneration?: string | number },
+  after: { generation?: string | number; metageneration?: string | number }
+): { generation: string; metageneration: string } {
+  const beforeGen = String(before.generation ?? '');
+  const beforeMeta = String(before.metageneration ?? '');
+  const afterGen = String(after.generation ?? '');
+  const afterMeta = String(after.metageneration ?? '');
+
+  if (!beforeGen || !beforeMeta || !afterGen || !afterMeta) {
+    throw new Error(
+      `Missing generation/metageneration in metadata: before=(${beforeGen},${beforeMeta}) after=(${afterGen},${afterMeta})`
+    );
+  }
+  if (beforeGen !== afterGen || beforeMeta !== afterMeta) {
+    throw new SourceDriftError(
+      `Source object changed during download: ` +
+        `generation ${beforeGen} → ${afterGen}, metageneration ${beforeMeta} → ${afterMeta}`,
+      { generation: beforeGen, metageneration: beforeMeta },
+      { generation: afterGen, metageneration: afterMeta }
+    );
+  }
+  return { generation: beforeGen, metageneration: beforeMeta };
+}
+
+/**
+ * Final drift check (segments ループ後、Firestore batch write 前)。
+ * 取得済み source snapshot と再取得した親 metadata を比較する。
+ *
+ * 一致 → 続行可能 / 不一致 → SourceDriftError throw (caller は cleanup + retry)
+ */
+export function verifyFinalDrift(
+  snapshot: { generation: string; metageneration: string },
+  finalMetadata: { generation?: string | number; metageneration?: string | number }
+): void {
+  const finalGen = String(finalMetadata.generation ?? '');
+  const finalMeta = String(finalMetadata.metageneration ?? '');
+  if (!finalGen || !finalMeta) {
+    throw new Error(
+      `Missing generation/metageneration in final metadata check: gen=${finalGen}, meta=${finalMeta}`
+    );
+  }
+  if (finalGen !== snapshot.generation || finalMeta !== snapshot.metageneration) {
+    throw new SourceDriftError(
+      `Source object changed during segments processing: ` +
+        `generation ${snapshot.generation} → ${finalGen}, metageneration ${snapshot.metageneration} → ${finalMeta}`,
+      snapshot,
+      { generation: finalGen, metageneration: finalMeta }
+    );
+  }
+}
+
+/**
+ * GCS File から source snapshot を 3-stage で取得する orchestration helper。
+ * (Codex High 1 反映: metadata-download-metadata で download 中の上書きを検出)
+ *
+ * mock 可能な最小 File-like interface のみ受け取るので unit test 可能。
+ * splitPdf 内では `bucket.file(name)` を渡す。
+ *
+ * @returns 一致した snapshot + download した bytes
+ * @throws SourceDriftError - generation または metageneration が download 前後で変化
+ * @throws Error - metadata に必須フィールド欠落
+ */
+export interface SnapshotFile {
+  // GCS @google-cloud/storage File.getMetadata は [Metadata, ApiResponse] の tuple を返す。
+  // 我々が使うのは先頭の Metadata のみだが、rest 要素を許容して real type と互換にする。
+  getMetadata(): Promise<
+    [
+      {
+        generation?: string | number;
+        metageneration?: string | number;
+        [k: string]: unknown;
+      },
+      ...unknown[],
+    ]
+  >;
+  download(): Promise<[Buffer, ...unknown[]]>;
+}
+
+export async function acquireSourceSnapshot(file: SnapshotFile): Promise<{
+  buffer: Buffer;
+  generation: string;
+  metageneration: string;
+}> {
+  const [metaBefore] = await file.getMetadata();
+  const [buffer] = await file.download();
+  const [metaAfter] = await file.getMetadata();
+  const consistent = verifySnapshotConsistency(metaBefore, metaAfter);
+  return {
+    buffer,
+    generation: consistent.generation,
+    metageneration: consistent.metageneration,
+  };
+}
+
+/**
+ * concurrent write retry 間の sleep。jitter 付き backoff で連続衝突を緩和する。
+ *
+ * Codex Medium 2 指摘: 連続上書き中の即 retry を避けるため 100ms / 300ms ベースで
+ * jitter を加える。
+ *
+ * @param attempt 0-indexed の試行回数 (0 → 1 回目失敗後の sleep, 1 → 2 回目失敗後の sleep)
+ */
+export async function backoffSleep(attempt: number): Promise<void> {
+  const baseMs = attempt === 0 ? 100 : 300;
+  const jitter = Math.floor(Math.random() * baseMs * 0.5);
+  await new Promise<void>((resolve) => setTimeout(resolve, baseMs + jitter));
+}

--- a/functions/src/pdf/splitSnapshot.ts
+++ b/functions/src/pdf/splitSnapshot.ts
@@ -2,8 +2,9 @@
  * 分割 PDF Source Snapshot 取得 / Drift 検出 / GCS URI parsing
  *
  * ADR-0016 MUST 5 (同一 read snapshot で source\* を取得 + concurrent write 検出) を
- * 純粋関数で実装する。Codex MCP セカンドオピニオン thread `019e231a-...` の High 1/H2
- * 指摘を反映した「3-stage metadata-download-metadata 一致確認」パターン。
+ * 純粋関数で実装する。「3-stage metadata-download-metadata 一致確認」パターンで
+ * download 中の親 PDF 上書きを generation + metageneration 両方で検知する
+ * (Codex MCP セカンドオピニオン High 1/H2 指摘反映、詳細は PR #456 description 参照)。
  *
  * Issue #445 PR-D2 (splitPdf 改修) で利用。
  *

--- a/functions/src/utils/hash.ts
+++ b/functions/src/utils/hash.ts
@@ -1,0 +1,21 @@
+/**
+ * 暗号学的ハッシュ計算の共通 helper。
+ *
+ * 同一の `crypto.createHash('sha256').update(buffer).digest('hex')` idiom が
+ * functions/scripts/test に 5+ 箇所散在していたため統一する (Issue #445 PR-D2 review)。
+ *
+ * 使用箇所: functions/src/pdf/pdfOperations.ts (source/derived sha256),
+ * functions/src/pdf/provenance.ts (型整合の正規化), scripts/lib/parentPdfProvenance.ts
+ * (将来 migrate 予定), pdf-feature-survey.ts (将来 migrate 予定)。
+ */
+
+import * as crypto from 'crypto';
+
+/**
+ * バッファの SHA-256 を 16 進文字列で返す。Uint8Array / Buffer の両方を受け取れる
+ * (`pdf-lib` の `PDFDocument.save()` は Uint8Array を返すため、Buffer 化せずに
+ * 直接渡して 2 回の Buffer 化 allocation を避ける)。
+ */
+export function sha256Hex(data: Uint8Array | Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}

--- a/functions/src/utils/hash.ts
+++ b/functions/src/utils/hash.ts
@@ -2,11 +2,11 @@
  * 暗号学的ハッシュ計算の共通 helper。
  *
  * 同一の `crypto.createHash('sha256').update(buffer).digest('hex')` idiom が
- * functions/scripts/test に 5+ 箇所散在していたため統一する (Issue #445 PR-D2 review)。
+ * functions/scripts/test に複数箇所散在していたため統一 (Issue #445 PR-D2 review)。
  *
- * 使用箇所: functions/src/pdf/pdfOperations.ts (source/derived sha256),
- * functions/src/pdf/provenance.ts (型整合の正規化), scripts/lib/parentPdfProvenance.ts
- * (将来 migrate 予定), pdf-feature-survey.ts (将来 migrate 予定)。
+ * 現在の使用箇所: `functions/src/pdf/pdfOperations.ts` の splitPdf 内 source/derived
+ * sha256 計算。他の inline `createHash('sha256')` 箇所 (`scripts/lib/parentPdfProvenance.ts`
+ * 等) の migrate は別 PR scope。
  */
 
 import * as crypto from 'crypto';

--- a/functions/test/hash.test.ts
+++ b/functions/test/hash.test.ts
@@ -1,0 +1,39 @@
+/**
+ * sha256Hex helper の単体テスト。
+ * Issue #445 PR-D2 review で `crypto.createHash('sha256').update(buf).digest('hex')` の
+ * inline 重複を排除するために導入した共通 helper のカバレッジ。
+ */
+
+import { expect } from 'chai';
+import { sha256Hex } from '../src/utils/hash';
+
+describe('sha256Hex', () => {
+  it('既知の入力に対する RFC ベクトル ("abc") を 64 桁 hex で返す', () => {
+    // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    const result = sha256Hex(Buffer.from('abc'));
+    expect(result).to.equal(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+  });
+
+  it('空 buffer は既知の hash を返す (RFC 6234)', () => {
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    const result = sha256Hex(Buffer.alloc(0));
+    expect(result).to.equal(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+  });
+
+  it('Uint8Array を直接受け取って Buffer と同じ結果を返す (pdf-lib 互換)', () => {
+    const bytes = new Uint8Array([0x61, 0x62, 0x63]); // 'abc'
+    const fromUint8 = sha256Hex(bytes);
+    const fromBuffer = sha256Hex(Buffer.from('abc'));
+    expect(fromUint8).to.equal(fromBuffer);
+  });
+
+  it('戻り値は常に 64 桁 lowercase hex', () => {
+    const result = sha256Hex(Buffer.from('test'));
+    expect(result).to.have.lengthOf(64);
+    expect(result).to.match(/^[0-9a-f]{64}$/);
+  });
+});

--- a/functions/test/provenance.test.ts
+++ b/functions/test/provenance.test.ts
@@ -1,0 +1,208 @@
+/**
+ * provenance.ts (createSplitProvenance + assertValidProvenanceInput) の単体テスト。
+ *
+ * Issue #445 PR-D2: ADR-0016 MUST 2 / MUST 5 で必須化した 10 fields の runtime 検証を
+ * pure function level でカバーする。実 splitPdf 経由の検証は
+ * splitPdfProvenance.integration.test.ts で別途実施。
+ */
+
+import { expect } from 'chai';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+  CreateSplitProvenanceInput,
+  ProvenanceValidationError,
+  assertValidProvenanceInput,
+  createSplitProvenance,
+} from '../src/pdf/provenance';
+
+function makeValidInput(
+  overrides: Partial<CreateSplitProvenanceInput> = {}
+): CreateSplitProvenanceInput {
+  return {
+    sourceGeneration: '1700000000000001',
+    sourceMetageneration: '1',
+    sourceSha256: 'a'.repeat(64),
+    sourcePath: 'attachments/abc/file.pdf',
+    sourceBucket: 'doc-split-dev.appspot.com',
+    derivedObjectPath: 'processed/doc-id-xyz/output.pdf',
+    derivedGeneration: '1700000000000002',
+    derivedMetageneration: '1',
+    derivedSha256: 'b'.repeat(64),
+    ...overrides,
+  };
+}
+
+describe('createSplitProvenance (ADR-0016 MUST 2 factory)', () => {
+  it('正常な 10 fields 入力で provenance を構築する', () => {
+    const input = makeValidInput();
+    const result = createSplitProvenance(input);
+    expect(result.sourceGeneration).to.equal('1700000000000001');
+    expect(result.sourceMetageneration).to.equal('1');
+    expect(result.sourceSha256).to.equal('a'.repeat(64));
+    expect(result.sourcePath).to.equal('attachments/abc/file.pdf');
+    expect(result.sourceBucket).to.equal('doc-split-dev.appspot.com');
+    expect(result.derivedObjectPath).to.equal('processed/doc-id-xyz/output.pdf');
+    expect(result.derivedGeneration).to.equal('1700000000000002');
+    expect(result.derivedMetageneration).to.equal('1');
+    expect(result.derivedSha256).to.equal('b'.repeat(64));
+    expect(result.createdAt).to.exist;
+  });
+
+  it('createdAt 省略時は Timestamp.now() を採用する', () => {
+    const before = Timestamp.now();
+    const result = createSplitProvenance(makeValidInput());
+    const after = Timestamp.now();
+    const resultMs = (result.createdAt as unknown as Timestamp).toMillis();
+    expect(resultMs).to.be.at.least(before.toMillis());
+    expect(resultMs).to.be.at.most(after.toMillis());
+  });
+
+  it('createdAt 明示指定時はそれを採用する', () => {
+    const fixed = Timestamp.fromMillis(1700000000000);
+    const result = createSplitProvenance(makeValidInput({ createdAt: fixed }));
+    expect((result.createdAt as unknown as Timestamp).toMillis()).to.equal(1700000000000);
+  });
+
+  it('sha256 hex を大文字で渡しても lowercase に正規化する', () => {
+    const result = createSplitProvenance(
+      makeValidInput({
+        sourceSha256: 'A'.repeat(64),
+        derivedSha256: 'BCDEF' + 'a'.repeat(59),
+      })
+    );
+    expect(result.sourceSha256).to.equal('a'.repeat(64));
+    expect(result.derivedSha256).to.equal('bcdef' + 'a'.repeat(59));
+  });
+});
+
+describe('assertValidProvenanceInput (10 fields 検証)', () => {
+  it('正常入力では throw しない', () => {
+    expect(() => assertValidProvenanceInput(makeValidInput())).to.not.throw();
+  });
+
+  describe('sha256 検証', () => {
+    it('sourceSha256 が 64 桁未満で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(makeValidInput({ sourceSha256: 'abc' }))
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'sourceSha256');
+    });
+
+    it('derivedSha256 に非 hex 文字が混入すると throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(
+          makeValidInput({ derivedSha256: 'g'.repeat(64) })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'derivedSha256');
+    });
+
+    it('sourceSha256 が空文字で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(makeValidInput({ sourceSha256: '' }))
+      ).to.throw(ProvenanceValidationError);
+    });
+  });
+
+  describe('generation 検証', () => {
+    it('sourceGeneration が非数値で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(
+          makeValidInput({ sourceGeneration: 'not-a-number' })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'sourceGeneration');
+    });
+
+    it('derivedMetageneration が小数で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(
+          makeValidInput({ derivedMetageneration: '1.5' })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'derivedMetageneration');
+    });
+
+    it('sourceMetageneration が空文字で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(makeValidInput({ sourceMetageneration: '' }))
+      ).to.throw(ProvenanceValidationError);
+    });
+  });
+
+  describe('path / bucket 検証', () => {
+    it('sourcePath が空文字で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(makeValidInput({ sourcePath: '' }))
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'sourcePath');
+    });
+
+    it('sourcePath に gs:// prefix が含まれていると throw (object name のみ受け取る)', () => {
+      expect(() =>
+        assertValidProvenanceInput(
+          makeValidInput({ sourcePath: 'gs://bucket/path.pdf' })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'sourcePath');
+    });
+
+    it('derivedObjectPath に gs:// prefix が含まれていると throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(
+          makeValidInput({
+            derivedObjectPath: 'gs://bucket/processed/doc/x.pdf',
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'derivedObjectPath');
+    });
+
+    it('sourceBucket が空文字で throw', () => {
+      expect(() =>
+        assertValidProvenanceInput(makeValidInput({ sourceBucket: '' }))
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'sourceBucket');
+    });
+  });
+
+  describe('type 検証 (TS bypass のための明示テスト)', () => {
+    it('sourceGeneration が undefined で throw', () => {
+      const bad = makeValidInput() as unknown as Record<string, unknown>;
+      delete bad.sourceGeneration;
+      expect(() =>
+        assertValidProvenanceInput(bad as unknown as CreateSplitProvenanceInput)
+      ).to.throw(ProvenanceValidationError);
+    });
+
+    it('sourceSha256 が number で throw', () => {
+      const bad = makeValidInput() as unknown as Record<string, unknown>;
+      bad.sourceSha256 = 12345;
+      expect(() =>
+        assertValidProvenanceInput(bad as unknown as CreateSplitProvenanceInput)
+      ).to.throw(ProvenanceValidationError);
+    });
+  });
+});
+
+describe('ProvenanceValidationError', () => {
+  it('field と reason プロパティを保持する', () => {
+    try {
+      assertValidProvenanceInput(makeValidInput({ sourceSha256: 'xx' }));
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).to.be.instanceOf(ProvenanceValidationError);
+      expect((err as ProvenanceValidationError).field).to.equal('sourceSha256');
+      expect((err as ProvenanceValidationError).reason).to.match(/64-char hex/);
+      expect((err as Error).name).to.equal('ProvenanceValidationError');
+    }
+  });
+});

--- a/functions/test/splitPdfDocIdNamespace.test.ts
+++ b/functions/test/splitPdfDocIdNamespace.test.ts
@@ -63,49 +63,50 @@ describe('splitPdf docId namespace 設計 (Issue #432 PR-B 衝突根治)', () =>
   });
 });
 
-describe('splitPdf orphan cleanup 補償処理 (Issue #432 PR-B Codex 補強)', () => {
-  it('Firestore set を try/catch でラップしている (補償処理の前提)', () => {
-    // 'await newDocRef.set(' が try ブロック内に存在することの近傍チェック
-    expect(content).to.match(/try\s*\{[\s\S]{0,2000}await newDocRef\.set\(/);
+describe('splitPdf cleanup / atomic write 設計 (Issue #445 PR-D2 atomic batch)', () => {
+  it('Firestore 書込は db.batch().commit() で atomic (Codex H3: partial state 排除)', () => {
+    // 個別 newDocRef.set() ループは PR-D2 で廃止し、accumulated payload を batch で一括書込
+    expect(content).to.match(/const\s+batch\s*=\s*db\.batch\(\)/);
+    expect(content).to.match(/batch\.set\(item\.newDocRef/);
+    expect(content).to.match(/await\s+batch\.commit\(\)/);
   });
 
-  it('Firestore set 失敗時に Storage orphan cleanup を試行する', () => {
-    expect(content).to.include('orphanCleanup');
-    // newFile.delete() が catch ブロック内で呼ばれる (近傍チェック)
-    expect(content).to.match(/catch\s*\(firestoreErr[\s\S]{0,2000}await newFile\.delete\(\)/);
+  it('segments を一旦 accumulate してから batch 書込する (atomic 化の前提)', () => {
+    // accumulated: AccumulatedSegment[] を build → final drift check 通過後 batch.commit
+    expect(content).to.match(/const\s+accumulated\s*:\s*AccumulatedSegment\[\]/);
+    expect(content).to.match(/accumulated\.push\(/);
   });
 
-  it('orphan cleanup の構造化ログキー (Cloud Logging 監視 contract)', () => {
+  it('drift / batch 失敗時の Storage cleanup は専用 helper で実行する', () => {
+    expect(content).to.include('cleanupAccumulatedStorageFiles');
+    // Promise.allSettled で best-effort
+    expect(content).to.match(/Promise\.allSettled/);
+  });
+
+  it('cleanup は ifGenerationMatch precondition で誤削除を防ぐ (Codex M3)', () => {
+    expect(content).to.match(/ifGenerationMatch\s*:\s*item\.derivedGeneration/);
+  });
+
+  it('cleanup helper の構造化ログキー (Cloud Logging 監視 contract)', () => {
     expect(content).to.include("operation: 'splitPdf'");
-    expect(content).to.match(/stage:\s*['"]firestoreSet['"]/);
-    expect(content).to.match(/stage:\s*['"]orphanCleanup['"]/);
-    expect(content).to.match(/cleanupResult:\s*['"]success['"]/);
-    expect(content).to.match(/cleanupResult:\s*['"]failed['"]/);
-  });
-
-  it('Firestore set 失敗時に元の例外を caller に伝播する (silent failure 防止)', () => {
-    // 補償処理経路の終端で必ず throw が発生 (success → throw firestoreErr / failure → throw wrapped)
-    expect(content).to.match(/throw firestoreErr;/);
-    expect(content).to.match(/throw wrapped;/);
-  });
-
-  it('createdDocIds.push は try ブロック内 (Firestore set 成功時のみ実行)', () => {
-    // try 外に出ると失敗時にも push されて splitInto に orphan id が混入
-    expect(content).to.match(/await newDocRef\.set\([\s\S]{0,3000}createdDocIds\.push/);
-    expect(content).not.to.match(/\}\s*finally\s*\{[\s\S]{0,500}createdDocIds\.push/);
-  });
-
-  it('二段失敗時は Error.cause で元例外を保持し orphanLeft マーカーを付与する (Sentry/log dedup での区別)', () => {
-    // wrapped.cause = firestoreErr; wrapped.orphanLeft = true; の存在を contract 化
-    expect(content).to.match(/wrapped\.cause\s*=\s*firestoreErr/);
-    expect(content).to.match(/wrapped\.orphanLeft\s*=\s*true/);
-    expect(content).to.include('manualCleanupCommand');
-  });
-
-  it('segments 途中失敗時に partial state 概要ログを出力する (運用 triage 支援)', () => {
+    // 3 つの cleanup 発火 stage を区別できる
     expect(content).to.match(/stage:\s*['"]segmentsLoop['"]/);
-    expect(content).to.include('partialChildIds');
-    expect(content).to.include('successfulSegments');
-    expect(content).to.include('failedSegmentIndex');
+    expect(content).to.match(/stage:\s*['"]finalDrift['"]/);
+    expect(content).to.match(/stage:\s*['"]firestoreBatch['"]/);
+    // 失敗件数 + manual cleanup hint
+    expect(content).to.match(/failedCount/);
+    expect(content).to.match(/manualCleanupHint/);
+  });
+
+  it('Firestore batch 失敗時は Error.cause で元例外を保持する (silent failure 防止)', () => {
+    expect(content).to.match(/wrapped\.cause\s*=\s*firestoreErr/);
+    expect(content).to.match(/throw wrapped/);
+  });
+
+  it('drift 検出時は HttpsError aborted で投げ retry max 後に最終 fail する', () => {
+    expect(content).to.match(
+      /HttpsError\(\s*['"]aborted['"][\s\S]{0,200}concurrent write detected/
+    );
+    expect(content).to.match(/MAX_RETRIES\s*=\s*2/);
   });
 });

--- a/functions/test/splitPdfDocIdNamespace.test.ts
+++ b/functions/test/splitPdfDocIdNamespace.test.ts
@@ -98,9 +98,11 @@ describe('splitPdf cleanup / atomic write 設計 (Issue #445 PR-D2 atomic batch)
     expect(content).to.match(/manualCleanupHint/);
   });
 
-  it('Firestore batch 失敗時は Error.cause で元例外を保持する (silent failure 防止)', () => {
-    expect(content).to.match(/wrapped\.cause\s*=\s*firestoreErr/);
-    expect(content).to.match(/throw wrapped/);
+  it('Firestore batch 失敗時は HttpsError(internal) で原因 message を client へ surface する (/review-pr silent-failure-hunter C1)', () => {
+    // 旧: throw wrapped (Error.cause) → INTERNAL に潰れる
+    // 新: throw new HttpsError('internal', ...message + originalErr.message..., { stage: 'firestoreBatch', ... })
+    expect(content).to.match(/HttpsError\(\s*['"]internal['"][\s\S]{0,400}firestoreErr/);
+    expect(content).to.match(/stage:\s*['"]firestoreBatch['"]/);
   });
 
   it('drift 検出時は HttpsError aborted で投げ retry max 後に最終 fail する', () => {

--- a/functions/test/splitPdfPayloadContract.test.ts
+++ b/functions/test/splitPdfPayloadContract.test.ts
@@ -26,8 +26,10 @@ const SOURCE_PATH = 'src/pdf/pdfOperations.ts';
 // 元ドキュメントを `isSplitSource: true` に更新する箇所の anchor。
 // 先行する `// 元ドキュメントのステータスを更新` コメントを起点にし、
 // forEach 内 split doc 書き込みの `newDocRef` 箇所と混同しないようにする。
+// PR-D2 (Issue #445) で `await docRef.update(...)` → `batch.update(docRef, ...)` に
+// 変更 (Codex post-impl High 反映: child + parent を同一 batch で 1 commit atomic 化)。
 const UPDATE_ANCHOR =
-  /元ドキュメントのステータスを更新[\s\S]*?await\s+docRef\.update\s*\(/;
+  /元ドキュメントのステータスを更新[\s\S]*?batch\.update\(\s*docRef\s*,\s*/;
 
 let payloadBlock: string | null = null;
 

--- a/functions/test/splitPdfProvenanceContract.test.ts
+++ b/functions/test/splitPdfProvenanceContract.test.ts
@@ -97,14 +97,19 @@ describe('splitPdf provenance 書込契約 (Issue #445 PR-D2 AC6 + Codex L3)', (
   });
 
   it('source sha256 は実際の download buffer から compute している (ADR MUST 5)', () => {
-    // createHash('sha256').update(buffer) が出現する (download した buffer が input)
-    expect(sourceText).to.match(/createHash\(['"]sha256['"]\)[\s\S]*?\.update\(buffer\)/);
+    // sha256Hex(buffer) で download した buffer から compute
+    expect(sourceText).to.match(/sha256Hex\(buffer\)/);
   });
 
-  it('derived sha256 は実際の newPdfBytes buffer から compute している', () => {
-    expect(sourceText).to.match(
-      /createHash\(['"]sha256['"]\)[\s\S]*?\.update\(Buffer\.from\(newPdfBytes\)\)/
-    );
+  it('derived sha256 は newPdfBytes (pdf-lib 出力) から compute している', () => {
+    // sha256Hex(newPdfBytes) を直接呼出 (Buffer.from で 2 重 allocate しない)
+    expect(sourceText).to.match(/sha256Hex\(newPdfBytes\)/);
+  });
+
+  it('sha256 計算は共通 helper sha256Hex を経由する (inline crypto.createHash 禁止)', () => {
+    expect(sourceText).to.match(/import\s*\{\s*sha256Hex\s*\}\s*from\s*['"]\.\.\/utils\/hash['"]/);
+    // pdfOperations.ts 内で inline createHash('sha256') を直接呼ばない (重複排除)
+    expect(sourceText).not.to.match(/crypto\.createHash\(['"]sha256['"]\)/);
   });
 
   it('Firestore は db.batch() で原子書込している (Codex H3 反映: partial state 排除)', () => {

--- a/functions/test/splitPdfProvenanceContract.test.ts
+++ b/functions/test/splitPdfProvenanceContract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * splitPdf provenance 書込パターン契約テスト (Issue #445 PR-D2)
+ *
+ * 目的: ADR-0016 MUST 2 (10 fields 必須) / MUST 5 (read snapshot 整合) の実装が
+ * splitPdf 内で恒久的に守られることを source grep で lock-in する。
+ *
+ * Codex MCP review Low 3 指摘:「createSplitProvenance( 呼び出し、10 field mapping、
+ * processed/${newDocRef.id}/ 由来の derivedObjectPath まで固定した方が価値がある」を反映。
+ *
+ * 方式: splitPdfPayloadContract.test.ts と同形式の grep-based contract。
+ * 実 emulator での 10 fields 完備 / drift retry / orphan 0 件 は別 integration test で検証。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+// 相対 import で ts-node の CJS resolution を維持 (純粋 package import のみだと
+// node が ESM 自動判定して __dirname が undefined になる)。
+// 検証対象モジュールの import なので semantic にも自然。
+import { ProvenanceValidationError as _AnchorImport } from '../src/pdf/provenance';
+
+const SOURCE_PATH = 'src/pdf/pdfOperations.ts';
+void _AnchorImport;
+
+let sourceText = '';
+
+describe('splitPdf provenance 書込契約 (Issue #445 PR-D2 AC6 + Codex L3)', () => {
+  before(() => {
+    const path = resolve(__dirname, '..', SOURCE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Source file not found: ${SOURCE_PATH}`);
+    }
+    sourceText = readFileSync(path, 'utf-8');
+  });
+
+  it('createSplitProvenance を provenance/splitSnapshot helper として import している', () => {
+    expect(sourceText).to.match(
+      /import\s*\{\s*createSplitProvenance\s*\}\s*from\s*['"]\.\/provenance['"]/
+    );
+  });
+
+  it('splitSnapshot helpers を import している (acquireSourceSnapshot / verifyFinalDrift / parseGcsUri / backoffSleep / SourceDriftError)', () => {
+    expect(sourceText).to.match(/SourceDriftError/);
+    expect(sourceText).to.match(/acquireSourceSnapshot/);
+    expect(sourceText).to.match(/verifyFinalDrift/);
+    expect(sourceText).to.match(/parseGcsUri/);
+    expect(sourceText).to.match(/backoffSleep/);
+  });
+
+  it('splitPdf 内で createSplitProvenance( を 1 箇所以上呼出している', () => {
+    const matches = sourceText.match(/createSplitProvenance\s*\(/g) ?? [];
+    expect(matches.length, 'createSplitProvenance must be called').to.be.at.least(1);
+  });
+
+  it('createSplitProvenance 呼出 block 内に 9 個の input fields が全て含まれる (createdAt は省略可)', () => {
+    // createSplitProvenance({ ... }) の中身を非貪欲に抽出
+    const block = sourceText.match(/createSplitProvenance\s*\(\s*\{([\s\S]*?)\}\s*\)/);
+    expect(block, 'createSplitProvenance({...}) block must exist').to.not.be.null;
+    const body = block![1];
+    for (const field of [
+      'sourceGeneration',
+      'sourceMetageneration',
+      'sourceSha256',
+      'sourcePath',
+      'sourceBucket',
+      'derivedObjectPath',
+      'derivedGeneration',
+      'derivedMetageneration',
+      'derivedSha256',
+    ]) {
+      expect(body, `createSplitProvenance must include ${field}`).to.match(
+        new RegExp(`\\b${field}\\s*[:,]`)
+      );
+    }
+  });
+
+  it('derivedObjectPath は processed/${docId}/${fileName} 形式を維持している', () => {
+    // newFilePath assignment が `processed/${...id}/${fileName}` パターン
+    expect(sourceText).to.match(
+      /newFilePath\s*=\s*`processed\/\$\{[^}]*newDocRef\.id[^`]*\}\/\$\{fileName\}`/
+    );
+  });
+
+  it('source\\* snapshot 取得は acquireSourceSnapshot helper 経由で 3-stage 実装されている (ADR MUST 5 / Codex H1)', () => {
+    // splitPdf 側で helper 呼出
+    expect(sourceText).to.match(/await\s+acquireSourceSnapshot\(file\)/);
+    // splitSnapshot.ts 側で 3-stage (getMetadata → download → getMetadata) 実装
+    const snapshotPath = resolve(__dirname, '..', 'src/pdf/splitSnapshot.ts');
+    const snapshotText = readFileSync(snapshotPath, 'utf-8');
+    const threeStage = snapshotText.match(
+      /file\.getMetadata\(\)[\s\S]*?file\.download\(\)[\s\S]*?file\.getMetadata\(\)/
+    );
+    expect(
+      threeStage,
+      '3-stage metadata-download-metadata in splitSnapshot.ts must exist'
+    ).to.not.be.null;
+  });
+
+  it('source sha256 は実際の download buffer から compute している (ADR MUST 5)', () => {
+    // createHash('sha256').update(buffer) が出現する (download した buffer が input)
+    expect(sourceText).to.match(/createHash\(['"]sha256['"]\)[\s\S]*?\.update\(buffer\)/);
+  });
+
+  it('derived sha256 は実際の newPdfBytes buffer から compute している', () => {
+    expect(sourceText).to.match(
+      /createHash\(['"]sha256['"]\)[\s\S]*?\.update\(Buffer\.from\(newPdfBytes\)\)/
+    );
+  });
+
+  it('Firestore は db.batch() で原子書込している (Codex H3 反映: partial state 排除)', () => {
+    expect(sourceText).to.match(/db\.batch\(\)/);
+    expect(sourceText).to.match(/batch\.set\(/);
+    expect(sourceText).to.match(/batch\.commit\(\)/);
+  });
+
+  it('drift cleanup は ifGenerationMatch precondition を使っている (Codex M3)', () => {
+    expect(sourceText).to.match(/ifGenerationMatch\s*:\s*(item\.)?derivedGeneration/);
+  });
+
+  it('retry 間に backoffSleep を実施している (Codex M2)', () => {
+    expect(sourceText).to.match(/await\s+backoffSleep\(/);
+  });
+
+  it('parseGcsUri で bucket mismatch を failed-precondition に変換している (Codex M1)', () => {
+    expect(sourceText).to.match(/parseGcsUri\(/);
+    expect(sourceText).to.match(
+      /HttpsError\(\s*['"]failed-precondition['"][\s\S]*?gs:\/\//
+    );
+  });
+
+  it('drift 検出時の HttpsError は aborted code で投げられる', () => {
+    expect(sourceText).to.match(
+      /HttpsError\(\s*['"]aborted['"][\s\S]*?concurrent write detected/
+    );
+  });
+
+  it('segments runtime 検証で startPage/endPage 範囲を invalid-argument で弾く (Codex L2)', () => {
+    expect(sourceText).to.match(
+      /HttpsError\(\s*['"]invalid-argument['"][\s\S]*?segments\[/
+    );
+  });
+});

--- a/functions/test/splitSnapshot.test.ts
+++ b/functions/test/splitSnapshot.test.ts
@@ -1,0 +1,263 @@
+/**
+ * splitSnapshot.ts (parseGcsUri / verifySnapshotConsistency / verifyFinalDrift /
+ * backoffSleep / SourceDriftError) の単体テスト。
+ *
+ * ADR-0016 MUST 5 + Codex MCP review High 1 / H2 / Medium 1 / Medium 2 反映。
+ */
+
+import { expect } from 'chai';
+import {
+  SnapshotFile,
+  SourceDriftError,
+  acquireSourceSnapshot,
+  backoffSleep,
+  parseGcsUri,
+  verifyFinalDrift,
+  verifySnapshotConsistency,
+} from '../src/pdf/splitSnapshot';
+
+describe('parseGcsUri (Codex Medium 1: gs:// URI parser)', () => {
+  it('"gs://bucket/object" を分解する', () => {
+    const r = parseGcsUri('gs://my-bucket/folder/file.pdf');
+    expect(r.bucket).to.equal('my-bucket');
+    expect(r.objectName).to.equal('folder/file.pdf');
+  });
+
+  it('object name にスラッシュ複数あっても保持する', () => {
+    const r = parseGcsUri('gs://b/a/b/c/d.pdf');
+    expect(r.objectName).to.equal('a/b/c/d.pdf');
+  });
+
+  it('expectedBucket と一致すれば成功', () => {
+    const r = parseGcsUri('gs://b/x.pdf', 'b');
+    expect(r.bucket).to.equal('b');
+  });
+
+  it('expectedBucket 不一致で throw', () => {
+    expect(() => parseGcsUri('gs://other/x.pdf', 'expected'))
+      .to.throw(Error)
+      .with.property('message')
+      .match(/bucket mismatch/);
+  });
+
+  it('"gs://" prefix がないと throw', () => {
+    expect(() => parseGcsUri('processed/abc/x.pdf')).to.throw(/Invalid GCS URI/);
+  });
+
+  it('https:// 等の別 scheme で throw', () => {
+    expect(() => parseGcsUri('https://example.com/x.pdf')).to.throw(/Invalid GCS URI/);
+  });
+
+  it('空文字で throw', () => {
+    expect(() => parseGcsUri('')).to.throw(/non-empty string/);
+  });
+
+  it('"gs://bucket" (object name なし) で throw', () => {
+    expect(() => parseGcsUri('gs://b')).to.throw(/Invalid GCS URI/);
+  });
+});
+
+describe('verifySnapshotConsistency (Codex High 1/H2: gen+metageneration 両方比較)', () => {
+  it('generation + metageneration 両方一致で snapshot を返す', () => {
+    const r = verifySnapshotConsistency(
+      { generation: '100', metageneration: '1' },
+      { generation: '100', metageneration: '1' }
+    );
+    expect(r.generation).to.equal('100');
+    expect(r.metageneration).to.equal('1');
+  });
+
+  it('generation drift で SourceDriftError throw', () => {
+    expect(() =>
+      verifySnapshotConsistency(
+        { generation: '100', metageneration: '1' },
+        { generation: '101', metageneration: '1' }
+      )
+    )
+      .to.throw(SourceDriftError)
+      .with.property('message')
+      .match(/generation 100 → 101/);
+  });
+
+  it('metageneration drift だけでも SourceDriftError throw (Codex H2)', () => {
+    expect(() =>
+      verifySnapshotConsistency(
+        { generation: '100', metageneration: '1' },
+        { generation: '100', metageneration: '2' }
+      )
+    )
+      .to.throw(SourceDriftError)
+      .with.property('message')
+      .match(/metageneration 1 → 2/);
+  });
+
+  it('数値型でも文字列に正規化して比較する', () => {
+    const r = verifySnapshotConsistency(
+      { generation: 100, metageneration: 1 },
+      { generation: '100', metageneration: '1' }
+    );
+    expect(r.generation).to.equal('100');
+  });
+
+  it('generation/metageneration が undefined で throw', () => {
+    expect(() =>
+      verifySnapshotConsistency({}, { generation: '100', metageneration: '1' })
+    ).to.throw(/Missing generation/);
+  });
+
+  it('SourceDriftError は before/after を保持する', () => {
+    try {
+      verifySnapshotConsistency(
+        { generation: '100', metageneration: '1' },
+        { generation: '101', metageneration: '2' }
+      );
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).to.be.instanceOf(SourceDriftError);
+      const drift = err as SourceDriftError;
+      expect(drift.before).to.deep.equal({ generation: '100', metageneration: '1' });
+      expect(drift.after).to.deep.equal({ generation: '101', metageneration: '2' });
+    }
+  });
+});
+
+describe('verifyFinalDrift (segments ループ後の最終 drift check)', () => {
+  it('一致時は何も throw しない', () => {
+    expect(() =>
+      verifyFinalDrift(
+        { generation: '100', metageneration: '1' },
+        { generation: '100', metageneration: '1' }
+      )
+    ).to.not.throw();
+  });
+
+  it('generation drift で SourceDriftError throw', () => {
+    expect(() =>
+      verifyFinalDrift(
+        { generation: '100', metageneration: '1' },
+        { generation: '101', metageneration: '1' }
+      )
+    ).to.throw(SourceDriftError);
+  });
+
+  it('metageneration drift で SourceDriftError throw (Codex H2)', () => {
+    expect(() =>
+      verifyFinalDrift(
+        { generation: '100', metageneration: '1' },
+        { generation: '100', metageneration: '2' }
+      )
+    ).to.throw(SourceDriftError);
+  });
+
+  it('final metadata に generation 欠落で generic Error', () => {
+    expect(() =>
+      verifyFinalDrift({ generation: '100', metageneration: '1' }, {})
+    ).to.throw(/Missing generation/);
+  });
+});
+
+describe('acquireSourceSnapshot (Codex M4: download 前後 metadata 変化を検出)', () => {
+  function makeFile(
+    metadataResponses: Array<{ generation: string; metageneration: string }>,
+    downloadBuffer: Buffer
+  ): SnapshotFile {
+    let metaCallCount = 0;
+    return {
+      getMetadata: async () => {
+        const r = metadataResponses[metaCallCount];
+        metaCallCount++;
+        if (!r) {
+          throw new Error(
+            `Unexpected getMetadata call ${metaCallCount}, only ${metadataResponses.length} responses queued`
+          );
+        }
+        return [r];
+      },
+      download: async () => [downloadBuffer],
+    };
+  }
+
+  it('metadata before/after が一致するとき snapshot を返す', async () => {
+    const file = makeFile(
+      [
+        { generation: '100', metageneration: '1' },
+        { generation: '100', metageneration: '1' },
+      ],
+      Buffer.from('pdf-bytes')
+    );
+    const snap = await acquireSourceSnapshot(file);
+    expect(snap.generation).to.equal('100');
+    expect(snap.metageneration).to.equal('1');
+    expect(snap.buffer.toString()).to.equal('pdf-bytes');
+  });
+
+  it('download 中に generation が変化したら SourceDriftError throw', async () => {
+    const file = makeFile(
+      [
+        { generation: '100', metageneration: '1' },
+        { generation: '101', metageneration: '1' },
+      ],
+      Buffer.from('partial-or-old-bytes')
+    );
+    try {
+      await acquireSourceSnapshot(file);
+      expect.fail('should have thrown SourceDriftError');
+    } catch (err) {
+      expect(err).to.be.instanceOf(SourceDriftError);
+      expect((err as SourceDriftError).before.generation).to.equal('100');
+      expect((err as SourceDriftError).after.generation).to.equal('101');
+    }
+  });
+
+  it('download 中に metageneration だけ変化しても SourceDriftError throw (Codex H2)', async () => {
+    const file = makeFile(
+      [
+        { generation: '100', metageneration: '1' },
+        { generation: '100', metageneration: '2' },
+      ],
+      Buffer.from('bytes')
+    );
+    try {
+      await acquireSourceSnapshot(file);
+      expect.fail('should have thrown SourceDriftError');
+    } catch (err) {
+      expect(err).to.be.instanceOf(SourceDriftError);
+    }
+  });
+
+  it('getMetadata を厳密に 2 回 + download を 1 回呼ぶ', async () => {
+    let metaCount = 0;
+    let downloadCount = 0;
+    const file: SnapshotFile = {
+      getMetadata: async () => {
+        metaCount++;
+        return [{ generation: '100', metageneration: '1' }];
+      },
+      download: async () => {
+        downloadCount++;
+        return [Buffer.from('x')];
+      },
+    };
+    await acquireSourceSnapshot(file);
+    expect(metaCount).to.equal(2);
+    expect(downloadCount).to.equal(1);
+  });
+});
+
+describe('backoffSleep (Codex Medium 2: jitter 付き backoff)', () => {
+  it('attempt=0 は 100-150ms 範囲で sleep する', async () => {
+    const start = Date.now();
+    await backoffSleep(0);
+    const elapsed = Date.now() - start;
+    expect(elapsed).to.be.at.least(95); // setTimeout 精度の許容範囲
+    expect(elapsed).to.be.at.most(200);
+  });
+
+  it('attempt=1 は 300-450ms 範囲で sleep する', async () => {
+    const start = Date.now();
+    await backoffSleep(1);
+    const elapsed = Date.now() - start;
+    expect(elapsed).to.be.at.least(295);
+    expect(elapsed).to.be.at.most(500);
+  });
+});


### PR DESCRIPTION
## Summary

ADR-0016 MUST 1-5 を実装。新規分割 PDF が Firestore に書込まれる際、`DocumentProvenance` 10 fields を必ず書込み、`derivedObjectPath` を canonical Storage identity 化する。`fileName` identity 依存を排除し、Issue #432 collision の構造的予防を確立。

**関連**: Refs #445 / Refs #432

## 主要変更

- `functions/src/pdf/provenance.ts` (新規): `createSplitProvenance()` factory + 10 fields runtime 検証
- `functions/src/pdf/splitSnapshot.ts` (新規): `parseGcsUri` / `verifySnapshotConsistency` / `verifyFinalDrift` / `acquireSourceSnapshot` (3-stage) / `backoffSleep` / `SourceDriftError`
- `functions/src/utils/hash.ts` (新規): `sha256Hex(Uint8Array | Buffer)` 共通 helper
- `functions/src/pdf/pdfOperations.ts` (modified): `splitPdf` refactor (retry loop + accumulate + final drift + atomic batch.commit + cleanup helper + HttpsError ラップ)
- `frontend/src/hooks/useDocuments.ts` (modified): `getReprocessClearFields()` に `provenance: deleteField()` 追加 (CLAUDE.md #178 MUST)
- tests: provenance 18 / splitSnapshot 24 / hash 4 / provenanceContract 15 / docIdNamespace 拡張 12 / payloadContract 5 (anchor 追従)

## 設計 (ADR-0016 MUST 1-5)

| MUST | 実装箇所 |
|------|----------|
| MUST 1: derivedObjectPath canonical 化 | `processed/${newDocRef.id}/${fileName}` 維持 |
| MUST 2: 10 fields 必須書込 | `createSplitProvenance()` factory + atomic batch.set |
| MUST 3: rotatePdfPages 改修 | scope 外 (PR-D3) |
| MUST 4: fileName identity 旧コードパス追加禁止 | scope 外 (PR-D5 lint) |
| MUST 5: 同一 read snapshot + concurrent write 検出 | `acquireSourceSnapshot` (3-stage) + `verifyFinalDrift` + retry 2 回 |

## 品質ゲート 経過

| Gate | 結果 |
|---|---|
| **Codex MCP impl-plan review** | NO-GO → High 3 + Medium 4 + Low 3 全反映 → **GO** |
| **/simplify** (3 agent 並列) | HIGH 1 + MEDIUM 2 反映 (sha256Hex 抽出 + Buffer dedup)、follow-up 明示 |
| **/safe-refactor** | HIGH/MEDIUM/LOW 全 0 件 |
| **Codex MCP post-impl review** | NO-GO → High 1 + Medium 1 + Low 2 全反映 → **GO** |
| **Evaluator 分離プロトコル** (5+ files) | **APPROVE** / HIGH 0 / LOW 3 反映済 |
| **/review-pr** (6 agent 並列) | Critical 3 + Important 3 反映 (HttpsError ラップ + FE provenance + 軽微 cleanup)、defer 明示 |

## 検証

- ✅ tsc clean (functions + frontend)
- ✅ npm test: **1079 passing**, 0 failing, 0 regression (前 998 → +81)
- ⏳ CI green 待ち
- ⏳ dev 環境 E2E (AC9): merge 前に doc-split-dev で実 PDF split 1 件 → Firestore Console で provenance 10 fields 目視

## Test plan

- [x] functions/ tsc + 1079 passing
- [x] frontend/ tsc clean
- [x] /simplify + /safe-refactor 通過
- [x] Codex MCP impl-plan + post-impl review GO
- [x] Evaluator APPROVE
- [x] /review-pr 6 agent 並列レビュー Critical/Important 反映
- [ ] CI green
- [ ] **dev 環境で実 PDF を 1 件 split → Firestore Console で child doc の `provenance` 10 fields 目視確認** (merge 前)

## Follow-up (本 PR scope 外)

- **PR-D3**: `rotatePdfPages` 改修 (in-place 編集禁止 + 新 path + 安全な delete)
- **PR-D4**: 既存 docs backfill (destructive、kanameone 5,725 + cocoro 539 docs)
- **PR-D5**: TypeScript branded type + lint rule + provenance? → required 評価
- **PR-D2-FE**: frontend で `provenance.derivedObjectPath` primary / `fileUrl` fallback 実装 (現状 optional のため breaking change なし)
- **Reuse**: `parseGcsUri` を ocrProcessor / rotatePdfPages / deleteDocument 3 既存 call sites へ migrate
- **Reuse**: `sleep` / `backoff` primitive を `functions/src/utils/sleep.ts` に統合
- **Efficiency**: segments loop の bounded concurrency 並列化 (5 segments × 200ms = ~1s 程度、観測データ伴って判断)
- **Observability**: Cloud Functions 300s timeout budget check (silent-failure-hunter I-3、別 Issue 推奨)
- **Tests**: emulator-based splitPdf integration test (cleanupAccumulatedStorageFiles + retry loop の runtime カバー)
- **Type design**: `AccumulatedSegment` を `{ stage: 'inflight' | 'committed' }` discriminated union 化 (PR-D3 で検討)

🤖 Generated with [Claude Code](https://claude.com/claude-code)