### PR TITLE
feat(pr-d4): PR-D4 S1-3 — Phase B write-free preflight revalidation + 47 tests (#445)

### DIFF
--- a/functions/test/prD4ArtifactReader.test.ts
+++ b/functions/test/prD4ArtifactReader.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Issue #445 PR-D4 S1-3: phase-b/artifactReader.ts streaming read + sha256 verify.
+ *
+ * BF22 反映: Phase A main artifact (chunk pointers) を読み、各 chunk を **逐次 stream read**
+ * しながら manifest sha256 値で integrity verify。全 chunk を一括メモリロードしない。
+ * AsyncIterable で 1 candidate ずつ caller (orchestrator) に yield する。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  readPhaseAArtifact,
+  ArtifactIntegrityError,
+  type ArtifactStorageReader,
+} from '../../scripts/pr-d4-backfill/phase-b/artifactReader';
+import type {
+  PhaseACandidate,
+  PhaseAClassifyChunk,
+  PhaseAClassifySummary,
+  BackfillManifest,
+} from '../../scripts/pr-d4-backfill/types';
+
+class FakeStorageReader implements ArtifactStorageReader {
+  private contents: Record<string, string>;
+  public reads: string[] = [];
+  constructor(contents: Record<string, string>) {
+    this.contents = contents;
+  }
+  async readJson(path: string): Promise<{ content: string; generation: number }> {
+    this.reads.push(path);
+    if (!(path in this.contents)) throw new Error(`not found: ${path}`);
+    return { content: this.contents[path], generation: 1 };
+  }
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function makeCandidate(i: number): PhaseACandidate {
+  return {
+    docId: `doc-${i}`,
+    category: 'MatchedByHash',
+    reason: 'test',
+    firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+    childObjectPath: `processed/doc-${i}/output.pdf`,
+    childGeneration: `${1000000 + i}`,
+    childMetageneration: '1',
+    parentDocId: `parent-${i}`,
+    parentObjectPath: `attachments/parent-${i}/source.pdf`,
+    parentGeneration: `${2000000 + i}`,
+    parentMetageneration: '1',
+    splitFromPages: { start: 1, end: 1 },
+  };
+}
+
+interface BuiltArtifact {
+  manifestPath: string;
+  mainArtifactPath: string;
+  contents: Record<string, string>;
+  manifest: BackfillManifest;
+}
+
+function buildArtifact(totalCandidates: number, chunkSize = 1000): BuiltArtifact {
+  const bucket = 'docsplit-dev-pr-d4-artifacts';
+  const runId = '20260514T100000Z-dev-pr-d4-v1';
+  const prefix = `gs://${bucket}/pr-d4-backfill-artifacts/${runId}`;
+  const mainPath = `${prefix}/phase-a-classify-summary.json`;
+  const manifestPath = `${prefix}/manifest.json`;
+  const candidates = Array.from({ length: totalCandidates }, (_, i) => makeCandidate(i));
+  const chunkPointers: { path: string; sha256: string; docCount: number }[] = [];
+  const contents: Record<string, string> = {};
+  for (let i = 0; i < Math.max(1, Math.ceil(totalCandidates / chunkSize)); i++) {
+    const slice = candidates.slice(i * chunkSize, (i + 1) * chunkSize);
+    if (slice.length === 0 && totalCandidates > 0) break;
+    const chunkPath = `${prefix}/phase-a-classify-summary-chunk-${i}.json`;
+    const chunkBody: PhaseAClassifyChunk = {
+      schemaVersion: 'pr-d4-v1.0',
+      chunkIndex: i,
+      candidates: slice,
+    };
+    const chunkContent = JSON.stringify(chunkBody);
+    contents[chunkPath] = chunkContent;
+    chunkPointers.push({ path: chunkPath, sha256: sha256Hex(chunkContent), docCount: slice.length });
+  }
+  const main: PhaseAClassifySummary = {
+    phase: 'A',
+    schemaVersion: 'pr-d4-v1.0',
+    scriptVersion: 'pr-d4-v1.0',
+    env: 'dev',
+    runId,
+    snapshotStartedAt: '2026-05-14T10:00:00.000Z',
+    snapshotCompletedAt: '2026-05-14T10:00:10.000Z',
+    bucketLocation: 'asia-northeast1',
+    cloudRunJobLocation: 'asia-northeast1',
+    egressFreeAssertion: true,
+    totalDocs: totalCandidates,
+    categoryDistribution: {
+      MatchedByHash: totalCandidates,
+      RepairableMissingFile: 0,
+      Ambiguous: 0,
+      LostOrUnrecoverable: 0,
+      NeedsManualReview: 0,
+    },
+    alreadyBackfilled: 0,
+    verifiedExistingProvenance: 0,
+    chunks: chunkPointers,
+  };
+  const mainContent = JSON.stringify(main);
+  contents[mainPath] = mainContent;
+  const manifest: BackfillManifest = {
+    schemaVersion: 'pr-d4-v1.0',
+    runId,
+    env: 'dev',
+    phaseA: {
+      mainArtifact: { path: mainPath, sha256: sha256Hex(mainContent) },
+      chunks: chunkPointers,
+    },
+  };
+  contents[manifestPath] = JSON.stringify(manifest);
+  return { manifestPath, mainArtifactPath: mainPath, contents, manifest };
+}
+
+async function collectCandidates(
+  iter: AsyncIterable<PhaseACandidate>
+): Promise<PhaseACandidate[]> {
+  const out: PhaseACandidate[] = [];
+  for await (const c of iter) out.push(c);
+  return out;
+}
+
+describe('readPhaseAArtifact (PR-D4 S1-3 streaming reader)', () => {
+  it('manifest 読込 → main artifact 読込 → chunks 順次 stream で全 candidate を yield', async () => {
+    const { manifestPath, contents } = buildArtifact(2500);
+    const reader = new FakeStorageReader(contents);
+    const stream = await readPhaseAArtifact({ manifestPath, reader });
+    const collected = await collectCandidates(stream.candidates());
+    expect(collected).to.have.length(2500);
+    expect(collected[0].docId).to.equal('doc-0');
+    expect(collected[2499].docId).to.equal('doc-2499');
+    expect(stream.phaseAManifestSha256).to.be.a('string').and.have.length(64);
+  });
+
+  it('chunks=[] (Phase A で 0 candidate) → 空 stream', async () => {
+    const { manifestPath, contents } = buildArtifact(0);
+    const reader = new FakeStorageReader(contents);
+    const stream = await readPhaseAArtifact({ manifestPath, reader });
+    const collected = await collectCandidates(stream.candidates());
+    expect(collected).to.have.length(0);
+  });
+
+  it('main artifact sha256 が manifest 値と不一致 → ArtifactIntegrityError (eager check)', async () => {
+    const { manifestPath, mainArtifactPath, contents } = buildArtifact(100);
+    contents[mainArtifactPath] = contents[mainArtifactPath] + ' '; // 1 byte tamper
+    const reader = new FakeStorageReader(contents);
+    let err: unknown = null;
+    try {
+      await readPhaseAArtifact({ manifestPath, reader });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(ArtifactIntegrityError);
+    expect((err as Error).message).to.match(/main artifact.*sha256/i);
+  });
+
+  it('chunk sha256 が manifest 値と不一致 → ArtifactIntegrityError', async () => {
+    const { manifestPath, contents, manifest } = buildArtifact(1500);
+    // chunk-1 を tamper
+    const chunk1Path = manifest.phaseA!.chunks[1].path;
+    contents[chunk1Path] = contents[chunk1Path] + ' ';
+    const reader = new FakeStorageReader(contents);
+    const stream = await readPhaseAArtifact({ manifestPath, reader });
+    let err: unknown = null;
+    try {
+      await collectCandidates(stream.candidates());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(ArtifactIntegrityError);
+    expect((err as Error).message).to.match(/chunk.*sha256/i);
+  });
+
+  it('manifest.phaseA 不在 → Error throw (eager check、Phase A 未完了 artifact)', async () => {
+    const { manifestPath, contents, manifest } = buildArtifact(100);
+    const tamperedManifest: BackfillManifest = { ...manifest, phaseA: undefined };
+    contents[manifestPath] = JSON.stringify(tamperedManifest);
+    const reader = new FakeStorageReader(contents);
+    let err: unknown = null;
+    try {
+      await readPhaseAArtifact({ manifestPath, reader });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.instanceOf(Error);
+    expect((err as Error).message).to.match(/phaseA/i);
+  });
+
+  it('BF22 streaming: chunks は yield 順序通り 1 chunk ずつ read される (全 chunk 同時メモリ不可)', async () => {
+    const { manifestPath, contents } = buildArtifact(3500);
+    const reader = new FakeStorageReader(contents);
+    const stream = await readPhaseAArtifact({ manifestPath, reader });
+    // manifest + main を先に読む → reads は ['manifest', 'main', 'chunk-0', 'chunk-1', 'chunk-2', 'chunk-3']
+    await collectCandidates(stream.candidates());
+    const chunkReadOrder = reader.reads.filter((p) => p.includes('chunk-'));
+    expect(chunkReadOrder).to.have.length(4);
+    chunkReadOrder.forEach((p, i) => expect(p).to.include(`chunk-${i}.json`));
+  });
+
+  it('candidatesIn は manifest.phaseA.chunks の docCount 合計 (streaming 開始前に判明)', async () => {
+    const { manifestPath, contents } = buildArtifact(2500);
+    const reader = new FakeStorageReader(contents);
+    const stream = await readPhaseAArtifact({ manifestPath, reader });
+    expect(stream.candidatesIn).to.equal(2500);
+  });
+
+  it('phaseAArtifactRef は main artifact path、phaseAManifestSha256 は main sha256', async () => {
+    const { manifestPath, mainArtifactPath, contents, manifest } = buildArtifact(100);
+    const reader = new FakeStorageReader(contents);
+    const stream = await readPhaseAArtifact({ manifestPath, reader });
+    expect(stream.phaseAArtifactRef).to.equal(mainArtifactPath);
+    expect(stream.phaseAManifestSha256).to.equal(manifest.phaseA!.mainArtifact.sha256);
+  });
+});

--- a/functions/test/prD4ArtifactWriter.test.ts
+++ b/functions/test/prD4ArtifactWriter.test.ts
@@ -27,7 +27,11 @@ import type {
 
 class FakeStorageWriter implements ArtifactStorageWriter {
   public writes: WrittenObject[] = [];
-  async writeJson(objectPath: string, content: string): Promise<void> {
+  async writeJson(
+    objectPath: string,
+    content: string,
+    _precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
     this.writes.push({ path: objectPath, content });
   }
 }

--- a/functions/test/prD4AuditClassify.test.ts
+++ b/functions/test/prD4AuditClassify.test.ts
@@ -71,7 +71,11 @@ class StaticBucketProber implements BucketProber {
 
 class FakeStorageWriter implements ArtifactStorageWriter {
   public writes: WrittenObject[] = [];
-  async writeJson(path: string, content: string) {
+  async writeJson(
+    path: string,
+    content: string,
+    _precondition?: { ifGenerationMatch: number }
+  ) {
     this.writes.push({ path, content });
   }
 }

--- a/functions/test/prD4ChildRevalidator.test.ts
+++ b/functions/test/prD4ChildRevalidator.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Issue #445 PR-D4 S1-3: phase-b/childRevalidator.ts (child object 現在 sha256 計算 + metadata 取得).
+ *
+ * 担当:
+ *   - child Storage object 存在確認 (HEAD)
+ *   - object content download
+ *   - raw bytes sha256 計算 (= provenance.derivedSha256)
+ *
+ * DI 化 (BucketProber + downloadBytes wrapper) で実 Storage アクセス不要。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  revalidateChildObject,
+  type ChildObjectDownloader,
+} from '../../scripts/pr-d4-backfill/phase-b/childRevalidator';
+
+class FakeDownloader implements ChildObjectDownloader {
+  private bytesByPath: Record<string, Buffer | null>;
+  public downloadCalls: string[] = [];
+  constructor(bytesByPath: Record<string, Buffer | null>) {
+    this.bytesByPath = bytesByPath;
+  }
+  async download(path: string): Promise<{
+    bytes: Buffer;
+    generation: string;
+    metageneration: string;
+  } | null> {
+    this.downloadCalls.push(path);
+    const b = this.bytesByPath[path];
+    if (b === undefined) return null;
+    if (b === null) return null;
+    return { bytes: b, generation: '12345', metageneration: '1' };
+  }
+}
+
+function sha256Hex(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+describe('revalidateChildObject (PR-D4 S1-3 child sha256 計算)', () => {
+  it('child 存在 → bytes / sha256 / generation / metageneration を返す', async () => {
+    const bytes = Buffer.from('hello PR-D4 phase B child content');
+    const downloader = new FakeDownloader({ 'processed/doc-1/output.pdf': bytes });
+    const result = await revalidateChildObject({
+      childObjectPath: 'processed/doc-1/output.pdf',
+      downloader,
+    });
+    expect(result.exists).to.equal(true);
+    if (result.exists) {
+      expect(result.derivedSha256).to.equal(sha256Hex(bytes));
+      expect(result.derivedGeneration).to.equal('12345');
+      expect(result.derivedMetageneration).to.equal('1');
+    }
+  });
+
+  it('child 不在 (HEAD null) → exists=false', async () => {
+    const downloader = new FakeDownloader({});
+    const result = await revalidateChildObject({
+      childObjectPath: 'processed/doc-1/output.pdf',
+      downloader,
+    });
+    expect(result.exists).to.equal(false);
+  });
+
+  it('childObjectPath null → exists=false (download 呼ばれない)', async () => {
+    const downloader = new FakeDownloader({});
+    const result = await revalidateChildObject({
+      childObjectPath: null,
+      downloader,
+    });
+    expect(result.exists).to.equal(false);
+    expect(downloader.downloadCalls).to.have.length(0);
+  });
+
+  it('sha256 は lowercase hex (provenance.derivedSha256 と整合)', async () => {
+    const bytes = Buffer.from('abc');
+    const downloader = new FakeDownloader({ 'p/a.pdf': bytes });
+    const result = await revalidateChildObject({
+      childObjectPath: 'p/a.pdf',
+      downloader,
+    });
+    expect(result.exists).to.equal(true);
+    if (result.exists) {
+      expect(result.derivedSha256).to.match(/^[a-f0-9]{64}$/);
+      expect(result.derivedSha256).to.equal(sha256Hex(bytes));
+    }
+  });
+
+  it('空 buffer (0 byte file) でも sha256 計算する (e3b0c44... empty hash)', async () => {
+    const downloader = new FakeDownloader({ 'p/empty.pdf': Buffer.alloc(0) });
+    const result = await revalidateChildObject({
+      childObjectPath: 'p/empty.pdf',
+      downloader,
+    });
+    expect(result.exists).to.equal(true);
+    if (result.exists) {
+      expect(result.derivedSha256).to.equal(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      );
+    }
+  });
+});

--- a/functions/test/prD4DriftDetector.test.ts
+++ b/functions/test/prD4DriftDetector.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Issue #445 PR-D4 S1-3: drift-detector.ts pure function テスト.
+ *
+ * Phase B step 3-4: Firestore `updateTime` + GCS `generation`/`metageneration` を
+ * Phase A artifact 値と比較し drift 種別を返す。pure (no Firestore/GCS access)、
+ * caller が最新値を取得して渡す。
+ *
+ * BF9 反映: drift 種別ごとにカウンタを分けて Phase B artifact に記録する前提。
+ */
+
+import { expect } from 'chai';
+import {
+  detectDrift,
+  type DriftDetectionInput,
+} from '../../scripts/pr-d4-backfill/phase-b/driftDetector';
+
+function baseInput(overrides: Partial<DriftDetectionInput> = {}): DriftDetectionInput {
+  return {
+    phaseA: {
+      firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+      childGeneration: '1000',
+      childMetageneration: '1',
+      parentGeneration: '2000',
+      parentMetageneration: '1',
+    },
+    current: {
+      firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+      childGeneration: '1000',
+      childMetageneration: '1',
+      parentGeneration: '2000',
+      parentMetageneration: '1',
+    },
+    ...overrides,
+  };
+}
+
+describe('detectDrift (PR-D4 S1-3 drift detector)', () => {
+  it('全項目一致 → kind=no-drift', () => {
+    const result = detectDrift(baseInput());
+    expect(result.kind).to.equal('no-drift');
+  });
+
+  it('Firestore updateTime 変化 → kind=firestoreUpdateTimeChanged (最優先で reported)', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T11:00:00.000Z',
+          childGeneration: '1000',
+          childMetageneration: '1',
+          parentGeneration: '2000',
+          parentMetageneration: '1',
+        },
+      })
+    );
+    expect(result.kind).to.equal('firestoreUpdateTimeChanged');
+  });
+
+  it('child generation 変化 → kind=childGenerationChanged', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+          childGeneration: '1001',
+          childMetageneration: '1',
+          parentGeneration: '2000',
+          parentMetageneration: '1',
+        },
+      })
+    );
+    expect(result.kind).to.equal('childGenerationChanged');
+  });
+
+  it('child metageneration 変化 → kind=childGenerationChanged (同 bucket categorize)', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+          childGeneration: '1000',
+          childMetageneration: '2',
+          parentGeneration: '2000',
+          parentMetageneration: '1',
+        },
+      })
+    );
+    expect(result.kind).to.equal('childGenerationChanged');
+  });
+
+  it('parent generation 変化 → kind=parentGenerationChanged', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+          childGeneration: '1000',
+          childMetageneration: '1',
+          parentGeneration: '2001',
+          parentMetageneration: '1',
+        },
+      })
+    );
+    expect(result.kind).to.equal('parentGenerationChanged');
+  });
+
+  it('parent metageneration 変化 → kind=parentGenerationChanged', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+          childGeneration: '1000',
+          childMetageneration: '1',
+          parentGeneration: '2000',
+          parentMetageneration: '2',
+        },
+      })
+    );
+    expect(result.kind).to.equal('parentGenerationChanged');
+  });
+
+  it('Firestore + child + parent すべて drift → 優先順位 firestore > child > parent で kind 決定', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T11:00:00.000Z',
+          childGeneration: '1001',
+          childMetageneration: '1',
+          parentGeneration: '2001',
+          parentMetageneration: '1',
+        },
+      })
+    );
+    expect(result.kind).to.equal('firestoreUpdateTimeChanged');
+  });
+
+  it('child + parent drift (Firestore 一致) → kind=childGenerationChanged (child 優先)', () => {
+    const result = detectDrift(
+      baseInput({
+        current: {
+          firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+          childGeneration: '1001',
+          childMetageneration: '1',
+          parentGeneration: '2001',
+          parentMetageneration: '1',
+        },
+      })
+    );
+    expect(result.kind).to.equal('childGenerationChanged');
+  });
+
+  it('phaseA.parentGeneration null + current.parentGeneration null (parent 不在) は no-drift 扱い', () => {
+    const result = detectDrift({
+      phaseA: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: null,
+        parentMetageneration: null,
+      },
+      current: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: null,
+        parentMetageneration: null,
+      },
+    });
+    expect(result.kind).to.equal('no-drift');
+  });
+
+  it('phaseA.parentGeneration null + current.parentGeneration あり (parent 新規発見) → parentGenerationChanged', () => {
+    const result = detectDrift({
+      phaseA: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: null,
+        parentMetageneration: null,
+      },
+      current: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: '2000',
+        parentMetageneration: '1',
+      },
+    });
+    expect(result.kind).to.equal('parentGenerationChanged');
+  });
+
+  it('phaseA.parentGeneration あり + current.parentGeneration null (parent 消失) → parentGenerationChanged', () => {
+    const result = detectDrift({
+      phaseA: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: '2000',
+        parentMetageneration: '1',
+      },
+      current: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: null,
+        parentMetageneration: null,
+      },
+    });
+    expect(result.kind).to.equal('parentGenerationChanged');
+  });
+
+  it('phaseA.childGeneration null + current.childGeneration あり → childGenerationChanged (orphan が埋まった)', () => {
+    const result = detectDrift({
+      phaseA: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: null,
+        childMetageneration: null,
+        parentGeneration: '2000',
+        parentMetageneration: '1',
+      },
+      current: {
+        firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+        childGeneration: '1000',
+        childMetageneration: '1',
+        parentGeneration: '2000',
+        parentMetageneration: '1',
+      },
+    });
+    expect(result.kind).to.equal('childGenerationChanged');
+  });
+});

