### PR TITLE
feat(pr-d4): PR-D4 S1-2 — Phase A read-only audit + classify + 47 tests (#445)

### DIFF
--- a/functions/test/prD4ArtifactWriter.test.ts
+++ b/functions/test/prD4ArtifactWriter.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Issue #445 PR-D4 S1-2: artifact-writer.ts streaming API テスト.
+ *
+ * impl-plan §4.1 の chunked GCS write + SHA256 manifest 仕様を固定する。
+ * BF19 (artifact 必須 metadata) + BF22 (chunked streaming) のカバレッジ。
+ *
+ * Codex MCP NO-GO 反映 (per-chunk flush): orchestrator が per-chunk buffer のみ保持し
+ * writer は writePhaseAChunk (1 chunk 単位) + finalizePhaseAArtifact (main + manifest) の
+ * 2 関数に分離。本テストは writer 単体の挙動を検証する。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  writePhaseAChunk,
+  finalizePhaseAArtifact,
+  type ArtifactStorageWriter,
+  type WrittenObject,
+} from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import type {
+  ArtifactChunkPointer,
+  PhaseACandidate,
+  PhaseAClassifyChunk,
+  PhaseAClassifySummary,
+  BackfillManifest,
+} from '../../scripts/pr-d4-backfill/types';
+
+class FakeStorageWriter implements ArtifactStorageWriter {
+  public writes: WrittenObject[] = [];
+  async writeJson(objectPath: string, content: string): Promise<void> {
+    this.writes.push({ path: objectPath, content });
+  }
+}
+
+function makeCandidate(i: number): PhaseACandidate {
+  return {
+    docId: `doc-${i}`,
+    category: 'MatchedByHash',
+    reason: 'test',
+    firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+    childObjectPath: `processed/doc-${i}/output.pdf`,
+    childGeneration: `${1000000 + i}`,
+    childMetageneration: '1',
+    parentDocId: `parent-${i}`,
+    parentObjectPath: `attachments/parent-${i}/source.pdf`,
+    parentGeneration: `${2000000 + i}`,
+    parentMetageneration: '1',
+    splitFromPages: { start: 1, end: 1 },
+  };
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+const COMMON = {
+  bucketName: 'docsplit-dev-pr-d4-artifacts',
+  runId: '20260514T100000Z-dev-pr-d4-v1',
+};
+
+describe('writePhaseAChunk (PR-D4 S1-2 per-chunk flush)', () => {
+  it('1 chunk file を書込み ArtifactChunkPointer (path + sha256 + docCount) を返す', async () => {
+    const writer = new FakeStorageWriter();
+    const candidates = [makeCandidate(0), makeCandidate(1), makeCandidate(2)];
+    const pointer = await writePhaseAChunk(
+      { ...COMMON, chunkIndex: 0, candidates },
+      writer
+    );
+    expect(writer.writes).to.have.length(1);
+    const written = writer.writes[0];
+    expect(written.path).to.equal(
+      'gs://docsplit-dev-pr-d4-artifacts/pr-d4-backfill-artifacts/20260514T100000Z-dev-pr-d4-v1/phase-a-classify-summary-chunk-0.json'
+    );
+    expect(pointer.path).to.equal(written.path);
+    expect(pointer.sha256).to.equal(sha256Hex(written.content));
+    expect(pointer.docCount).to.equal(3);
+
+    const chunk = JSON.parse(written.content) as PhaseAClassifyChunk;
+    expect(chunk.chunkIndex).to.equal(0);
+    expect(chunk.candidates).to.have.length(3);
+    expect(chunk.candidates[0].docId).to.equal('doc-0');
+    expect(chunk.candidates[2].docId).to.equal('doc-2');
+  });
+
+  it('chunkIndex は入力をそのまま使用 (caller が連番管理)', async () => {
+    const writer = new FakeStorageWriter();
+    await writePhaseAChunk(
+      { ...COMMON, chunkIndex: 5, candidates: [makeCandidate(0)] },
+      writer
+    );
+    expect(writer.writes[0].path).to.include('chunk-5.json');
+    const chunk = JSON.parse(writer.writes[0].content) as PhaseAClassifyChunk;
+    expect(chunk.chunkIndex).to.equal(5);
+  });
+
+  it('GCS object path は gs://{bucket}/pr-d4-backfill-artifacts/{runId}/{filename} 形式', async () => {
+    const writer = new FakeStorageWriter();
+    await writePhaseAChunk(
+      { ...COMMON, chunkIndex: 0, candidates: [makeCandidate(0)] },
+      writer
+    );
+    expect(writer.writes[0].path).to.match(
+      /^gs:\/\/docsplit-dev-pr-d4-artifacts\/pr-d4-backfill-artifacts\/20260514T100000Z-dev-pr-d4-v1\/phase-a-classify-summary-chunk-0\.json$/
+    );
+  });
+});
+
+describe('finalizePhaseAArtifact (PR-D4 S1-2 main + manifest writer)', () => {
+  function buildFinalizeInput(
+    chunkPointers: ArtifactChunkPointer[]
+  ): Parameters<typeof finalizePhaseAArtifact>[0] {
+    return {
+      ...COMMON,
+      env: 'dev',
+      snapshotStartedAt: '2026-05-14T10:00:00.000Z',
+      snapshotCompletedAt: '2026-05-14T10:15:00.000Z',
+      bucketLocation: 'asia-northeast1',
+      cloudRunJobLocation: 'asia-northeast1',
+      egressFreeAssertion: true,
+      totalDocs: chunkPointers.reduce((acc, c) => acc + c.docCount, 0),
+      categoryDistribution: {
+        MatchedByHash: 0,
+        RepairableMissingFile: 0,
+        Ambiguous: 0,
+        LostOrUnrecoverable: 0,
+        NeedsManualReview: 0,
+      },
+      alreadyBackfilled: 0,
+      verifiedExistingProvenance: 0,
+      chunks: chunkPointers,
+    };
+  }
+
+  it('main + manifest を書込み (chunks=[] でも書込まれる)', async () => {
+    const writer = new FakeStorageWriter();
+    const result = await finalizePhaseAArtifact(buildFinalizeInput([]), writer);
+    expect(writer.writes).to.have.length(2);
+    expect(result.mainArtifactPath).to.match(/phase-a-classify-summary\.json$/);
+    expect(result.manifestPath).to.match(/manifest\.json$/);
+  });
+
+  it('main artifact の chunks[] には入力 ArtifactChunkPointer 配列が記録される', async () => {
+    const writer = new FakeStorageWriter();
+    const pointers: ArtifactChunkPointer[] = [
+      { path: 'gs://b/p/chunk-0.json', sha256: 'aa', docCount: 1000 },
+      { path: 'gs://b/p/chunk-1.json', sha256: 'bb', docCount: 500 },
+    ];
+    await finalizePhaseAArtifact(buildFinalizeInput(pointers), writer);
+    const main = JSON.parse(
+      writer.writes.find((w) => w.path.endsWith('phase-a-classify-summary.json'))!.content
+    ) as PhaseAClassifySummary;
+    expect(main.chunks).to.deep.equal(pointers);
+    expect(main.totalDocs).to.equal(1500);
+  });
+
+  it('manifest.json には phaseA.mainArtifact (sha256) + phaseA.chunks が記録される', async () => {
+    const writer = new FakeStorageWriter();
+    const pointers: ArtifactChunkPointer[] = [
+      { path: 'gs://b/p/chunk-0.json', sha256: 'aabb', docCount: 100 },
+    ];
+    await finalizePhaseAArtifact(buildFinalizeInput(pointers), writer);
+    const mainContent = writer.writes.find((w) =>
+      w.path.endsWith('phase-a-classify-summary.json')
+    )!.content;
+    const manifestContent = writer.writes.find((w) => w.path.endsWith('manifest.json'))!.content;
+    const manifest = JSON.parse(manifestContent) as BackfillManifest;
+    expect(manifest.runId).to.equal('20260514T100000Z-dev-pr-d4-v1');
+    expect(manifest.env).to.equal('dev');
+    expect(manifest.phaseA).to.exist;
+    expect(manifest.phaseA!.mainArtifact.sha256).to.equal(sha256Hex(mainContent));
+    expect(manifest.phaseA!.chunks).to.deep.equal(pointers);
+  });
+
+  it('書込順は main → manifest (consumer が manifest 読めれば main + 全 chunk 書込完了 invariant)', async () => {
+    const writer = new FakeStorageWriter();
+    await finalizePhaseAArtifact(buildFinalizeInput([]), writer);
+    expect(writer.writes[0].path).to.match(/phase-a-classify-summary\.json$/);
+    expect(writer.writes[1].path).to.match(/manifest\.json$/);
+  });
+
+  it('summary metadata (snapshotStartedAt 等) は main artifact に保持される', async () => {
+    const writer = new FakeStorageWriter();
+    await finalizePhaseAArtifact(
+      {
+        ...buildFinalizeInput([]),
+        snapshotStartedAt: '2026-05-14T11:11:11.000Z',
+        snapshotCompletedAt: '2026-05-14T11:55:55.000Z',
+        bucketLocation: 'us-central1',
+        cloudRunJobLocation: 'us-central1',
+        categoryDistribution: {
+          MatchedByHash: 10,
+          RepairableMissingFile: 5,
+          Ambiguous: 3,
+          LostOrUnrecoverable: 2,
+          NeedsManualReview: 1,
+        },
+        alreadyBackfilled: 12,
+        verifiedExistingProvenance: 8,
+        totalDocs: 41,
+      },
+      writer
+    );
+    const main = JSON.parse(
+      writer.writes.find((w) => w.path.endsWith('phase-a-classify-summary.json'))!.content
+    ) as PhaseAClassifySummary;
+    expect(main.snapshotStartedAt).to.equal('2026-05-14T11:11:11.000Z');
+    expect(main.snapshotCompletedAt).to.equal('2026-05-14T11:55:55.000Z');
+    expect(main.bucketLocation).to.equal('us-central1');
+    expect(main.categoryDistribution.MatchedByHash).to.equal(10);
+    expect(main.alreadyBackfilled).to.equal(12);
+    expect(main.verifiedExistingProvenance).to.equal(8);
+    expect(main.totalDocs).to.equal(41);
+  });
+});

--- a/functions/test/prD4AuditClassify.test.ts
+++ b/functions/test/prD4AuditClassify.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Issue #445 PR-D4 S1-2: audit-classify.ts (Phase A orchestrator) テスト.
+ *
+ * documents collection を全件 stream → docSnapshotter → categoryClassifier →
+ * artifact-writer に流す pipeline を組立てる。
+ *
+ * 検証観点:
+ *   - alreadyBackfilled (provenanceBackfill 存在) / verifiedExistingProvenance (provenance
+ *     存在 + provenanceBackfill 不在) は candidates から除外され count のみ記録される
+ *   - その他は 5 分類別に candidates として artifact 化
+ *   - categoryDistribution は 5 値全部 present (0 件でも 0 を書く)
+ *   - bucket location 検証エラー時は throw + artifact 書込まれない
+ */
+
+import { expect } from 'chai';
+import {
+  runPhaseA,
+  type DocumentSource,
+  type DocumentSourceRecord,
+} from '../../scripts/pr-d4-backfill/phase-a/auditClassify';
+import {
+  type ArtifactStorageWriter,
+  type WrittenObject,
+} from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import {
+  type ParentFetcher,
+  type BucketProber,
+} from '../../scripts/pr-d4-backfill/phase-a/docSnapshotter';
+import type {
+  PhaseAClassifySummary,
+  PhaseAClassifyChunk,
+} from '../../scripts/pr-d4-backfill/types';
+
+class FakeDocumentSource implements DocumentSource {
+  private docs: DocumentSourceRecord[];
+  constructor(docs: DocumentSourceRecord[]) {
+    this.docs = docs;
+  }
+  async *streamAll(): AsyncIterable<DocumentSourceRecord> {
+    for (const doc of this.docs) yield doc;
+  }
+}
+
+class StaticParentFetcher implements ParentFetcher {
+  private parents: Record<string, { fileUrl: string | null } | null>;
+  constructor(parents: Record<string, { fileUrl: string | null } | null>) {
+    this.parents = parents;
+  }
+  async fetchParent(id: string) {
+    return id in this.parents ? this.parents[id] : null;
+  }
+}
+
+class StaticBucketProber implements BucketProber {
+  private metadataByPath: Record<
+    string,
+    { generation: string; metageneration: string } | null
+  >;
+  constructor(
+    metadataByPath: Record<
+      string,
+      { generation: string; metageneration: string } | null
+    >
+  ) {
+    this.metadataByPath = metadataByPath;
+  }
+  async getMetadata(path: string) {
+    return path in this.metadataByPath ? this.metadataByPath[path] : null;
+  }
+}
+
+class FakeStorageWriter implements ArtifactStorageWriter {
+  public writes: WrittenObject[] = [];
+  async writeJson(path: string, content: string) {
+    this.writes.push({ path, content });
+  }
+}
+
+const BUCKET = 'docsplit-dev.firebasestorage.app';
+
+function fullDoc(id: string, overrides: Partial<DocumentSourceRecord> = {}): DocumentSourceRecord {
+  return {
+    id,
+    fileUrl: `gs://${BUCKET}/processed/${id}/output.pdf`,
+    parentDocumentId: `parent-${id}`,
+    splitFromPages: { start: 1, end: 1 },
+    updateTimeIso: '2026-05-14T10:00:00.000Z',
+    hasProvenance: false,
+    hasProvenanceBackfill: false,
+    ...overrides,
+  };
+}
+
+function buildInput(
+  docs: DocumentSourceRecord[],
+  parents: Record<string, { fileUrl: string | null } | null>,
+  metadata: Record<string, { generation: string; metageneration: string } | null>,
+  writer: ArtifactStorageWriter
+) {
+  return {
+    env: 'dev' as const,
+    runId: '20260514T100000Z-dev-pr-d4-v1',
+    productionDataBucketName: BUCKET,
+    artifactBucketName: 'docsplit-dev-pr-d4-artifacts',
+    cloudRunLocation: 'asia-northeast1',
+    bucketLocation: 'asia-northeast1',
+    documentSource: new FakeDocumentSource(docs),
+    parentFetcher: new StaticParentFetcher(parents),
+    bucketProber: new StaticBucketProber(metadata),
+    artifactWriter: writer,
+    snapshotStartedAt: '2026-05-14T10:00:00.000Z',
+    nowProvider: () => '2026-05-14T10:00:01.000Z',
+  };
+}
+
+describe('runPhaseA (PR-D4 S1-2 orchestrator)', () => {
+  it('全 doc が 5 分類別に集計される (MatchedByHash + Ambiguous 各 1 件)', async () => {
+    const docs = [
+      fullDoc('m1'),
+      fullDoc('a1'),
+    ];
+    const parents = {
+      'parent-m1': { fileUrl: `gs://${BUCKET}/attachments/parent-m1/source.pdf` },
+      'parent-a1': null,
+    };
+    const metadata = {
+      'processed/m1/output.pdf': { generation: '1', metageneration: '1' },
+      'processed/a1/output.pdf': { generation: '2', metageneration: '1' },
+      'attachments/parent-m1/source.pdf': { generation: '3', metageneration: '1' },
+    };
+    const writer = new FakeStorageWriter();
+    const result = await runPhaseA(buildInput(docs, parents, metadata, writer));
+    expect(result.totalDocs).to.equal(2);
+    expect(result.categoryDistribution.MatchedByHash).to.equal(1);
+    expect(result.categoryDistribution.Ambiguous).to.equal(1);
+    expect(result.categoryDistribution.RepairableMissingFile).to.equal(0);
+    expect(result.categoryDistribution.LostOrUnrecoverable).to.equal(0);
+    expect(result.categoryDistribution.NeedsManualReview).to.equal(0);
+    expect(result.alreadyBackfilled).to.equal(0);
+    expect(result.verifiedExistingProvenance).to.equal(0);
+  });
+
+  it('provenanceBackfill 既存 doc は alreadyBackfilled count 加算 + candidates 除外', async () => {
+    const docs = [
+      fullDoc('m1'),
+      fullDoc('already', { hasProvenanceBackfill: true, hasProvenance: true }),
+    ];
+    const parents = {
+      'parent-m1': { fileUrl: `gs://${BUCKET}/attachments/parent-m1/source.pdf` },
+    };
+    const metadata = {
+      'processed/m1/output.pdf': { generation: '1', metageneration: '1' },
+      'attachments/parent-m1/source.pdf': { generation: '2', metageneration: '1' },
+    };
+    const writer = new FakeStorageWriter();
+    const result = await runPhaseA(buildInput(docs, parents, metadata, writer));
+    expect(result.totalDocs).to.equal(2);
+    expect(result.alreadyBackfilled).to.equal(1);
+    expect(result.categoryDistribution.MatchedByHash).to.equal(1);
+
+    const chunkContent = writer.writes.find((w) => w.path.includes('chunk-0.json'))!.content;
+    const chunk = JSON.parse(chunkContent) as PhaseAClassifyChunk;
+    expect(chunk.candidates).to.have.length(1);
+    expect(chunk.candidates[0].docId).to.equal('m1');
+  });
+
+  it('provenance 存在 + provenanceBackfill 不在 → verifiedExistingProvenance + candidates 除外 (MUST 7 immutable skip)', async () => {
+    const docs = [
+      fullDoc('verified', { hasProvenance: true, hasProvenanceBackfill: false }),
+      fullDoc('m1'),
+    ];
+    const parents = {
+      'parent-m1': { fileUrl: `gs://${BUCKET}/attachments/parent-m1/source.pdf` },
+    };
+    const metadata = {
+      'processed/m1/output.pdf': { generation: '1', metageneration: '1' },
+      'attachments/parent-m1/source.pdf': { generation: '2', metageneration: '1' },
+    };
+    const writer = new FakeStorageWriter();
+    const result = await runPhaseA(buildInput(docs, parents, metadata, writer));
+    expect(result.verifiedExistingProvenance).to.equal(1);
+    expect(result.alreadyBackfilled).to.equal(0);
+    expect(result.categoryDistribution.MatchedByHash).to.equal(1);
+
+    const chunkContent = writer.writes.find((w) => w.path.includes('chunk-0.json'))!.content;
+    const chunk = JSON.parse(chunkContent) as PhaseAClassifyChunk;
+    expect(chunk.candidates).to.have.length(1);
+    expect(chunk.candidates[0].docId).to.equal('m1');
+  });
+
+  it('bucket location 不一致なら BucketLocationMismatchError throw + artifact 書込まれない', async () => {
+    const writer = new FakeStorageWriter();
+    let threw = false;
+    try {
+      await runPhaseA({
+        ...buildInput([], {}, {}, writer),
+        bucketLocation: 'us-central1',
+        cloudRunLocation: 'asia-northeast1',
+      });
+    } catch (err) {
+      threw = true;
+      expect((err as Error).name).to.equal('BucketLocationMismatchError');
+    }
+    expect(threw, 'expected throw').to.equal(true);
+    expect(writer.writes).to.have.length(0);
+  });
+
+  it('main artifact に egressFreeAssertion / bucketLocation / cloudRunJobLocation 記録', async () => {
+    const writer = new FakeStorageWriter();
+    await runPhaseA(buildInput([], {}, {}, writer));
+    const main = JSON.parse(
+      writer.writes.find((w) => w.path.endsWith('phase-a-classify-summary.json'))!.content
+    ) as PhaseAClassifySummary;
+    expect(main.egressFreeAssertion).to.equal(true);
+    expect(main.bucketLocation).to.equal('asia-northeast1');
+    expect(main.cloudRunJobLocation).to.equal('asia-northeast1');
+  });
+
+  it('totalDocs はストリーム全 doc 数 (alreadyBackfilled + verifiedExistingProvenance + Σcategory)', async () => {
+    const docs = [
+      fullDoc('m1'),
+      fullDoc('m2'),
+      fullDoc('a1'),
+      fullDoc('verified', { hasProvenance: true }),
+      fullDoc('backfilled', { hasProvenance: true, hasProvenanceBackfill: true }),
+    ];
+    const parents = {
+      'parent-m1': { fileUrl: `gs://${BUCKET}/attachments/parent-m1/source.pdf` },
+      'parent-m2': { fileUrl: `gs://${BUCKET}/attachments/parent-m2/source.pdf` },
+      'parent-a1': null,
+    };
+    const metadata = {
+      'processed/m1/output.pdf': { generation: '1', metageneration: '1' },
+      'processed/m2/output.pdf': { generation: '2', metageneration: '1' },
+      'processed/a1/output.pdf': { generation: '3', metageneration: '1' },
+      'attachments/parent-m1/source.pdf': { generation: '4', metageneration: '1' },
+      'attachments/parent-m2/source.pdf': { generation: '5', metageneration: '1' },
+    };
+    const writer = new FakeStorageWriter();
+    const result = await runPhaseA(buildInput(docs, parents, metadata, writer));
+    expect(result.totalDocs).to.equal(5);
+    expect(result.alreadyBackfilled).to.equal(1);
+    expect(result.verifiedExistingProvenance).to.equal(1);
+    expect(result.categoryDistribution.MatchedByHash).to.equal(2);
+    expect(result.categoryDistribution.Ambiguous).to.equal(1);
+    expect(
+      result.alreadyBackfilled +
+        result.verifiedExistingProvenance +
+        Object.values(result.categoryDistribution).reduce((a, b) => a + b, 0)
+    ).to.equal(5);
+  });
+
+  it('candidates の order は streaming 順を維持 (operator 監査用)', async () => {
+    const docs = [fullDoc('z1'), fullDoc('a1'), fullDoc('m1')];
+    const parents = {
+      'parent-z1': { fileUrl: `gs://${BUCKET}/attachments/parent-z1/source.pdf` },
+      'parent-a1': { fileUrl: `gs://${BUCKET}/attachments/parent-a1/source.pdf` },
+      'parent-m1': { fileUrl: `gs://${BUCKET}/attachments/parent-m1/source.pdf` },
+    };
+    const metadata = {
+      'processed/z1/output.pdf': { generation: '1', metageneration: '1' },
+      'processed/a1/output.pdf': { generation: '2', metageneration: '1' },
+      'processed/m1/output.pdf': { generation: '3', metageneration: '1' },
+      'attachments/parent-z1/source.pdf': { generation: '4', metageneration: '1' },
+      'attachments/parent-a1/source.pdf': { generation: '5', metageneration: '1' },
+      'attachments/parent-m1/source.pdf': { generation: '6', metageneration: '1' },
+    };
+    const writer = new FakeStorageWriter();
+    await runPhaseA(buildInput(docs, parents, metadata, writer));
+    const chunk = JSON.parse(
+      writer.writes.find((w) => w.path.includes('chunk-0.json'))!.content
+    ) as PhaseAClassifyChunk;
+    expect(chunk.candidates.map((c) => c.docId)).to.deep.equal(['z1', 'a1', 'm1']);
+  });
+
+  it('BF22 streaming: 1000 件超で per-chunk flush され chunkCount=2 + 各 chunk の docCount 確認', async () => {
+    const docs = Array.from({ length: 1500 }, (_, i) => fullDoc(`m${i}`));
+    const parents: Record<string, { fileUrl: string | null } | null> = {};
+    const metadata: Record<string, { generation: string; metageneration: string } | null> = {};
+    for (let i = 0; i < 1500; i++) {
+      parents[`parent-m${i}`] = {
+        fileUrl: `gs://${BUCKET}/attachments/parent-m${i}/source.pdf`,
+      };
+      metadata[`processed/m${i}/output.pdf`] = { generation: `${i}`, metageneration: '1' };
+      metadata[`attachments/parent-m${i}/source.pdf`] = {
+        generation: `p${i}`,
+        metageneration: '1',
+      };
+    }
+    const writer = new FakeStorageWriter();
+    const result = await runPhaseA(buildInput(docs, parents, metadata, writer));
+    expect(result.chunkCount).to.equal(2);
+    expect(result.categoryDistribution.MatchedByHash).to.equal(1500);
+
+    // 2 chunks + main + manifest = 4 writes
+    expect(writer.writes).to.have.length(4);
+    const chunkWrites = writer.writes.filter((w) => w.path.includes('chunk-'));
+    expect(chunkWrites).to.have.length(2);
+
+    // chunk index 連番、docCount 合計 == 1500
+    const chunk0 = JSON.parse(
+      chunkWrites.find((w) => w.path.includes('chunk-0.json'))!.content
+    );
+    const chunk1 = JSON.parse(
+      chunkWrites.find((w) => w.path.includes('chunk-1.json'))!.content
+    );
+    expect(chunk0.chunkIndex).to.equal(0);
+    expect(chunk1.chunkIndex).to.equal(1);
+    expect(chunk0.candidates.length + chunk1.candidates.length).to.equal(1500);
+    expect(chunk0.candidates.length).to.equal(1000);
+    expect(chunk1.candidates.length).to.equal(500);
+  });
+
+  it('BF22 streaming: 書込順は chunks (streaming) → main → manifest', async () => {
+    const docs = Array.from({ length: 1200 }, (_, i) => fullDoc(`m${i}`));
+    const parents: Record<string, { fileUrl: string | null } | null> = {};
+    const metadata: Record<string, { generation: string; metageneration: string } | null> = {};
+    for (let i = 0; i < 1200; i++) {
+      parents[`parent-m${i}`] = {
+        fileUrl: `gs://${BUCKET}/attachments/parent-m${i}/source.pdf`,
+      };
+      metadata[`processed/m${i}/output.pdf`] = { generation: `${i}`, metageneration: '1' };
+      metadata[`attachments/parent-m${i}/source.pdf`] = {
+        generation: `p${i}`,
+        metageneration: '1',
+      };
+    }
+    const writer = new FakeStorageWriter();
+    await runPhaseA(buildInput(docs, parents, metadata, writer));
+    const order = writer.writes.map((w) => {
+      if (w.path.endsWith('manifest.json')) return 'manifest';
+      if (w.path.endsWith('phase-a-classify-summary.json')) return 'main';
+      return 'chunk';
+    });
+    // 全 chunk 書込は main より前、main は manifest より前
+    const lastChunkIdx = order.lastIndexOf('chunk');
+    const mainIdx = order.indexOf('main');
+    const manifestIdx = order.indexOf('manifest');
+    expect(lastChunkIdx).to.be.lessThan(mainIdx);
+    expect(mainIdx).to.be.lessThan(manifestIdx);
+  });
+
+  it('結果には mainArtifactPath / manifestPath / chunkCount が含まれる', async () => {
+    const docs = [fullDoc('m1')];
+    const parents = {
+      'parent-m1': { fileUrl: `gs://${BUCKET}/attachments/parent-m1/source.pdf` },
+    };
+    const metadata = {
+      'processed/m1/output.pdf': { generation: '1', metageneration: '1' },
+      'attachments/parent-m1/source.pdf': { generation: '2', metageneration: '1' },
+    };
+    const writer = new FakeStorageWriter();
+    const result = await runPhaseA(buildInput(docs, parents, metadata, writer));
+    expect(result.mainArtifactPath).to.match(/phase-a-classify-summary\.json$/);
+    expect(result.manifestPath).to.match(/manifest\.json$/);
+    expect(result.chunkCount).to.equal(1);
+  });
+});

--- a/functions/test/prD4BucketLocationVerifier.test.ts
+++ b/functions/test/prD4BucketLocationVerifier.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #445 PR-D4 S1-2: bucket-location-verifier.ts pure function テスト。
+ *
+ * impl-plan v3.1 §4.1 「bucket location 確認 (Codex 2nd review I4 反映、BF19 連動)」:
+ * - Cloud Run Job region と target bucket location が同一なら egress 無料
+ * - 不一致なら abort + artifact `egressFreeAssertion: false` 記録
+ */
+
+import { expect } from 'chai';
+import {
+  verifyBucketLocation,
+  BucketLocationMismatchError,
+} from '../../scripts/pr-d4-backfill/phase-a/bucketLocationVerifier';
+
+describe('verifyBucketLocation (PR-D4 S1-2 region check)', () => {
+  it('cloudRunLocation === bucketLocation なら egressFreeAssertion=true で正常終了', () => {
+    const result = verifyBucketLocation({
+      cloudRunLocation: 'asia-northeast1',
+      bucketLocation: 'asia-northeast1',
+    });
+    expect(result.egressFreeAssertion).to.equal(true);
+    expect(result.bucketLocation).to.equal('asia-northeast1');
+    expect(result.cloudRunJobLocation).to.equal('asia-northeast1');
+  });
+
+  it('region 不一致は BucketLocationMismatchError を throw する (egress 課金前提崩れ)', () => {
+    expect(() =>
+      verifyBucketLocation({
+        cloudRunLocation: 'asia-northeast1',
+        bucketLocation: 'us-central1',
+      })
+    ).to.throw(BucketLocationMismatchError);
+  });
+
+  it('region 不一致 throw 時の error.message に両 region が含まれる (operator 監査用)', () => {
+    try {
+      verifyBucketLocation({
+        cloudRunLocation: 'asia-northeast1',
+        bucketLocation: 'us-central1',
+      });
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).to.be.instanceOf(BucketLocationMismatchError);
+      const msg = (err as Error).message;
+      expect(msg).to.include('asia-northeast1');
+      expect(msg).to.include('us-central1');
+    }
+  });
+
+  it('region 大文字小文字 / 末尾空白の差は normalize して比較する (GCS API は大文字、Cloud Run は小文字を返すケースに対応)', () => {
+    const result = verifyBucketLocation({
+      cloudRunLocation: 'asia-northeast1',
+      bucketLocation: 'ASIA-NORTHEAST1 ',
+    });
+    expect(result.egressFreeAssertion).to.equal(true);
+  });
+
+  it('multi-region bucket (例: ASIA) は single-region cloudRunLocation と非同等 → mismatch', () => {
+    expect(() =>
+      verifyBucketLocation({
+        cloudRunLocation: 'asia-northeast1',
+        bucketLocation: 'ASIA',
+      })
+    ).to.throw(BucketLocationMismatchError);
+  });
+
+  it('cloudRunLocation 空文字なら ValidationError (configuration bug 検出)', () => {
+    expect(() =>
+      verifyBucketLocation({ cloudRunLocation: '', bucketLocation: 'asia-northeast1' })
+    ).to.throw(/cloudRunLocation/);
+  });
+
+  it('bucketLocation 空文字なら ValidationError', () => {
+    expect(() =>
+      verifyBucketLocation({ cloudRunLocation: 'asia-northeast1', bucketLocation: '' })
+    ).to.throw(/bucketLocation/);
+  });
+});

