### PR TITLE
feat(provenance): PR-D4 S1-1 — backfill factory 基盤 + 15 tests (#445)

### DIFF
--- a/functions/src/pdf/provenance.ts
+++ b/functions/src/pdf/provenance.ts
@@ -1,16 +1,21 @@
 /**
  * 分割 PDF Provenance Factory + Runtime Validation
  *
- * ADR-0016 MUST 2 (10 fields) / MUST 5 (read snapshot 整合) を実装する factory。
- * sha256 hex 長さ・generation 数値文字列・path 非空を runtime 検証する。
+ * ADR-0016 MUST 2 (10 fields) / MUST 5 (read snapshot 整合) / MUST 6 (provenanceBackfill) を実装する factory。
+ * sha256 hex 長さ・generation 数値文字列・path 非空・confidence-evidence 整合性を runtime 検証する。
  *
- * Issue #445 PR-D2 (splitPdf 改修) で利用。
+ * Issue #445 PR-D2 (splitPdf 改修) / PR-D3 (rotatePdfPages 改修) / PR-D4 (legacy backfill) で利用。
  *
  * 詳細: docs/adr/0016-document-identity-and-provenance.md
  */
 
 import { Timestamp } from 'firebase-admin/firestore';
-import type { DocumentProvenance } from '../../../shared/types';
+import type {
+  BackfillClassifierCategory,
+  BackfillConfidence,
+  DocumentProvenance,
+  ProvenanceBackfillMetadata,
+} from '../../../shared/types';
 
 const SHA256_HEX_RE = /^[0-9a-fA-F]{64}$/;
 const NUMERIC_STRING_RE = /^[0-9]+$/;
@@ -221,4 +226,132 @@ export function createRotationProvenance(
     createdAt: input.base.createdAt,
   };
   return provenance as unknown as DocumentProvenance;
+}
+
+// ============================================================
+// createBackfillProvenance (ADR-0016 MUST 6 / Issue #445 PR-D4)
+// ============================================================
+
+/**
+ * createBackfillProvenance() の入力型。
+ *
+ * 設計:
+ * - `provenanceFields`: caller が現在の GCS state から組立てた 10 fields (CreateSplitProvenanceInput と同形)。
+ *   `createdAt` は **split 完了時刻** (= document.createdAt 由来) を渡す。backfill 実行時刻ではない (Codex 1st Critical 2 反映)。
+ * - `confidence`: rotate gate 動作と連動。`evidence` との整合性を runtime 検証 (Codex 1st Critical 6 反映)。
+ * - `classifierCategory`: PR-C3c classifier 出力を記録 (Codex 2nd review I7 反映)。
+ * - `evidence`: 現物計算結果 (再現性 + 監査)。
+ * - `backfillScriptVersion`: 例 'pr-d4-v1.0' (script 改修で再 backfill を区別)。
+ * - `backfilledAt`: 省略時は Timestamp.now()。
+ */
+export interface CreateBackfillProvenanceInput {
+  provenanceFields: CreateSplitProvenanceInput;
+  confidence: BackfillConfidence;
+  classifierCategory: BackfillClassifierCategory;
+  evidence: {
+    parentExists: boolean;
+    parentSha256MatchedAtBackfill: boolean | null;
+    childSha256ComputedAtBackfill: boolean;
+  };
+  backfillScriptVersion: string;
+  backfilledAt?: Timestamp;
+}
+
+/**
+ * confidence と evidence の整合性を検証する (ADR-0016 MUST 6 / Codex 1st Critical 6 反映)。
+ *
+ * 低 confidence の doc を "verified" に昇格させる経路を構造的に閉鎖する。
+ *
+ * - `derived-bytes-verified`: parent 現存 + parent sha256 match + child sha256 実計算 の **3 つ全部** 必須
+ * - `child-snapshot-only`: child sha256 実計算 必須 (parent 状態は問わない)
+ * - `metadata-only`: child sha256 実計算 **しない** (定義上スキップ、Codex 2nd L3 反映)
+ */
+function assertConfidenceEvidenceConsistency(
+  confidence: BackfillConfidence,
+  evidence: CreateBackfillProvenanceInput['evidence']
+): void {
+  switch (confidence) {
+    case 'derived-bytes-verified':
+      if (!evidence.parentExists) {
+        throw new ProvenanceValidationError(
+          'evidence.parentExists',
+          'derived-bytes-verified requires parentExists=true'
+        );
+      }
+      if (evidence.parentSha256MatchedAtBackfill !== true) {
+        throw new ProvenanceValidationError(
+          'evidence.parentSha256MatchedAtBackfill',
+          'derived-bytes-verified requires parentSha256MatchedAtBackfill=true (re-split bytes match)'
+        );
+      }
+      if (!evidence.childSha256ComputedAtBackfill) {
+        throw new ProvenanceValidationError(
+          'evidence.childSha256ComputedAtBackfill',
+          'derived-bytes-verified requires childSha256ComputedAtBackfill=true'
+        );
+      }
+      break;
+    case 'child-snapshot-only':
+      if (!evidence.childSha256ComputedAtBackfill) {
+        throw new ProvenanceValidationError(
+          'evidence.childSha256ComputedAtBackfill',
+          'child-snapshot-only requires childSha256ComputedAtBackfill=true (現 child sha256 実計算必須)'
+        );
+      }
+      break;
+    case 'metadata-only':
+      if (evidence.childSha256ComputedAtBackfill) {
+        throw new ProvenanceValidationError(
+          'evidence.childSha256ComputedAtBackfill',
+          'metadata-only definition skips actual sha256 compute; set childSha256ComputedAtBackfill=false'
+        );
+      }
+      break;
+    default: {
+      // exhaustiveness check
+      const _exhaustive: never = confidence;
+      throw new ProvenanceValidationError('confidence', `unknown confidence: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * legacy backfill 用に provenance 10 fields + provenanceBackfill metadata を構築する factory。
+ *
+ * 検証手順:
+ * 1. `assertValidProvenanceInput(provenanceFields)` で 10 fields の型・形式を検証
+ * 2. `backfillScriptVersion` 非空検証
+ * 3. `assertConfidenceEvidenceConsistency` で confidence-evidence 整合性検証 (Critical 6 反映)
+ *
+ * 出力:
+ * - `provenance`: createSplitProvenance と同形 (sha256 lowercase 正規化、createdAt は input 由来)
+ * - `provenanceBackfill`: legacy-observed metadata (backfilledAt は別時刻、evidence 完備)
+ *
+ * Phase C で Firestore atomic batch に渡される 2 オブジェクト。
+ */
+export function createBackfillProvenance(input: CreateBackfillProvenanceInput): {
+  provenance: DocumentProvenance;
+  provenanceBackfill: ProvenanceBackfillMetadata;
+} {
+  assertValidProvenanceInput(input.provenanceFields);
+  assertNonEmptyString(input.backfillScriptVersion, 'backfillScriptVersion');
+  assertConfidenceEvidenceConsistency(input.confidence, input.evidence);
+
+  const provenance = createSplitProvenance(input.provenanceFields);
+  const provenanceBackfill = {
+    method: 'legacy-observed' as const,
+    confidence: input.confidence,
+    backfilledAt: input.backfilledAt ?? Timestamp.now(),
+    evidence: {
+      parentExists: input.evidence.parentExists,
+      parentSha256MatchedAtBackfill: input.evidence.parentSha256MatchedAtBackfill,
+      childSha256ComputedAtBackfill: input.evidence.childSha256ComputedAtBackfill,
+      backfillScriptVersion: input.backfillScriptVersion,
+      classifierCategory: input.classifierCategory,
+    },
+  };
+  return {
+    provenance,
+    provenanceBackfill: provenanceBackfill as unknown as ProvenanceBackfillMetadata,
+  };
 }

--- a/functions/src/pdf/provenance.ts
+++ b/functions/src/pdf/provenance.ts
@@ -236,16 +236,25 @@ export function createRotationProvenance(
  * createBackfillProvenance() の入力型。
  *
  * 設計:
- * - `provenanceFields`: caller が現在の GCS state から組立てた 10 fields (CreateSplitProvenanceInput と同形)。
- *   `createdAt` は **split 完了時刻** (= document.createdAt 由来) を渡す。backfill 実行時刻ではない (Codex 1st Critical 2 反映)。
+ * - `provenanceFields`: caller が現在の GCS state から組立てた 10 fields (CreateSplitProvenanceInput 派生)。
+ *   `createdAt` は **必須** で **split 完了時刻** (= document.createdAt 由来) を渡す。
+ *   backfill 実行時刻ではない (ADR Critical 2 反映、Codex 4th review High 1 反映で `createdAt` の型レベル必須化)。
+ *   `createSplitProvenance()` の fallback `Timestamp.now()` が走ると ADR Critical 2 違反になるため、
+ *   入力型から `createdAt` を Required pick して compile-time enforce。
  * - `confidence`: rotate gate 動作と連動。`evidence` との整合性を runtime 検証 (Codex 1st Critical 6 反映)。
  * - `classifierCategory`: PR-C3c classifier 出力を記録 (Codex 2nd review I7 反映)。
- * - `evidence`: 現物計算結果 (再現性 + 監査)。
+ *   classifierCategory ↔ confidence invariant (MatchedByHash → derived-bytes-verified 等) は **Phase C caller**
+ *   (S1-4 で実装) で enforce する。factory level では両方を独立に受け取り、dev fixture が
+ *   `Ambiguous → child-snapshot-only` 等を作成できる柔軟性を保つ (impl-plan §4.0 / Codex 4th review Medium 2)。
+ * - `evidence`: 現物計算結果 (再現性 + 監査)。boolean は **strict** で検証 (`!== true` / `!== false`、
+ *   `as unknown as` TS bypass 経由の hostile input をブロック、Codex 4th review Medium 1)。
  * - `backfillScriptVersion`: 例 'pr-d4-v1.0' (script 改修で再 backfill を区別)。
  * - `backfilledAt`: 省略時は Timestamp.now()。
  */
 export interface CreateBackfillProvenanceInput {
-  provenanceFields: CreateSplitProvenanceInput;
+  provenanceFields: Omit<CreateSplitProvenanceInput, 'createdAt'> & {
+    createdAt: Timestamp;
+  };
   confidence: BackfillConfidence;
   classifierCategory: BackfillClassifierCategory;
   evidence: {
@@ -265,6 +274,10 @@ export interface CreateBackfillProvenanceInput {
  * - `derived-bytes-verified`: parent 現存 + parent sha256 match + child sha256 実計算 の **3 つ全部** 必須
  * - `child-snapshot-only`: child sha256 実計算 必須 (parent 状態は問わない)
  * - `metadata-only`: child sha256 実計算 **しない** (定義上スキップ、Codex 2nd L3 反映)
+ *
+ * boolean 比較は **strict** (`!== true` / `!== false`、Codex 4th review Medium 1 反映)。
+ * `as unknown as` TS bypass で `parentExists: 1` や `childSha256ComputedAtBackfill: "yes"` を渡しても
+ * truthy で素通りしない。defense in depth として hostile input をブロックする。
  */
 function assertConfidenceEvidenceConsistency(
   confidence: BackfillConfidence,
@@ -272,38 +285,38 @@ function assertConfidenceEvidenceConsistency(
 ): void {
   switch (confidence) {
     case 'derived-bytes-verified':
-      if (!evidence.parentExists) {
+      if (evidence.parentExists !== true) {
         throw new ProvenanceValidationError(
           'evidence.parentExists',
-          'derived-bytes-verified requires parentExists=true'
+          'derived-bytes-verified requires parentExists strictly === true'
         );
       }
       if (evidence.parentSha256MatchedAtBackfill !== true) {
         throw new ProvenanceValidationError(
           'evidence.parentSha256MatchedAtBackfill',
-          'derived-bytes-verified requires parentSha256MatchedAtBackfill=true (re-split bytes match)'
+          'derived-bytes-verified requires parentSha256MatchedAtBackfill strictly === true (re-split bytes match)'
         );
       }
-      if (!evidence.childSha256ComputedAtBackfill) {
+      if (evidence.childSha256ComputedAtBackfill !== true) {
         throw new ProvenanceValidationError(
           'evidence.childSha256ComputedAtBackfill',
-          'derived-bytes-verified requires childSha256ComputedAtBackfill=true'
+          'derived-bytes-verified requires childSha256ComputedAtBackfill strictly === true'
         );
       }
       break;
     case 'child-snapshot-only':
-      if (!evidence.childSha256ComputedAtBackfill) {
+      if (evidence.childSha256ComputedAtBackfill !== true) {
         throw new ProvenanceValidationError(
           'evidence.childSha256ComputedAtBackfill',
-          'child-snapshot-only requires childSha256ComputedAtBackfill=true (現 child sha256 実計算必須)'
+          'child-snapshot-only requires childSha256ComputedAtBackfill strictly === true (現 child sha256 実計算必須)'
         );
       }
       break;
     case 'metadata-only':
-      if (evidence.childSha256ComputedAtBackfill) {
+      if (evidence.childSha256ComputedAtBackfill !== false) {
         throw new ProvenanceValidationError(
           'evidence.childSha256ComputedAtBackfill',
-          'metadata-only definition skips actual sha256 compute; set childSha256ComputedAtBackfill=false'
+          'metadata-only definition skips actual sha256 compute; childSha256ComputedAtBackfill must strictly === false'
         );
       }
       break;
@@ -333,6 +346,14 @@ export function createBackfillProvenance(input: CreateBackfillProvenanceInput): 
   provenance: DocumentProvenance;
   provenanceBackfill: ProvenanceBackfillMetadata;
 } {
+  // defense in depth: TS bypass (`as unknown as`) 経路でも createdAt 省略を block する
+  // (Codex 4th review High 1 反映、ADR Critical 2 = split 完了時刻 ≠ backfill 実行時刻)
+  if (input.provenanceFields.createdAt === undefined) {
+    throw new ProvenanceValidationError(
+      'provenanceFields.createdAt',
+      'backfill では split 完了時刻を明示渡しが必須 (document.createdAt 由来)。createSplitProvenance の Timestamp.now() fallback を回避'
+    );
+  }
   assertValidProvenanceInput(input.provenanceFields);
   assertNonEmptyString(input.backfillScriptVersion, 'backfillScriptVersion');
   assertConfidenceEvidenceConsistency(input.confidence, input.evidence);

--- a/functions/test/provenance.test.ts
+++ b/functions/test/provenance.test.ts
@@ -9,9 +9,11 @@
 import { expect } from 'chai';
 import { Timestamp } from 'firebase-admin/firestore';
 import {
+  CreateBackfillProvenanceInput,
   CreateSplitProvenanceInput,
   ProvenanceValidationError,
   assertValidProvenanceInput,
+  createBackfillProvenance,
   createSplitProvenance,
 } from '../src/pdf/provenance';
 
@@ -204,5 +206,257 @@ describe('ProvenanceValidationError', () => {
       expect((err as ProvenanceValidationError).reason).to.match(/64-char hex/);
       expect((err as Error).name).to.equal('ProvenanceValidationError');
     }
+  });
+});
+
+// ============================================================
+// createBackfillProvenance (ADR-0016 MUST 6 / Issue #445 PR-D4)
+// ============================================================
+
+function makeBackfillInput(
+  overrides: Partial<CreateBackfillProvenanceInput> = {}
+): CreateBackfillProvenanceInput {
+  return {
+    provenanceFields: makeValidInput(),
+    confidence: 'derived-bytes-verified',
+    classifierCategory: 'MatchedByHash',
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+    backfillScriptVersion: 'pr-d4-v1.0',
+    ...overrides,
+  };
+}
+
+describe('createBackfillProvenance (ADR-0016 MUST 6 factory)', () => {
+  describe('正常系: confidence ごとの構築', () => {
+    it('derived-bytes-verified で provenance 10 fields + backfill metadata を構築する', () => {
+      const result = createBackfillProvenance(makeBackfillInput());
+      // provenance side (10 fields の値を継承)
+      expect(result.provenance.sourceGeneration).to.equal('1700000000000001');
+      expect(result.provenance.sourceSha256).to.equal('a'.repeat(64));
+      expect(result.provenance.derivedObjectPath).to.equal('processed/doc-id-xyz/output.pdf');
+      expect(result.provenance.derivedSha256).to.equal('b'.repeat(64));
+      // backfill metadata side
+      expect(result.provenanceBackfill.method).to.equal('legacy-observed');
+      expect(result.provenanceBackfill.confidence).to.equal('derived-bytes-verified');
+      expect(result.provenanceBackfill.backfilledAt).to.exist;
+      expect(result.provenanceBackfill.evidence.parentExists).to.equal(true);
+      expect(result.provenanceBackfill.evidence.parentSha256MatchedAtBackfill).to.equal(true);
+      expect(result.provenanceBackfill.evidence.childSha256ComputedAtBackfill).to.equal(true);
+      expect(result.provenanceBackfill.evidence.backfillScriptVersion).to.equal('pr-d4-v1.0');
+      expect(result.provenanceBackfill.evidence.classifierCategory).to.equal('MatchedByHash');
+    });
+
+    it('child-snapshot-only で構築する (parent 不在 + child sha256 実計算済)', () => {
+      const result = createBackfillProvenance(
+        makeBackfillInput({
+          confidence: 'child-snapshot-only',
+          classifierCategory: 'Ambiguous',
+          evidence: {
+            parentExists: false,
+            parentSha256MatchedAtBackfill: null,
+            childSha256ComputedAtBackfill: true,
+          },
+        })
+      );
+      expect(result.provenanceBackfill.confidence).to.equal('child-snapshot-only');
+      expect(result.provenanceBackfill.evidence.parentExists).to.equal(false);
+      expect(result.provenanceBackfill.evidence.parentSha256MatchedAtBackfill).to.be.null;
+      expect(result.provenanceBackfill.evidence.classifierCategory).to.equal('Ambiguous');
+    });
+
+    it('metadata-only で構築する (childSha256ComputedAtBackfill=false 許容)', () => {
+      const result = createBackfillProvenance(
+        makeBackfillInput({
+          confidence: 'metadata-only',
+          classifierCategory: 'Ambiguous',
+          evidence: {
+            parentExists: false,
+            parentSha256MatchedAtBackfill: null,
+            childSha256ComputedAtBackfill: false,
+          },
+        })
+      );
+      expect(result.provenanceBackfill.confidence).to.equal('metadata-only');
+      expect(result.provenanceBackfill.evidence.childSha256ComputedAtBackfill).to.equal(false);
+    });
+  });
+
+  describe('時刻フィールド', () => {
+    it('backfilledAt 省略時は Timestamp.now() を採用する', () => {
+      const before = Timestamp.now();
+      const result = createBackfillProvenance(makeBackfillInput());
+      const after = Timestamp.now();
+      const ms = (result.provenanceBackfill.backfilledAt as unknown as Timestamp).toMillis();
+      expect(ms).to.be.at.least(before.toMillis());
+      expect(ms).to.be.at.most(after.toMillis());
+    });
+
+    it('backfilledAt 明示指定時はそれを採用する', () => {
+      const fixed = Timestamp.fromMillis(1700000000000);
+      const result = createBackfillProvenance(makeBackfillInput({ backfilledAt: fixed }));
+      expect((result.provenanceBackfill.backfilledAt as unknown as Timestamp).toMillis()).to.equal(
+        1700000000000
+      );
+    });
+
+    it('provenance.createdAt は input.provenanceFields.createdAt を継承する (split 完了時刻)', () => {
+      const splitCompletedAt = Timestamp.fromMillis(1690000000000);
+      const result = createBackfillProvenance(
+        makeBackfillInput({
+          provenanceFields: { ...makeValidInput(), createdAt: splitCompletedAt },
+          backfilledAt: Timestamp.fromMillis(1700000000000),
+        })
+      );
+      expect((result.provenance.createdAt as unknown as Timestamp).toMillis()).to.equal(
+        1690000000000
+      );
+      expect(
+        (result.provenanceBackfill.backfilledAt as unknown as Timestamp).toMillis()
+      ).to.equal(1700000000000);
+    });
+  });
+
+  describe('sha256 lowercase 正規化', () => {
+    it('provenance fields の sha256 を lowercase 化する', () => {
+      const result = createBackfillProvenance(
+        makeBackfillInput({
+          provenanceFields: makeValidInput({
+            sourceSha256: 'A'.repeat(64),
+            derivedSha256: 'B'.repeat(64),
+          }),
+        })
+      );
+      expect(result.provenance.sourceSha256).to.equal('a'.repeat(64));
+      expect(result.provenance.derivedSha256).to.equal('b'.repeat(64));
+    });
+  });
+
+  describe('validation: provenance fields の 10 fields 検証 (assertValidProvenanceInput 流用)', () => {
+    it('sourceSha256 短すぎで ProvenanceValidationError', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            provenanceFields: makeValidInput({ sourceSha256: 'abc' }),
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'sourceSha256');
+    });
+
+    it('derivedObjectPath に gs:// prefix で throw', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            provenanceFields: makeValidInput({
+              derivedObjectPath: 'gs://bucket/x.pdf',
+            }),
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'derivedObjectPath');
+    });
+  });
+
+  describe('validation: backfillScriptVersion', () => {
+    it('空文字で ProvenanceValidationError', () => {
+      expect(() =>
+        createBackfillProvenance(makeBackfillInput({ backfillScriptVersion: '' }))
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'backfillScriptVersion');
+    });
+  });
+
+  describe('validation: confidence-evidence 整合性 (ADR Critical 6 反映)', () => {
+    it('derived-bytes-verified で parentExists=false なら throw (verified には parent 現存必須)', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            confidence: 'derived-bytes-verified',
+            evidence: {
+              parentExists: false,
+              parentSha256MatchedAtBackfill: true,
+              childSha256ComputedAtBackfill: true,
+            },
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.parentExists');
+    });
+
+    it('derived-bytes-verified で parentSha256MatchedAtBackfill !== true なら throw', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            confidence: 'derived-bytes-verified',
+            evidence: {
+              parentExists: true,
+              parentSha256MatchedAtBackfill: null,
+              childSha256ComputedAtBackfill: true,
+            },
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.parentSha256MatchedAtBackfill');
+    });
+
+    it('derived-bytes-verified で childSha256ComputedAtBackfill=false なら throw', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            confidence: 'derived-bytes-verified',
+            evidence: {
+              parentExists: true,
+              parentSha256MatchedAtBackfill: true,
+              childSha256ComputedAtBackfill: false,
+            },
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.childSha256ComputedAtBackfill');
+    });
+
+    it('child-snapshot-only で childSha256ComputedAtBackfill=false なら throw (現 child sha256 実計算必須)', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            confidence: 'child-snapshot-only',
+            evidence: {
+              parentExists: false,
+              parentSha256MatchedAtBackfill: null,
+              childSha256ComputedAtBackfill: false,
+            },
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.childSha256ComputedAtBackfill');
+    });
+
+    it('metadata-only で childSha256ComputedAtBackfill=true なら throw (metadata-only は実計算スキップが定義)', () => {
+      expect(() =>
+        createBackfillProvenance(
+          makeBackfillInput({
+            confidence: 'metadata-only',
+            evidence: {
+              parentExists: true,
+              parentSha256MatchedAtBackfill: null,
+              childSha256ComputedAtBackfill: true,
+            },
+          })
+        )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.childSha256ComputedAtBackfill');
+    });
   });
 });

--- a/functions/test/provenance.test.ts
+++ b/functions/test/provenance.test.ts
@@ -213,11 +213,22 @@ describe('ProvenanceValidationError', () => {
 // createBackfillProvenance (ADR-0016 MUST 6 / Issue #445 PR-D4)
 // ============================================================
 
+// helper: provenanceFields の createdAt 必須化を満たす (Codex 4th High 1 反映)
+function makeBackfillFields(
+  overrides: Partial<CreateSplitProvenanceInput> = {}
+): CreateBackfillProvenanceInput['provenanceFields'] {
+  return {
+    ...makeValidInput(overrides),
+    // ADR Critical 2 / Codex 4th High 1: backfill では split 完了時刻を必須渡し
+    createdAt: overrides.createdAt ?? Timestamp.fromMillis(1690000000000),
+  };
+}
+
 function makeBackfillInput(
   overrides: Partial<CreateBackfillProvenanceInput> = {}
 ): CreateBackfillProvenanceInput {
   return {
-    provenanceFields: makeValidInput(),
+    provenanceFields: makeBackfillFields(),
     confidence: 'derived-bytes-verified',
     classifierCategory: 'MatchedByHash',
     evidence: {
@@ -307,7 +318,7 @@ describe('createBackfillProvenance (ADR-0016 MUST 6 factory)', () => {
       const splitCompletedAt = Timestamp.fromMillis(1690000000000);
       const result = createBackfillProvenance(
         makeBackfillInput({
-          provenanceFields: { ...makeValidInput(), createdAt: splitCompletedAt },
+          provenanceFields: makeBackfillFields({ createdAt: splitCompletedAt }),
           backfilledAt: Timestamp.fromMillis(1700000000000),
         })
       );
@@ -324,7 +335,7 @@ describe('createBackfillProvenance (ADR-0016 MUST 6 factory)', () => {
     it('provenance fields の sha256 を lowercase 化する', () => {
       const result = createBackfillProvenance(
         makeBackfillInput({
-          provenanceFields: makeValidInput({
+          provenanceFields: makeBackfillFields({
             sourceSha256: 'A'.repeat(64),
             derivedSha256: 'B'.repeat(64),
           }),
@@ -340,7 +351,7 @@ describe('createBackfillProvenance (ADR-0016 MUST 6 factory)', () => {
       expect(() =>
         createBackfillProvenance(
           makeBackfillInput({
-            provenanceFields: makeValidInput({ sourceSha256: 'abc' }),
+            provenanceFields: makeBackfillFields({ sourceSha256: 'abc' }),
           })
         )
       )
@@ -352,7 +363,7 @@ describe('createBackfillProvenance (ADR-0016 MUST 6 factory)', () => {
       expect(() =>
         createBackfillProvenance(
           makeBackfillInput({
-            provenanceFields: makeValidInput({
+            provenanceFields: makeBackfillFields({
               derivedObjectPath: 'gs://bucket/x.pdf',
             }),
           })
@@ -454,6 +465,67 @@ describe('createBackfillProvenance (ADR-0016 MUST 6 factory)', () => {
             },
           })
         )
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.childSha256ComputedAtBackfill');
+    });
+  });
+
+  describe('validation: defense in depth (Codex 4th review 反映)', () => {
+    it('provenanceFields.createdAt 省略 (TS bypass) で ProvenanceValidationError (ADR Critical 2 enforcement)', () => {
+      // TS 型レベルでは createdAt 必須だが、`as unknown as` で省略を強制した場合に
+      // factory の runtime guard が backfill 実行時刻を split 完了時刻に混入させない
+      const bad = makeBackfillInput() as unknown as Record<string, unknown>;
+      const provenanceFields = { ...(bad.provenanceFields as Record<string, unknown>) };
+      delete provenanceFields.createdAt;
+      bad.provenanceFields = provenanceFields;
+      expect(() =>
+        createBackfillProvenance(bad as unknown as CreateBackfillProvenanceInput)
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'provenanceFields.createdAt');
+    });
+
+    it('derived-bytes-verified で parentExists=1 (truthy non-boolean) なら throw (strict boolean check)', () => {
+      const bad = makeBackfillInput() as unknown as Record<string, unknown>;
+      bad.evidence = {
+        parentExists: 1,
+        parentSha256MatchedAtBackfill: true,
+        childSha256ComputedAtBackfill: true,
+      };
+      expect(() =>
+        createBackfillProvenance(bad as unknown as CreateBackfillProvenanceInput)
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.parentExists');
+    });
+
+    it('derived-bytes-verified で childSha256ComputedAtBackfill="yes" (truthy string) なら throw', () => {
+      const bad = makeBackfillInput() as unknown as Record<string, unknown>;
+      bad.evidence = {
+        parentExists: true,
+        parentSha256MatchedAtBackfill: true,
+        childSha256ComputedAtBackfill: 'yes',
+      };
+      expect(() =>
+        createBackfillProvenance(bad as unknown as CreateBackfillProvenanceInput)
+      )
+        .to.throw(ProvenanceValidationError)
+        .with.property('field', 'evidence.childSha256ComputedAtBackfill');
+    });
+
+    it('metadata-only で childSha256ComputedAtBackfill=1 (truthy non-boolean) なら throw (=== false 必須)', () => {
+      const bad = makeBackfillInput({ confidence: 'metadata-only' }) as unknown as Record<
+        string,
+        unknown
+      >;
+      bad.evidence = {
+        parentExists: true,
+        parentSha256MatchedAtBackfill: null,
+        childSha256ComputedAtBackfill: 1,
+      };
+      expect(() =>
+        createBackfillProvenance(bad as unknown as CreateBackfillProvenanceInput)
       )
         .to.throw(ProvenanceValidationError)
         .with.property('field', 'evidence.childSha256ComputedAtBackfill');

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -82,6 +82,18 @@ export interface Document {
    */
   provenance?: DocumentProvenance;
 
+  /**
+   * legacy backfill metadata (ADR-0016 MUST 6 / Issue #445 PR-D4)
+   *
+   * 意味論:
+   * - field absent = PR-D2/D3 で生成された verified provenance (split 完了時刻の正当 bytes 証拠)
+   * - field exists = PR-D4 backfill で書込まれた legacy doc (split 時点正当ではない)
+   *
+   * Consumer は provenance 単独で "verified split-time origin" と判定してはならない (ADR MUST 6 Consumer contract)。
+   * rotate gate は backfilled doc を confidence === 'derived-bytes-verified' のみ許可 (ADR MUST 3 拡張)。
+   */
+  provenanceBackfill?: ProvenanceBackfillMetadata;
+
   // Phase 7: 顧客確定機能
   customerId?: string | null;                    // 顧客ID（「該当なし」選択時はnull）
   customerCandidates?: CustomerCandidateInfo[];  // 構造化された候補リスト
@@ -161,6 +173,78 @@ export interface DocumentProvenance {
   derivedSha256: string;
   /** provenance 書込時刻 (= split 完了時刻)。audit field、bytes identity 照合対象ではない */
   createdAt: Timestamp;
+}
+
+/**
+ * Backfill confidence 階層 (ADR-0016 MUST 6)
+ *
+ * 高 → 低:
+ * - `derived-bytes-verified`: parent + child 現存、再 split で sha256 一致 (Issue #432 silent corruption 被害なし)
+ * - `child-snapshot-only`: 現 child sha256/generation 実計算記録のみ、parent 不在 or 再 split 不一致
+ *   (壊れた legacy bytes の可能性あり、dev/test fixture のみで作成、本番 Phase C では原則記録しない)
+ * - `metadata-only`: child GCS metadata のみで sha256 実計算スキップ (PR-D4 では原則禁止、明示 approval 必要)
+ *
+ * rotate gate 動作 (ADR MUST 3 拡張):
+ * - `derived-bytes-verified`: allow
+ * - `child-snapshot-only` / `metadata-only`: failed-precondition reject
+ */
+export type BackfillConfidence =
+  | 'derived-bytes-verified'
+  | 'child-snapshot-only'
+  | 'metadata-only';
+
+/**
+ * Backfill 時に記録する 5 分類カテゴリ (ADR-0016 MUST 6 evidence.classifierCategory、Codex 2nd review I7 反映)。
+ *
+ * 内訳:
+ * - PR-C3c classifier 4 メンバー (`scripts/lib/collisionClassifier.ts` の `Classification`):
+ *   `MatchedByHash | RepairableMissingFile | Ambiguous | LostOrUnrecoverable`
+ * - PR-D4 で追加した classifier 通過不能ケースのフォールバック: `NeedsManualReview`
+ *   (splitFromPages 不在 / dual parent 等で classifier に渡せない doc を記録するための値、
+ *   impl-plan §8 fixture 拡張表参照)
+ *
+ * `Classification` を直接 import せず別定義する理由: `shared/` は `scripts/` に依存できない
+ * (frontend bundle 経路 + layer 規約)。drift 防止は doc-audit と PR review でカバーする。
+ */
+export type BackfillClassifierCategory =
+  | 'MatchedByHash'
+  | 'RepairableMissingFile'
+  | 'Ambiguous'
+  | 'LostOrUnrecoverable'
+  | 'NeedsManualReview';
+
+/**
+ * 既存 docs への legacy backfill metadata (ADR-0016 MUST 6 / PR-D4)
+ *
+ * 必須記録項目:
+ * - `method`: enum で将来別 method を追加する余地を残す
+ * - `confidence`: 階層化された信頼度 (rotate gate 動作と連動)
+ * - `backfilledAt`: backfill 実行時刻 (≠ provenance.createdAt = split 完了時刻、Codex 1st Critical 2 反映)
+ * - `evidence`: 再現性 / 監査用の現物計算情報
+ *
+ * MUST 7 (ADR-0016): provenance exists + provenanceBackfill absent な doc は immutable skip。
+ * 既存 verified provenance を低信頼度 backfill で破壊する経路を構造的に閉鎖する。
+ */
+export interface ProvenanceBackfillMetadata {
+  /** backfill 方法 (enum、将来拡張余地) */
+  method: 'legacy-observed';
+  /** rotate gate 動作と連動する confidence 階層 */
+  confidence: BackfillConfidence;
+  /** backfill 実行時刻 (≠ provenance.createdAt) */
+  backfilledAt: Timestamp;
+  /** 再現性 / 監査用の現物計算情報 */
+  evidence: {
+    /** 親 Storage object が backfill 時点で存在したか */
+    parentExists: boolean;
+    /** 再 split で sha256 一致を検証した場合 true、未検証 null */
+    parentSha256MatchedAtBackfill: boolean | null;
+    /** child object から sha256 を実計算したか */
+    childSha256ComputedAtBackfill: boolean;
+    /** 例: 'pr-d4-v1.0' (script 改修で再 backfill 区別) */
+    backfillScriptVersion: string;
+    /** PR-C3c classifier 出力 (Codex 2nd review I7 反映) */
+    classifierCategory: BackfillClassifierCategory;
+  };
 }
 
 // ============================================

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -91,6 +91,12 @@ export interface Document {
    *
    * Consumer は provenance 単独で "verified split-time origin" と判定してはならない (ADR MUST 6 Consumer contract)。
    * rotate gate は backfilled doc を confidence === 'derived-bytes-verified' のみ許可 (ADR MUST 3 拡張)。
+   *
+   * **判定方法 (Codex 4th review Low 1 反映)**: TypeScript 上の型表面は `undefined` を absence として扱う
+   * (`strictNullChecks` 下で `null` 不可)。一方 Firestore 経由で読み込んだ document に `provenanceBackfill: null`
+   * が混入する可能性がある (古い書込経路 / 手動修復等)。Consumer は `provenanceBackfill === undefined`
+   * ではなく **field 存在チェック** (`'provenanceBackfill' in doc` または等価) または `!= null` (loose) で判定し、
+   * truthiness check (`if (provenanceBackfill)`) は **使わない** (空オブジェクト判定の事故を防ぐ)。
    */
   provenanceBackfill?: ProvenanceBackfillMetadata;
 


### PR DESCRIPTION
## Summary

Issue #445 PR-D4 (legacy provenance backfill, destructive migration) の **基盤層 (S1-1)** を実装。ADR-0016 MUST 6/7 を実装する型 + factory + unit test のみ。

- `ProvenanceBackfillMetadata` 型 + `BackfillConfidence` / `BackfillClassifierCategory` 型 export
- `Document.provenanceBackfill?` optional field 追加 (MUST 7 field-absence 判定の前提)
- `createBackfillProvenance()` factory + `assertConfidenceEvidenceConsistency()` helper
- factory unit test 15 件追加

Phase A-D 実装 / Dockerfile / GitHub Actions workflow / container build & push は別セッション (S1-2 以降)。

## ADR-0016 整合性

| 制約 | 本 PR での対応 |
|------|---------------|
| MUST 6 (provenanceBackfill metadata) | ✅ 6 サブフィールド (method/confidence/backfilledAt + evidence の 5 sub) 実装 |
| MUST 7 (immutable skip) | ✅ optional field 採用で field-absence 判定の前提を確立 |
| MUST 3 拡張 (rotate gate 連動) | 🔜 後続セッションで rotatePdfPages 側を改修 |
| Critical 2 (createdAt 分離) | ✅ provenance.createdAt (split 完了) と provenanceBackfill.backfilledAt (backfill 実行) を別 field で分離 |
| Critical 6 (昇格防止) | ✅ assertConfidenceEvidenceConsistency で derived-bytes-verified の 3 evidence (parentExists / parentSha256MatchedAtBackfill / childSha256ComputedAtBackfill) 必須化 |

## 品質ゲート

| ゲート | 結果 |
|--------|------|
| TDD (RED → GREEN → REFACTOR) | ✅ 15 cases テストファースト |
| /simplify (3 並列 Agent: reuse / quality / efficiency) | ✅ Reuse 1 件 fix (BackfillClassifierCategory JSDoc 不正確 → 5 メンバーの内訳を明文化)、Quality/Efficiency clean |
| /safe-refactor | ✅ HIGH/MEDIUM/LOW 0 件 |
| /codex review | ⏭️ Bash版/MCP版とも timeout、PR コメントで後追い実施 (本変更は基盤層・非 destructive で Codex 必須対象外) |
| type-check (test + src) | ✅ pass |
| build (functions tsc) | ✅ pass |
| 全 unit test | ✅ 1147 passing で regression なし (新規 15 + 既存 18 + 他 1114) |
| Evaluator 分離 (5+ ファイル) | ✅ 対象外 (3 ファイル) |

## Test plan

- [x] `cd functions && npm run type-check:test` → pass
- [x] `cd functions && npm run build` → pass
- [x] `cd functions && npm test` → 1147 passing
- [x] `cd functions && npx mocha test/provenance.test.ts` → 33 passing (createSplitProvenance 既存 + createBackfillProvenance 新規 + assertValidProvenanceInput / ProvenanceValidationError)
- [ ] PR 後追い: Codex review (Bash / MCP) で High/Medium 指摘なき GO 確認
- [ ] frontend bundle 影響なし確認 (shared/types.ts optional field 追加のみ、既存 import 経路を壊さない)

## Next Steps (PR-D4 残作業マイルストーン)

| Stage | 内容 | 完了条件 |
|-------|------|---------|
| S1-2 | Phase A 実装 (audit + classify、read-only) | classify summary artifact + chunking |
| S1-3 | Phase B 実装 (write-free preflight revalidation) | drift skip rate < 1% test |
| S1-4 | Phase C 実装 (atomic backfill verified docs) | precondition + GCS sentinel lock |
| S1-5 | Phase D 実装 (verify + gate behavior) | rotate gate test 期待通り |
| S1-6 | Dockerfile + .github/workflows/pr-d4-backfill.yml | workflow_dispatch + Cloud Run Job trigger |
| S1-7 | container build + push (dev で実行) → image tag 取得 | **S1 完了条件** |
| S2-S7 | dev rehearsal 7-stage × 2 周 → cocoro / kanameone 段階展開 (impl-plan §9-10) | ユーザー番号認可フェーズ |

詳細: `docs/specs/pr-d4-backfill-impl-plan.md` §9 (7-stage table)

Refs #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added legacy data backfill support with comprehensive provenance metadata. Users can now distinguish between directly verified and backfilled information through confidence classification and evidence tracking, enabling better visibility into data origin and reconstruction methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/462)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->