--- a/functions/test/prD4ParentReSplitVerifier.test.ts
+++ b/functions/test/prD4ParentReSplitVerifier.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #445 PR-D4 S1-3: parentReSplitVerifier.ts (parent 再 download + 再 split + child sha256 一致確認).
+ *
+ * MatchedByHash 候補に対する Phase B 主要処理:
+ *   1. parent PDF download
+ *   2. parent bytes の sha256 計算 (= provenance.sourceSha256 canonical 値)
+ *   3. splitFromPages で page selection 再 split (scripts/lib/pdfRegenerator.ts 流用)
+ *   4. 再 split 結果の sha256 と現 child sha256 を比較
+ *
+ * 結果: parentSha256MatchedAtBackfill = true (一致) / false (不一致 = 別 bytes、本番 Phase C 書込対象外)
+ *
+ * 注意: pdf-lib の cross-process non-determinism は本 module では発生しない (parent + child
+ * を **同一プロセス内** で取得して比較するため)。ただし「現在 parent bytes」が「split 時点の
+ * parent bytes」と異なれば当然 mismatch となる (rotate 等で parent 自体が変化したケース)。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  verifyParentReSplit,
+  type ParentObjectDownloader,
+} from '../../scripts/pr-d4-backfill/phase-b/parentReSplitVerifier';
+import { PDFDocument } from 'pdf-lib';
+
+class FakeParentDownloader implements ParentObjectDownloader {
+  private bytesByPath: Record<string, Buffer | null>;
+  public downloadCalls: string[] = [];
+  constructor(bytesByPath: Record<string, Buffer | null>) {
+    this.bytesByPath = bytesByPath;
+  }
+  async download(path: string): Promise<{
+    bytes: Buffer;
+    generation: string;
+    metageneration: string;
+  } | null> {
+    this.downloadCalls.push(path);
+    if (!(path in this.bytesByPath)) return null;
+    const b = this.bytesByPath[path];
+    if (b === null) return null;
+    return { bytes: b, generation: 'pgen', metageneration: 'pmgen' };
+  }
+  async getMetadataOnly(path: string) {
+    if (!(path in this.bytesByPath)) return null;
+    const b = this.bytesByPath[path];
+    if (b === null) return null;
+    return { generation: 'pgen', metageneration: 'pmgen' };
+  }
+}
+
+function sha256Hex(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+async function makePdfBuffer(pageCount: number): Promise<Buffer> {
+  const pdf = await PDFDocument.create();
+  for (let i = 0; i < pageCount; i++) {
+    pdf.addPage([100, 100]);
+  }
+  const bytes = await pdf.save();
+  return Buffer.from(bytes);
+}
+
+describe('verifyParentReSplit (PR-D4 S1-3 parent 再 split 検証)', () => {
+  it('parent 不在 → exists=false (download 呼ばない)', async () => {
+    const downloader = new FakeParentDownloader({});
+    const result = await verifyParentReSplit({
+      parentObjectPath: null,
+      splitFromPages: { start: 1, end: 1 },
+      childBytes: Buffer.from('child'),
+      downloader,
+    });
+    expect(result.parentExists).to.equal(false);
+    expect(downloader.downloadCalls).to.have.length(0);
+  });
+
+  it('parent path あり + GCS 404 → exists=false', async () => {
+    const downloader = new FakeParentDownloader({ 'attachments/parent-1/source.pdf': null });
+    const result = await verifyParentReSplit({
+      parentObjectPath: 'attachments/parent-1/source.pdf',
+      splitFromPages: { start: 1, end: 1 },
+      childBytes: Buffer.from('child'),
+      downloader,
+    });
+    expect(result.parentExists).to.equal(false);
+  });
+
+  it('parent download 成功 + 再 split で child sha256 一致 → parentSha256MatchedAtBackfill=true', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    // 期待 child = parent から page 2 のみ抽出して再 split したもの
+    const parentPdf = await PDFDocument.load(parentBytes);
+    const childPdf = await PDFDocument.create();
+    const [copiedPage] = await childPdf.copyPages(parentPdf, [1]);
+    childPdf.addPage(copiedPage);
+    const expectedChildBytes = Buffer.from(await childPdf.save());
+
+    const downloader = new FakeParentDownloader({
+      'attachments/parent-1/source.pdf': parentBytes,
+    });
+    const result = await verifyParentReSplit({
+      parentObjectPath: 'attachments/parent-1/source.pdf',
+      splitFromPages: { start: 2, end: 2 },
+      childBytes: expectedChildBytes,
+      downloader,
+    });
+    expect(result.parentExists).to.equal(true);
+    if (result.parentExists) {
+      expect(result.parentSha256MatchedAtBackfill).to.equal(true);
+      expect(result.sourceSha256).to.equal(sha256Hex(parentBytes));
+      expect(result.sourceGeneration).to.equal('pgen');
+      expect(result.sourceMetageneration).to.equal('pmgen');
+    }
+  });
+
+  it('parent download 成功だが child bytes が再 split と不一致 → parentSha256MatchedAtBackfill=false', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const downloader = new FakeParentDownloader({
+      'attachments/parent-1/source.pdf': parentBytes,
+    });
+    const result = await verifyParentReSplit({
+      parentObjectPath: 'attachments/parent-1/source.pdf',
+      splitFromPages: { start: 1, end: 1 },
+      childBytes: Buffer.from('不一致 child bytes'),
+      downloader,
+    });
+    expect(result.parentExists).to.equal(true);
+    if (result.parentExists) {
+      expect(result.parentSha256MatchedAtBackfill).to.equal(false);
+      // sourceSha256 + sourceGeneration は parent 実体から取得済 (Phase C で記録される)
+      expect(result.sourceSha256).to.equal(sha256Hex(parentBytes));
+    }
+  });
+
+  it('splitFromPages.endPage が parent 総ページ数を超える → 再 split 不能 → parentExists=true, matched=false', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const downloader = new FakeParentDownloader({
+      'attachments/parent-1/source.pdf': parentBytes,
+    });
+    const result = await verifyParentReSplit({
+      parentObjectPath: 'attachments/parent-1/source.pdf',
+      splitFromPages: { start: 1, end: 99 }, // out of bounds
+      childBytes: Buffer.from('whatever'),
+      downloader,
+    });
+    expect(result.parentExists).to.equal(true);
+    if (result.parentExists) {
+      // out-of-bounds は再 split 失敗 → matched=false で記録
+      expect(result.parentSha256MatchedAtBackfill).to.equal(false);
+    }
+  });
+
+  it('parent PDF parse 失敗 (壊れた bytes) → parentExists=true, matched=false', async () => {
+    const downloader = new FakeParentDownloader({
+      'attachments/parent-1/source.pdf': Buffer.from('not a pdf'),
+    });
+    const result = await verifyParentReSplit({
+      parentObjectPath: 'attachments/parent-1/source.pdf',
+      splitFromPages: { start: 1, end: 1 },
+      childBytes: Buffer.from('whatever'),
+      downloader,
+    });
+    expect(result.parentExists).to.equal(true);
+    if (result.parentExists) {
+      expect(result.parentSha256MatchedAtBackfill).to.equal(false);
+    }
+  });
+
+  it('splitFromPages null → exists=true で matched=false (再 split 不能)', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const downloader = new FakeParentDownloader({
+      'attachments/parent-1/source.pdf': parentBytes,
+    });
+    const result = await verifyParentReSplit({
+      parentObjectPath: 'attachments/parent-1/source.pdf',
+      splitFromPages: null,
+      childBytes: Buffer.from('whatever'),
+      downloader,
+    });
+    expect(result.parentExists).to.equal(true);
+    if (result.parentExists) {
+      expect(result.parentSha256MatchedAtBackfill).to.equal(false);
+    }
+  });
+});