--- a/functions/test/prD4CategoryClassifier.test.ts
+++ b/functions/test/prD4CategoryClassifier.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #445 PR-D4 S1-2: category-classifier-adapter.ts pure function テスト。
+ *
+ * Phase A は **構造分類** のみ (hash 計算は Phase B 担当)。
+ * doc の親存在 + 子オブジェクト存在 + splitFromPages 存在 を見て 5 分類を予測する:
+ *
+ * | 構造的状態                                  | category               |
+ * |--------------------------------------------|------------------------|
+ * | parentDocumentId 不在 or splitFromPages 不在 | NeedsManualReview      |
+ * | child 存在 + parent + 元 PDF 存在            | MatchedByHash (予測)   |
+ * | child 不在 + parent + 元 PDF 存在            | RepairableMissingFile  |
+ * | child 存在 + parent 不在 or 元 PDF 不在       | Ambiguous              |
+ * | child 不在 + parent 不在 or 元 PDF 不在       | LostOrUnrecoverable    |
+ */
+
+import { expect } from 'chai';
+import {
+  classifyForPhaseA,
+  type PhaseADocSnapshot,
+} from '../../scripts/pr-d4-backfill/phase-a/categoryClassifier';
+
+function makeSnapshot(overrides: Partial<PhaseADocSnapshot> = {}): PhaseADocSnapshot {
+  return {
+    docId: 'doc-x',
+    parentDocumentId: 'parent-x',
+    splitFromPages: { start: 1, end: 1 },
+    childObjectExists: true,
+    parent: { exists: true, originalPdfExists: true },
+    ...overrides,
+  };
+}
+
+describe('classifyForPhaseA (PR-D4 S1-2 5-category predictor)', () => {
+  describe('NeedsManualReview: structural data 不足', () => {
+    it('parentDocumentId 不在 → NeedsManualReview', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ parentDocumentId: null })
+      );
+      expect(result.category).to.equal('NeedsManualReview');
+      expect(result.reason).to.include('parentDocumentId');
+    });
+
+    it('splitFromPages 不在 → NeedsManualReview', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ splitFromPages: null })
+      );
+      expect(result.category).to.equal('NeedsManualReview');
+      expect(result.reason).to.include('splitFromPages');
+    });
+
+    it('parentDocumentId 不在 + splitFromPages 不在 → NeedsManualReview (両方原因)', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ parentDocumentId: null, splitFromPages: null })
+      );
+      expect(result.category).to.equal('NeedsManualReview');
+    });
+  });
+
+  describe('MatchedByHash 予測: 全構造要件揃い', () => {
+    it('child 存在 + parent 存在 + 元 PDF 存在 → MatchedByHash (Phase B が verify する)', () => {
+      const result = classifyForPhaseA(makeSnapshot());
+      expect(result.category).to.equal('MatchedByHash');
+      expect(result.reason).to.include('Phase B');
+    });
+  });
+
+  describe('RepairableMissingFile: child orphan + parent OK', () => {
+    it('child 不在 + parent 存在 + 元 PDF 存在 → RepairableMissingFile', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ childObjectExists: false })
+      );
+      expect(result.category).to.equal('RepairableMissingFile');
+      expect(result.reason).to.match(/orphan|regenerate/i);
+    });
+  });
+
+  describe('Ambiguous: child 存在 + parent 状態不完全 (verify 不能)', () => {
+    it('child 存在 + parent doc 不在 → Ambiguous', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ parent: { exists: false } })
+      );
+      expect(result.category).to.equal('Ambiguous');
+      expect(result.reason).to.match(/parent/i);
+    });
+
+    it('child 存在 + parent doc 存在だが 元 PDF 不在 → Ambiguous', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ parent: { exists: true, originalPdfExists: false } })
+      );
+      expect(result.category).to.equal('Ambiguous');
+      expect(result.reason).to.match(/original.*pdf/i);
+    });
+  });
+
+  describe('LostOrUnrecoverable: child 不在 + parent 状態不完全 (regenerate 不能)', () => {
+    it('child 不在 + parent doc 不在 → LostOrUnrecoverable', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ childObjectExists: false, parent: { exists: false } })
+      );
+      expect(result.category).to.equal('LostOrUnrecoverable');
+    });
+
+    it('child 不在 + parent doc 存在だが 元 PDF 不在 → LostOrUnrecoverable', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({
+          childObjectExists: false,
+          parent: { exists: true, originalPdfExists: false },
+        })
+      );
+      expect(result.category).to.equal('LostOrUnrecoverable');
+    });
+  });
+
+  describe('reason に分類根拠を含む (operator 監査用)', () => {
+    it('MatchedByHash 予測の reason は "structural" + "Phase B" の言及を含む', () => {
+      const result = classifyForPhaseA(makeSnapshot());
+      expect(result.reason).to.match(/structural|Phase B/i);
+    });
+
+    it('NeedsManualReview の reason は不足 field 名を含む', () => {
+      const result = classifyForPhaseA(makeSnapshot({ splitFromPages: null }));
+      expect(result.reason).to.include('splitFromPages');
+    });
+  });
+
+  describe('parent field の null と { exists: false } 区別', () => {
+    it('parentDocumentId null + parent null → NeedsManualReview (parent 取得自体不能)', () => {
+      const result = classifyForPhaseA(
+        makeSnapshot({ parentDocumentId: null, parent: null })
+      );
+      expect(result.category).to.equal('NeedsManualReview');
+    });
+
+    it('parentDocumentId あり + parent null は不正状態 → defensive に NeedsManualReview', () => {
+      const result = classifyForPhaseA(makeSnapshot({ parent: null }));
+      // parent 取得未実施 = caller bug 扱い、安全側で manual review に倒す
+      expect(result.category).to.equal('NeedsManualReview');
+    });
+  });
+});

--- a/functions/test/prD4DocSnapshotter.test.ts
+++ b/functions/test/prD4DocSnapshotter.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Issue #445 PR-D4 S1-2: doc-snapshotter.ts pure-ish (DI 化) テスト.
+ *
+ * Firestore doc + parent doc + Storage HEAD を組み合わせて PhaseADocSnapshot +
+ * PhaseACandidate metadata を構築する。実 Firestore/Storage 接続は DI 化し、
+ * unit test は in-memory mock で実行する。
+ */
+
+import { expect } from 'chai';
+import {
+  snapshotDocForPhaseA,
+  type SnapshotDocInput,
+  type ParentFetcher,
+  type BucketProber,
+} from '../../scripts/pr-d4-backfill/phase-a/docSnapshotter';
+
+class FakeParentFetcher implements ParentFetcher {
+  private parents: Record<string, { fileUrl: string | null } | null>;
+  constructor(parents: Record<string, { fileUrl: string | null } | null>) {
+    this.parents = parents;
+  }
+  async fetchParent(parentDocId: string) {
+    return parentDocId in this.parents ? this.parents[parentDocId] : null;
+  }
+}
+
+class FakeBucketProber implements BucketProber {
+  private metadataByPath: Record<
+    string,
+    { generation: string; metageneration: string } | null
+  >;
+  constructor(
+    metadataByPath: Record<
+      string,
+      { generation: string; metageneration: string } | null
+    >
+  ) {
+    this.metadataByPath = metadataByPath;
+  }
+  async getMetadata(path: string) {
+    return path in this.metadataByPath ? this.metadataByPath[path] : null;
+  }
+}
+
+function buildInput(overrides: Partial<SnapshotDocInput> = {}): SnapshotDocInput {
+  return {
+    doc: {
+      id: 'doc-1',
+      fileUrl: 'gs://docsplit-dev.firebasestorage.app/processed/doc-1/output.pdf',
+      parentDocumentId: 'parent-1',
+      splitFromPages: { start: 1, end: 1 },
+      updateTimeIso: '2026-05-14T10:00:00.000Z',
+    },
+    bucketName: 'docsplit-dev.firebasestorage.app',
+    parentFetcher: new FakeParentFetcher({
+      'parent-1': {
+        fileUrl: 'gs://docsplit-dev.firebasestorage.app/attachments/parent-1/source.pdf',
+      },
+    }),
+    bucketProber: new FakeBucketProber({
+      'processed/doc-1/output.pdf': { generation: '1234567890', metageneration: '1' },
+      'attachments/parent-1/source.pdf': { generation: '9876543210', metageneration: '1' },
+    }),
+    ...overrides,
+  };
+}
+
+describe('snapshotDocForPhaseA (PR-D4 S1-2 doc-snapshotter)', () => {
+  it('全フィールド揃った正常 doc (child + parent + 元 PDF 存在) で snapshot + candidate を返す', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(buildInput());
+    expect(snapshot.docId).to.equal('doc-1');
+    expect(snapshot.parentDocumentId).to.equal('parent-1');
+    expect(snapshot.splitFromPages).to.deep.equal({ start: 1, end: 1 });
+    expect(snapshot.childObjectExists).to.equal(true);
+    expect(snapshot.parent).to.deep.equal({ exists: true, originalPdfExists: true });
+
+    expect(candidate.docId).to.equal('doc-1');
+    expect(candidate.firestoreUpdateTime).to.equal('2026-05-14T10:00:00.000Z');
+    expect(candidate.childObjectPath).to.equal('processed/doc-1/output.pdf');
+    expect(candidate.childGeneration).to.equal('1234567890');
+    expect(candidate.childMetageneration).to.equal('1');
+    expect(candidate.parentDocId).to.equal('parent-1');
+    expect(candidate.parentObjectPath).to.equal('attachments/parent-1/source.pdf');
+    expect(candidate.parentGeneration).to.equal('9876543210');
+    expect(candidate.parentMetageneration).to.equal('1');
+    expect(candidate.splitFromPages).to.deep.equal({ start: 1, end: 1 });
+  });
+
+  it('child object Storage 不在 (HEAD null) → childObjectExists=false, generation/metageneration=null', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        bucketProber: new FakeBucketProber({
+          'attachments/parent-1/source.pdf': { generation: '9876543210', metageneration: '1' },
+          // child は登録なし → null 返却
+        }),
+      })
+    );
+    expect(snapshot.childObjectExists).to.equal(false);
+    expect(candidate.childGeneration).to.equal(null);
+    expect(candidate.childMetageneration).to.equal(null);
+    // childObjectPath は doc.fileUrl 由来で記録される (Storage 不在でも path は分かる)
+    expect(candidate.childObjectPath).to.equal('processed/doc-1/output.pdf');
+  });
+
+  it('parent doc 不在 (Firestore に無い) → parent={exists:false} + parent path/generation/metageneration=null', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        parentFetcher: new FakeParentFetcher({}),
+      })
+    );
+    expect(snapshot.parent).to.deep.equal({ exists: false });
+    expect(candidate.parentObjectPath).to.equal(null);
+    expect(candidate.parentGeneration).to.equal(null);
+    expect(candidate.parentMetageneration).to.equal(null);
+    expect(candidate.parentDocId).to.equal('parent-1');
+  });
+
+  it('parent doc 存在だが fileUrl null → parent.originalPdfExists=false', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        parentFetcher: new FakeParentFetcher({ 'parent-1': { fileUrl: null } }),
+      })
+    );
+    expect(snapshot.parent).to.deep.equal({ exists: true, originalPdfExists: false });
+    expect(candidate.parentObjectPath).to.equal(null);
+    expect(candidate.parentGeneration).to.equal(null);
+  });
+
+  it('parent doc 存在 + fileUrl あるが Storage HEAD 不在 → parent.originalPdfExists=false', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        bucketProber: new FakeBucketProber({
+          'processed/doc-1/output.pdf': { generation: '1234567890', metageneration: '1' },
+          // parent path は登録なし
+        }),
+      })
+    );
+    expect(snapshot.parent).to.deep.equal({ exists: true, originalPdfExists: false });
+    expect(candidate.parentObjectPath).to.equal('attachments/parent-1/source.pdf');
+    expect(candidate.parentGeneration).to.equal(null);
+    expect(candidate.parentMetageneration).to.equal(null);
+  });
+
+  it('parentDocumentId null → parentFetcher 呼ばずに parent=null, parent path/generation/metageneration 全 null', async () => {
+    let fetchCalls = 0;
+    class CountingFetcher implements ParentFetcher {
+      async fetchParent(_id: string) {
+        fetchCalls++;
+        return null;
+      }
+    }
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        doc: {
+          id: 'doc-noparent',
+          fileUrl: 'gs://docsplit-dev.firebasestorage.app/processed/doc-noparent/output.pdf',
+          parentDocumentId: null,
+          splitFromPages: null,
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+        },
+        parentFetcher: new CountingFetcher(),
+      })
+    );
+    expect(fetchCalls).to.equal(0);
+    expect(snapshot.parent).to.equal(null);
+    expect(snapshot.parentDocumentId).to.equal(null);
+    expect(snapshot.splitFromPages).to.equal(null);
+    expect(candidate.parentDocId).to.equal(null);
+    expect(candidate.parentObjectPath).to.equal(null);
+    expect(candidate.parentGeneration).to.equal(null);
+    expect(candidate.parentMetageneration).to.equal(null);
+    expect(candidate.splitFromPages).to.equal(null);
+  });
+
+  it('doc.fileUrl が bucket 不一致 → childObjectPath=null + Storage HEAD スキップ (F-B4 反映)', async () => {
+    let probeCalls = 0;
+    class CountingProber implements BucketProber {
+      async getMetadata(_path: string) {
+        probeCalls++;
+        return null;
+      }
+    }
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        doc: {
+          id: 'doc-1',
+          fileUrl: 'gs://other-bucket/processed/doc-1/output.pdf', // 別 bucket
+          parentDocumentId: null,
+          splitFromPages: null,
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+        },
+        bucketProber: new CountingProber(),
+      })
+    );
+    expect(probeCalls).to.equal(0);
+    expect(snapshot.childObjectExists).to.equal(false);
+    expect(candidate.childObjectPath).to.equal(null);
+    expect(candidate.childGeneration).to.equal(null);
+  });
+
+  it('doc.fileUrl が null → childObjectPath=null, childObjectExists=false', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        doc: {
+          id: 'doc-1',
+          fileUrl: null,
+          parentDocumentId: null,
+          splitFromPages: null,
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+        },
+      })
+    );
+    expect(snapshot.childObjectExists).to.equal(false);
+    expect(candidate.childObjectPath).to.equal(null);
+  });
+
+  it('parent.fileUrl が bucket 不一致 → parent.originalPdfExists=false + Storage HEAD スキップ', async () => {
+    const { snapshot, candidate } = await snapshotDocForPhaseA(
+      buildInput({
+        parentFetcher: new FakeParentFetcher({
+          'parent-1': { fileUrl: 'gs://other-bucket/attachments/parent-1/source.pdf' },
+        }),
+      })
+    );
+    expect(snapshot.parent).to.deep.equal({ exists: true, originalPdfExists: false });
+    expect(candidate.parentObjectPath).to.equal(null);
+    expect(candidate.parentGeneration).to.equal(null);
+  });
+});