--- a/functions/test/prD4PhaseBArtifactWriter.test.ts
+++ b/functions/test/prD4PhaseBArtifactWriter.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Issue #445 PR-D4 S1-3: phase-b/artifactWriter.ts (writePhaseBChunk + finalizePhaseBArtifact).
+ *
+ * Phase A writer と類似構造で Phase B 専用 schema を扱う。manifest.json は Phase A の
+ * 内容を保持しつつ phaseB section を additive で追記する (caller 経由)。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  writePhaseBChunk,
+  finalizePhaseBArtifact,
+  type FinalizePhaseBInput,
+} from '../../scripts/pr-d4-backfill/phase-b/artifactWriter';
+import type {
+  ArtifactStorageWriter,
+} from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import type {
+  ArtifactChunkPointer,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+  BackfillManifest,
+} from '../../scripts/pr-d4-backfill/types';
+
+class FakeStorageWriter implements ArtifactStorageWriter {
+  public writes: { path: string; content: string; ifGenerationMatch: number | undefined }[] = [];
+  async writeJson(
+    path: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
+    this.writes.push({
+      path,
+      content,
+      ifGenerationMatch: precondition?.ifGenerationMatch,
+    });
+  }
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function makeCandidate(i: number): PhaseBRevalidatedCandidate {
+  return {
+    docId: `doc-${i}`,
+    category: 'MatchedByHash',
+    computedConfidence: 'derived-bytes-verified',
+    computedProvenance: {
+      sourceGeneration: `s${i}`,
+      sourceMetageneration: '1',
+      sourceSha256: 'a'.repeat(64),
+      sourcePath: `attachments/parent-${i}/source.pdf`,
+      sourceBucket: 'docsplit-dev.firebasestorage.app',
+      derivedObjectPath: `processed/doc-${i}/output.pdf`,
+      derivedGeneration: `d${i}`,
+      derivedMetageneration: '1',
+      derivedSha256: 'b'.repeat(64),
+      createdAt: '2026-04-01T00:00:00.000Z',
+    },
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+  };
+}
+
+const COMMON = {
+  bucketName: 'docsplit-dev-pr-d4-artifacts',
+  runId: '20260514T100000Z-dev-pr-d4-v1',
+};
+
+describe('writePhaseBChunk (PR-D4 S1-3 per-chunk flush)', () => {
+  it('1 chunk file を書込み ArtifactChunkPointer を返す', async () => {
+    const writer = new FakeStorageWriter();
+    const candidates = [makeCandidate(0), makeCandidate(1)];
+    const pointer = await writePhaseBChunk(
+      { ...COMMON, chunkIndex: 0, candidates },
+      writer
+    );
+    expect(writer.writes).to.have.length(1);
+    expect(writer.writes[0].path).to.equal(
+      'gs://docsplit-dev-pr-d4-artifacts/pr-d4-backfill-artifacts/20260514T100000Z-dev-pr-d4-v1/phase-b-revalidation-summary-chunk-0.json'
+    );
+    expect(pointer.sha256).to.equal(sha256Hex(writer.writes[0].content));
+    expect(pointer.docCount).to.equal(2);
+
+    const chunk = JSON.parse(writer.writes[0].content) as PhaseBRevalidatedChunk;
+    expect(chunk.chunkIndex).to.equal(0);
+    expect(chunk.revalidated).to.have.length(2);
+    expect(chunk.revalidated[0].docId).to.equal('doc-0');
+  });
+
+  it('chunkIndex は caller が連番管理', async () => {
+    const writer = new FakeStorageWriter();
+    await writePhaseBChunk(
+      { ...COMMON, chunkIndex: 7, candidates: [makeCandidate(0)] },
+      writer
+    );
+    expect(writer.writes[0].path).to.include('chunk-7.json');
+  });
+});
+
+describe('finalizePhaseBArtifact (PR-D4 S1-3 main + manifest update)', () => {
+  function buildInput(
+    chunkPointers: ArtifactChunkPointer[],
+    overrides: Partial<FinalizePhaseBInput> = {}
+  ): FinalizePhaseBInput {
+    return {
+      ...COMMON,
+      env: 'dev',
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+      revalidationCompletedAt: '2026-05-14T11:15:00.000Z',
+      phaseAArtifactRef: `gs://${COMMON.bucketName}/pr-d4-backfill-artifacts/${COMMON.runId}/phase-a-classify-summary.json`,
+      phaseAManifestSha256: 'a'.repeat(64),
+      candidatesIn: 6264,
+      candidatesOut: chunkPointers.reduce((a, c) => a + c.docCount, 0),
+      driftSkipped: {
+        firestoreUpdateTimeChanged: 12,
+        childGenerationChanged: 3,
+        parentGenerationChanged: 8,
+      },
+      verifyFailedMatchedByHash: 100,
+      skippedNonMatchedByHash: 1200,
+      chunks: chunkPointers,
+      existingManifest: {
+        schemaVersion: 'pr-d4-v1.0',
+        runId: COMMON.runId,
+        env: 'dev',
+        phaseA: {
+          mainArtifact: {
+            path: `gs://${COMMON.bucketName}/pr-d4-backfill-artifacts/${COMMON.runId}/phase-a-classify-summary.json`,
+            sha256: 'a'.repeat(64),
+          },
+          chunks: [],
+        },
+      },
+      manifestGeneration: 42,
+      ...overrides,
+    };
+  }
+
+  it('main + manifest (Phase A 保持 + phaseB 追記) を書込む', async () => {
+    const writer = new FakeStorageWriter();
+    const result = await finalizePhaseBArtifact(buildInput([]), writer);
+    expect(writer.writes).to.have.length(2);
+    expect(result.mainArtifactPath).to.match(/phase-b-revalidation-summary\.json$/);
+    expect(result.manifestPath).to.match(/manifest\.json$/);
+
+    const manifest = JSON.parse(
+      writer.writes.find((w) => w.path.endsWith('manifest.json'))!.content
+    ) as BackfillManifest;
+    expect(manifest.phaseA, 'phaseA preserved').to.exist;
+    expect(manifest.phaseB, 'phaseB added').to.exist;
+    expect(manifest.phaseB!.chunks).to.deep.equal([]);
+  });
+
+  it('main artifact に candidatesIn / candidatesOut / driftSkipped / phaseAArtifactRef が記録される', async () => {
+    const writer = new FakeStorageWriter();
+    const pointers: ArtifactChunkPointer[] = [
+      { path: 'gs://b/p/chunk-0.json', sha256: 'aa', docCount: 1000 },
+      { path: 'gs://b/p/chunk-1.json', sha256: 'bb', docCount: 500 },
+    ];
+    await finalizePhaseBArtifact(buildInput(pointers), writer);
+    const main = JSON.parse(
+      writer.writes.find((w) => w.path.endsWith('phase-b-revalidation-summary.json'))!.content
+    ) as PhaseBRevalidationSummary;
+    expect(main.phase).to.equal('B');
+    expect(main.candidatesIn).to.equal(6264);
+    expect(main.candidatesOut).to.equal(1500);
+    expect(main.driftSkipped.firestoreUpdateTimeChanged).to.equal(12);
+    expect(main.driftSkipped.childGenerationChanged).to.equal(3);
+    expect(main.driftSkipped.parentGenerationChanged).to.equal(8);
+    expect(main.verifyFailedMatchedByHash).to.equal(100);
+    expect(main.skippedNonMatchedByHash).to.equal(1200);
+    expect(main.phaseAArtifactRef).to.match(/phase-a-classify-summary\.json$/);
+    expect(main.phaseAManifestSha256).to.have.length(64);
+    expect(main.chunks).to.deep.equal(pointers);
+  });
+
+  it('manifest.phaseB.mainArtifact sha256 は実 main content の sha256 と一致', async () => {
+    const writer = new FakeStorageWriter();
+    await finalizePhaseBArtifact(buildInput([]), writer);
+    const mainContent = writer.writes.find((w) =>
+      w.path.endsWith('phase-b-revalidation-summary.json')
+    )!.content;
+    const manifestContent = writer.writes.find((w) => w.path.endsWith('manifest.json'))!.content;
+    const manifest = JSON.parse(manifestContent) as BackfillManifest;
+    expect(manifest.phaseB!.mainArtifact.sha256).to.equal(sha256Hex(mainContent));
+  });
+
+  it('書込順は main → manifest (consumer が manifest 読めれば main + 全 chunk 完了 invariant)', async () => {
+    const writer = new FakeStorageWriter();
+    await finalizePhaseBArtifact(buildInput([]), writer);
+    expect(writer.writes[0].path).to.match(/phase-b-revalidation-summary\.json$/);
+    expect(writer.writes[1].path).to.match(/manifest\.json$/);
+  });
+
+  it('manifest write は input.manifestGeneration を ifGenerationMatch として渡し CAS update (Codex S1-3 Critical)', async () => {
+    const writer = new FakeStorageWriter();
+    await finalizePhaseBArtifact(buildInput([], { manifestGeneration: 99 }), writer);
+    const mainWrite = writer.writes.find((w) =>
+      w.path.endsWith('phase-b-revalidation-summary.json')
+    )!;
+    const manifestWrite = writer.writes.find((w) => w.path.endsWith('manifest.json'))!;
+    // main は新規 (precondition なし → default 0)
+    expect(mainWrite.ifGenerationMatch).to.equal(undefined);
+    // manifest は既存 (Phase A が作成済) → 渡された generation を ifGenerationMatch に
+    expect(manifestWrite.ifGenerationMatch).to.equal(99);
+  });
+});

--- a/functions/test/prD4RevalidationOrchestrator.test.ts
+++ b/functions/test/prD4RevalidationOrchestrator.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Issue #445 PR-D4 S1-3: revalidationOrchestrator.ts (Phase B orchestrator).
+ *
+ * Phase A artifact streaming read → 各 candidate に drift 検出 + child revalidation +
+ * MatchedByHash の parent 再 split verify → 結果を per-chunk flush で Phase B artifact 書込。
+ *
+ * 検証観点:
+ *   - 非 MatchedByHash candidate は revalidation スキップ (skippedNonMatchedByHash++)
+ *   - drift 検出された MatchedByHash は driftSkipped に分類カウンタ加算
+ *   - MatchedByHash で drift なし + verify pass → derived-bytes-verified で revalidated に追加
+ *   - MatchedByHash で drift なし + verify fail → verifyFailedMatchedByHash++ (revalidated 追加なし)
+ *   - BF22 streaming flush (per-chunk buffer 上限 ≤ 1000)
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  runPhaseB,
+  type FirestoreReReader,
+  type RunPhaseBInput,
+} from '../../scripts/pr-d4-backfill/phase-b/revalidationOrchestrator';
+import type { ArtifactStorageReader } from '../../scripts/pr-d4-backfill/phase-b/artifactReader';
+import type {
+  ChildObjectDownloader,
+} from '../../scripts/pr-d4-backfill/phase-b/childRevalidator';
+import type {
+  ParentObjectDownloader,
+} from '../../scripts/pr-d4-backfill/phase-b/parentReSplitVerifier';
+import type {
+  ArtifactStorageWriter,
+  WrittenObject,
+} from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import type {
+  PhaseACandidate,
+  PhaseAClassifyChunk,
+  PhaseAClassifySummary,
+  BackfillManifest,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+} from '../../scripts/pr-d4-backfill/types';
+import { PDFDocument } from 'pdf-lib';
+
+function sha256Hex(input: string | Buffer): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+async function makePdfBuffer(pageCount: number): Promise<Buffer> {
+  const pdf = await PDFDocument.create();
+  for (let i = 0; i < pageCount; i++) pdf.addPage([100, 100]);
+  return Buffer.from(await pdf.save());
+}
+
+async function makeChildPdfFromParent(
+  parentBytes: Buffer,
+  start: number,
+  end: number
+): Promise<Buffer> {
+  const parent = await PDFDocument.load(parentBytes);
+  const child = await PDFDocument.create();
+  const indices = Array.from({ length: end - start + 1 }, (_, i) => start - 1 + i);
+  const pages = await child.copyPages(parent, indices);
+  pages.forEach((p) => child.addPage(p));
+  return Buffer.from(await child.save());
+}
+
+// --- In-memory storage (read + write) ---
+class InMemoryStorage implements ArtifactStorageReader, ArtifactStorageWriter {
+  public contents: Record<string, string> = {};
+  public generations: Record<string, number> = {};
+  public writes: WrittenObject[] = [];
+  async readJson(path: string): Promise<{ content: string; generation: number }> {
+    if (!(path in this.contents)) throw new Error(`not found: ${path}`);
+    return { content: this.contents[path], generation: this.generations[path] ?? 1 };
+  }
+  async writeJson(
+    path: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
+    // テスト用 CAS シミュレーション
+    const existing = this.generations[path] ?? 0;
+    const ifGen = precondition?.ifGenerationMatch ?? 0;
+    if (ifGen === 0 && existing !== 0) {
+      throw new Error(`412 PreconditionFailed: path=${path} expected new (gen=0), existing gen=${existing}`);
+    }
+    if (ifGen !== 0 && existing !== ifGen) {
+      throw new Error(`412 PreconditionFailed: path=${path} expected gen=${ifGen}, existing gen=${existing}`);
+    }
+    this.contents[path] = content;
+    this.generations[path] = existing + 1;
+    this.writes.push({ path, content });
+  }
+}
+
+// --- Firestore re-fetch fake ---
+class FakeFirestoreReReader implements FirestoreReReader {
+  private docs: Record<
+    string,
+    {
+      updateTimeIso: string;
+      createdAtIso: string;
+    } | null
+  >;
+  constructor(
+    docs: Record<string, { updateTimeIso: string; createdAtIso: string } | null>
+  ) {
+    this.docs = docs;
+  }
+  async fetchDoc(
+    docId: string
+  ): Promise<{ updateTimeIso: string; createdAtIso: string } | null> {
+    return docId in this.docs ? this.docs[docId] : null;
+  }
+}
+
+// --- Child downloader fake ---
+class FakeChildDownloader implements ChildObjectDownloader {
+  private bytesByPath: Record<string, Buffer>;
+  private metaByPath: Record<string, { generation: string; metageneration: string }>;
+  constructor(
+    bytesByPath: Record<string, Buffer>,
+    metaByPath: Record<string, { generation: string; metageneration: string }>
+  ) {
+    this.bytesByPath = bytesByPath;
+    this.metaByPath = metaByPath;
+  }
+  async download(path: string) {
+    if (!(path in this.bytesByPath)) return null;
+    return {
+      bytes: this.bytesByPath[path],
+      generation: this.metaByPath[path]?.generation ?? '1',
+      metageneration: this.metaByPath[path]?.metageneration ?? '1',
+    };
+  }
+}
+
+// --- Parent downloader fake (reuses child interface shape) ---
+class FakeParentDownloader implements ParentObjectDownloader {
+  private bytesByPath: Record<string, Buffer>;
+  private metaByPath: Record<string, { generation: string; metageneration: string }>;
+  public downloadCalls: string[] = [];
+  public metadataCalls: string[] = [];
+  constructor(
+    bytesByPath: Record<string, Buffer>,
+    metaByPath: Record<string, { generation: string; metageneration: string }>
+  ) {
+    this.bytesByPath = bytesByPath;
+    this.metaByPath = metaByPath;
+  }
+  async download(path: string) {
+    this.downloadCalls.push(path);
+    if (!(path in this.bytesByPath)) return null;
+    return {
+      bytes: this.bytesByPath[path],
+      generation: this.metaByPath[path]?.generation ?? '1',
+      metageneration: this.metaByPath[path]?.metageneration ?? '1',
+    };
+  }
+  async getMetadataOnly(path: string) {
+    this.metadataCalls.push(path);
+    if (!(path in this.metaByPath)) return null;
+    return this.metaByPath[path];
+  }
+}
+
+const BUCKET = 'docsplit-dev-pr-d4-artifacts';
+const PROD_BUCKET = 'docsplit-dev.firebasestorage.app';
+const RUN_ID = '20260514T100000Z-dev-pr-d4-v1';
+const PREFIX = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}`;
+
+function setupPhaseAArtifact(
+  storage: InMemoryStorage,
+  candidates: PhaseACandidate[]
+): void {
+  // 直接 contents に書込む際は generations も 1 に初期化 (writeJson 経由ではないので
+  // CAS 用 generation が立たないため、Phase B finalize の manifest update が 412 にならないよう手動設定)
+  function setContent(path: string, content: string): void {
+    storage.contents[path] = content;
+    storage.generations[path] = 1;
+  }
+  const chunkPath = `${PREFIX}/phase-a-classify-summary-chunk-0.json`;
+  const chunkBody: PhaseAClassifyChunk = {
+    schemaVersion: 'pr-d4-v1.0',
+    chunkIndex: 0,
+    candidates,
+  };
+  const chunkContent = JSON.stringify(chunkBody);
+  setContent(chunkPath, chunkContent);
+  const chunkPointer = {
+    path: chunkPath,
+    sha256: sha256Hex(chunkContent),
+    docCount: candidates.length,
+  };
+  const main: PhaseAClassifySummary = {
+    phase: 'A',
+    schemaVersion: 'pr-d4-v1.0',
+    scriptVersion: 'pr-d4-v1.0',
+    env: 'dev',
+    runId: RUN_ID,
+    snapshotStartedAt: '2026-05-14T10:00:00.000Z',
+    snapshotCompletedAt: '2026-05-14T10:00:10.000Z',
+    bucketLocation: 'asia-northeast1',
+    cloudRunJobLocation: 'asia-northeast1',
+    egressFreeAssertion: true,
+    totalDocs: candidates.length,
+    categoryDistribution: {
+      MatchedByHash: candidates.filter((c) => c.category === 'MatchedByHash').length,
+      RepairableMissingFile: candidates.filter((c) => c.category === 'RepairableMissingFile').length,
+      Ambiguous: candidates.filter((c) => c.category === 'Ambiguous').length,
+      LostOrUnrecoverable: candidates.filter((c) => c.category === 'LostOrUnrecoverable').length,
+      NeedsManualReview: candidates.filter((c) => c.category === 'NeedsManualReview').length,
+    },
+    alreadyBackfilled: 0,
+    verifiedExistingProvenance: 0,
+    chunks: [chunkPointer],
+  };
+  const mainPath = `${PREFIX}/phase-a-classify-summary.json`;
+  const mainContent = JSON.stringify(main);
+  setContent(mainPath, mainContent);
+  const manifestPath = `${PREFIX}/manifest.json`;
+  const manifest: BackfillManifest = {
+    schemaVersion: 'pr-d4-v1.0',
+    runId: RUN_ID,
+    env: 'dev',
+    phaseA: {
+      mainArtifact: { path: mainPath, sha256: sha256Hex(mainContent) },
+      chunks: [chunkPointer],
+    },
+  };
+  setContent(manifestPath, JSON.stringify(manifest));
+}
+
+function makePhaseACandidate(
+  i: number,
+  overrides: Partial<PhaseACandidate> = {}
+): PhaseACandidate {
+  return {
+    docId: `doc-${i}`,
+    category: 'MatchedByHash',
+    reason: 'structural-prediction',
+    firestoreUpdateTime: '2026-05-14T10:00:00.000Z',
+    childObjectPath: `processed/doc-${i}/output.pdf`,
+    childGeneration: `cg${i}`,
+    childMetageneration: '1',
+    parentDocId: `parent-${i}`,
+    parentObjectPath: `attachments/parent-${i}/source.pdf`,
+    parentGeneration: `pg${i}`,
+    parentMetageneration: '1',
+    splitFromPages: { start: 1, end: 1 },
+    ...overrides,
+  };
+}
+
+describe('runPhaseB (PR-D4 S1-3 revalidation orchestrator)', () => {
+  it('MatchedByHash + drift なし + verify pass → revalidated に derived-bytes-verified で追加', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const childBytes = await makeChildPdfFromParent(parentBytes, 1, 1);
+    const phaseACandidates: PhaseACandidate[] = [
+      makePhaseACandidate(1),
+    ];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({
+        'doc-1': {
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+          createdAtIso: '2026-04-01T00:00:00.000Z',
+        },
+      }),
+      childDownloader: new FakeChildDownloader(
+        { 'processed/doc-1/output.pdf': childBytes },
+        { 'processed/doc-1/output.pdf': { generation: 'cg1', metageneration: '1' } }
+      ),
+      parentDownloader: new FakeParentDownloader(
+        { 'attachments/parent-1/source.pdf': parentBytes },
+        { 'attachments/parent-1/source.pdf': { generation: 'pg1', metageneration: '1' } }
+      ),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+      nowProvider: () => '2026-05-14T11:00:01.000Z',
+    };
+    const result = await runPhaseB(input);
+    expect(result.candidatesIn).to.equal(1);
+    expect(result.candidatesOut).to.equal(1);
+    expect(result.verifyFailedMatchedByHash).to.equal(0);
+
+    const chunkContent = storage.writes.find((w) => w.path.includes('phase-b') && w.path.includes('chunk-0.json'))!.content;
+    const chunk = JSON.parse(chunkContent) as PhaseBRevalidatedChunk;
+    expect(chunk.revalidated).to.have.length(1);
+    expect(chunk.revalidated[0].docId).to.equal('doc-1');
+    expect(chunk.revalidated[0].computedConfidence).to.equal('derived-bytes-verified');
+    expect(chunk.revalidated[0].computedProvenance.derivedSha256).to.equal(sha256Hex(childBytes));
+    expect(chunk.revalidated[0].computedProvenance.sourceSha256).to.equal(sha256Hex(parentBytes));
+    expect(chunk.revalidated[0].computedProvenance.createdAt).to.equal('2026-04-01T00:00:00.000Z');
+    expect(chunk.revalidated[0].computedProvenance.sourceBucket).to.equal(PROD_BUCKET);
+    expect(chunk.revalidated[0].evidence.parentExists).to.equal(true);
+    expect(chunk.revalidated[0].evidence.parentSha256MatchedAtBackfill).to.equal(true);
+    expect(chunk.revalidated[0].evidence.childSha256ComputedAtBackfill).to.equal(true);
+  });
+
+  it('drift 検出 (Firestore updateTime 変化) → driftSkipped.firestoreUpdateTimeChanged++、revalidated 追加なし', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const childBytes = await makeChildPdfFromParent(parentBytes, 1, 1);
+    const phaseACandidates = [makePhaseACandidate(1)];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({
+        'doc-1': {
+          updateTimeIso: '2026-05-14T11:00:00.000Z', // drift
+          createdAtIso: '2026-04-01T00:00:00.000Z',
+        },
+      }),
+      childDownloader: new FakeChildDownloader(
+        { 'processed/doc-1/output.pdf': childBytes },
+        { 'processed/doc-1/output.pdf': { generation: 'cg1', metageneration: '1' } }
+      ),
+      parentDownloader: new FakeParentDownloader(
+        { 'attachments/parent-1/source.pdf': parentBytes },
+        { 'attachments/parent-1/source.pdf': { generation: 'pg1', metageneration: '1' } }
+      ),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+    };
+    const result = await runPhaseB(input);
+    expect(result.candidatesOut).to.equal(0);
+    expect(result.driftSkipped.firestoreUpdateTimeChanged).to.equal(1);
+    expect(result.driftSkipped.childGenerationChanged).to.equal(0);
+    expect(result.driftSkipped.parentGenerationChanged).to.equal(0);
+  });
+
+  it('MatchedByHash で verify fail (child bytes 不一致) → verifyFailedMatchedByHash++', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const wrongChild = Buffer.from('not matching content');
+    const phaseACandidates = [makePhaseACandidate(1)];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({
+        'doc-1': {
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+          createdAtIso: '2026-04-01T00:00:00.000Z',
+        },
+      }),
+      childDownloader: new FakeChildDownloader(
+        { 'processed/doc-1/output.pdf': wrongChild },
+        { 'processed/doc-1/output.pdf': { generation: 'cg1', metageneration: '1' } }
+      ),
+      parentDownloader: new FakeParentDownloader(
+        { 'attachments/parent-1/source.pdf': parentBytes },
+        { 'attachments/parent-1/source.pdf': { generation: 'pg1', metageneration: '1' } }
+      ),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+    };
+    const result = await runPhaseB(input);
+    expect(result.candidatesOut).to.equal(0);
+    expect(result.verifyFailedMatchedByHash).to.equal(1);
+  });
+
+  it('非 MatchedByHash candidate → skippedNonMatchedByHash++ (revalidation/parent download スキップ)', async () => {
+    let parentDownloads = 0;
+    class CountingParentDl implements ParentObjectDownloader {
+      async download() {
+        parentDownloads++;
+        return null;
+      }
+      async getMetadataOnly() {
+        return null;
+      }
+    }
+    const phaseACandidates: PhaseACandidate[] = [
+      makePhaseACandidate(1, { category: 'Ambiguous' }),
+      makePhaseACandidate(2, { category: 'RepairableMissingFile' }),
+      makePhaseACandidate(3, { category: 'LostOrUnrecoverable' }),
+      makePhaseACandidate(4, { category: 'NeedsManualReview' }),
+    ];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({}),
+      childDownloader: new FakeChildDownloader({}, {}),
+      parentDownloader: new CountingParentDl(),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+    };
+    const result = await runPhaseB(input);
+    expect(result.skippedNonMatchedByHash).to.equal(4);
+    expect(result.candidatesOut).to.equal(0);
+    expect(parentDownloads).to.equal(0);
+  });
+
+  it('main artifact に candidatesIn / candidatesOut / driftSkipped が記録される', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const childBytes = await makeChildPdfFromParent(parentBytes, 1, 1);
+    const phaseACandidates = [
+      makePhaseACandidate(1),
+      makePhaseACandidate(2, { category: 'Ambiguous' }),
+    ];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({
+        'doc-1': {
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+          createdAtIso: '2026-04-01T00:00:00.000Z',
+        },
+      }),
+      childDownloader: new FakeChildDownloader(
+        { 'processed/doc-1/output.pdf': childBytes },
+        { 'processed/doc-1/output.pdf': { generation: 'cg1', metageneration: '1' } }
+      ),
+      parentDownloader: new FakeParentDownloader(
+        { 'attachments/parent-1/source.pdf': parentBytes },
+        { 'attachments/parent-1/source.pdf': { generation: 'pg1', metageneration: '1' } }
+      ),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+      nowProvider: () => '2026-05-14T11:00:01.000Z',
+    };
+    await runPhaseB(input);
+    const mainContent = storage.writes.find((w) =>
+      w.path.endsWith('phase-b-revalidation-summary.json')
+    )!.content;
+    const main = JSON.parse(mainContent) as PhaseBRevalidationSummary;
+    expect(main.candidatesIn).to.equal(2);
+    expect(main.candidatesOut).to.equal(1);
+    expect(main.skippedNonMatchedByHash).to.equal(1);
+    expect(main.revalidationStartedAt).to.equal('2026-05-14T11:00:00.000Z');
+    expect(main.revalidationCompletedAt).to.equal('2026-05-14T11:00:01.000Z');
+  });
+
+  it('FirestoreReReader.fetchDoc が null (createdAt 不在 / doc 消失) → firestoreUpdateTimeChanged++ で除外', async () => {
+    const phaseACandidates = [makePhaseACandidate(1)];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({}), // doc-1 不在
+      childDownloader: new FakeChildDownloader({}, {}),
+      parentDownloader: new FakeParentDownloader({}, {}),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+    };
+    const result = await runPhaseB(input);
+    expect(result.candidatesOut).to.equal(0);
+    expect(result.driftSkipped.firestoreUpdateTimeChanged).to.equal(1);
+  });
+
+  it('child orphan (childObjectExists=false) なら parent download 呼ばずに verifyFailed カウンタ (cost 削減)', async () => {
+    let parentDownloadCalls = 0;
+    class CountingParentDl implements ParentObjectDownloader {
+      async download() {
+        parentDownloadCalls++;
+        return null;
+      }
+      async getMetadataOnly() {
+        return null;
+      }
+    }
+    const phaseACandidates = [makePhaseACandidate(1)];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({
+        'doc-1': {
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+          createdAtIso: '2026-04-01T00:00:00.000Z',
+        },
+      }),
+      childDownloader: new FakeChildDownloader({}, {}), // child 不在
+      parentDownloader: new CountingParentDl(),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+    };
+    const result = await runPhaseB(input);
+    expect(parentDownloadCalls).to.equal(0);
+    // child 不在 + Phase A は parent あり → parentGeneration drift で skip
+    expect(result.driftSkipped.childGenerationChanged + result.driftSkipped.parentGenerationChanged).to.equal(1);
+    expect(result.candidatesOut).to.equal(0);
+  });
+
+  it('manifest.phaseA は保持されつつ phaseB が additive 追記される', async () => {
+    const parentBytes = await makePdfBuffer(3);
+    const childBytes = await makeChildPdfFromParent(parentBytes, 1, 1);
+    const phaseACandidates = [makePhaseACandidate(1)];
+    const storage = new InMemoryStorage();
+    setupPhaseAArtifact(storage, phaseACandidates);
+    const input: RunPhaseBInput = {
+      env: 'dev',
+      runId: RUN_ID,
+      artifactBucketName: BUCKET,
+      manifestPath: `${PREFIX}/manifest.json`,
+      artifactReader: storage,
+      artifactWriter: storage,
+      firestoreReReader: new FakeFirestoreReReader({
+        'doc-1': {
+          updateTimeIso: '2026-05-14T10:00:00.000Z',
+          createdAtIso: '2026-04-01T00:00:00.000Z',
+        },
+      }),
+      childDownloader: new FakeChildDownloader(
+        { 'processed/doc-1/output.pdf': childBytes },
+        { 'processed/doc-1/output.pdf': { generation: 'cg1', metageneration: '1' } }
+      ),
+      parentDownloader: new FakeParentDownloader(
+        { 'attachments/parent-1/source.pdf': parentBytes },
+        { 'attachments/parent-1/source.pdf': { generation: 'pg1', metageneration: '1' } }
+      ),
+      productionDataBucketName: PROD_BUCKET,
+      revalidationStartedAt: '2026-05-14T11:00:00.000Z',
+    };
+    await runPhaseB(input);
+    const finalManifest = JSON.parse(
+      storage.contents[`${PREFIX}/manifest.json`]
+    ) as BackfillManifest;
+    expect(finalManifest.phaseA, 'phaseA preserved').to.exist;
+    expect(finalManifest.phaseB, 'phaseB added').to.exist;
+    expect(finalManifest.phaseA!.chunks).to.have.length(1);
+  });
+});

--- a/scripts/pr-d4-backfill/index.ts
+++ b/scripts/pr-d4-backfill/index.ts
@@ -27,6 +27,12 @@ import {
   GcsBucketProber,
   GcsArtifactStorageWriter,
 } from './phase-a/adapters';
+import { runPhaseB } from './phase-b/revalidationOrchestrator';
+import {
+  GcsArtifactReader,
+  GcsObjectDownloader,
+  FirestoreReReaderImpl,
+} from './phase-b/adapters';
 
 function readArg(name: string, defaultValue?: string): string | undefined {
   const idx = process.argv.indexOf(name);
@@ -62,8 +68,8 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const phase = readArg('--phase', 'A');
-  if (phase !== 'A') {
-    console.error(`FATAL: phase ${phase} not implemented in S1-2 (only Phase A is available)`);
+  if (phase !== 'A' && phase !== 'B') {
+    console.error(`FATAL: phase ${phase} not implemented (only Phase A / B are available in S1-3)`);
     process.exit(2);
   }
 
@@ -96,34 +102,69 @@ async function main(): Promise<void> {
   const productionBucketRef = admin.storage().bucket(productionBucket);
   const artifactBucketRef = admin.storage().bucket(artifactBucketName);
 
-  const snapshotStartedAt = new Date().toISOString();
-  const result = await runPhaseA({
-    env: envName,
-    runId,
-    productionDataBucketName: productionBucket,
-    artifactBucketName,
-    cloudRunLocation,
-    bucketLocation,
-    documentSource: new FirestoreDocumentSource(db),
-    parentFetcher: new FirestoreParentFetcher(db),
-    bucketProber: new GcsBucketProber(productionBucketRef),
-    artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
-    snapshotStartedAt,
-  });
+  if (phase === 'A') {
+    const snapshotStartedAt = new Date().toISOString();
+    const result = await runPhaseA({
+      env: envName,
+      runId,
+      productionDataBucketName: productionBucket,
+      artifactBucketName,
+      cloudRunLocation,
+      bucketLocation,
+      documentSource: new FirestoreDocumentSource(db),
+      parentFetcher: new FirestoreParentFetcher(db),
+      bucketProber: new GcsBucketProber(productionBucketRef),
+      artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
+      snapshotStartedAt,
+    });
 
-  console.log('\nPhase A complete:');
-  console.log(`  totalDocs: ${result.totalDocs}`);
-  console.log(`  alreadyBackfilled: ${result.alreadyBackfilled}`);
-  console.log(`  verifiedExistingProvenance: ${result.verifiedExistingProvenance}`);
-  console.log('  categoryDistribution:');
-  for (const [cat, count] of Object.entries(result.categoryDistribution)) {
-    console.log(`    ${cat}: ${count}`);
+    console.log('\nPhase A complete:');
+    console.log(`  totalDocs: ${result.totalDocs}`);
+    console.log(`  alreadyBackfilled: ${result.alreadyBackfilled}`);
+    console.log(`  verifiedExistingProvenance: ${result.verifiedExistingProvenance}`);
+    console.log('  categoryDistribution:');
+    for (const [cat, count] of Object.entries(result.categoryDistribution)) {
+      console.log(`    ${cat}: ${count}`);
+    }
+    console.log(`  chunkCount: ${result.chunkCount}`);
+    console.log(`  mainArtifact: ${result.mainArtifactPath}`);
+    console.log(`  manifest: ${result.manifestPath}`);
+    console.log(`  snapshotStartedAt: ${snapshotStartedAt}`);
+    console.log(`  snapshotCompletedAt: ${result.snapshotCompletedAt}`);
+  } else {
+    // Phase B: Phase A artifact 経由 manifest を読み revalidation 実施
+    const manifestPath = `gs://${artifactBucketName}/pr-d4-backfill-artifacts/${runId}/manifest.json`;
+    console.log(`\nPhase B starting with manifest: ${manifestPath}`);
+
+    const revalidationStartedAt = new Date().toISOString();
+    const result = await runPhaseB({
+      env: envName,
+      runId,
+      artifactBucketName,
+      manifestPath,
+      artifactReader: new GcsArtifactReader(artifactBucketRef),
+      artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
+      firestoreReReader: new FirestoreReReaderImpl(db),
+      childDownloader: new GcsObjectDownloader(productionBucketRef),
+      parentDownloader: new GcsObjectDownloader(productionBucketRef),
+      productionDataBucketName: productionBucket,
+      revalidationStartedAt,
+    });
+
+    console.log('\nPhase B complete:');
+    console.log(`  candidatesIn: ${result.candidatesIn}`);
+    console.log(`  candidatesOut: ${result.candidatesOut}`);
+    console.log(`  skippedNonMatchedByHash: ${result.skippedNonMatchedByHash}`);
+    console.log(`  verifyFailedMatchedByHash: ${result.verifyFailedMatchedByHash}`);
+    console.log('  driftSkipped:');
+    console.log(`    firestoreUpdateTimeChanged: ${result.driftSkipped.firestoreUpdateTimeChanged}`);
+    console.log(`    childGenerationChanged: ${result.driftSkipped.childGenerationChanged}`);
+    console.log(`    parentGenerationChanged: ${result.driftSkipped.parentGenerationChanged}`);
+    console.log(`  mainArtifact: ${result.mainArtifactPath}`);
+    console.log(`  manifest: ${result.manifestPath}`);
+    console.log(`  revalidationStartedAt: ${revalidationStartedAt}`);
+    console.log(`  revalidationCompletedAt: ${result.revalidationCompletedAt}`);
   }