--- a/scripts/pr-d4-backfill/index.ts
+++ b/scripts/pr-d4-backfill/index.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env ts-node
+/**
+ * Issue #445 PR-D4 S1-2: Phase A CLI entry point.
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=<project-id> \
+ *   STORAGE_BUCKET=<production-data-bucket> \
+ *   ARTIFACT_BUCKET=<pr-d4-artifact-bucket> \
+ *   npx ts-node scripts/pr-d4-backfill/index.ts \
+ *     --env <dev|cocoro|kanameone> \
+ *     --phase A \
+ *     [--run-id <id>] \
+ *     [--cloud-run-location asia-northeast1] \
+ *     [--bucket-location asia-northeast1]
+ *
+ * Phase A は read-only。Firestore documents collection を全件 stream + 構造分類し、
+ * artifact bucket に main + chunks + manifest を JSON で書込む。
+ * Phase B/C/D は本 file の switch を拡張する形で S1-3 以降で追加予定。
+ */
+
+import * as admin from 'firebase-admin';
+import type { BackfillEnvName } from './types';
+import { runPhaseA } from './phase-a/auditClassify';
+import {
+  FirestoreDocumentSource,
+  FirestoreParentFetcher,
+  GcsBucketProber,
+  GcsArtifactStorageWriter,
+} from './phase-a/adapters';
+
+function readArg(name: string, defaultValue?: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  if (idx < 0 || idx + 1 >= process.argv.length) return defaultValue;
+  const value = process.argv[idx + 1];
+  // 値が `--` で始まる場合は別 flag を誤って value として吸い込んでいる → defaultValue 扱い
+  if (value.startsWith('--')) return defaultValue;
+  return value;
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`FATAL: env ${name} required`);
+    process.exit(2);
+  }
+  return v;
+}
+
+function isBackfillEnv(s: string): s is BackfillEnvName {
+  return s === 'dev' || s === 'cocoro' || s === 'kanameone';
+}
+
+function generateRunId(env: BackfillEnvName): string {
+  const ts = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  return `${ts}-${env}-pr-d4-v1`;
+}
+
+async function main(): Promise<void> {
+  const envName = readArg('--env');
+  if (!envName || !isBackfillEnv(envName)) {
+    console.error('FATAL: --env <dev|cocoro|kanameone> required');
+    process.exit(2);
+  }
+  const phase = readArg('--phase', 'A');
+  if (phase !== 'A') {
+    console.error(`FATAL: phase ${phase} not implemented in S1-2 (only Phase A is available)`);
+    process.exit(2);
+  }
+
+  const projectId = requireEnv('FIREBASE_PROJECT_ID');
+  const productionBucket = requireEnv('STORAGE_BUCKET');
+  const artifactBucketName = requireEnv('ARTIFACT_BUCKET');
+  // --cloud-run-location / --bucket-location は **明示指定必須**。default を与えると、
+  // 実 bucket location を確認せず "asia-northeast1" を assume してしまい、
+  // 別 region に作られた bucket への cross-region egress を見逃す (Codex MCP Important 1)
+  const cloudRunLocation = readArg('--cloud-run-location');
+  const bucketLocation = readArg('--bucket-location');
+  if (!cloudRunLocation || !bucketLocation) {
+    console.error('FATAL: --cloud-run-location and --bucket-location are required (no default).');
+    console.error('       bucket location 確認は egress 課金前提のため明示指定必須');
+    process.exit(2);
+  }
+  const runId = readArg('--run-id', generateRunId(envName))!;
+
+  console.log('Phase A (PR-D4 S1-2) starting:');
+  console.log(`  env: ${envName}`);
+  console.log(`  projectId: ${projectId}`);
+  console.log(`  productionBucket: ${productionBucket}`);
+  console.log(`  artifactBucket: ${artifactBucketName}`);
+  console.log(`  runId: ${runId}`);
+  console.log(`  cloudRunLocation: ${cloudRunLocation}`);
+  console.log(`  bucketLocation: ${bucketLocation}`);
+
+  admin.initializeApp({ projectId, storageBucket: productionBucket });
+  const db = admin.firestore();
+  const productionBucketRef = admin.storage().bucket(productionBucket);
+  const artifactBucketRef = admin.storage().bucket(artifactBucketName);
+
+  const snapshotStartedAt = new Date().toISOString();
+  const result = await runPhaseA({
+    env: envName,
+    runId,
+    productionDataBucketName: productionBucket,
+    artifactBucketName,
+    cloudRunLocation,
+    bucketLocation,
+    documentSource: new FirestoreDocumentSource(db),
+    parentFetcher: new FirestoreParentFetcher(db),
+    bucketProber: new GcsBucketProber(productionBucketRef),
+    artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
+    snapshotStartedAt,
+  });
+
+  console.log('\nPhase A complete:');
+  console.log(`  totalDocs: ${result.totalDocs}`);
+  console.log(`  alreadyBackfilled: ${result.alreadyBackfilled}`);
+  console.log(`  verifiedExistingProvenance: ${result.verifiedExistingProvenance}`);
+  console.log('  categoryDistribution:');
+  for (const [cat, count] of Object.entries(result.categoryDistribution)) {
+    console.log(`    ${cat}: ${count}`);
+  }
+  console.log(`  chunkCount: ${result.chunkCount}`);
+  console.log(`  mainArtifact: ${result.mainArtifactPath}`);
+  console.log(`  manifest: ${result.manifestPath}`);
+  console.log(`  snapshotStartedAt: ${snapshotStartedAt}`);
+  console.log(`  snapshotCompletedAt: ${result.snapshotCompletedAt}`);
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/pr-d4-backfill/phase-a/adapters.ts
+++ b/scripts/pr-d4-backfill/phase-a/adapters.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #445 PR-D4 S1-2: production concrete adapters for Phase A.
+ *
+ * 各 interface (DocumentSource / ParentFetcher / BucketProber / ArtifactStorageWriter) を
+ * Firebase admin SDK + @google-cloud/storage で実装する thin wrapper。
+ *
+ * unit test 対象外 (real SDK 接続のため)。動作検証は dev rehearsal (S2 stage) で行う。
+ * 本 file の目的は production wiring を一箇所にまとめ、index.ts を簡潔に保つこと。
+ */
+
+import * as admin from 'firebase-admin';
+import type { Bucket } from '@google-cloud/storage';
+import type {
+  DocumentSource,
+  DocumentSourceRecord,
+} from './auditClassify';
+import type { ParentFetcher, BucketProber } from './docSnapshotter';
+import type { ArtifactStorageWriter } from './artifactWriter';
+
+/**
+ * Firestore _updateTime → ISO8601 UTC 文字列.
+ *
+ * Firestore admin SDK の DocumentSnapshot.updateTime は write 経由で必ず set される
+ * (常に Timestamp 型)。undefined が来るのは未取得 snapshot のみで Phase A の
+ * `.get()` 経路では発生しないため、defensive に空時刻を返す。
+ */
+function timestampToIso(ts: admin.firestore.Timestamp | undefined): string {
+  if (!ts) return new Date(0).toISOString();
+  return ts.toDate().toISOString();
+}
+
+/**
+ * Firestore documents collection を cursor pagination で全件 stream する DocumentSource 実装。
+ *
+ * batchSize 単位で取得し、orderBy('__name__') で安定 cursor を維持する。
+ * 大量 docs 環境 (kanameone 5,725 件) でも memory 一括ロードを避ける。
+ */
+export class FirestoreDocumentSource implements DocumentSource {
+  private db: admin.firestore.Firestore;
+  private batchSize: number;
+
+  constructor(db: admin.firestore.Firestore, batchSize = 500) {
+    this.db = db;
+    this.batchSize = batchSize;
+  }
+
+  async *streamAll(): AsyncIterable<DocumentSourceRecord> {
+    let lastDocId: string | null = null;
+    while (true) {
+      let query: admin.firestore.Query = this.db
+        .collection('documents')
+        .orderBy(admin.firestore.FieldPath.documentId())
+        .limit(this.batchSize);
+      if (lastDocId !== null) {
+        query = query.startAfter(lastDocId);
+      }
+      const snap = await query.get();
+      if (snap.empty) return;
+      for (const docSnap of snap.docs) {
+        const data = docSnap.data();
+        yield {
+          id: docSnap.id,
+          fileUrl: typeof data.fileUrl === 'string' ? data.fileUrl : null,
+          parentDocumentId:
+            typeof data.parentDocumentId === 'string' ? data.parentDocumentId : null,
+          splitFromPages:
+            data.splitFromPages &&
+            typeof data.splitFromPages.start === 'number' &&
+            typeof data.splitFromPages.end === 'number'
+              ? { start: data.splitFromPages.start, end: data.splitFromPages.end }
+              : null,
+          updateTimeIso: timestampToIso(docSnap.updateTime),
+          hasProvenance: 'provenance' in data,
+          hasProvenanceBackfill: 'provenanceBackfill' in data,
+        };
+      }
+      lastDocId = snap.docs[snap.docs.length - 1].id;
+      if (snap.size < this.batchSize) return;
+    }
+  }
+}
+
+/**
+ * Firestore documents collection から parent doc を fetch する ParentFetcher 実装。
+ *
+ * 同一 run 内で同じ parent を何度も参照するケース (split された複数 child が同じ parent)
+ * があるため、in-memory LRU cache で同 parent の重複 read を抑制する。
+ */
+export class FirestoreParentFetcher implements ParentFetcher {
+  private db: admin.firestore.Firestore;
+  private cache: Map<string, { fileUrl: string | null } | null>;
+  private maxCacheSize: number;
+
+  constructor(db: admin.firestore.Firestore, maxCacheSize = 10000) {
+    this.db = db;
+    this.cache = new Map();
+    this.maxCacheSize = maxCacheSize;
+  }
+
+  async fetchParent(parentDocId: string): Promise<{ fileUrl: string | null } | null> {
+    if (this.cache.has(parentDocId)) {
+      return this.cache.get(parentDocId) ?? null;
+    }
+    const docSnap = await this.db.collection('documents').doc(parentDocId).get();
+    const result: { fileUrl: string | null } | null = docSnap.exists
+      ? { fileUrl: typeof docSnap.data()?.fileUrl === 'string' ? (docSnap.data()!.fileUrl as string) : null }
+      : null;
+    if (this.cache.size >= this.maxCacheSize) {
+      // 簡易 LRU: 最古キー (insertion order) を 1 件削除
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) this.cache.delete(oldestKey);
+    }
+    this.cache.set(parentDocId, result);
+    return result;
+  }
+}
+
+/**
+ * GCS Bucket HEAD で object metadata を取得する BucketProber 実装。
+ *
+ * 404 (object 不在) は null 返却。それ以外のエラーは throw (caller で abort)。
+ */
+export class GcsBucketProber implements BucketProber {
+  private bucket: Bucket;
+
+  constructor(bucket: Bucket) {
+    this.bucket = bucket;
+  }
+
+  async getMetadata(
+    objectPath: string
+  ): Promise<{ generation: string; metageneration: string } | null> {
+    try {
+      const [metadata] = await this.bucket.file(objectPath).getMetadata();
+      return {
+        generation: String(metadata.generation ?? ''),
+        metageneration: String(metadata.metageneration ?? ''),
+      };
+    } catch (err) {
+      // @google-cloud/storage は 404 を ApiError with code 404 として throw する
+      const code = (err as { code?: number }).code;
+      if (code === 404) return null;
+      throw err;
+    }
+  }
+}
+
+/**
+ * GCS Bucket に JSON 文字列を書込む ArtifactStorageWriter 実装。
+ *
+ * 入力 path は `gs://{bucket}/{object}` 形式。bucket name 部分が
+ * `this.artifactBucket.name` と一致しない場合は throw (config bug 検出)。
+ */
+export class GcsArtifactStorageWriter implements ArtifactStorageWriter {
+  private artifactBucket: Bucket;
+
+  constructor(artifactBucket: Bucket) {
+    this.artifactBucket = artifactBucket;
+  }
+
+  async writeJson(objectPath: string, content: string): Promise<void> {
+    const match = objectPath.match(/^gs:\/\/([^/]+)\/(.+)$/);
+    if (!match) {
+      throw new Error(`invalid GCS object path (expected gs://bucket/path): ${objectPath}`);
+    }
+    const [, bucketName, path] = match;
+    if (bucketName !== this.artifactBucket.name) {
+      throw new Error(
+        `artifact bucket mismatch: expected ${this.artifactBucket.name}, got ${bucketName} (path=${objectPath})`
+      );
+    }
+    // ifGenerationMatch: 0 で **既存 object の overwrite を拒否** する (Codex MCP Important 2 反映)。
+    // run-id 単位で artifact directory を分けているため、同一 run-id の re-run は
+    // 新 run-id を発行することを caller に強制する。これにより Phase B が「古い chunk +
+    // 新しい partial main」のような不整合 artifact を読む事故を構造的に閉鎖する。
+    await this.artifactBucket.file(path).save(content, {
+      contentType: 'application/json',
+      resumable: false,
+      preconditionOpts: { ifGenerationMatch: 0 },
+      metadata: {
+        cacheControl: 'no-store',
+      },
+    });
+  }
+}

--- a/scripts/pr-d4-backfill/phase-a/artifactWriter.ts
+++ b/scripts/pr-d4-backfill/phase-a/artifactWriter.ts
@@ -1,0 +1,158 @@
+/**
+ * Issue #445 PR-D4 S1-2: Phase A artifact writer (streaming chunked GCS write + SHA256 manifest).
+ *
+ * impl-plan v3.1 §4.1 + BF22 (streaming) を実装する:
+ * - chunks: phase-a-classify-summary-chunk-{N}.json (≤ 1000 candidates each)
+ * - main artifact: phase-a-classify-summary.json (metadata + chunk pointers)
+ * - manifest: manifest.json (cross-phase で additive 追記)
+ *
+ * 書込順は chunks (streaming, one-at-a-time) → main → manifest。
+ * orchestrator は per-chunk buffer (≤ 1000 docs) のみ保持し、全 candidates を一括
+ * メモリ保持しない (BF22 厳密適合、Codex MCP NO-GO 反映)。
+ *
+ * 依存性逆転: ArtifactStorageWriter interface 経由で GCS Bucket を受け取り、unit test
+ * は in-memory mock で実行する。
+ */
+
+import * as crypto from 'crypto';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  BackfillManifest,
+  PhaseACandidate,
+  PhaseAClassifyChunk,
+  PhaseAClassifySummary,
+} from '../types';
+import {
+  PR_D4_ARTIFACT_SCHEMA_VERSION,
+  PR_D4_SCRIPT_VERSION,
+} from '../types';
+import type { BackfillClassifierCategory } from '../../../shared/types';
+
+export interface ArtifactStorageWriter {
+  /**
+   * `gs://{bucket}/{path}` 形式の path に JSON 文字列を書込む。
+   * 実装側で必要に応じて Content-Type 設定 + ifGenerationMatch: 0 (overwrite 禁止) を強制。
+   */
+  writeJson(objectPath: string, content: string): Promise<void>;
+}
+
+/** test 側で書込履歴を assertion するための表現 */
+export interface WrittenObject {
+  path: string;
+  content: string;
+}
+
+/**
+ * 1 chunk 書込入力 (orchestrator が per-chunk flush で呼び出す)。
+ */
+export interface WritePhaseAChunkInput {
+  bucketName: string;
+  runId: string;
+  chunkIndex: number;
+  candidates: PhaseACandidate[];
+}
+
+/**
+ * Phase A main artifact + manifest 書込入力 (orchestrator が streaming 完了後に 1 度だけ呼ぶ)。
+ */
+export interface FinalizePhaseAInput {
+  bucketName: string;
+  runId: string;
+  env: BackfillEnvName;
+  snapshotStartedAt: string;
+  snapshotCompletedAt: string;
+  bucketLocation: string;
+  cloudRunJobLocation: string;
+  egressFreeAssertion: boolean;
+  totalDocs: number;
+  categoryDistribution: Record<BackfillClassifierCategory, number>;
+  alreadyBackfilled: number;
+  verifiedExistingProvenance: number;
+  chunks: ArtifactChunkPointer[];
+}
+
+export interface FinalizePhaseAResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function buildObjectPath(bucketName: string, runId: string, fileName: string): string {
+  return `gs://${bucketName}/pr-d4-backfill-artifacts/${runId}/${fileName}`;
+}
+
+/**
+ * 1 chunk 分の candidates を chunk file に書込み、ArtifactChunkPointer を返す。
+ * orchestrator が buffer がフルになった時点 / streaming 完了時の残バッファ flush で呼ぶ。
+ */
+export async function writePhaseAChunk(
+  input: WritePhaseAChunkInput,
+  writer: ArtifactStorageWriter
+): Promise<ArtifactChunkPointer> {
+  const chunkBody: PhaseAClassifyChunk = {
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    chunkIndex: input.chunkIndex,
+    candidates: input.candidates,
+  };
+  const chunkContent = JSON.stringify(chunkBody);
+  const chunkPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    `phase-a-classify-summary-chunk-${input.chunkIndex}.json`
+  );
+  await writer.writeJson(chunkPath, chunkContent);
+  return {
+    path: chunkPath,
+    sha256: sha256Hex(chunkContent),
+    docCount: input.candidates.length,
+  };
+}
+
+/**
+ * 全 chunk 書込完了後に main artifact + manifest を書込む。consumer が manifest 読めれば
+ * 全 file 書込完了 invariant を満たす書込順 (main → manifest)。
+ */
+export async function finalizePhaseAArtifact(
+  input: FinalizePhaseAInput,
+  writer: ArtifactStorageWriter
+): Promise<FinalizePhaseAResult> {
+  const mainBody: PhaseAClassifySummary = {
+    phase: 'A',
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    scriptVersion: PR_D4_SCRIPT_VERSION,
+    env: input.env,
+    runId: input.runId,
+    snapshotStartedAt: input.snapshotStartedAt,
+    snapshotCompletedAt: input.snapshotCompletedAt,
+    bucketLocation: input.bucketLocation,
+    cloudRunJobLocation: input.cloudRunJobLocation,
+    egressFreeAssertion: input.egressFreeAssertion,
+    totalDocs: input.totalDocs,
+    categoryDistribution: input.categoryDistribution,
+    alreadyBackfilled: input.alreadyBackfilled,
+    verifiedExistingProvenance: input.verifiedExistingProvenance,
+    chunks: input.chunks,
+  };
+  const mainContent = JSON.stringify(mainBody);
+  const mainPath = buildObjectPath(input.bucketName, input.runId, 'phase-a-classify-summary.json');
+  await writer.writeJson(mainPath, mainContent);
+
+  const manifestBody: BackfillManifest = {
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    runId: input.runId,
+    env: input.env,
+    phaseA: {
+      mainArtifact: { path: mainPath, sha256: sha256Hex(mainContent) },
+      chunks: input.chunks,
+    },
+  };
+  const manifestContent = JSON.stringify(manifestBody);
+  const manifestPath = buildObjectPath(input.bucketName, input.runId, 'manifest.json');
+  await writer.writeJson(manifestPath, manifestContent);
+
+  return { mainArtifactPath: mainPath, manifestPath };
+}