-  console.log(`  chunkCount: ${result.chunkCount}`);
-  console.log(`  mainArtifact: ${result.mainArtifactPath}`);
-  console.log(`  manifest: ${result.manifestPath}`);
-  console.log(`  snapshotStartedAt: ${snapshotStartedAt}`);
-  console.log(`  snapshotCompletedAt: ${result.snapshotCompletedAt}`);
 }
 
 main().catch((err) => {

--- a/scripts/pr-d4-backfill/phase-a/adapters.ts
+++ b/scripts/pr-d4-backfill/phase-a/adapters.ts
@@ -158,7 +158,11 @@ export class GcsArtifactStorageWriter implements ArtifactStorageWriter {
     this.artifactBucket = artifactBucket;
   }
 
-  async writeJson(objectPath: string, content: string): Promise<void> {
+  async writeJson(
+    objectPath: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
     const match = objectPath.match(/^gs:\/\/([^/]+)\/(.+)$/);
     if (!match) {
       throw new Error(`invalid GCS object path (expected gs://bucket/path): ${objectPath}`);
@@ -169,14 +173,14 @@ export class GcsArtifactStorageWriter implements ArtifactStorageWriter {
         `artifact bucket mismatch: expected ${this.artifactBucket.name}, got ${bucketName} (path=${objectPath})`
       );
     }
-    // ifGenerationMatch: 0 で **既存 object の overwrite を拒否** する (Codex MCP Important 2 反映)。
-    // run-id 単位で artifact directory を分けているため、同一 run-id の re-run は
-    // 新 run-id を発行することを caller に強制する。これにより Phase B が「古い chunk +
-    // 新しい partial main」のような不整合 artifact を読む事故を構造的に閉鎖する。
+    // precondition 省略 → ifGenerationMatch: 0 (新規 only、Phase A 互換)。
+    // precondition 指定 → 渡された値で compare-and-swap (Phase B が manifest update する際に
+    //                     Phase A reader が取得した generation を渡す、Codex MCP S1-3 Critical 反映)
+    const ifGenerationMatch = precondition?.ifGenerationMatch ?? 0;
     await this.artifactBucket.file(path).save(content, {
       contentType: 'application/json',
       resumable: false,
-      preconditionOpts: { ifGenerationMatch: 0 },
+      preconditionOpts: { ifGenerationMatch },
       metadata: {
         cacheControl: 'no-store',
       },

--- a/scripts/pr-d4-backfill/phase-a/artifactWriter.ts
+++ b/scripts/pr-d4-backfill/phase-a/artifactWriter.ts
@@ -29,12 +29,25 @@ import {
 } from '../types';
 import type { BackfillClassifierCategory } from '../../../shared/types';
 
+/**
+ * `precondition.ifGenerationMatch`:
+ *   - 省略 → 既存 object 拒否 (`ifGenerationMatch: 0` 相当、Phase A 新規書込 default)
+ *   - `0` → 同じく既存 object 拒否
+ *   - `> 0` → compare-and-swap: 指定 generation と一致するときのみ overwrite、不一致は 412 fail
+ *
+ * Phase B が既存 manifest を update する際は Phase A reader が取得した generation を渡す
+ * (Codex MCP S1-3 Critical 反映)。
+ */
+export interface WriteJsonPrecondition {
+  ifGenerationMatch: number;
+}
+
 export interface ArtifactStorageWriter {
-  /**
-   * `gs://{bucket}/{path}` 形式の path に JSON 文字列を書込む。
-   * 実装側で必要に応じて Content-Type 設定 + ifGenerationMatch: 0 (overwrite 禁止) を強制。
-   */
-  writeJson(objectPath: string, content: string): Promise<void>;
+  writeJson(
+    objectPath: string,
+    content: string,
+    precondition?: WriteJsonPrecondition
+  ): Promise<void>;
 }
 
 /** test 側で書込履歴を assertion するための表現 */

--- a/scripts/pr-d4-backfill/phase-b/adapters.ts
+++ b/scripts/pr-d4-backfill/phase-b/adapters.ts
@@ -1,0 +1,136 @@
+/**
+ * Issue #445 PR-D4 S1-3: production concrete adapters for Phase B.
+ *
+ * - GcsArtifactReader: artifact bucket からの read 専用 (Phase A 出力を Phase B が読む)
+ * - GcsObjectDownloader: production bucket からの download + metadata (child + parent 共通)
+ * - FirestoreReReader: documents collection 再 fetch (updateTime + createdAt)
+ *
+ * unit test 対象外 (real SDK 接続のため)、dev rehearsal で動作検証。
+ */
+
+import * as admin from 'firebase-admin';
+import type { Bucket } from '@google-cloud/storage';
+import type { ArtifactStorageReader } from './artifactReader';
+import type { ChildObjectDownloader } from './childRevalidator';
+import type { ParentObjectDownloader } from './parentReSplitVerifier';
+import type { FirestoreReReader } from './revalidationOrchestrator';
+
+/**
+ * GCS bucket からの read (Phase B が Phase A artifact を消費)。
+ * `gs://{bucket}/{path}` 形式で受取り、bucket name が一致する artifact bucket からのみ
+ * 読み込む (configuration bug 検出)。
+ */
+export class GcsArtifactReader implements ArtifactStorageReader {
+  private artifactBucket: Bucket;
+
+  constructor(artifactBucket: Bucket) {
+    this.artifactBucket = artifactBucket;
+  }
+
+  async readJson(objectPath: string): Promise<{ content: string; generation: number }> {
+    const match = objectPath.match(/^gs:\/\/([^/]+)\/(.+)$/);
+    if (!match) {
+      throw new Error(`invalid GCS object path: ${objectPath}`);
+    }
+    const [, bucketName, path] = match;
+    if (bucketName !== this.artifactBucket.name) {
+      throw new Error(
+        `artifact bucket mismatch: expected ${this.artifactBucket.name}, got ${bucketName} (path=${objectPath})`
+      );
+    }
+    const file = this.artifactBucket.file(path);
+    const [contents] = await file.download();
+    const [metadata] = await file.getMetadata();
+    return {
+      content: contents.toString('utf8'),
+      generation: Number(metadata.generation ?? 0),
+    };
+  }
+}
+
+/**
+ * production bucket からの object download (bytes + metadata)。
+ * child / parent 両方の downloader interface を satisfies する (両者は型同一)。
+ */
+export class GcsObjectDownloader implements ChildObjectDownloader, ParentObjectDownloader {
+  private productionBucket: Bucket;
+
+  constructor(productionBucket: Bucket) {
+    this.productionBucket = productionBucket;
+  }
+
+  async download(
+    objectPath: string
+  ): Promise<{ bytes: Buffer; generation: string; metageneration: string } | null> {
+    try {
+      const file = this.productionBucket.file(objectPath);
+      const [bytes] = await file.download();
+      const [metadata] = await file.getMetadata();
+      return {
+        bytes,
+        generation: String(metadata.generation ?? ''),
+        metageneration: String(metadata.metageneration ?? ''),
+      };
+    } catch (err) {
+      const code = (err as { code?: number }).code;
+      if (code === 404) return null;
+      throw err;
+    }
+  }
+
+  async getMetadataOnly(
+    objectPath: string
+  ): Promise<{ generation: string; metageneration: string } | null> {
+    try {
+      const [metadata] = await this.productionBucket.file(objectPath).getMetadata();
+      return {
+        generation: String(metadata.generation ?? ''),
+        metageneration: String(metadata.metageneration ?? ''),
+      };
+    } catch (err) {
+      const code = (err as { code?: number }).code;
+      if (code === 404) return null;
+      throw err;
+    }
+  }
+}
+
+/**
+ * Firestore documents collection から doc を fetch し updateTime + createdAt を取得。
+ *
+ * ADR-0016 Critical 2 反映: provenance.createdAt = document.createdAt 由来 (split 完了時刻)。
+ * - doc 不在: null 返却 (orchestrator が firestoreUpdateTimeChanged 等に分類)
+ * - doc 存在だが createdAt 不在 / 不正型: null 返却 (silent epoch fallback 禁止)
+ * - doc 存在 + createdAt 正常: { updateTimeIso, createdAtIso } 返却
+ */
+export class FirestoreReReaderImpl implements FirestoreReReader {
+  private db: admin.firestore.Firestore;
+
+  constructor(db: admin.firestore.Firestore) {
+    this.db = db;
+  }
+
+  async fetchDoc(
+    docId: string
+  ): Promise<{ updateTimeIso: string; createdAtIso: string } | null> {
+    const docSnap = await this.db.collection('documents').doc(docId).get();
+    if (!docSnap.exists) return null;
+    const data = docSnap.data() ?? {};
+    const updateTime = docSnap.updateTime;
+    if (!updateTime) return null;
+    const updateTimeIso = updateTime.toDate().toISOString();
+
+    const createdAt = data.createdAt;
+    let createdAtIso: string | null = null;
+    if (createdAt && typeof createdAt === 'object' && 'toDate' in createdAt) {
+      createdAtIso = (createdAt as { toDate(): Date }).toDate().toISOString();
+    } else if (typeof createdAt === 'string' && createdAt.length > 0) {
+      createdAtIso = createdAt;
+    }
+    if (createdAtIso === null) {
+      // createdAt 不在 / 不正型 → null 返却で silent epoch fallback 禁止 (evaluator HIGH 1)
+      return null;
+    }
+    return { updateTimeIso, createdAtIso };
+  }
+}

--- a/scripts/pr-d4-backfill/phase-b/artifactReader.ts
+++ b/scripts/pr-d4-backfill/phase-b/artifactReader.ts
@@ -1,0 +1,122 @@
+/**
+ * Issue #445 PR-D4 S1-3: Phase A artifact streaming reader (BF22 反映).
+ *
+ * Phase B が Phase A 出力を消費する経路:
+ *   1. manifest.json 読込 → phaseA section から main path + sha256 取得
+ *   2. main artifact 読込 + sha256 verify (不一致 → ArtifactIntegrityError)
+ *   3. main.chunks 配列を順次 1 chunk ずつ stream read + sha256 verify + candidates yield
+ *
+ * caller (orchestrator) は AsyncIterable<PhaseACandidate> を for-await で消費し、
+ * 全 chunk を一括メモリロードしない (chunk 1 件 ≤ 1000 candidates が in-memory 上限)。
+ */
+
+import * as crypto from 'crypto';
+import type {
+  PhaseACandidate,
+  PhaseAClassifyChunk,
+  PhaseAClassifySummary,
+  BackfillManifest,
+} from '../types';
+
+export class ArtifactIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArtifactIntegrityError';
+  }
+}
+
+export interface ArtifactStorageReader {
+  /**
+   * `gs://{bucket}/{path}` 形式の path から content を読み、object generation も返す。
+   * generation は manifest update 時の compare-and-swap 用 (CAS で他者上書き検出)。
+   */
+  readJson(objectPath: string): Promise<{ content: string; generation: number }>;
+}
+
+export interface ReadPhaseAArtifactInput {
+  manifestPath: string;
+  reader: ArtifactStorageReader;
+}
+
+export interface PhaseAArtifactStream {
+  /** Phase A main artifact path (caller が後段 artifact に記録) */
+  phaseAArtifactRef: string;
+  /**
+   * Phase A main artifact 内容の sha256 (= manifest.phaseA.mainArtifact.sha256)。
+   * field 名は **Phase A main artifact の sha256** であり manifest 自体の sha256 ではない。
+   * caller (Phase B finalize) が後段 artifact `phaseAManifestSha256` field に記録する用途。
+   */
+  phaseAManifestSha256: string;
+  /** Phase A 候補件数 (chunks 配列の docCount 合計、streaming 開始前判明) */
+  candidatesIn: number;
+  /**
+   * Phase A 開始時点の manifest 全体 (caller が finalizePhaseBArtifact の existingManifest に
+   * そのまま渡せる)。orchestrator が manifest を二重 read することを避けるため reader が保持。
+   */
+  manifest: BackfillManifest;
+  /**
+   * manifest.json の GCS generation (Phase B finalize で compare-and-swap update 用)。
+   * Phase B 実行中に他者が manifest を上書きしていれば finalize 時に 412 fail。
+   */
+  manifestGeneration: number;
+  /** 全 candidate を順次 yield する AsyncIterable */
+  candidates(): AsyncIterable<PhaseACandidate>;
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * manifest → main → chunks を eager に initialize し stream object を返す。
+ * chunks 本体は AsyncIterable 内で 1 chunk ずつ stream read する (BF22 維持)。
+ */
+export async function readPhaseAArtifact(
+  input: ReadPhaseAArtifactInput
+): Promise<PhaseAArtifactStream> {
+  const manifestRead = await input.reader.readJson(input.manifestPath);
+  const manifest = JSON.parse(manifestRead.content) as BackfillManifest;
+  if (!manifest.phaseA) {
+    throw new Error(
+      `manifest.phaseA section absent (Phase A artifact not finalized): ${input.manifestPath}`
+    );
+  }
+  const phaseAArtifactRef = manifest.phaseA.mainArtifact.path;
+  const phaseAManifestSha256 = manifest.phaseA.mainArtifact.sha256;
+
+  const mainRead = await input.reader.readJson(phaseAArtifactRef);
+  const mainContent = mainRead.content;
+  const actualMainSha = sha256Hex(mainContent);
+  if (actualMainSha !== phaseAManifestSha256) {
+    throw new ArtifactIntegrityError(
+      `main artifact sha256 mismatch: expected ${phaseAManifestSha256}, got ${actualMainSha} (path=${phaseAArtifactRef})`
+    );
+  }
+  const main = JSON.parse(mainContent) as PhaseAClassifySummary;
+  const chunkPointers = main.chunks;
+  const candidatesIn = chunkPointers.reduce((acc, c) => acc + c.docCount, 0);
+
+  async function* streamCandidates(): AsyncIterable<PhaseACandidate> {
+    for (const pointer of chunkPointers) {
+      const chunkRead = await input.reader.readJson(pointer.path);
+      const chunkContent = chunkRead.content;
+      const actualSha = sha256Hex(chunkContent);
+      if (actualSha !== pointer.sha256) {
+        throw new ArtifactIntegrityError(
+          `chunk sha256 mismatch: expected ${pointer.sha256}, got ${actualSha} (path=${pointer.path})`
+        );
+      }
+      const chunk = JSON.parse(chunkContent) as PhaseAClassifyChunk;
+      for (const candidate of chunk.candidates) yield candidate;
+    }
+  }
+
+  return {
+    phaseAArtifactRef,
+    phaseAManifestSha256,
+    candidatesIn,
+    manifest,
+    manifestGeneration: manifestRead.generation,
+    candidates: streamCandidates,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-b/artifactWriter.ts
+++ b/scripts/pr-d4-backfill/phase-b/artifactWriter.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #445 PR-D4 S1-3: Phase B artifact writer (per-chunk flush + main + manifest 追記).
+ *
+ * 構造は Phase A writer と類似。Phase B 専用の schema を扱う。
+ * manifest.json は既存 Phase A 内容を保持しつつ phaseB section を additive で追記する
+ * (caller が existingManifest を渡し、本 module が phaseB section を上書き)。
+ *
+ * 書込順: chunks (orchestrator が per-chunk flush) → main → manifest。
+ */
+
+import * as crypto from 'crypto';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  BackfillManifest,
+  PhaseBDriftSkipped,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+} from '../types';
+import { PR_D4_ARTIFACT_SCHEMA_VERSION, PR_D4_SCRIPT_VERSION } from '../types';
+import type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+
+export type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+export type { WrittenObject } from '../phase-a/artifactWriter';
+
+export interface WritePhaseBChunkInput {
+  bucketName: string;
+  runId: string;
+  chunkIndex: number;
+  candidates: PhaseBRevalidatedCandidate[];
+}
+
+export interface FinalizePhaseBInput {
+  bucketName: string;
+  runId: string;
+  env: BackfillEnvName;
+  revalidationStartedAt: string;
+  revalidationCompletedAt: string;
+  phaseAArtifactRef: string;
+  phaseAManifestSha256: string;
+  candidatesIn: number;
+  candidatesOut: number;
+  driftSkipped: PhaseBDriftSkipped;
+  verifyFailedMatchedByHash: number;
+  skippedNonMatchedByHash: number;
+  chunks: ArtifactChunkPointer[];
+  /** Phase A 完了時点の manifest (Phase B が phaseB section を追記する) */
+  existingManifest: BackfillManifest;
+  /**
+   * Phase A manifest を read した時点の GCS generation。
+   * Phase B finalize で manifest を CAS update する際に precondition として渡す。
+   * 0 を指定すると新規 only (Phase A 互換)、>0 で他者上書き検出。
+   */
+  manifestGeneration: number;
+}
+
+export interface FinalizePhaseBResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function buildObjectPath(bucketName: string, runId: string, fileName: string): string {
+  return `gs://${bucketName}/pr-d4-backfill-artifacts/${runId}/${fileName}`;
+}
+
+export async function writePhaseBChunk(
+  input: WritePhaseBChunkInput,
+  writer: ArtifactStorageWriter
+): Promise<ArtifactChunkPointer> {
+  const chunkBody: PhaseBRevalidatedChunk = {
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    chunkIndex: input.chunkIndex,
+    revalidated: input.candidates,
+  };
+  const chunkContent = JSON.stringify(chunkBody);
+  const chunkPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    `phase-b-revalidation-summary-chunk-${input.chunkIndex}.json`
+  );
+  await writer.writeJson(chunkPath, chunkContent);
+  return {
+    path: chunkPath,
+    sha256: sha256Hex(chunkContent),
+    docCount: input.candidates.length,
+  };
+}
+
+export async function finalizePhaseBArtifact(
+  input: FinalizePhaseBInput,
+  writer: ArtifactStorageWriter
+): Promise<FinalizePhaseBResult> {
+  const mainBody: PhaseBRevalidationSummary = {
+    phase: 'B',
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    scriptVersion: PR_D4_SCRIPT_VERSION,
+    env: input.env,
+    runId: input.runId,
+    phaseAArtifactRef: input.phaseAArtifactRef,
+    phaseAManifestSha256: input.phaseAManifestSha256,
+    revalidationStartedAt: input.revalidationStartedAt,
+    revalidationCompletedAt: input.revalidationCompletedAt,
+    candidatesIn: input.candidatesIn,
+    candidatesOut: input.candidatesOut,
+    driftSkipped: input.driftSkipped,
+    verifyFailedMatchedByHash: input.verifyFailedMatchedByHash,
+    skippedNonMatchedByHash: input.skippedNonMatchedByHash,
+    chunks: input.chunks,
+  };
+  const mainContent = JSON.stringify(mainBody);
+  const mainPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    'phase-b-revalidation-summary.json'
+  );
+  await writer.writeJson(mainPath, mainContent);
+
+  // existingManifest を base に phaseB を追記 (Phase A の phaseA section は保持)
+  const updatedManifest: BackfillManifest = {
+    ...input.existingManifest,
+    phaseB: {
+      mainArtifact: { path: mainPath, sha256: sha256Hex(mainContent) },
+      chunks: input.chunks,
+    },
+  };
+  const manifestContent = JSON.stringify(updatedManifest);
+  const manifestPath = buildObjectPath(input.bucketName, input.runId, 'manifest.json');
+  // manifest は既存 (Phase A が作成済) なので compare-and-swap で update。
+  // Phase B 実行中に他者が manifest を書換えていれば 412 fail (artifact 整合性保証)。
+  await writer.writeJson(manifestPath, manifestContent, {
+    ifGenerationMatch: input.manifestGeneration,
+  });
+
+  return { mainArtifactPath: mainPath, manifestPath };
+}

--- a/scripts/pr-d4-backfill/phase-b/childRevalidator.ts
+++ b/scripts/pr-d4-backfill/phase-b/childRevalidator.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #445 PR-D4 S1-3: child object 現在 sha256 計算 + metadata 取得.
+ *
+ * Phase B では各 candidate の child object を **実 download** し sha256 を計算する
+ * (= provenance.derivedSha256 の canonical 値)。Phase A は HEAD のみで metadata
+ * 取得のみだったが、Phase B では Phase C 書込対象 doc に対し実 bytes 計算が必要。
+ *
+ * DI 化: ChildObjectDownloader interface で実 GCS download を抽象化。unit test は
+ * in-memory mock で実行する。
+ *
+ * 並行度制御 (impl-plan §4.2 rate limit): GCS download N=4 並行で開始 (Codex 2nd I3)。
+ * 本 module は 1 doc 単位、orchestrator が p-limit / Promise.all 等で並行 fan-out する。
+ */
+
+import * as crypto from 'crypto';
+
+export interface ChildObjectDownloader {
+  /**
+   * GCS から object download (HEAD + GET 同時)。
+   * - 存在: bytes + metadata
+   * - 不在: null
+   */
+  download(objectPath: string): Promise<{
+    bytes: Buffer;
+    generation: string;
+    metageneration: string;
+  } | null>;
+}
+
+export interface ChildRevalidationInput {
+  /** child Storage object path (gs:// prefix なし、bucket 共通)、null = orphan で download skip */
+  childObjectPath: string | null;
+  downloader: ChildObjectDownloader;
+}
+
+export type ChildRevalidationResult =
+  | { exists: false }
+  | {
+      exists: true;
+      bytes: Buffer;
+      derivedSha256: string;
+      derivedGeneration: string;
+      derivedMetageneration: string;
+    };
+
+function sha256HexLower(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+export async function revalidateChildObject(
+  input: ChildRevalidationInput
+): Promise<ChildRevalidationResult> {
+  if (input.childObjectPath === null) {
+    return { exists: false };
+  }
+  const downloaded = await input.downloader.download(input.childObjectPath);
+  if (downloaded === null) {
+    return { exists: false };
+  }
+  return {
+    exists: true,
+    bytes: downloaded.bytes,
+    derivedSha256: sha256HexLower(downloaded.bytes),
+    derivedGeneration: downloaded.generation,
+    derivedMetageneration: downloaded.metageneration,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-b/driftDetector.ts
+++ b/scripts/pr-d4-backfill/phase-b/driftDetector.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #445 PR-D4 S1-3: Phase B drift detector (pure function).
+ *
+ * impl-plan §4.2 step 3-4:
+ *   3. Firestore getDocument() で updateTime 取得し artifact 値と比較 → drift なら skip
+ *   4. GCS child.getMetadata() で generation/metageneration 取得し artifact 値と比較 → drift なら skip
+ *
+ * caller (orchestrator) が最新値を取得して本 pure function に渡す。drift 種別を返し、
+ * artifact に分類カウンタ (BF9) として記録する。
+ *
+ * drift 優先順位 (UI 表示と統計の一貫性):
+ *   1. firestoreUpdateTimeChanged: business doc 自体の変化 (status / fileName / 何でも)
+ *   2. childGenerationChanged: child Storage の変化 (rotate / replace 等)
+ *   3. parentGenerationChanged: parent Storage の変化
+ *
+ * MatchedByHash の re-split verify は parent generation drift 検出後にスキップする
+ * (parent が変わっているなら現 parent から再 split しても child との一致を期待できない)。
+ */
+
+export interface DriftSnapshot {
+  /** Firestore _updateTime を ISO8601 文字列化 */
+  firestoreUpdateTime: string;
+  /** child Storage object generation (null = object 不在) */
+  childGeneration: string | null;
+  childMetageneration: string | null;
+  /** parent Storage object generation (null = parent 不在 or parentDocumentId 未指定) */
+  parentGeneration: string | null;
+  parentMetageneration: string | null;
+}
+
+export interface DriftDetectionInput {
+  phaseA: DriftSnapshot;
+  current: DriftSnapshot;
+}
+
+export type DriftKind =
+  | 'no-drift'
+  | 'firestoreUpdateTimeChanged'
+  | 'childGenerationChanged'
+  | 'parentGenerationChanged';
+
+export interface DriftDetectionResult {
+  kind: DriftKind;
+}
+
+export function detectDrift(input: DriftDetectionInput): DriftDetectionResult {
+  const { phaseA, current } = input;
+
+  if (phaseA.firestoreUpdateTime !== current.firestoreUpdateTime) {
+    return { kind: 'firestoreUpdateTimeChanged' };
+  }
+  if (
+    phaseA.childGeneration !== current.childGeneration ||
+    phaseA.childMetageneration !== current.childMetageneration
+  ) {
+    return { kind: 'childGenerationChanged' };
+  }
+  if (
+    phaseA.parentGeneration !== current.parentGeneration ||
+    phaseA.parentMetageneration !== current.parentMetageneration
+  ) {
+    return { kind: 'parentGenerationChanged' };
+  }
+  return { kind: 'no-drift' };
+}

--- a/scripts/pr-d4-backfill/phase-b/parentReSplitVerifier.ts
+++ b/scripts/pr-d4-backfill/phase-b/parentReSplitVerifier.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #445 PR-D4 S1-3: parent PDF 再 download + 再 split + child sha256 一致確認.
+ *
+ * MatchedByHash 候補に対する Phase B 主要処理 (impl-plan §4.2 step 5):
+ *   1. parent PDF download (DI 化)
+ *   2. parent bytes sha256 計算 (= provenance.sourceSha256 canonical 値)
+ *   3. splitFromPages で page selection 再 split (scripts/lib/pdfRegenerator.ts 流用)
+ *   4. 再 split 結果の sha256 と現 child sha256 を比較
+ *
+ * 結果:
+ *   - parentExists=false: parent 不在 (HEAD null or parentObjectPath null)
+ *   - parentExists=true + parentSha256MatchedAtBackfill=true: 完全一致 (derived-bytes-verified 候補)
+ *   - parentExists=true + parentSha256MatchedAtBackfill=false: 不一致 (child-snapshot-only 相当、
+ *     本番 Phase C 書込対象外)
+ *
+ * 再 split が throw する経路 (out of bounds / 壊れた PDF) は exception 化せず
+ * matched=false で記録する (1 doc の問題が全 Phase B run を停止させない、graceful degrade)。
+ */
+
+import * as crypto from 'crypto';
+import { regenerateChildPdf } from '../../lib/pdfRegenerator';
+
+export interface ParentObjectDownloader {
+  download(objectPath: string): Promise<{
+    bytes: Buffer;
+    generation: string;
+    metageneration: string;
+  } | null>;
+  /**
+   * HEAD のみで metadata 取得 (drift 検出を bytes download より前に行う用途、Codex MCP Important 反映)。
+   * download() のコストを drift 検出後に遅延することで cross-region egress / 大規模 PDF 転送を回避。
+   */
+  getMetadataOnly(objectPath: string): Promise<{
+    generation: string;
+    metageneration: string;
+  } | null>;
+}
+
+export interface ParentReSplitInput {
+  /** gs:// prefix なし object path。null = parent 不在で download skip */
+  parentObjectPath: string | null;
+  splitFromPages: { start: number; end: number } | null;
+  /** Phase B が現在 download した child bytes (= 比較対象) */
+  childBytes: Buffer;
+  downloader: ParentObjectDownloader;
+}
+
+export type ParentReSplitResult =
+  | { parentExists: false }
+  | {
+      parentExists: true;
+      parentSha256MatchedAtBackfill: boolean;
+      sourceSha256: string;
+      sourceGeneration: string;
+      sourceMetageneration: string;
+    };
+
+function sha256HexLower(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+async function safeRegenerate(
+  parentBytes: Buffer,
+  splitFromPages: { start: number; end: number } | null
+): Promise<Buffer | null> {
+  if (splitFromPages === null) return null;
+  try {
+    return await regenerateChildPdf(parentBytes, splitFromPages.start, splitFromPages.end);
+  } catch {
+    return null;
+  }
+}
+
+export async function verifyParentReSplit(
+  input: ParentReSplitInput
+): Promise<ParentReSplitResult> {
+  if (input.parentObjectPath === null) {
+    return { parentExists: false };
+  }
+  const downloaded = await input.downloader.download(input.parentObjectPath);
+  if (downloaded === null) {
+    return { parentExists: false };
+  }
+
+  const sourceSha256 = sha256HexLower(downloaded.bytes);
+  const regenerated = await safeRegenerate(downloaded.bytes, input.splitFromPages);
+  const matched =
+    regenerated !== null &&
+    regenerated.equals(input.childBytes);
+
+  return {
+    parentExists: true,
+    parentSha256MatchedAtBackfill: matched,
+    sourceSha256,
+    sourceGeneration: downloaded.generation,
+    sourceMetageneration: downloaded.metageneration,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-b/revalidationOrchestrator.ts
+++ b/scripts/pr-d4-backfill/phase-b/revalidationOrchestrator.ts
@@ -1,0 +1,267 @@
+/**
+ * Issue #445 PR-D4 S1-3: Phase B orchestrator (write-free preflight revalidation).
+ *
+ * Phase A artifact streaming read → 各 candidate に drift 検出 + child revalidation +
+ * MatchedByHash の parent 再 split verify → 結果を per-chunk flush (BF22)。
+ *
+ * 処理フロー (impl-plan §4.2):
+ *   1. Phase A manifest 読込 + main artifact 整合性検証 (artifactReader.eager init)
+ *   2. 各 PhaseACandidate を AsyncIterable で streaming consume
+ *   3. category === 'MatchedByHash' 以外 → skippedNonMatchedByHash++ で continue
+ *   4. Firestore _updateTime 再 fetch (createdAt 取得を兼ねる)
+ *   5. child object download + sha256 計算 (revalidateChildObject)
+ *   6. drift 検出 (detectDrift)
+ *      - 検出 → driftSkipped 対応カウンタ++ で continue
+ *   7. parent download + 再 split + verify (verifyParentReSplit)
+ *      - parentSha256MatchedAtBackfill=false → verifyFailedMatchedByHash++ で continue
+ *      - parent 不在 → verifyFailedMatchedByHash++ で continue (本番 Phase C 対象外)
+ *   8. PhaseBRevalidatedCandidate を per-chunk buffer に追加、満杯時 flush
+ *   9. 全 candidate 処理後、残 buffer flush + finalize (main + manifest)
+ */
+
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  PhaseBDriftSkipped,
+  PhaseBRevalidatedCandidate,
+} from '../types';
+import { PR_D4_CANDIDATES_PER_CHUNK } from '../types';
+import {
+  readPhaseAArtifact,
+  type ArtifactStorageReader,
+} from './artifactReader';
+import { detectDrift } from './driftDetector';
+import {
+  revalidateChildObject,
+  type ChildObjectDownloader,
+} from './childRevalidator';
+import {
+  verifyParentReSplit,
+  type ParentObjectDownloader,
+} from './parentReSplitVerifier';
+import {
+  writePhaseBChunk,
+  finalizePhaseBArtifact,
+} from './artifactWriter';
+import type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+
+/**
+ * Firestore re-read: updateTime + createdAt を返す。createdAt は ADR Critical 2 反映で
+ * provenance.createdAt = document.createdAt 由来 (split 完了時刻) として記録する。
+ */
+export interface FirestoreReReader {
+  fetchDoc(
+    docId: string
+  ): Promise<{ updateTimeIso: string; createdAtIso: string } | null>;
+}
+
+export interface RunPhaseBInput {
+  env: BackfillEnvName;
+  runId: string;
+  /** artifact 保存 bucket (Phase A と同一 = manifest 共有) */
+  artifactBucketName: string;
+  /** Phase A manifest path */
+  manifestPath: string;
+  artifactReader: ArtifactStorageReader;
+  artifactWriter: ArtifactStorageWriter;
+  firestoreReReader: FirestoreReReader;
+  childDownloader: ChildObjectDownloader;
+  parentDownloader: ParentObjectDownloader;
+  /** production data bucket name (provenance.sourceBucket 記録用) */
+  productionDataBucketName: string;
+  revalidationStartedAt: string;
+  /** テスト用 clock (省略時 system clock) */
+  nowProvider?: () => string;
+}
+
+export interface RunPhaseBResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+  candidatesIn: number;
+  candidatesOut: number;
+  driftSkipped: PhaseBDriftSkipped;
+  verifyFailedMatchedByHash: number;
+  skippedNonMatchedByHash: number;
+  revalidationCompletedAt: string;
+}
+
+function initDriftSkipped(): PhaseBDriftSkipped {
+  return {
+    firestoreUpdateTimeChanged: 0,
+    childGenerationChanged: 0,
+    parentGenerationChanged: 0,
+  };
+}
+
+export async function runPhaseB(input: RunPhaseBInput): Promise<RunPhaseBResult> {
+  const stream = await readPhaseAArtifact({
+    manifestPath: input.manifestPath,
+    reader: input.artifactReader,
+  });
+  const existingManifest = stream.manifest;
+
+  let skippedNonMatchedByHash = 0;
+  let verifyFailedMatchedByHash = 0;
+  const driftSkipped = initDriftSkipped();
+  let candidatesIn = 0;
+  let candidatesOut = 0;
+
+  const chunkPointers: ArtifactChunkPointer[] = [];
+  let buffer: PhaseBRevalidatedCandidate[] = [];
+  let chunkIndex = 0;
+
+  async function flushBuffer(): Promise<void> {
+    if (buffer.length === 0) return;
+    const pointer = await writePhaseBChunk(
+      {
+        bucketName: input.artifactBucketName,
+        runId: input.runId,
+        chunkIndex,
+        candidates: buffer,
+      },
+      input.artifactWriter
+    );
+    chunkPointers.push(pointer);
+    chunkIndex++;
+    buffer = [];
+  }
+
+  for await (const candidate of stream.candidates()) {
+    candidatesIn++;
+
+    if (candidate.category !== 'MatchedByHash') {
+      skippedNonMatchedByHash++;
+      continue;
+    }
+
+    // Firestore re-fetch (updateTime + createdAt)。
+    // fsRead === null = doc 不在 or createdAt 不在 (silent epoch 防止、evaluator HIGH 1)
+    const fsRead = await input.firestoreReReader.fetchDoc(candidate.docId);
+    if (fsRead === null) {
+      driftSkipped.firestoreUpdateTimeChanged++;
+      continue;
+    }
+
+    // child revalidate (download + sha256)
+    const childResult = await revalidateChildObject({
+      childObjectPath: candidate.childObjectPath,
+      downloader: input.childDownloader,
+    });
+    const currentChildGeneration = childResult.exists ? childResult.derivedGeneration : null;
+    const currentChildMetageneration = childResult.exists ? childResult.derivedMetageneration : null;
+
+    // parent metadata HEAD のみ (drift 検出 → 不一致なら parent bytes download スキップ、Codex MCP Important 反映)
+    const parentMeta = candidate.parentObjectPath
+      ? await input.parentDownloader.getMetadataOnly(candidate.parentObjectPath)
+      : null;
+    const currentParentGeneration = parentMeta?.generation ?? null;
+    const currentParentMetageneration = parentMeta?.metageneration ?? null;
+
+    // drift 検出 (parent bytes download 前)
+    const drift = detectDrift({
+      phaseA: {
+        firestoreUpdateTime: candidate.firestoreUpdateTime,
+        childGeneration: candidate.childGeneration,
+        childMetageneration: candidate.childMetageneration,
+        parentGeneration: candidate.parentGeneration,
+        parentMetageneration: candidate.parentMetageneration,
+      },
+      current: {
+        firestoreUpdateTime: fsRead.updateTimeIso,
+        childGeneration: currentChildGeneration,
+        childMetageneration: currentChildMetageneration,
+        parentGeneration: currentParentGeneration,
+        parentMetageneration: currentParentMetageneration,
+      },
+    });
+
+    if (drift.kind !== 'no-drift') {
+      driftSkipped[drift.kind]++;
+      continue;
+    }
+
+    // child 不在 (orphan) は parent verify せず verifyFailed に分類
+    if (!childResult.exists) {
+      verifyFailedMatchedByHash++;
+      continue;
+    }
+
+    // drift なし + child 存在 → parent bytes download + re-split verify
+    const parentResult = await verifyParentReSplit({
+      parentObjectPath: candidate.parentObjectPath,
+      splitFromPages: candidate.splitFromPages,
+      childBytes: childResult.bytes,
+      downloader: input.parentDownloader,
+    });
+
+    if (!parentResult.parentExists || !parentResult.parentSha256MatchedAtBackfill) {
+      verifyFailedMatchedByHash++;
+      continue;
+    }
+
+    // MatchedByHash + drift なし + parent 再 split 一致 → derived-bytes-verified
+    const revalidated: PhaseBRevalidatedCandidate = {
+      docId: candidate.docId,
+      category: 'MatchedByHash',
+      computedConfidence: 'derived-bytes-verified',
+      computedProvenance: {
+        sourceGeneration: parentResult.sourceGeneration,
+        sourceMetageneration: parentResult.sourceMetageneration,
+        sourceSha256: parentResult.sourceSha256,
+        sourcePath: candidate.parentObjectPath!,
+        sourceBucket: input.productionDataBucketName,
+        derivedObjectPath: candidate.childObjectPath!,
+        derivedGeneration: childResult.derivedGeneration,
+        derivedMetageneration: childResult.derivedMetageneration,
+        derivedSha256: childResult.derivedSha256,
+        createdAt: fsRead.createdAtIso,
+      },
+      evidence: {
+        parentExists: true,
+        parentSha256MatchedAtBackfill: true,
+        childSha256ComputedAtBackfill: true,
+      },
+    };
+
+    buffer.push(revalidated);
+    candidatesOut++;
+    if (buffer.length >= PR_D4_CANDIDATES_PER_CHUNK) {
+      await flushBuffer();
+    }
+  }
+  await flushBuffer();
+
+  const revalidationCompletedAt = (input.nowProvider ?? (() => new Date().toISOString()))();
+
+  const finalizeResult = await finalizePhaseBArtifact(
+    {
+      bucketName: input.artifactBucketName,
+      runId: input.runId,
+      env: input.env,
+      revalidationStartedAt: input.revalidationStartedAt,
+      revalidationCompletedAt,
+      phaseAArtifactRef: stream.phaseAArtifactRef,
+      phaseAManifestSha256: stream.phaseAManifestSha256,
+      candidatesIn,
+      candidatesOut,
+      driftSkipped,
+      verifyFailedMatchedByHash,
+      skippedNonMatchedByHash,
+      chunks: chunkPointers,
+      existingManifest,
+      manifestGeneration: stream.manifestGeneration,
+    },
+    input.artifactWriter
+  );
+
+  return {
+    mainArtifactPath: finalizeResult.mainArtifactPath,
+    manifestPath: finalizeResult.manifestPath,
+    candidatesIn,
+    candidatesOut,
+    driftSkipped,
+    verifyFailedMatchedByHash,
+    skippedNonMatchedByHash,
+    revalidationCompletedAt,
+  };
+}

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -11,7 +11,7 @@
  * - BackfillClassifierCategory: shared/types.ts (PR-D4 S1-1 で確定済)
  */
 
-import type { BackfillClassifierCategory } from '../../shared/types';
+import type { BackfillClassifierCategory, BackfillConfidence } from '../../shared/types';
 
 /**
  * artifact schema version (script 改修時に bump)。Phase A/B/C/D で共通の prefix を持つ。
@@ -164,3 +164,102 @@ export interface BackfillManifest {
 
 /** chunk 1 件あたり最大件数 (impl-plan §4.1 BF19 / BF22 反映) */
 export const PR_D4_CANDIDATES_PER_CHUNK = 1000 as const;
+
+// ============================================================================
+// Phase B types (impl-plan §4.2)
+// ============================================================================
+
+/**
+ * Phase B drift skip 種別ごとのカウンタ (BF9 / impl-plan §4.2)。
+ *
+ * - `firestoreUpdateTimeChanged`: Phase A 取得後に Firestore doc が更新された (status 変化等)
+ * - `childGenerationChanged`: Phase A 取得後に child Storage object が更新された
+ *   (rotate / replace / delete-then-write 等)
+ * - `parentGenerationChanged`: Phase A 取得後に parent Storage object が更新された
+ *   (MatchedByHash の再 split 検証で parent も再照合するため検出される)
+ */
+export interface PhaseBDriftSkipped {
+  firestoreUpdateTimeChanged: number;
+  childGenerationChanged: number;
+  parentGenerationChanged: number;
+}
+
+/**
+ * Phase B revalidated 1 candidate (impl-plan §4.2 chunk 構造)。
+ *
+ * 設計判断:
+ * - 本 PR スコープでは **MatchedByHash かつ drift 無し かつ re-split verify 結果記録済**
+ *   のみが revalidated[] に入る。Phase C で `provenance` + `provenanceBackfill` 書込対象は
+ *   `computedConfidence === 'derived-bytes-verified'` 限定 (ADR MUST 7 + impl-plan §4.0)
+ * - `computedProvenance` は Phase C atomic batch に渡す 10 fields を完全構築済。caller は
+ *   `createBackfillProvenance()` factory にそのまま渡せる
+ * - `computedConfidence === 'derived-bytes-verified'`: re-split で sha256 一致確認済
+ * - `computedConfidence === 'child-snapshot-only'`: re-split で sha256 不一致 (dev fixture
+ *   テスト用、本番 Phase C は書込しない)
+ * - `evidence` は ProvenanceBackfillMetadata.evidence に詰込まれる runtime 整合性検証情報
+ */
+export interface PhaseBRevalidatedCandidate {
+  docId: string;
+  category: BackfillClassifierCategory;
+  computedConfidence: BackfillConfidence;
+  computedProvenance: {
+    sourceGeneration: string;
+    sourceMetageneration: string;
+    sourceSha256: string;
+    sourcePath: string;
+    sourceBucket: string;
+    derivedObjectPath: string;
+    derivedGeneration: string;
+    derivedMetageneration: string;
+    derivedSha256: string;
+    /** ISO8601 (= document.createdAt から取得した split 完了時刻、Phase C で Timestamp 化) */
+    createdAt: string;
+  };
+  evidence: {
+    parentExists: boolean;
+    parentSha256MatchedAtBackfill: boolean;
+    childSha256ComputedAtBackfill: boolean;
+  };
+}
+
+/**
+ * Phase B revalidated chunk (1 chunk ≤ PR_D4_CANDIDATES_PER_CHUNK 件)。
+ */
+export interface PhaseBRevalidatedChunk {
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  chunkIndex: number;
+  revalidated: PhaseBRevalidatedCandidate[];
+}
+
+/**
+ * Phase B main artifact 構造 (impl-plan §4.2)。
+ *
+ * 設計:
+ * - `candidatesIn`: Phase A artifact から streaming read した candidates 全件
+ *   (`PhaseAClassifySummary.totalDocs` ではなく Phase A revalidate 対象 = candidates 配列件数)
+ * - `candidatesOut`: revalidated[] に入った件数 = chunks の docCount 合計
+ * - `driftSkipped`: drift 検出された件数の内訳 (合計 = candidatesIn - candidatesOut - skipped 他)
+ * - `verifyFailedMatchedByHash`: MatchedByHash で drift 無しだが re-split verify 失敗した件数
+ *   (本番 Phase C 書込対象外)
+ * - `skippedNonMatchedByHash`: Phase A で MatchedByHash 以外の category だった件数
+ *   (Phase B では re-split しない、本番 Phase C 書込対象外)
+ * - `phaseAArtifactRef`: Phase A main artifact path (consumer が manifest chain を再構成可能)
+ * - `phaseAManifestSha256`: Phase B 起動時に検証した manifest sha256 (Phase A → B 連携の整合性)
+ */
+export interface PhaseBRevalidationSummary {
+  phase: 'B';
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  scriptVersion: PrD4ScriptVersion;
+  env: BackfillEnvName;
+  runId: string;
+  phaseAArtifactRef: string;
+  phaseAManifestSha256: string;
+  revalidationStartedAt: string;
+  revalidationCompletedAt: string;
+  candidatesIn: number;
+  candidatesOut: number;
+  driftSkipped: PhaseBDriftSkipped;
+  verifyFailedMatchedByHash: number;
+  skippedNonMatchedByHash: number;
+  chunks: ArtifactChunkPointer[];
+}


### PR DESCRIPTION
## Summary

- Issue #445 PR-D4 S1-3: Phase B 実装 (write-free preflight revalidation)
- Phase A artifact streaming read → 各 MatchedByHash 候補に drift 検出 + child download + sha256 計算 + parent download + 再 split + child sha256 一致確認
- derived-bytes-verified のみ revalidated[] に追加 → Phase B artifact (main + chunks + manifest 追記) を GCS 書込
- production Firestore / production GCS への write なし (write-free invariant 確認済)

## 構造

| Layer | File | 役割 |
|-------|------|------|
| Types | scripts/pr-d4-backfill/types.ts | Phase B schemas 追加 |
| Reader | phase-b/artifactReader.ts | Phase A artifact streaming + sha256 verify + manifest generation 取得 |
| Detector | phase-b/driftDetector.ts | pure function (3 種 drift 分類) |
| Child | phase-b/childRevalidator.ts | child download + sha256 計算 |
| Parent | phase-b/parentReSplitVerifier.ts | parent download + 再 split + 一致確認 |
| Writer | phase-b/artifactWriter.ts | per-chunk flush + main + **manifest CAS update** |
| Orchestrator | phase-b/revalidationOrchestrator.ts | BF22 per-chunk buffer + drift 先行 + bytes download 遅延 |
| Adapters | phase-b/adapters.ts | Firebase admin SDK + GCS wrapper (getMetadataOnly 追加) |
| Tests | functions/test/prD4{ArtifactReader,DriftDetector,ChildRevalidator,ParentReSplitVerifier,PhaseBArtifactWriter,RevalidationOrchestrator}.test.ts | 47 tests |

Phase A 側:
- phase-a/artifactWriter.ts + adapters.ts: ArtifactStorageWriter に optional `precondition.ifGenerationMatch` 追加 (Phase B が CAS update できるよう interface 拡張)
- index.ts: --phase B 対応

## Acceptance Criteria (impl-plan v3.1 §5)

- **BF9** drift 検出 doc が driftSkipped に記録 + Phase C 入力候補から除外: ✅ PASS
- **BF22** chunked streaming (writer + reader 両方): ✅ PASS
- **ADR-0016 Critical 2** (createdAt = document.createdAt、Timestamp.now() 不使用): ✅ PASS — adapters.fetchDoc が createdAt 不在時 null 返却で silent epoch fallback を構造的に閉鎖
- **impl-plan §4.2 step 5** MatchedByHash のみ parent 再 split + child sha256 一致確認: ✅ PASS

## Quality Gate

- **TDD**: 47 new unit tests (artifactReader 8 / driftDetector 12 / childRevalidator 5 / parentReSplitVerifier 7 / phaseBArtifactWriter 7 / revalidationOrchestrator 8)
- **evaluator**: REQUEST_CHANGES → HIGH 1 件 (createdAt epoch fallback) を反映で APPROVE 相当
- **pr-review-toolkit:code-reviewer**: HIGH 3 件 (createdAt + manifest 二重 read + Phase C 型整合 JSDoc 明文化) を反映
- **Codex MCP review**: 1st NO-GO → 2nd GO
  - **Critical**: manifest 既存 + ifGenerationMatch:0 で 412 fail → reader が manifest generation を返し writer が CAS update する経路に refactor
  - **Important**: parent bytes download が drift 検出より先 → ParentObjectDownloader に `getMetadataOnly` 追加し orchestrator を `drift → bytes download` の順に refactor
- **全テスト**: 1245 passing (新規 47 + 既存 1198)、scripts/functions/frontend tsc clean

## Test plan

- [x] \`cd functions && npm test\` 全 1245 passing 確認
- [x] \`cd functions && npm run type-check:test\` clean
- [x] \`npx tsc -p scripts/tsconfig.json --noEmit\` clean
- [x] \`cd frontend && npm run typecheck\` clean (shared/types.ts 影響なし)
- [ ] dev rehearsal (S2 stage): Cloud Run Job 実行で実 Firestore + GCS 接続検証 (本 PR スコープ外、後続 PR)

## 次セッション (S1-4)

Phase C (atomic backfill verified docs) 実装。Phase B artifact streaming read + GCS sentinel object 排他 lock + atomic batch で provenance 10 fields + provenanceBackfill metadata を書込 + batch precondition failure doc 単位隔離 + global write rate limiter。

Refs #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)