--- a/scripts/pr-d4-backfill/phase-a/auditClassify.ts
+++ b/scripts/pr-d4-backfill/phase-a/auditClassify.ts
@@ -1,0 +1,213 @@
+/**
+ * Issue #445 PR-D4 S1-2: Phase A orchestrator (streaming chunked, BF22 厳密適合).
+ *
+ * documents collection を全件 stream → docSnapshotter → categoryClassifier →
+ * **per-chunk flush** → finalize の pipeline。orchestrator は per-chunk buffer
+ * (≤ PR_D4_CANDIDATES_PER_CHUNK 件) のみ保持し全 candidates を一括メモリ保持しない。
+ *
+ * 処理フロー (impl-plan §4.1, Codex MCP NO-GO 反映):
+ *   1. bucket location 検証 (cloud run vs target bucket) - 不一致なら abort
+ *   2. documents collection 全件 stream (cursor pagination)
+ *   3. 各 doc:
+ *      - hasProvenanceBackfill → alreadyBackfilled++ (candidates buffer 入れない)
+ *      - hasProvenance && !hasProvenanceBackfill → verifiedExistingProvenance++ (MUST 7)
+ *      - 上記以外 → snapshotter で構造観測 → classifier で 5 分類 → buffer 追加
+ *   4. buffer が PR_D4_CANDIDATES_PER_CHUNK に達したら writePhaseAChunk で flush
+ *   5. streaming 完了後 残 buffer を flush → finalizePhaseAArtifact (main + manifest)
+ *
+ * 書込責務: Firestore への書込なし (Phase C 担当)。GCS write は artifact bucket のみ。
+ */
+
+import type { BackfillClassifierCategory } from '../../../shared/types';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  PhaseACandidate,
+} from '../types';
+import { PR_D4_CANDIDATES_PER_CHUNK } from '../types';
+import { classifyForPhaseA } from './categoryClassifier';
+import {
+  snapshotDocForPhaseA,
+  type ParentFetcher,
+  type BucketProber,
+} from './docSnapshotter';
+import { verifyBucketLocation } from './bucketLocationVerifier';
+import {
+  finalizePhaseAArtifact,
+  writePhaseAChunk,
+  type ArtifactStorageWriter,
+} from './artifactWriter';
+
+/**
+ * documents collection 1 doc 分の入力。
+ *
+ * `hasProvenance` / `hasProvenanceBackfill` は **field existence チェック** で渡す
+ * (`'provenance' in data` / `'provenanceBackfill' in data`、Codex 4th review Low 1 反映)。
+ */
+export interface DocumentSourceRecord {
+  id: string;
+  fileUrl: string | null;
+  parentDocumentId: string | null;
+  splitFromPages: { start: number; end: number } | null;
+  /** Firestore _updateTime を ISO8601 文字列化 (Phase B drift 検出基準) */
+  updateTimeIso: string;
+  hasProvenance: boolean;
+  hasProvenanceBackfill: boolean;
+}
+
+export interface DocumentSource {
+  /** documents collection を cursor pagination で全件 stream する */
+  streamAll(): AsyncIterable<DocumentSourceRecord>;
+}
+
+export interface RunPhaseAInput {
+  env: BackfillEnvName;
+  runId: string;
+  /**
+   * 本 environment の production data bucket (例: docsplit-dev.firebasestorage.app)。
+   * snapshotter が child/parent PDF の存在確認に使用。**artifact 書込先とは別 bucket** で、
+   * artifactBucketName と混同しないこと (両者は別目的、別物理 bucket)。
+   */
+  productionDataBucketName: string;
+  /** artifact (main + chunks + manifest) 保存先 bucket (例: docsplit-dev-pr-d4-artifacts) */
+  artifactBucketName: string;
+  cloudRunLocation: string;
+  bucketLocation: string;
+  documentSource: DocumentSource;
+  parentFetcher: ParentFetcher;
+  bucketProber: BucketProber;
+  artifactWriter: ArtifactStorageWriter;
+  snapshotStartedAt: string;
+  /** テスト時計の DI (省略時 = system clock)。snapshot 完了時刻を artifact に書く */
+  nowProvider?: () => string;
+}
+
+export interface RunPhaseAResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+  chunkCount: number;
+  totalDocs: number;
+  alreadyBackfilled: number;
+  verifiedExistingProvenance: number;
+  categoryDistribution: Record<BackfillClassifierCategory, number>;
+  /** artifact 内 snapshotCompletedAt と同一値 (caller がログ出力する canonical 値) */
+  snapshotCompletedAt: string;
+}
+
+function initCategoryDistribution(): Record<BackfillClassifierCategory, number> {
+  return {
+    MatchedByHash: 0,
+    RepairableMissingFile: 0,
+    Ambiguous: 0,
+    LostOrUnrecoverable: 0,
+    NeedsManualReview: 0,
+  };
+}
+
+export async function runPhaseA(input: RunPhaseAInput): Promise<RunPhaseAResult> {
+  // 1. bucket location 検証 (失敗時は throw で早期 abort、artifact 書込まれない)
+  const locationResult = verifyBucketLocation({
+    cloudRunLocation: input.cloudRunLocation,
+    bucketLocation: input.bucketLocation,
+  });
+
+  let totalDocs = 0;
+  let alreadyBackfilled = 0;
+  let verifiedExistingProvenance = 0;
+  const categoryDistribution = initCategoryDistribution();
+
+  // BF22: per-chunk buffer のみ保持 (全 candidates 一括メモリロード禁止)
+  const chunkPointers: ArtifactChunkPointer[] = [];
+  let buffer: PhaseACandidate[] = [];
+  let chunkIndex = 0;
+
+  async function flushBuffer(): Promise<void> {
+    if (buffer.length === 0) return;
+    const pointer = await writePhaseAChunk(
+      {
+        bucketName: input.artifactBucketName,
+        runId: input.runId,
+        chunkIndex,
+        candidates: buffer,
+      },
+      input.artifactWriter
+    );
+    chunkPointers.push(pointer);
+    chunkIndex++;
+    buffer = [];
+  }
+
+  // 2. documents collection 全件 stream
+  for await (const doc of input.documentSource.streamAll()) {
+    totalDocs++;
+
+    if (doc.hasProvenanceBackfill) {
+      alreadyBackfilled++;
+      continue;
+    }
+    if (doc.hasProvenance) {
+      verifiedExistingProvenance++;
+      continue;
+    }
+
+    const { snapshot, candidate } = await snapshotDocForPhaseA({
+      doc: {
+        id: doc.id,
+        fileUrl: doc.fileUrl,
+        parentDocumentId: doc.parentDocumentId,
+        splitFromPages: doc.splitFromPages,
+        updateTimeIso: doc.updateTimeIso,
+      },
+      bucketName: input.productionDataBucketName,
+      parentFetcher: input.parentFetcher,
+      bucketProber: input.bucketProber,
+    });
+    const classification = classifyForPhaseA(snapshot);
+    categoryDistribution[classification.category]++;
+    buffer.push({
+      ...candidate,
+      category: classification.category,
+      reason: classification.reason,
+    });
+
+    if (buffer.length >= PR_D4_CANDIDATES_PER_CHUNK) {
+      await flushBuffer();
+    }
+  }
+  // 残 buffer を flush
+  await flushBuffer();
+
+  // 3. snapshot 完了時刻 (streaming 直後、main/manifest 書込前)
+  const snapshotCompletedAt = (input.nowProvider ?? (() => new Date().toISOString()))();
+
+  // 4. main + manifest 書込 (consumer が manifest 読めれば全 chunk + main 完了 invariant)
+  const finalizeResult = await finalizePhaseAArtifact(
+    {
+      bucketName: input.artifactBucketName,
+      runId: input.runId,
+      env: input.env,
+      snapshotStartedAt: input.snapshotStartedAt,
+      snapshotCompletedAt,
+      bucketLocation: locationResult.bucketLocation,
+      cloudRunJobLocation: locationResult.cloudRunJobLocation,
+      egressFreeAssertion: locationResult.egressFreeAssertion,
+      totalDocs,
+      categoryDistribution,
+      alreadyBackfilled,
+      verifiedExistingProvenance,
+      chunks: chunkPointers,
+    },
+    input.artifactWriter
+  );
+
+  return {
+    mainArtifactPath: finalizeResult.mainArtifactPath,
+    manifestPath: finalizeResult.manifestPath,
+    chunkCount: chunkPointers.length,
+    totalDocs,
+    alreadyBackfilled,
+    verifiedExistingProvenance,
+    categoryDistribution,
+    snapshotCompletedAt,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-a/bucketLocationVerifier.ts
+++ b/scripts/pr-d4-backfill/phase-a/bucketLocationVerifier.ts
@@ -1,0 +1,74 @@
+/**
+ * Issue #445 PR-D4 S1-2: bucket location verifier (Codex 2nd I4 / BF19 反映).
+ *
+ * Cloud Run Job が動いている region と target bucket location を比較し、不一致なら
+ * abort する。impl-plan §4.1 「bucket location 確認」に対応。
+ *
+ * 一致しないと:
+ *   - egress (cross-region traffic) が課金される
+ *   - Phase A の read-only 想定の cost 見積もりが破綻
+ *   - Phase B/C/D の write も同様に egress 課金になる
+ *
+ * BF19 (artifact metadata) との連動: 検証結果 (bucketLocation / cloudRunJobLocation /
+ * egressFreeAssertion) を artifact main file の field に記録する (caller 側)。
+ */
+
+export class BucketLocationMismatchError extends Error {
+  public readonly cloudRunLocation: string;
+  public readonly bucketLocation: string;
+  constructor(cloudRunLocation: string, bucketLocation: string) {
+    super(
+      `Cloud Run Job location (${cloudRunLocation}) does not match target bucket location (${bucketLocation}). ` +
+        'cross-region egress will be billed and Phase A cost assumption breaks. abort.'
+    );
+    this.name = 'BucketLocationMismatchError';
+    this.cloudRunLocation = cloudRunLocation;
+    this.bucketLocation = bucketLocation;
+  }
+}
+
+export interface VerifyBucketLocationInput {
+  /** caller が undefined を渡しても runtime で reject できるよう型上 optional */
+  cloudRunLocation: string | undefined;
+  bucketLocation: string | undefined;
+}
+
+export interface VerifyBucketLocationResult {
+  cloudRunJobLocation: string;
+  bucketLocation: string;
+  egressFreeAssertion: true;
+}
+
+function normalize(location: string): string {
+  return location.trim().toLowerCase();
+}
+
+/**
+ * cloudRunLocation === bucketLocation を検証 (大文字小文字 / 末尾空白を正規化して比較)。
+ * 不一致なら BucketLocationMismatchError を throw。
+ *
+ * multi-region bucket (例: ASIA, US, EU) は single-region cloudRunLocation と
+ * 同一文字列にならないため自動的に mismatch 判定される (egress 課金リスクは存在)。
+ */
+export function verifyBucketLocation(
+  input: VerifyBucketLocationInput
+): VerifyBucketLocationResult {
+  const cloudRunLocation = input.cloudRunLocation;
+  const bucketLocation = input.bucketLocation;
+  if (!cloudRunLocation || cloudRunLocation.trim() === '') {
+    throw new Error('cloudRunLocation is empty (configuration bug?)');
+  }
+  if (!bucketLocation || bucketLocation.trim() === '') {
+    throw new Error('bucketLocation is empty (configuration bug?)');
+  }
+
+  if (normalize(cloudRunLocation) !== normalize(bucketLocation)) {
+    throw new BucketLocationMismatchError(cloudRunLocation, bucketLocation);
+  }
+
+  return {
+    cloudRunJobLocation: cloudRunLocation,
+    bucketLocation,
+    egressFreeAssertion: true,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-a/categoryClassifier.ts
+++ b/scripts/pr-d4-backfill/phase-a/categoryClassifier.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #445 PR-D4 S1-2: Phase A 構造分類アダプタ (PR-C3c classifier コンセプト流用).
+ *
+ * Phase A は **read-only audit** で hash 計算は実施しない (Phase B 担当)。
+ * doc の構造的状態 (parent 存在 + child 存在 + splitFromPages 存在) のみから
+ * 5 分類を予測し、Phase B/C/D の処理対象を絞り込むための artifact を作る。
+ *
+ * 5 分類は shared/types.ts の BackfillClassifierCategory を流用 (4 値は PR-C3c
+ * collisionClassifier.ts の Classification と同じ語彙、NeedsManualReview は
+ * PR-D4 で追加した structural-data-missing fallback)。
+ *
+ * 注意:
+ *   - "MatchedByHash" は **予測**。Phase B で actual hash verify した時に downgrade
+ *     される可能性がある (downgrade 先は Phase B 側で記録、Phase A artifact は触らない)
+ *   - PR-C3c collisionClassifier.ts の `classifyOrphan` / `classifyCollisionGroup` は
+ *     hash evidence を入力に取るため Phase A では使えない。本 module は同じ語彙で
+ *     **構造判定だけ** を行う独立 pure function。
+ */
+
+import type { BackfillClassifierCategory } from '../../../shared/types';
+
+/**
+ * 1 doc 分の構造的 snapshot (Phase A での classify 入力)。
+ *
+ * 設計:
+ *   - `childObjectExists`: child PDF が GCS bucket 内に実在するか (Storage HEAD で判定済)
+ *   - `parent`: parentDocumentId が指す Firestore doc の状態 + 元 PDF 存在
+ *     - null: parentDocumentId が null (parent 取得自体不能)
+ *     - {exists:false}: parentDocumentId は値があるが Firestore doc が見つからない
+ *     - {exists:true, originalPdfExists}: parent doc は存在、元 PDF の存在は別 field
+ */
+export interface PhaseADocSnapshot {
+  docId: string;
+  parentDocumentId: string | null;
+  splitFromPages: { start: number; end: number } | null;
+  childObjectExists: boolean;
+  parent:
+    | { exists: true; originalPdfExists: boolean }
+    | { exists: false }
+    | null;
+}
+
+export interface PhaseAClassificationResult {
+  category: BackfillClassifierCategory;
+  reason: string;
+}
+
+/**
+ * 構造的 5 分類予測。
+ *
+ * | snapshot 状態                                | category               |
+ * |---------------------------------------------|------------------------|
+ * | parentDocumentId 不在 or splitFromPages 不在  | NeedsManualReview      |
+ * | parent.null (取得未実施 = caller bug)         | NeedsManualReview      |
+ * | child + parent ok + 元 PDF ok                | MatchedByHash (予測)   |
+ * | child orphan + parent ok + 元 PDF ok         | RepairableMissingFile  |
+ * | child ok + parent 不完全                     | Ambiguous              |
+ * | child orphan + parent 不完全                 | LostOrUnrecoverable    |
+ */
+export function classifyForPhaseA(
+  snapshot: PhaseADocSnapshot
+): PhaseAClassificationResult {
+  // 1. structural-data-missing fallback (PR-D4 で追加した 5 番目分類)
+  // 各 NeedsManualReview ブランチは exclusive。両 null → 片 null → defensive の順は
+  // operator 監査 reason の精度を最大化するため意図的に分割している (順序入れ替え禁止)。
+  if (snapshot.parentDocumentId === null && snapshot.splitFromPages === null) {
+    return {
+      category: 'NeedsManualReview',
+      reason: 'structural-data-missing: parentDocumentId and splitFromPages both absent',
+    };
+  }
+  if (snapshot.parentDocumentId === null) {
+    return {
+      category: 'NeedsManualReview',
+      reason: 'structural-data-missing: parentDocumentId absent (cannot trace split origin)',
+    };
+  }
+  if (snapshot.splitFromPages === null) {
+    return {
+      category: 'NeedsManualReview',
+      reason: 'structural-data-missing: splitFromPages absent (cannot determine page range)',
+    };
+  }
+  if (snapshot.parent === null) {
+    // caller bug: parentDocumentId はあるのに parent fetch を実施せず null で渡した
+    return {
+      category: 'NeedsManualReview',
+      reason: 'parent-fetch-not-performed: defensive fallback (snapshot.parent === null but parentDocumentId exists)',
+    };
+  }
+
+  const parentOk =
+    snapshot.parent.exists === true && snapshot.parent.originalPdfExists === true;
+
+  if (snapshot.childObjectExists && parentOk) {
+    return {
+      category: 'MatchedByHash',
+      reason: 'structural-prediction: child object + parent doc + original PDF all present; Phase B will verify with hash compute',
+    };
+  }
+
+  if (!snapshot.childObjectExists && parentOk) {
+    return {
+      category: 'RepairableMissingFile',
+      reason: 'child-orphan: child object missing in Storage; parent doc + original PDF available for regenerate-from-parent',
+    };
+  }
+
+  if (snapshot.childObjectExists && !parentOk) {
+    return {
+      category: 'Ambiguous',
+      reason: buildAmbiguousReason(snapshot.parent),
+    };
+  }
+
+  // !childObjectExists && !parentOk
+  return {
+    category: 'LostOrUnrecoverable',
+    reason: buildLostReason(snapshot.parent),
+  };
+}
+
+function buildAmbiguousReason(
+  parent: { exists: true; originalPdfExists: boolean } | { exists: false }
+): string {
+  if (parent.exists === false) {
+    return 'child object exists but parent doc not found in Firestore; cannot verify provenance';
+  }
+  // parent.exists === true && parent.originalPdfExists === false
+  return 'child object exists but parent original PDF missing in Storage; cannot verify provenance';
+}
+
+function buildLostReason(
+  parent: { exists: true; originalPdfExists: boolean } | { exists: false }
+): string {
+  if (parent.exists === false) {
+    return 'child orphan + parent doc not found in Firestore; cannot regenerate';
+  }
+  // parent.exists === true && parent.originalPdfExists === false
+  return 'child orphan + parent doc exists but parent original PDF missing in Storage; cannot regenerate';
+}

--- a/scripts/pr-d4-backfill/phase-a/docSnapshotter.ts
+++ b/scripts/pr-d4-backfill/phase-a/docSnapshotter.ts
@@ -1,0 +1,132 @@
+/**
+ * Issue #445 PR-D4 S1-2: Phase A doc-snapshotter (Firestore doc + parent + GCS HEAD → PhaseADocSnapshot).
+ *
+ * 1 doc 分の構造的状態を Firestore + Storage HEAD で観測し、
+ *   - PhaseADocSnapshot: classifyForPhaseA() への入力
+ *   - PhaseACandidate metadata: artifact に保存する per-doc record
+ * を構築する。
+ *
+ * 依存性逆転: ParentFetcher / BucketProber interface で Firestore / GCS を抽象化し、
+ * unit test は in-memory mock で実行する。
+ *
+ * F-B4 反映: doc.fileUrl の bucket が target bucket と不一致なら childObjectPath は
+ * null 扱い (本 environment 外の Storage 参照を本 environment の data として誤計上しない)。
+ */
+
+import type { PhaseACandidate } from '../types';
+import type { PhaseADocSnapshot } from './categoryClassifier';
+
+export interface ParentFetcher {
+  /**
+   * parent doc を Firestore から fetch。
+   * - 存在しない: null
+   * - 存在 + fileUrl なし: { fileUrl: null }
+   * - 存在 + fileUrl あり: { fileUrl: 'gs://...' }
+   */
+  fetchParent(
+    parentDocId: string
+  ): Promise<{ fileUrl: string | null } | null>;
+}
+
+export interface BucketProber {
+  /**
+   * GCS HEAD 相当。object が存在すれば metadata を返し、404 なら null を返す。
+   * 入力 path は bucket name を含まない object path (例: 'processed/doc-1/output.pdf')。
+   */
+  getMetadata(
+    objectPath: string
+  ): Promise<{ generation: string; metageneration: string } | null>;
+}
+
+export interface SnapshotDocInput {
+  doc: {
+    id: string;
+    fileUrl: string | null;
+    parentDocumentId: string | null;
+    splitFromPages: { start: number; end: number } | null;
+    /** Firestore _updateTime を ISO8601 文字列化 (Phase B drift 検出基準) */
+    updateTimeIso: string;
+  };
+  /** 本 environment の primary bucket 名 (例: docsplit-dev.firebasestorage.app) */
+  bucketName: string;
+  parentFetcher: ParentFetcher;
+  bucketProber: BucketProber;
+}
+
+export interface SnapshotDocResult {
+  snapshot: PhaseADocSnapshot;
+  candidate: Omit<PhaseACandidate, 'category' | 'reason'>;
+}
+
+/**
+ * `gs://<bucket>/<path>` から path を抽出。`expectedBucket` と一致しない場合は null
+ * (本 environment 外 Storage を本 environment data として誤計上しない、F-B4 反映)。
+ */
+function extractPathIfBucketMatches(
+  url: string | null | undefined,
+  expectedBucket: string
+): string | null {
+  if (!url || typeof url !== 'string') return null;
+  const match = url.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (!match) return null;
+  const [, bucket, path] = match;
+  return bucket === expectedBucket ? path : null;
+}
+
+export async function snapshotDocForPhaseA(
+  input: SnapshotDocInput
+): Promise<SnapshotDocResult> {
+  const { doc, bucketName, parentFetcher, bucketProber } = input;
+
+  // --- child object 観測 ---
+  const childObjectPath = extractPathIfBucketMatches(doc.fileUrl, bucketName);
+  let childMetadata: { generation: string; metageneration: string } | null = null;
+  if (childObjectPath !== null) {
+    childMetadata = await bucketProber.getMetadata(childObjectPath);
+  }
+  const childObjectExists = childMetadata !== null;
+
+  // --- parent doc + parent object 観測 ---
+  let parentSnapshotState: PhaseADocSnapshot['parent'] = null;
+  let parentObjectPath: string | null = null;
+  let parentMetadata: { generation: string; metageneration: string } | null = null;
+
+  if (doc.parentDocumentId !== null) {
+    const parentDoc = await parentFetcher.fetchParent(doc.parentDocumentId);
+    if (parentDoc === null) {
+      parentSnapshotState = { exists: false };
+    } else {
+      parentObjectPath = extractPathIfBucketMatches(parentDoc.fileUrl, bucketName);
+      if (parentObjectPath !== null) {
+        parentMetadata = await bucketProber.getMetadata(parentObjectPath);
+      }
+      parentSnapshotState = {
+        exists: true,
+        originalPdfExists: parentMetadata !== null,
+      };
+    }
+  }
+
+  const snapshot: PhaseADocSnapshot = {
+    docId: doc.id,
+    parentDocumentId: doc.parentDocumentId,
+    splitFromPages: doc.splitFromPages,
+    childObjectExists,
+    parent: parentSnapshotState,
+  };
+
+  const candidate: Omit<PhaseACandidate, 'category' | 'reason'> = {
+    docId: doc.id,
+    firestoreUpdateTime: doc.updateTimeIso,
+    childObjectPath,
+    childGeneration: childMetadata?.generation ?? null,
+    childMetageneration: childMetadata?.metageneration ?? null,
+    parentDocId: doc.parentDocumentId,
+    parentObjectPath,
+    parentGeneration: parentMetadata?.generation ?? null,
+    parentMetageneration: parentMetadata?.metageneration ?? null,
+    splitFromPages: doc.splitFromPages,
+  };
+
+  return { snapshot, candidate };
+}

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -1,0 +1,166 @@
+/**
+ * Issue #445 PR-D4 S1-2: Phase A artifact schemas (read-only audit + classify).
+ *
+ * impl-plan v3.1 §4.1 の artifact 構造を型で固定する。
+ *
+ * 配置: scripts/pr-d4-backfill/ 配下に独立。Phase B/C/D の型も同ディレクトリで段階追加予定
+ * (S1-3 以降)。shared/types.ts に置かないのは frontend bundle と layer 規約を守るため。
+ *
+ * 参照:
+ * - impl-plan: docs/specs/pr-d4-backfill-impl-plan.md §4.1
+ * - BackfillClassifierCategory: shared/types.ts (PR-D4 S1-1 で確定済)
+ */
+
+import type { BackfillClassifierCategory } from '../../shared/types';
+
+/**
+ * artifact schema version (script 改修時に bump)。Phase A/B/C/D で共通の prefix を持つ。
+ */
+export const PR_D4_ARTIFACT_SCHEMA_VERSION = 'pr-d4-v1.0' as const;
+export type PrD4ArtifactSchemaVersion = typeof PR_D4_ARTIFACT_SCHEMA_VERSION;
+
+/**
+ * scriptVersion: script 改修で artifact 互換性に影響する場合に bump。
+ * schemaVersion と独立: schemaVersion は wire-format、scriptVersion は logic 実装。
+ */
+export const PR_D4_SCRIPT_VERSION = 'pr-d4-v1.0' as const;
+export type PrD4ScriptVersion = typeof PR_D4_SCRIPT_VERSION;
+
+/**
+ * 環境名 (Phase A 起動時に CLI / env var で受け取る)。マルチクライアント運用と整合。
+ * - dev: doc-split-dev (開発・rehearsal)
+ * - cocoro: docsplit-cocoro (本番 539 docs)
+ * - kanameone: docsplit-kanameone (本番 5,725 docs)
+ */
+export type BackfillEnvName = 'dev' | 'cocoro' | 'kanameone';
+
+/**
+ * GCS chunk pointer (artifact main file に埋め込み、Phase B/C/D が streaming read 時に
+ * sha256 verify するため使う)。BF19/BF22 反映。
+ */
+export interface ArtifactChunkPointer {
+  /** 例: gs://docsplit-kanameone-pr-d4-artifacts/{run-id}/phase-a-classify-summary-chunk-0.json */
+  path: string;
+  /** chunk file の content sha256 (hex lowercase) */
+  sha256: string;
+  /** chunk 内の candidates 件数 (chunking 規則: 1000 docs/chunk が上限、最終 chunk は ≤ 1000) */
+  docCount: number;
+}
+
+/**
+ * Phase A artifact 内に保持する 1 doc 分の評価結果 (Phase B の入力)。
+ *
+ * 設計判断:
+ * - `category`: 5 分類 (BackfillClassifierCategory)
+ * - `reason`: classifier が返した文字列 (Ambiguous の細分化情報を含む、operator 監査用)
+ * - `splitFromPages`: Phase B で再 split 検証する際の入力 (Phase A 時点 snapshot)
+ * - `firestoreUpdateTime`: Phase B の drift 検出基準 (ISO8601、Firestore Timestamp 由来)
+ * - `parent*` フィールド: parent doc が存在しない / parentDocumentId 不在のケースは null
+ * - `child*` フィールド: orphan (Storage 実体なし) は null (childObjectPath は記録するが
+ *   generation/metageneration は取得不能 = null)
+ */
+export interface PhaseACandidate {
+  docId: string;
+  category: BackfillClassifierCategory;
+  reason: string;
+  firestoreUpdateTime: string;
+  /** child Storage 内 object path (gs:// prefix なし、bucket は env 共通) */
+  childObjectPath: string | null;
+  childGeneration: string | null;
+  childMetageneration: string | null;
+  /** parent doc id (split 親、document.parentDocumentId 由来) */
+  parentDocId: string | null;
+  parentObjectPath: string | null;
+  parentGeneration: string | null;
+  parentMetageneration: string | null;
+  /** 子 doc の document.splitFromPages snapshot (Phase B の再 split で必要) */
+  splitFromPages: { start: number; end: number } | null;
+}
+
+/**
+ * Phase A artifact (main file) の構造。chunks 配列 + summary metadata のみで、
+ * candidates 本体は別 chunk file に格納 (BF22 chunked streaming 反映)。
+ */
+export interface PhaseAClassifySummary {
+  phase: 'A';
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  scriptVersion: PrD4ScriptVersion;
+  env: BackfillEnvName;
+  /** Phase A 実行を一意識別する ID (例: 20260514T100000Z-dev-pr-d4-v1) */
+  runId: string;
+  /** Firestore snapshot 読込開始時刻 (ISO8601 UTC) */
+  snapshotStartedAt: string;
+  /** Firestore snapshot 読込完了時刻 (ISO8601 UTC) */
+  snapshotCompletedAt: string;
+  /** target bucket の region (Codex 2nd I4 / BF19 反映) */
+  bucketLocation: string;
+  /** Cloud Run Job 実行 region */
+  cloudRunJobLocation: string;
+  /** bucketLocation === cloudRunJobLocation の検証結果 (egress 無料 assertion) */
+  egressFreeAssertion: boolean;
+  /** documents collection 全件数 (alreadyBackfilled + verifiedExistingProvenance + Σcategoryを含む) */
+  totalDocs: number;
+  /**
+   * 5 分類別の candidate 件数。`alreadyBackfilled` + `verifiedExistingProvenance` は除外。
+   * keys は BackfillClassifierCategory の全 5 値が必ず present (0 件でも 0 を記録)。
+   */
+  categoryDistribution: Record<BackfillClassifierCategory, number>;
+  /**
+   * provenanceBackfill 既存 doc 件数 (PR-D4 で再 backfill しない、count のみ artifact 化)。
+   */
+  alreadyBackfilled: number;
+  /**
+   * provenance 存在 + provenanceBackfill 不在 = verified split-time provenance (PR-D2/D3 生成、
+   * ADR MUST 7 で immutable skip)。candidates には含めず count のみ artifact 化。
+   */
+  verifiedExistingProvenance: number;
+  /** candidates を格納した chunk file の pointers (順序保持) */
+  chunks: ArtifactChunkPointer[];
+}
+
+/**
+ * Phase A chunk file の構造 (1000 candidates まで含む)。main artifact から chunks[] で参照。
+ */
+export interface PhaseAClassifyChunk {
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  /** chunks[] 配列内 index (0-based) */
+  chunkIndex: number;
+  candidates: PhaseACandidate[];
+}
+
+/**
+ * manifest.json の構造 (BF19/BF22 反映)。
+ *
+ * Phase A 完了時に書込み、Phase B/C/D 各 phase 完了時に同じ manifest を更新追記する
+ * (各 phase chunk の sha256 と path を蓄積)。
+ *
+ * 設計:
+ * - `runId`: Phase A の runId と同一 (cross-phase で 1 run = 1 manifest)
+ * - `phaseA.mainArtifact`: main artifact file の {path, sha256}
+ * - `phaseA.chunks`: PhaseAClassifySummary.chunks と同内容 (重複だが consumer の便宜)
+ * - Phase B/C/D 追記時は `phaseB`/`phaseC`/`phaseD` field を additive で増やす
+ */
+export interface BackfillManifest {
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  runId: string;
+  env: BackfillEnvName;
+  phaseA?: {
+    mainArtifact: { path: string; sha256: string };
+    chunks: ArtifactChunkPointer[];
+  };
+  phaseB?: {
+    mainArtifact: { path: string; sha256: string };
+    chunks: ArtifactChunkPointer[];
+  };
+  phaseC?: {
+    mainArtifact: { path: string; sha256: string };
+    chunks: ArtifactChunkPointer[];
+  };
+  phaseD?: {
+    mainArtifact: { path: string; sha256: string };
+    chunks: ArtifactChunkPointer[];
+  };
+}
+
+/** chunk 1 件あたり最大件数 (impl-plan §4.1 BF19 / BF22 反映) */
+export const PR_D4_CANDIDATES_PER_CHUNK = 1000 as const;


### PR DESCRIPTION
## Summary

- Issue #445 PR-D4 S1-2: Phase A 実装 (read-only audit + classify、scripts/pr-d4-backfill/ 新規ディレクトリ)
- documents collection 全件 stream → 5 分類 → GCS artifact (main + chunks + manifest) JSON 書込
- Firestore / production GCS への write 経路なし (read-only invariant 確認済)
- session71 で merge 済の S1-1 (基盤層 types + factory) を消費する最初の caller、Phase B/C/D は S1-3 以降で積上げ

## 構造

| Layer | File | LoC |
|-------|------|----:|
| Types | scripts/pr-d4-backfill/types.ts | 153 |
| Verifier | phase-a/bucketLocationVerifier.ts | 82 |
| Classifier | phase-a/categoryClassifier.ts | 139 |
| Snapshotter | phase-a/docSnapshotter.ts | 137 |
| Writer | phase-a/artifactWriter.ts | 156 |
| Orchestrator | phase-a/auditClassify.ts | 192 |
| Adapters | phase-a/adapters.ts | 175 |
| CLI | scripts/pr-d4-backfill/index.ts | 131 |
| Tests | functions/test/prD4*.test.ts (5 files) | 1055 |

## Acceptance Criteria (impl-plan v3.1 §5)

- **BF8** Phase A artifact 出力で 5 分類分布記録: ✅ PASS — categoryDistribution + alreadyBackfilled + verifiedExistingProvenance を main artifact に記録
- **BF19** schemaVersion + SHA256 manifest + 1000 docs/chunk: ✅ PASS
- **BF22** chunked streaming (全 chunk 一括メモリロード禁止): ✅ PASS — orchestrator が per-chunk buffer のみ保持、buffer 満杯時に flush (Codex MCP NO-GO → GO 反映)
- **MUST 7** (ADR-0016 immutable skip): ✅ PASS

## Quality Gate

- **TDD**: 47 new unit tests (RED→GREEN→REFACTOR)
  - prD4ArtifactWriter: 8 / prD4BucketLocationVerifier: 7 / prD4CategoryClassifier: 13 / prD4DocSnapshotter: 9 / prD4AuditClassify: 10
- **evaluator**: APPROVE with notes (snapshotCompletedAt 二重取得 + bucketName 命名 + classifier 順序依存コメント の 3 件は本 PR で全反映)
- **pr-review-toolkit:code-reviewer**: No critical/high (M1 readArg flag-as-value bug + M2 updateTime cast 簡素化 反映)
- **Codex MCP review**: 1st NO-GO → 2nd GO
  - Critical: BF22 strict adherence (per-chunk flush refactor)
  - Important 1: --cloud-run-location / --bucket-location default 削除 → 明示必須
  - Important 2: artifact overwrite 禁止 (ifGenerationMatch: 0)
- **全テスト**: 1198 passing (新規 47 + 既存 1151)、scripts/functions/frontend tsc clean

## Test plan

- [x] `cd functions && npm test` 全 1198 passing 確認
- [x] `cd functions && npm run type-check:test` clean
- [x] `npx tsc -p scripts/tsconfig.json --noEmit` clean
- [x] `cd frontend && npm run typecheck` clean (shared/types.ts 影響なし)
- [ ] dev rehearsal (S2 stage): Cloud Run Job 実行で実 Firestore + GCS 接続検証 (本 PR スコープ外、後続 PR で追加)

## 次セッション (S1-3)

Phase B (write-free preflight revalidation) 実装。Phase A artifact streaming read + Firestore updateTime/GCS generation drift 検出 + MatchedByHash candidates の hash verify (実際の re-split + fingerprint compare)。

Refs #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR-D4 Phase A backfill script for processing and classifying documents
  * Document snapshots and structural classification pipeline
  * Artifact generation and storage for backfill results
  * Cloud location verification to optimize resource efficiency

* **Tests**
  * Added comprehensive test coverage for Phase A artifact writing, document classification, bucket location verification, and document snapshots

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/464)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->