### PR TITLE
feat(pr-d4): PR-D4 S1-4 — Phase C atomic backfill (#445)

### DIFF
--- a/functions/test/prD4PhaseCArtifactWriter.test.ts
+++ b/functions/test/prD4PhaseCArtifactWriter.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C artifactWriter (BF22) テスト.
+ *
+ * chunk 書込 (≤1000 docs/chunk) + main artifact + manifest CAS update の挙動検証。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  finalizePhaseCArtifact,
+  writePhaseCChunk,
+  type ArtifactStorageWriter,
+} from '../../scripts/pr-d4-backfill/phase-c/artifactWriter';
+import type {
+  BackfillManifest,
+  PhaseCBackfillChunk,
+  PhaseCBackfillSummary,
+  PhaseCImmutableSkippedDoc,
+  PhaseCPreconditionFailedDoc,
+  PhaseCWrittenDoc,
+} from '../../scripts/pr-d4-backfill/types';
+
+interface WrittenObject {
+  path: string;
+  content: string;
+  precondition?: { ifGenerationMatch: number };
+}
+
+class FakeArtifactWriter implements ArtifactStorageWriter {
+  public objects: WrittenObject[] = [];
+  async writeJson(
+    objectPath: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
+    this.objects.push({ path: objectPath, content, precondition });
+  }
+}
+
+function sha256Hex(s: string): string {
+  return crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+}
+
+const RUN_ID = '20260515T000000Z-dev-pr-d4-v1';
+const BUCKET = 'docsplit-dev-pr-d4-artifacts';
+
+describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
+  describe('writePhaseCChunk', () => {
+    it('chunk 構造を schemaVersion + chunkIndex 付きで JSON 化し sha256 / docCount 返却', async () => {
+      const writer = new FakeArtifactWriter();
+      const writtenDocs: PhaseCWrittenDoc[] = [
+        {
+          docId: 'd1',
+          writeStatus: 'ok',
+          newProvenanceBackfillSha256: 'a'.repeat(64),
+          lastUpdateTimeAfter: '2026-05-15T01:00:00.000Z',
+        },
+      ];
+      const preconditionFailedDocs: PhaseCPreconditionFailedDoc[] = [
+        { docId: 'd2', reason: 'lastUpdateTime drift', retryCount: 3 },
+      ];
+      const immutableSkippedDocs: PhaseCImmutableSkippedDoc[] = [
+        { docId: 'd3', reason: 'provenance exists, provenanceBackfill absent' },
+      ];
+
+      const pointer = await writePhaseCChunk(
+        {
+          bucketName: BUCKET,
+          runId: RUN_ID,
+          chunkIndex: 0,
+          writtenDocs,
+          preconditionFailedDocs,
+          immutableSkippedDocs,
+        },
+        writer
+      );
+
+      expect(writer.objects).to.have.length(1);
+      expect(writer.objects[0].path).to.equal(
+        `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-backfill-summary-chunk-0.json`
+      );
+      const parsed: PhaseCBackfillChunk = JSON.parse(writer.objects[0].content);
+      expect(parsed.schemaVersion).to.equal('pr-d4-v1.0');
+      expect(parsed.chunkIndex).to.equal(0);
+      expect(parsed.writtenDocs).to.have.length(1);
+      expect(parsed.preconditionFailedDocs).to.have.length(1);
+      expect(parsed.immutableSkippedDocs).to.have.length(1);
+
+      expect(pointer.path).to.equal(writer.objects[0].path);
+      expect(pointer.sha256).to.equal(sha256Hex(writer.objects[0].content));
+      expect(pointer.docCount).to.equal(1); // writtenDocs.length
+    });
+
+    it('docCount = writtenDocs.length のみ (precondition/skip は含めない)', async () => {
+      const writer = new FakeArtifactWriter();
+      const pointer = await writePhaseCChunk(
+        {
+          bucketName: BUCKET,
+          runId: RUN_ID,
+          chunkIndex: 5,
+          writtenDocs: [],
+          preconditionFailedDocs: [
+            { docId: 'x', reason: 'lastUpdateTime drift', retryCount: 1 },
+            { docId: 'y', reason: 'transient retry exhausted', retryCount: 3 },
+          ],
+          immutableSkippedDocs: [
+            { docId: 'z', reason: 'provenance exists, provenanceBackfill absent' },
+          ],
+        },
+        writer
+      );
+      expect(pointer.docCount).to.equal(0);
+    });
+  });
+
+  describe('finalizePhaseCArtifact (main + manifest CAS)', () => {
+    it('main artifact が PhaseCBackfillSummary schema を満たし、書込後に manifest を ifGenerationMatch 付きで CAS update', async () => {
+      const writer = new FakeArtifactWriter();
+      const existingManifest: BackfillManifest = {
+        schemaVersion: 'pr-d4-v1.0',
+        runId: RUN_ID,
+        env: 'dev',
+        phaseA: {
+          mainArtifact: { path: 'gs://x/phase-a-classify-summary.json', sha256: 'aaa' },
+          chunks: [],
+        },
+        phaseB: {
+          mainArtifact: { path: 'gs://x/phase-b-revalidation-summary.json', sha256: 'bbb' },
+          chunks: [],
+        },
+      };
+
+      const result = await finalizePhaseCArtifact(
+        {
+          bucketName: BUCKET,
+          runId: RUN_ID,
+          env: 'dev',
+          backfillStartedAt: '2026-05-15T00:00:00.000Z',
+          backfillCompletedAt: '2026-05-15T00:30:00.000Z',
+          phaseBArtifactRef: 'gs://x/phase-b-revalidation-summary.json',
+          phaseBManifestSha256: 'phase-b-manifest-sha',
+          candidatesIn: 100,
+          writtenDocs: 98,
+          preconditionFailedDocs: 1,
+          skippedImmutable: 1,
+          lockAcquiredGeneration: '12345',
+          lockReleasedAt: '2026-05-15T00:30:01.000Z',
+          rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },
+          chunks: [
+            {
+              path: `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-backfill-summary-chunk-0.json`,
+              sha256: 'c'.repeat(64),
+              docCount: 98,
+            },
+          ],
+          existingManifest,
+          manifestGeneration: 7,
+        },
+        writer
+      );
+
+      expect(writer.objects).to.have.length(2);
+
+      // 1 つ目: main artifact (precondition なし)
+      const mainObj = writer.objects[0];
+      expect(mainObj.path).to.equal(result.mainArtifactPath);
+      expect(mainObj.precondition).to.be.undefined;
+      const mainBody: PhaseCBackfillSummary = JSON.parse(mainObj.content);
+      expect(mainBody.phase).to.equal('C');
+      expect(mainBody.schemaVersion).to.equal('pr-d4-v1.0');
+      expect(mainBody.env).to.equal('dev');
+      expect(mainBody.candidatesIn).to.equal(100);
+      expect(mainBody.writtenDocs).to.equal(98);
+      expect(mainBody.preconditionFailedDocs).to.equal(1);
+      expect(mainBody.skippedImmutable).to.equal(1);
+      expect(mainBody.lockAcquiredGeneration).to.equal('12345');
+      expect(mainBody.chunks).to.have.length(1);
+      expect(mainBody.rateLimiterConfig).to.deep.equal({
+        tokensPerSecond: 100,
+        burstCapacity: 100,
+      });
+
+      // 2 つ目: manifest (precondition 付き、phaseA/B は保持 + phaseC 追記)
+      const manifestObj = writer.objects[1];
+      expect(manifestObj.path).to.equal(result.manifestPath);
+      expect(manifestObj.precondition).to.deep.equal({ ifGenerationMatch: 7 });
+      const manifestBody: BackfillManifest = JSON.parse(manifestObj.content);
+      expect(manifestBody.phaseA).to.deep.equal(existingManifest.phaseA);
+      expect(manifestBody.phaseB).to.deep.equal(existingManifest.phaseB);
+      expect(manifestBody.phaseC).to.exist;
+      expect(manifestBody.phaseC!.mainArtifact.path).to.equal(result.mainArtifactPath);
+      expect(manifestBody.phaseC!.mainArtifact.sha256).to.equal(sha256Hex(mainObj.content));
+      expect(manifestBody.phaseC!.chunks).to.have.length(1);
+    });
+
+    it('manifestGeneration=0 → 新規 only precondition (race detect for first writer)', async () => {
+      const writer = new FakeArtifactWriter();
+      await finalizePhaseCArtifact(
+        {
+          bucketName: BUCKET,
+          runId: RUN_ID,
+          env: 'dev',
+          backfillStartedAt: '2026-05-15T00:00:00.000Z',
+          backfillCompletedAt: '2026-05-15T00:30:00.000Z',
+          phaseBArtifactRef: 'gs://x/phase-b.json',
+          phaseBManifestSha256: 'bbb',
+          candidatesIn: 0,
+          writtenDocs: 0,
+          preconditionFailedDocs: 0,
+          skippedImmutable: 0,
+          lockAcquiredGeneration: '1',
+          lockReleasedAt: '2026-05-15T00:30:01.000Z',
+          rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },
+          chunks: [],
+          existingManifest: {
+            schemaVersion: 'pr-d4-v1.0',
+            runId: RUN_ID,
+            env: 'dev',
+          },
+          manifestGeneration: 0,
+        },
+        writer
+      );
+      expect(writer.objects[1].precondition).to.deep.equal({ ifGenerationMatch: 0 });
+    });
+  });
+});

--- a/functions/test/prD4PhaseCArtifactWriter.test.ts
+++ b/functions/test/prD4PhaseCArtifactWriter.test.ts
@@ -16,7 +16,9 @@ import type {
   PhaseCBackfillChunk,
   PhaseCBackfillSummary,
   PhaseCImmutableSkippedDoc,
+  PhaseCOutOfScopeDoc,
   PhaseCPreconditionFailedDoc,
+  PhaseCUnprocessableDoc,
   PhaseCWrittenDoc,
 } from '../../scripts/pr-d4-backfill/types';
 
@@ -62,6 +64,17 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
       const immutableSkippedDocs: PhaseCImmutableSkippedDoc[] = [
         { docId: 'd3', reason: 'provenance exists, provenanceBackfill absent' },
       ];
+      const unprocessableDocs: PhaseCUnprocessableDoc[] = [
+        { docId: 'd4', reason: 'missing' },
+      ];
+      const outOfScopeDocs: PhaseCOutOfScopeDoc[] = [
+        {
+          docId: 'd5',
+          reason: 'confidence not derived-bytes-verified',
+          observedCategory: 'MatchedByHash',
+          observedConfidence: 'child-snapshot-only',
+        },
+      ];
 
       const pointer = await writePhaseCChunk(
         {
@@ -71,6 +84,8 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
           writtenDocs,
           preconditionFailedDocs,
           immutableSkippedDocs,
+          unprocessableDocs,
+          outOfScopeDocs,
         },
         writer
       );
@@ -85,13 +100,16 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
       expect(parsed.writtenDocs).to.have.length(1);
       expect(parsed.preconditionFailedDocs).to.have.length(1);
       expect(parsed.immutableSkippedDocs).to.have.length(1);
+      expect(parsed.unprocessableDocs).to.have.length(1);
+      expect(parsed.outOfScopeDocs).to.have.length(1);
 
       expect(pointer.path).to.equal(writer.objects[0].path);
       expect(pointer.sha256).to.equal(sha256Hex(writer.objects[0].content));
-      expect(pointer.docCount).to.equal(1); // writtenDocs.length
+      // Codex 5th I3 反映: docCount は全カテゴリ合計 (BF22 artifact 完全性)
+      expect(pointer.docCount).to.equal(5);
     });
 
-    it('docCount = writtenDocs.length のみ (precondition/skip は含めない)', async () => {
+    it('docCount = 全カテゴリ合計 (Codex 5th I3、writtenDocs だけでなく precondition/skip/unprocessable/outOfScope も含める)', async () => {
       const writer = new FakeArtifactWriter();
       const pointer = await writePhaseCChunk(
         {
@@ -106,10 +124,15 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
           immutableSkippedDocs: [
             { docId: 'z', reason: 'provenance exists, provenanceBackfill absent' },
           ],
+          unprocessableDocs: [
+            { docId: 'u1', reason: 'missing' },
+            { docId: 'u2', reason: 'validation', message: 'invalid sha256' },
+          ],
+          outOfScopeDocs: [],
         },
         writer
       );
-      expect(pointer.docCount).to.equal(0);
+      expect(pointer.docCount).to.equal(5);
     });
   });
 
@@ -140,9 +163,11 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
           phaseBArtifactRef: 'gs://x/phase-b-revalidation-summary.json',
           phaseBManifestSha256: 'phase-b-manifest-sha',
           candidatesIn: 100,
-          writtenDocs: 98,
+          writtenDocs: 96,
           preconditionFailedDocs: 1,
           skippedImmutable: 1,
+          unprocessableDocs: 1,
+          outOfScopeDocs: 1,
           lockAcquiredGeneration: '12345',
           lockReleasedAt: '2026-05-15T00:30:01.000Z',
           rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },
@@ -150,7 +175,7 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
             {
               path: `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-backfill-summary-chunk-0.json`,
               sha256: 'c'.repeat(64),
-              docCount: 98,
+              docCount: 100,
             },
           ],
           existingManifest,
@@ -170,9 +195,19 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
       expect(mainBody.schemaVersion).to.equal('pr-d4-v1.0');
       expect(mainBody.env).to.equal('dev');
       expect(mainBody.candidatesIn).to.equal(100);
-      expect(mainBody.writtenDocs).to.equal(98);
+      expect(mainBody.writtenDocs).to.equal(96);
       expect(mainBody.preconditionFailedDocs).to.equal(1);
       expect(mainBody.skippedImmutable).to.equal(1);
+      expect(mainBody.unprocessableDocs).to.equal(1);
+      expect(mainBody.outOfScopeDocs).to.equal(1);
+      // 保全式: candidatesIn = writtenDocs + preconditionFailedDocs + skippedImmutable + unprocessableDocs + outOfScopeDocs
+      expect(
+        mainBody.writtenDocs +
+          mainBody.preconditionFailedDocs +
+          mainBody.skippedImmutable +
+          mainBody.unprocessableDocs +
+          mainBody.outOfScopeDocs
+      ).to.equal(mainBody.candidatesIn);
       expect(mainBody.lockAcquiredGeneration).to.equal('12345');
       expect(mainBody.chunks).to.have.length(1);
       expect(mainBody.rateLimiterConfig).to.deep.equal({
@@ -208,6 +243,8 @@ describe('Phase C artifactWriter (PR-D4 S1-4 BF22)', () => {
           writtenDocs: 0,
           preconditionFailedDocs: 0,
           skippedImmutable: 0,
+          unprocessableDocs: 0,
+          outOfScopeDocs: 0,
           lockAcquiredGeneration: '1',
           lockReleasedAt: '2026-05-15T00:30:01.000Z',
           rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },

--- a/functions/test/prD4PhaseCBackfillOrchestrator.test.ts
+++ b/functions/test/prD4PhaseCBackfillOrchestrator.test.ts
@@ -463,7 +463,7 @@ describe('runPhaseC orchestrator (PR-D4 S1-4 統合)', () => {
     ).to.equal(result.candidatesIn);
   });
 
-  it('lockReleasedAt は release 後の時刻 (Evaluator MEDIUM 反映、finalize 開始時刻ではない)', async () => {
+  it('lock 順序: finalize → release (Codex 6th Critical 反映、release 前の finalize で artifact 整合性保証)', async () => {
     const storage = new FakeArtifactStorage();
     const lock = new FakeLockStore();
     const batch = new FakeBatchAdapter();
@@ -471,24 +471,54 @@ describe('runPhaseC orchestrator (PR-D4 S1-4 統合)', () => {
     const rateLimiter = new FakeRateLimiter();
     storage.seedPhaseBArtifacts([buildCandidate('d1')]);
 
-    // nowProvider が呼ばれた順を観測
-    const nowCalls: string[] = [];
-    let i = 0;
-    const times = [
-      '2026-05-15T00:00:00.000Z', // backfillStartedAt
-      '2026-05-15T00:30:00.000Z', // lockReleasedAt (release 後)
-    ];
-    const input = buildRunInput({ storage, lock, batch, individual, rateLimiter });
-    input.nowProvider = () => {
-      const t = times[Math.min(i, times.length - 1)];
-      nowCalls.push(t);
-      i++;
-      return t;
+    // storage write 履歴と lock release の順序を観測
+    const eventOrder: string[] = [];
+    const origRelease = lock.release.bind(lock);
+    lock.release = async (input) => {
+      eventOrder.push('lock-released');
+      return origRelease(input);
+    };
+    const origWriteJson = storage.writeJson.bind(storage);
+    storage.writeJson = async (path, content, precondition) => {
+      if (path.includes('manifest.json')) eventOrder.push('manifest-written');
+      else if (path.includes('phase-c-backfill-summary.json')) {
+        eventOrder.push('main-artifact-written');
+      }
+      return origWriteJson(path, content, precondition);
     };
 
-    const result = await runPhaseC(input);
-    expect(result.lockReleasedAt).to.equal('2026-05-15T00:30:00.000Z');
-    // lock 解放は finalize 前 = nowProvider 2 回目より前に lock.released が increment
-    expect(lock.released).to.equal(1);
+    await runPhaseC(buildRunInput({ storage, lock, batch, individual, rateLimiter }));
+    // 順序: main artifact → manifest → release (release は finalize 後)
+    expect(eventOrder).to.deep.equal([
+      'main-artifact-written',
+      'manifest-written',
+      'lock-released',
+    ]);
+  });
+
+  it('既存 provenanceBackfill (= already backfilled) → skipReason "already backfilled" で skip (Codex 6th Important 反映)', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    storage.seedPhaseBArtifacts([buildCandidate('already-bf')]);
+    // 既 backfilled snapshot を返すよう adapter を上書き
+    const origReRead = batch.reReadForBatch.bind(batch);
+    batch.reReadForBatch = async (docIds) => {
+      const m = await origReRead(docIds);
+      m.set('already-bf', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: { sourceSha256: 'x' },
+        provenanceBackfill: { method: 'legacy-observed', confidence: 'derived-bytes-verified' },
+      });
+      return m;
+    };
+
+    const result = await runPhaseC(buildRunInput({ storage, lock, batch, individual, rateLimiter }));
+    expect(result.writtenDocs).to.equal(0);
+    expect(result.skippedImmutable).to.equal(1);
+    expect(batch.commitCalls).to.equal(0); // immutable skip で commit 不要
   });
 });

--- a/functions/test/prD4PhaseCBackfillOrchestrator.test.ts
+++ b/functions/test/prD4PhaseCBackfillOrchestrator.test.ts
@@ -327,7 +327,7 @@ describe('runPhaseC orchestrator (PR-D4 S1-4 統合)', () => {
     expect(manifestWrite!.precondition).to.exist;
   });
 
-  it('既存 lock 検出 → LockHeldByOthersError throw (Phase B artifact は読まない)', async () => {
+  it('既存 lock 検出 → LockHeldByOthersError throw (Phase B artifact は読まない、別 owner lock は解放されない)', async () => {
     const storage = new FakeArtifactStorage();
     const lock = new FakeLockStore();
     const batch = new FakeBatchAdapter();
@@ -353,8 +353,9 @@ describe('runPhaseC orchestrator (PR-D4 S1-4 統合)', () => {
     }
     expect(err).to.be.instanceOf(LockHeldByOthersError);
     expect(batch.commitCalls).to.equal(0);
-    // lock 解放呼び出し試行はあるが、別 owner なので失敗 (best-effort)
-    // FakeLockStore は generation mismatch で error throw → swallow
+    // acquire 失敗時は orchestrator の try ブロックに入らない → release も呼ばれない
+    // (= 別 owner の lock が誤って解放されないことを構造的に保証、code-reviewer #5 反映)
+    expect(lock.released).to.equal(0);
   });
 
   it('batch 失敗 → fallback individual update で 5 件書込', async () => {
@@ -409,5 +410,85 @@ describe('runPhaseC orchestrator (PR-D4 S1-4 統合)', () => {
     expect(result.writtenDocs).to.equal(0);
     expect(lock.released).to.equal(1);
     expect(batch.commitCalls).to.equal(0);
+  });
+
+  it('保全式: candidatesIn = writtenDocs + preconditionFailedDocs + skippedImmutable + unprocessableDocs + outOfScopeDocs (Evaluator HIGH 反映)', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    const candidates = Array.from({ length: 5 }, (_, i) => buildCandidate(`d${i}`));
+    storage.seedPhaseBArtifacts(candidates);
+
+    const result = await runPhaseC(
+      buildRunInput({ storage, lock, batch, individual, rateLimiter })
+    );
+    expect(
+      result.writtenDocs +
+        result.preconditionFailedDocs +
+        result.skippedImmutable +
+        result.unprocessableDocs +
+        result.outOfScopeDocs
+    ).to.equal(result.candidatesIn);
+  });
+
+  it('out-of-scope hard-gate (Codex 5th C1): Phase B の異種 candidate は outOfScopeDocs に記録され Firestore 書込なし', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    // 1 doc を out-of-scope (Ambiguous + child-snapshot-only) で混入
+    const outOfScope = buildCandidate('amb-1');
+    outOfScope.category = 'Ambiguous';
+    outOfScope.computedConfidence = 'child-snapshot-only';
+    const candidates = [buildCandidate('ok-1'), outOfScope, buildCandidate('ok-2')];
+    storage.seedPhaseBArtifacts(candidates);
+
+    const result = await runPhaseC(
+      buildRunInput({ storage, lock, batch, individual, rateLimiter })
+    );
+    expect(result.candidatesIn).to.equal(3);
+    expect(result.writtenDocs).to.equal(2); // ok-1 + ok-2
+    expect(result.outOfScopeDocs).to.equal(1);
+    expect(result.preconditionFailedDocs).to.equal(0);
+    // 保全式
+    expect(
+      result.writtenDocs +
+        result.preconditionFailedDocs +
+        result.skippedImmutable +
+        result.unprocessableDocs +
+        result.outOfScopeDocs
+    ).to.equal(result.candidatesIn);
+  });
+
+  it('lockReleasedAt は release 後の時刻 (Evaluator MEDIUM 反映、finalize 開始時刻ではない)', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    storage.seedPhaseBArtifacts([buildCandidate('d1')]);
+
+    // nowProvider が呼ばれた順を観測
+    const nowCalls: string[] = [];
+    let i = 0;
+    const times = [
+      '2026-05-15T00:00:00.000Z', // backfillStartedAt
+      '2026-05-15T00:30:00.000Z', // lockReleasedAt (release 後)
+    ];
+    const input = buildRunInput({ storage, lock, batch, individual, rateLimiter });
+    input.nowProvider = () => {
+      const t = times[Math.min(i, times.length - 1)];
+      nowCalls.push(t);
+      i++;
+      return t;
+    };
+
+    const result = await runPhaseC(input);
+    expect(result.lockReleasedAt).to.equal('2026-05-15T00:30:00.000Z');
+    // lock 解放は finalize 前 = nowProvider 2 回目より前に lock.released が increment
+    expect(lock.released).to.equal(1);
   });
 });

--- a/functions/test/prD4PhaseCBackfillOrchestrator.test.ts
+++ b/functions/test/prD4PhaseCBackfillOrchestrator.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C backfillOrchestrator 統合テスト.
+ *
+ * lock acquire → Phase B chunk streaming → batchWriter / individualRetryWriter →
+ * per-chunk flush → finalize (main + manifest) → lock release の統合動作検証。
+ *
+ * fake adapters で in-memory に Phase B manifest + chunks を seed して run。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import { Timestamp } from 'firebase-admin/firestore';
+import { runPhaseC } from '../../scripts/pr-d4-backfill/phase-c/backfillOrchestrator';
+import {
+  LockHeldByOthersError,
+  type AcquireResult,
+  type LockObjectStore,
+} from '../../scripts/pr-d4-backfill/phase-c/lockManager';
+import type {
+  BatchReReadResult,
+  BatchUpdateEntry,
+  CommitBatchResult,
+  FirestoreBatchAdapter,
+} from '../../scripts/pr-d4-backfill/phase-c/batchWriter';
+import type {
+  FirestoreIndividualAdapter,
+  IndividualUpdateInput,
+  IndividualUpdateResult,
+} from '../../scripts/pr-d4-backfill/phase-c/individualRetryWriter';
+import type { RateLimiter } from '../../scripts/pr-d4-backfill/phase-c/rateLimiter';
+import type {
+  ArtifactStorageReader,
+} from '../../scripts/pr-d4-backfill/phase-c/artifactReader';
+import type { ArtifactStorageWriter } from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import type {
+  BackfillManifest,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+  PhaseCBackfillSummary,
+} from '../../scripts/pr-d4-backfill/types';
+
+function sha256Hex(s: string): string {
+  return crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+}
+
+const RUN_ID = '20260515T010000Z-dev-pr-d4-v1';
+const ARTIFACT_BUCKET = 'docsplit-dev-pr-d4-artifacts';
+const PHASE_B_MAIN_PATH = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-b-revalidation-summary.json`;
+const PHASE_B_CHUNK_PATH_0 = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-b-revalidation-summary-chunk-0.json`;
+const MANIFEST_PATH = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/manifest.json`;
+
+function buildCandidate(docId: string): PhaseBRevalidatedCandidate {
+  return {
+    docId,
+    category: 'MatchedByHash',
+    computedConfidence: 'derived-bytes-verified',
+    computedProvenance: {
+      sourceGeneration: '1000',
+      sourceMetageneration: '1',
+      sourceSha256: 'a'.repeat(64),
+      sourcePath: 'original/parent.pdf',
+      sourceBucket: 'docsplit-dev-storage',
+      derivedObjectPath: `processed/${docId}.pdf`,
+      derivedGeneration: '2000',
+      derivedMetageneration: '1',
+      derivedSha256: 'b'.repeat(64),
+      createdAt: '2026-05-13T10:00:00.000Z',
+    },
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+  };
+}
+
+interface FakeArtifactObject {
+  content: string;
+  generation: number;
+}
+
+class FakeArtifactStorage implements ArtifactStorageReader, ArtifactStorageWriter {
+  public objects = new Map<string, FakeArtifactObject>();
+  private nextGen = 1;
+  public writeCalls: Array<{
+    path: string;
+    content: string;
+    precondition?: { ifGenerationMatch: number };
+  }> = [];
+
+  async readJson(path: string): Promise<{ content: string; generation: number }> {
+    const obj = this.objects.get(path);
+    if (!obj) throw new Error(`object not found: ${path}`);
+    return { content: obj.content, generation: obj.generation };
+  }
+
+  async writeJson(
+    path: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
+    this.writeCalls.push({ path, content, precondition });
+    this.objects.set(path, { content, generation: this.nextGen++ });
+  }
+
+  seedPhaseBArtifacts(candidates: PhaseBRevalidatedCandidate[]): void {
+    const chunkBody: PhaseBRevalidatedChunk = {
+      schemaVersion: 'pr-d4-v1.0',
+      chunkIndex: 0,
+      revalidated: candidates,
+    };
+    const chunkContent = JSON.stringify(chunkBody);
+    this.objects.set(PHASE_B_CHUNK_PATH_0, { content: chunkContent, generation: this.nextGen++ });
+
+    const mainBody: PhaseBRevalidationSummary = {
+      phase: 'B',
+      schemaVersion: 'pr-d4-v1.0',
+      scriptVersion: 'pr-d4-v1.0',
+      env: 'dev',
+      runId: RUN_ID,
+      phaseAArtifactRef: 'gs://x/phase-a.json',
+      phaseAManifestSha256: 'aaa',
+      revalidationStartedAt: '2026-05-14T00:00:00.000Z',
+      revalidationCompletedAt: '2026-05-14T00:30:00.000Z',
+      candidatesIn: candidates.length,
+      candidatesOut: candidates.length,
+      driftSkipped: {
+        firestoreUpdateTimeChanged: 0,
+        childGenerationChanged: 0,
+        parentGenerationChanged: 0,
+      },
+      verifyFailedMatchedByHash: 0,
+      skippedNonMatchedByHash: 0,
+      chunks: [
+        {
+          path: PHASE_B_CHUNK_PATH_0,
+          sha256: sha256Hex(chunkContent),
+          docCount: candidates.length,
+        },
+      ],
+    };
+    const mainContent = JSON.stringify(mainBody);
+    this.objects.set(PHASE_B_MAIN_PATH, { content: mainContent, generation: this.nextGen++ });
+
+    const manifest: BackfillManifest = {
+      schemaVersion: 'pr-d4-v1.0',
+      runId: RUN_ID,
+      env: 'dev',
+      phaseA: {
+        mainArtifact: { path: 'gs://x/phase-a.json', sha256: 'aaa' },
+        chunks: [],
+      },
+      phaseB: {
+        mainArtifact: { path: PHASE_B_MAIN_PATH, sha256: sha256Hex(mainContent) },
+        chunks: [
+          {
+            path: PHASE_B_CHUNK_PATH_0,
+            sha256: sha256Hex(chunkContent),
+            docCount: candidates.length,
+          },
+        ],
+      },
+    };
+    const manifestContent = JSON.stringify(manifest);
+    this.objects.set(MANIFEST_PATH, {
+      content: manifestContent,
+      generation: this.nextGen++,
+    });
+  }
+}
+
+class FakeLockStore implements LockObjectStore {
+  private objects = new Map<string, { body: string; generation: number }>();
+  private nextGen = 1;
+  public acquired = 0;
+  public released = 0;
+
+  async acquire(input: { path: string; body: string }): Promise<AcquireResult> {
+    this.acquired++;
+    const existing = this.objects.get(input.path);
+    if (existing) {
+      return {
+        acquired: false,
+        existing: { body: existing.body, generation: String(existing.generation) },
+      };
+    }
+    const gen = this.nextGen++;
+    this.objects.set(input.path, { body: input.body, generation: gen });
+    return { acquired: true, generation: String(gen) };
+  }
+
+  async release(input: { path: string; acquiredGeneration: string }): Promise<void> {
+    this.released++;
+    const obj = this.objects.get(input.path);
+    if (!obj) throw new Error('lock not found');
+    if (String(obj.generation) !== input.acquiredGeneration) throw new Error('gen mismatch');
+    this.objects.delete(input.path);
+  }
+
+  seedExistingLock(path: string, body: string): void {
+    this.objects.set(path, { body, generation: this.nextGen++ });
+  }
+}
+
+class FakeBatchAdapter implements FirestoreBatchAdapter {
+  public commitCalls = 0;
+  public commitBehavior: 'ok' | 'batch-failed' = 'ok';
+  async reReadForBatch(docIds: string[]): Promise<Map<string, BatchReReadResult>> {
+    const m = new Map<string, BatchReReadResult>();
+    for (const id of docIds) {
+      m.set(id, {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+    }
+    return m;
+  }
+  async commitBatch(entries: BatchUpdateEntry[]): Promise<CommitBatchResult> {
+    this.commitCalls++;
+    if (this.commitBehavior === 'batch-failed') {
+      return { kind: 'batch-failed', reason: 'precondition', message: 'drift' };
+    }
+    return {
+      kind: 'ok',
+      writeResults: entries.map((e) => ({
+        docId: e.docId,
+        updateTime: '2026-05-15T01:00:00.000Z',
+      })),
+    };
+  }
+}
+
+class FakeIndividualAdapter implements FirestoreIndividualAdapter {
+  public calls = 0;
+  public behavior: 'ok' | 'all-precondition-failed' = 'ok';
+  async updateOne(_input: IndividualUpdateInput): Promise<IndividualUpdateResult> {
+    this.calls++;
+    if (this.behavior === 'all-precondition-failed') {
+      return { kind: 'precondition-failed' };
+    }
+    return { kind: 'ok', updateTime: '2026-05-15T01:00:00.000Z' };
+  }
+}
+
+class FakeRateLimiter implements RateLimiter {
+  public calls: number[] = [];
+  async acquire(tokens: number = 1): Promise<void> {
+    this.calls.push(tokens);
+  }
+}
+
+function buildRunInput(deps: {
+  storage: FakeArtifactStorage;
+  lock: FakeLockStore;
+  batch: FakeBatchAdapter;
+  individual: FakeIndividualAdapter;
+  rateLimiter: RateLimiter;
+}): Parameters<typeof runPhaseC>[0] {
+  let nowCallCount = 0;
+  return {
+    env: 'dev',
+    runId: RUN_ID,
+    jobId: 'job-001',
+    lockOwner: 'github-actions-run-100',
+    artifactBucketName: ARTIFACT_BUCKET,
+    manifestPath: MANIFEST_PATH,
+    artifactReader: deps.storage,
+    artifactWriter: deps.storage,
+    lockStore: deps.lock,
+    batchAdapter: deps.batch,
+    individualAdapter: deps.individual,
+    rateLimiter: deps.rateLimiter,
+    rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },
+    backfillScriptVersion: 'pr-d4-v1.0',
+    expectedDurationSec: 3600,
+    nowProvider: () => {
+      // started → released で 2 種類の時刻を返す
+      const times = ['2026-05-15T00:00:00.000Z', '2026-05-15T00:30:00.000Z'];
+      const t = times[Math.min(nowCallCount, times.length - 1)];
+      nowCallCount++;
+      return t;
+    },
+    backfilledAtProvider: () => Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+  };
+}
+
+describe('runPhaseC orchestrator (PR-D4 S1-4 統合)', () => {
+  it('happy path: 5 docs を全件書込し、main + manifest + chunk が出力される + lock release', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    const candidates = Array.from({ length: 5 }, (_, i) => buildCandidate(`d${i}`));
+    storage.seedPhaseBArtifacts(candidates);
+
+    const result = await runPhaseC(
+      buildRunInput({ storage, lock, batch, individual, rateLimiter })
+    );
+
+    expect(result.candidatesIn).to.equal(5);
+    expect(result.writtenDocs).to.equal(5);
+    expect(result.preconditionFailedDocs).to.equal(0);
+    expect(result.skippedImmutable).to.equal(0);
+    expect(lock.acquired).to.equal(1);
+    expect(lock.released).to.equal(1);
+    expect(batch.commitCalls).to.equal(1);
+    expect(individual.calls).to.equal(0);
+
+    // main + chunk + manifest が書込まれている
+    const mainObj = storage.writeCalls.find((c) =>
+      c.path.includes('phase-c-backfill-summary.json')
+    );
+    expect(mainObj).to.exist;
+    const main: PhaseCBackfillSummary = JSON.parse(mainObj!.content);
+    expect(main.phase).to.equal('C');
+    expect(main.writtenDocs).to.equal(5);
+    expect(main.lockAcquiredGeneration).to.equal(result.lockAcquiredGeneration);
+
+    const manifestWrite = storage.writeCalls.find((c) =>
+      c.path.endsWith('/manifest.json')
+    );
+    expect(manifestWrite).to.exist;
+    expect(manifestWrite!.precondition).to.exist;
+  });
+
+  it('既存 lock 検出 → LockHeldByOthersError throw (Phase B artifact は読まない)', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    // Phase B seed なし (orchestrator が manifest 読みに行く前で abort することを検証)
+    lock.seedExistingLock(
+      `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-locks/dev-phase-c.lock`,
+      JSON.stringify({
+        lockSchemaVersion: 'pr-d4-v1.0',
+        runId: 'older',
+        jobId: 'older-job',
+        startedAt: '2026-05-14T00:00:00.000Z',
+        expectedDurationSec: 3600,
+        lockOwner: 'github-actions-run-1',
+      })
+    );
+    let err: Error | null = null;
+    try {
+      await runPhaseC(buildRunInput({ storage, lock, batch, individual, rateLimiter }));
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).to.be.instanceOf(LockHeldByOthersError);
+    expect(batch.commitCalls).to.equal(0);
+    // lock 解放呼び出し試行はあるが、別 owner なので失敗 (best-effort)
+    // FakeLockStore は generation mismatch で error throw → swallow
+  });
+
+  it('batch 失敗 → fallback individual update で 5 件書込', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    batch.commitBehavior = 'batch-failed';
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    const candidates = Array.from({ length: 5 }, (_, i) => buildCandidate(`d${i}`));
+    storage.seedPhaseBArtifacts(candidates);
+
+    const result = await runPhaseC(
+      buildRunInput({ storage, lock, batch, individual, rateLimiter })
+    );
+    expect(result.writtenDocs).to.equal(5);
+    expect(result.preconditionFailedDocs).to.equal(0);
+    expect(batch.commitCalls).to.equal(1);
+    expect(individual.calls).to.equal(5); // fallback 5 docs
+  });
+
+  it('全 fallback 失敗 → preconditionFailedDocs 集計反映', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    batch.commitBehavior = 'batch-failed';
+    const individual = new FakeIndividualAdapter();
+    individual.behavior = 'all-precondition-failed';
+    const rateLimiter = new FakeRateLimiter();
+    const candidates = Array.from({ length: 3 }, (_, i) => buildCandidate(`d${i}`));
+    storage.seedPhaseBArtifacts(candidates);
+
+    const result = await runPhaseC(
+      buildRunInput({ storage, lock, batch, individual, rateLimiter })
+    );
+    expect(result.writtenDocs).to.equal(0);
+    expect(result.preconditionFailedDocs).to.equal(3);
+  });
+
+  it('candidates=[] でも lock acquire → release + 空 chunk なしで finalize 完了', async () => {
+    const storage = new FakeArtifactStorage();
+    const lock = new FakeLockStore();
+    const batch = new FakeBatchAdapter();
+    const individual = new FakeIndividualAdapter();
+    const rateLimiter = new FakeRateLimiter();
+    storage.seedPhaseBArtifacts([]);
+
+    const result = await runPhaseC(
+      buildRunInput({ storage, lock, batch, individual, rateLimiter })
+    );
+    expect(result.candidatesIn).to.equal(0);
+    expect(result.writtenDocs).to.equal(0);
+    expect(lock.released).to.equal(1);
+    expect(batch.commitCalls).to.equal(0);
+  });
+});

--- a/functions/test/prD4PhaseCBatchWriter.test.ts
+++ b/functions/test/prD4PhaseCBatchWriter.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Issue #445 PR-D4 S1-4: processBatch (Phase C BF10/BF11/BF14/BF18/BF23) テスト.
+ *
+ * 20 docs/batch + lastUpdateTime precondition + immutable skip + rate limiter 通過の
+ * 統合挙動を検証。Firestore SDK / GCS は fake adapter で in-memory 模擬。
+ */
+
+import { expect } from 'chai';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+  processBatch,
+  type BatchReReadResult,
+  type BatchUpdateEntry,
+  type CommitBatchResult,
+  type FirestoreBatchAdapter,
+} from '../../scripts/pr-d4-backfill/phase-c/batchWriter';
+import type { RateLimiter } from '../../scripts/pr-d4-backfill/phase-c/rateLimiter';
+import type { PhaseBRevalidatedCandidate } from '../../scripts/pr-d4-backfill/types';
+
+class FakeRateLimiter implements RateLimiter {
+  public acquireCalls: number[] = [];
+  async acquire(tokens: number = 1): Promise<void> {
+    this.acquireCalls.push(tokens);
+  }
+}
+
+class FakeBatchAdapter implements FirestoreBatchAdapter {
+  public reReadCalls: string[][] = [];
+  public commitCalls: BatchUpdateEntry[][] = [];
+  public snapshots = new Map<string, BatchReReadResult>();
+  public commitBehavior: 'ok' | 'precondition-fail' | 'transient-fail' = 'ok';
+  /** commit 後の updateTime 固定値 */
+  public commitUpdateTime = '2026-05-15T01:00:00.000Z';
+
+  async reReadForBatch(docIds: string[]): Promise<Map<string, BatchReReadResult>> {
+    this.reReadCalls.push([...docIds]);
+    const result = new Map<string, BatchReReadResult>();
+    for (const docId of docIds) {
+      const snap = this.snapshots.get(docId);
+      if (snap) result.set(docId, snap);
+    }
+    return result;
+  }
+
+  async commitBatch(entries: BatchUpdateEntry[]): Promise<CommitBatchResult> {
+    this.commitCalls.push(entries);
+    if (this.commitBehavior === 'precondition-fail') {
+      return {
+        kind: 'batch-failed',
+        reason: 'precondition',
+        message: 'lastUpdateTime drift in at least one doc',
+      };
+    }
+    if (this.commitBehavior === 'transient-fail') {
+      return {
+        kind: 'batch-failed',
+        reason: 'transient',
+        message: 'network timeout',
+      };
+    }
+    return {
+      kind: 'ok',
+      writeResults: entries.map((e) => ({
+        docId: e.docId,
+        updateTime: this.commitUpdateTime,
+      })),
+    };
+  }
+}
+
+function buildCandidate(
+  docId: string,
+  overrides: Partial<PhaseBRevalidatedCandidate> = {}
+): PhaseBRevalidatedCandidate {
+  return {
+    docId,
+    category: 'MatchedByHash',
+    computedConfidence: 'derived-bytes-verified',
+    computedProvenance: {
+      sourceGeneration: '1000',
+      sourceMetageneration: '1',
+      sourceSha256: 'a'.repeat(64),
+      sourcePath: 'original/parent.pdf',
+      sourceBucket: 'docsplit-dev-storage',
+      derivedObjectPath: `processed/${docId}.pdf`,
+      derivedGeneration: '2000',
+      derivedMetageneration: '1',
+      derivedSha256: 'b'.repeat(64),
+      createdAt: '2026-05-13T10:00:00.000Z',
+    },
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+    ...overrides,
+  };
+}
+
+function freshDeps() {
+  const rateLimiter = new FakeRateLimiter();
+  const adapter = new FakeBatchAdapter();
+  return { rateLimiter, adapter };
+}
+
+const BACKFILL_SCRIPT_VERSION = 'pr-d4-v1.0';
+
+describe('processBatch (PR-D4 S1-4 Phase C BF10/BF11/BF14/BF18/BF23)', () => {
+  describe('happy path (BF10/BF11)', () => {
+    it('20 docs 全部 batch 成功 → writtenDocs 完備', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = Array.from({ length: 20 }, (_, i) => buildCandidate(`doc-${i}`));
+      for (const c of candidates) {
+        adapter.snapshots.set(c.docId, {
+          exists: true,
+          updateTime: '2026-05-14T22:00:00.000Z',
+          provenance: undefined,
+          provenanceBackfill: undefined,
+        });
+      }
+
+      const result = await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs).to.have.length(20);
+      expect(result.immutableSkippedDocs).to.deep.equal([]);
+      expect(result.missingDocs).to.deep.equal([]);
+      // 全 writtenDoc が writeStatus=ok + sha256 + lastUpdateTimeAfter
+      for (const w of result.writtenDocs) {
+        expect(w.writeStatus).to.equal('ok');
+        expect(w.newProvenanceBackfillSha256).to.match(/^[0-9a-f]{64}$/);
+        expect(w.lastUpdateTimeAfter).to.equal('2026-05-15T01:00:00.000Z');
+      }
+    });
+
+    it('commitBatch entries に lastUpdateTimePrecondition (Phase B 再読込値) が渡される', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = [buildCandidate('d1'), buildCandidate('d2')];
+      adapter.snapshots.set('d1', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      adapter.snapshots.set('d2', {
+        exists: true,
+        updateTime: '2026-05-14T22:01:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(adapter.commitCalls.length).to.equal(1);
+      const entries = adapter.commitCalls[0];
+      expect(entries.find((e) => e.docId === 'd1')!.lastUpdateTimePrecondition).to.equal(
+        '2026-05-14T22:00:00.000Z'
+      );
+      expect(entries.find((e) => e.docId === 'd2')!.lastUpdateTimePrecondition).to.equal(
+        '2026-05-14T22:01:00.000Z'
+      );
+    });
+  });
+
+  describe('immutable skip (BF14)', () => {
+    it('provenance 存在 + provenanceBackfill 不在 doc は batch から除外', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = [buildCandidate('verified'), buildCandidate('new')];
+      adapter.snapshots.set('verified', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: { sourceSha256: 'x' }, // 既存 verified
+        provenanceBackfill: undefined,
+      });
+      adapter.snapshots.set('new', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+
+      const result = await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs).to.have.length(1);
+      expect(result.writtenDocs[0].docId).to.equal('new');
+      expect(result.immutableSkippedDocs).to.have.length(1);
+      expect(result.immutableSkippedDocs[0].docId).to.equal('verified');
+      expect(adapter.commitCalls[0].map((e) => e.docId)).to.deep.equal(['new']);
+    });
+
+    it('全 doc が immutable skip → commitBatch 呼ばれず all-committed(writtenDocs=[]) で返る', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = [buildCandidate('v1'), buildCandidate('v2')];
+      for (const c of candidates) {
+        adapter.snapshots.set(c.docId, {
+          exists: true,
+          updateTime: '2026-05-14T22:00:00.000Z',
+          provenance: { sourceSha256: 'x' },
+          provenanceBackfill: undefined,
+        });
+      }
+      const result = await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs).to.have.length(0);
+      expect(result.immutableSkippedDocs).to.have.length(2);
+      expect(adapter.commitCalls).to.have.length(0);
+    });
+  });
+
+  describe('missing doc handling', () => {
+    it('doc 不在 (re-read で exists=false) → missingDocs に記録 + batch から除外', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = [buildCandidate('found'), buildCandidate('missing')];
+      adapter.snapshots.set('found', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      adapter.snapshots.set('missing', {
+        exists: false,
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      const result = await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs.map((w) => w.docId)).to.deep.equal(['found']);
+      expect(result.missingDocs).to.deep.equal(['missing']);
+    });
+  });
+
+  describe('batch failure (BF18 caller fallback 用)', () => {
+    it('precondition 失敗 → outcome=batch-failed + candidatesForFallback (skip/missing 除外)', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      adapter.commitBehavior = 'precondition-fail';
+      const candidates = [
+        buildCandidate('a'),
+        buildCandidate('b'),
+        buildCandidate('verified'),
+        buildCandidate('missing'),
+      ];
+      adapter.snapshots.set('a', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      adapter.snapshots.set('b', {
+        exists: true,
+        updateTime: '2026-05-14T22:01:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      adapter.snapshots.set('verified', {
+        exists: true,
+        updateTime: '2026-05-14T22:02:00.000Z',
+        provenance: { sourceSha256: 'x' },
+        provenanceBackfill: undefined,
+      });
+      adapter.snapshots.set('missing', {
+        exists: false,
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+
+      const result = await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('batch-failed');
+      if (result.outcome !== 'batch-failed') throw new Error('unreachable');
+      expect(result.candidatesForFallback.map((c) => c.docId)).to.deep.equal(['a', 'b']);
+      expect(result.immutableSkippedDocs.map((s) => s.docId)).to.deep.equal(['verified']);
+      expect(result.missingDocs).to.deep.equal(['missing']);
+      expect(result.lastUpdateTimePreconditions.get('a')).to.equal('2026-05-14T22:00:00.000Z');
+      expect(result.lastUpdateTimePreconditions.get('b')).to.equal('2026-05-14T22:01:00.000Z');
+      expect(result.failureReason).to.match(/precondition/);
+    });
+
+    it('transient 失敗 → outcome=batch-failed + reason=transient', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      adapter.commitBehavior = 'transient-fail';
+      const candidates = [buildCandidate('a')];
+      adapter.snapshots.set('a', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      const result = await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('batch-failed');
+      if (result.outcome !== 'batch-failed') throw new Error('unreachable');
+      expect(result.failureReason).to.match(/transient/);
+    });
+  });
+
+  describe('rate limiter (BF23)', () => {
+    it('rateLimiter.acquire が eligible 数 (=10) で 1 度呼ばれる (batch 内 1 acquire)', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = Array.from({ length: 10 }, (_, i) => buildCandidate(`doc-${i}`));
+      for (const c of candidates) {
+        adapter.snapshots.set(c.docId, {
+          exists: true,
+          updateTime: '2026-05-14T22:00:00.000Z',
+          provenance: undefined,
+          provenanceBackfill: undefined,
+        });
+      }
+      await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(rateLimiter.acquireCalls).to.deep.equal([10]);
+    });
+
+    it('immutable skip 除外後の eligible 数のみ rate limiter token 消費', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      // 全 6 doc を verified (skip) + 1 doc 通常
+      const candidates = [
+        ...Array.from({ length: 6 }, (_, i) => buildCandidate(`v-${i}`)),
+        buildCandidate('new-1'),
+      ];
+      for (let i = 0; i < 6; i++) {
+        adapter.snapshots.set(`v-${i}`, {
+          exists: true,
+          updateTime: '2026-05-14T22:00:00.000Z',
+          provenance: { sourceSha256: 'x' },
+          provenanceBackfill: undefined,
+        });
+      }
+      adapter.snapshots.set('new-1', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      // eligible 1 件のみ acquire される (skip 分は token 消費しない)
+      expect(rateLimiter.acquireCalls).to.deep.equal([1]);
+    });
+
+    it('全 doc が immutable skip → rateLimiter.acquire は呼ばれない (commit 不要)', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const candidates = [buildCandidate('v1')];
+      adapter.snapshots.set('v1', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: { sourceSha256: 'x' },
+        provenanceBackfill: undefined,
+      });
+      await processBatch(
+        {
+          candidates,
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(rateLimiter.acquireCalls).to.deep.equal([]);
+    });
+  });
+
+  describe('empty input', () => {
+    it('candidates=[] → outcome=all-committed (writtenDocs=[]) で returnreReadForBatch も commit も呼ばない', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const result = await processBatch(
+        {
+          candidates: [],
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs).to.deep.equal([]);
+      expect(adapter.reReadCalls).to.have.length(0);
+      expect(adapter.commitCalls).to.have.length(0);
+    });
+  });
+});

--- a/functions/test/prD4PhaseCBatchWriter.test.ts
+++ b/functions/test/prD4PhaseCBatchWriter.test.ts
@@ -133,7 +133,8 @@ describe('processBatch (PR-D4 S1-4 Phase C BF10/BF11/BF14/BF18/BF23)', () => {
       if (result.outcome !== 'all-committed') throw new Error('unreachable');
       expect(result.writtenDocs).to.have.length(20);
       expect(result.immutableSkippedDocs).to.deep.equal([]);
-      expect(result.missingDocs).to.deep.equal([]);
+      expect(result.unprocessableDocs).to.deep.equal([]);
+      expect(result.outOfScopeDocs).to.deep.equal([]);
       // 全 writtenDoc が writeStatus=ok + sha256 + lastUpdateTimeAfter
       for (const w of result.writtenDocs) {
         expect(w.writeStatus).to.equal('ok');
@@ -241,8 +242,8 @@ describe('processBatch (PR-D4 S1-4 Phase C BF10/BF11/BF14/BF18/BF23)', () => {
     });
   });
 
-  describe('missing doc handling', () => {
-    it('doc 不在 (re-read で exists=false) → missingDocs に記録 + batch から除外', async () => {
+  describe('unprocessable doc handling (Codex 5th C2)', () => {
+    it('doc 不在 (re-read で exists=false) → unprocessableDocs.reason="missing" に記録', async () => {
       const { rateLimiter, adapter } = freshDeps();
       const candidates = [buildCandidate('found'), buildCandidate('missing')];
       adapter.snapshots.set('found', {
@@ -268,7 +269,92 @@ describe('processBatch (PR-D4 S1-4 Phase C BF10/BF11/BF14/BF18/BF23)', () => {
       expect(result.outcome).to.equal('all-committed');
       if (result.outcome !== 'all-committed') throw new Error('unreachable');
       expect(result.writtenDocs.map((w) => w.docId)).to.deep.equal(['found']);
-      expect(result.missingDocs).to.deep.equal(['missing']);
+      expect(result.unprocessableDocs).to.deep.equal([{ docId: 'missing', reason: 'missing' }]);
+    });
+
+    it('provenance fields に invalid sha256 が含まれる → unprocessableDocs.reason="validation"', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const broken = buildCandidate('broken');
+      broken.computedProvenance.derivedSha256 = 'not-a-sha256'; // ProvenanceValidationError 誘発
+      adapter.snapshots.set('broken', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      const result = await processBatch(
+        {
+          candidates: [broken],
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs).to.have.length(0);
+      expect(result.unprocessableDocs).to.have.length(1);
+      expect(result.unprocessableDocs[0].docId).to.equal('broken');
+      expect(result.unprocessableDocs[0].reason).to.equal('validation');
+      expect(result.unprocessableDocs[0].message).to.match(/derivedSha256/);
+    });
+  });
+
+  describe('out-of-scope hard-gate (Codex 5th C1、impl-plan §4.0)', () => {
+    it('category !== MatchedByHash → outOfScopeDocs に分類 (書込なし)', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const c = buildCandidate('amb');
+      c.category = 'Ambiguous';
+      c.computedConfidence = 'child-snapshot-only';
+      adapter.snapshots.set('amb', {
+        exists: true,
+        updateTime: '2026-05-14T22:00:00.000Z',
+        provenance: undefined,
+        provenanceBackfill: undefined,
+      });
+      const result = await processBatch(
+        {
+          candidates: [c],
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.writtenDocs).to.have.length(0);
+      expect(result.outOfScopeDocs).to.deep.equal([
+        {
+          docId: 'amb',
+          reason: 'category not MatchedByHash',
+          observedCategory: 'Ambiguous',
+          observedConfidence: 'child-snapshot-only',
+        },
+      ]);
+      // hard-gate で commit / reReadForBatch すら呼ばれない
+      expect(adapter.commitCalls).to.have.length(0);
+      expect(adapter.reReadCalls).to.have.length(0);
+    });
+
+    it('MatchedByHash + confidence !== derived-bytes-verified → outOfScopeDocs に分類', async () => {
+      const { rateLimiter, adapter } = freshDeps();
+      const c = buildCandidate('snapshot');
+      c.computedConfidence = 'child-snapshot-only'; // MatchedByHash のままだが confidence 違い
+      const result = await processBatch(
+        {
+          candidates: [c],
+          backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+          backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+        },
+        adapter,
+        rateLimiter
+      );
+      expect(result.outcome).to.equal('all-committed');
+      if (result.outcome !== 'all-committed') throw new Error('unreachable');
+      expect(result.outOfScopeDocs[0].reason).to.equal('confidence not derived-bytes-verified');
+      expect(result.outOfScopeDocs[0].observedConfidence).to.equal('child-snapshot-only');
     });
   });
 
@@ -319,7 +405,7 @@ describe('processBatch (PR-D4 S1-4 Phase C BF10/BF11/BF14/BF18/BF23)', () => {
       if (result.outcome !== 'batch-failed') throw new Error('unreachable');
       expect(result.candidatesForFallback.map((c) => c.docId)).to.deep.equal(['a', 'b']);
       expect(result.immutableSkippedDocs.map((s) => s.docId)).to.deep.equal(['verified']);
-      expect(result.missingDocs).to.deep.equal(['missing']);
+      expect(result.unprocessableDocs).to.deep.equal([{ docId: 'missing', reason: 'missing' }]);
       expect(result.lastUpdateTimePreconditions.get('a')).to.equal('2026-05-14T22:00:00.000Z');
       expect(result.lastUpdateTimePreconditions.get('b')).to.equal('2026-05-14T22:01:00.000Z');
       expect(result.failureReason).to.match(/precondition/);

--- a/functions/test/prD4PhaseCImmutableSkipChecker.test.ts
+++ b/functions/test/prD4PhaseCImmutableSkipChecker.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #445 PR-D4 S1-4: immutableSkipChecker (Phase C BF14) テスト.
+ *
+ * field existence で判定するロジックを deterministic に検証。
+ * Codex 3rd I3 (null sentinel 禁止) の lock-in。
+ */
+
+import { expect } from 'chai';
+import { checkImmutableSkip } from '../../scripts/pr-d4-backfill/phase-c/immutableSkipChecker';
+
+describe('checkImmutableSkip (PR-D4 S1-4 Phase C BF14)', () => {
+  it('両 field 不在 → skip=false (新規 backfill 対象)', () => {
+    const result = checkImmutableSkip({
+      provenance: undefined,
+      provenanceBackfill: undefined,
+    });
+    expect(result).to.deep.equal({ skip: false });
+  });
+
+  it('provenance 存在 + provenanceBackfill 不在 → skip=true (verified existing、immutable)', () => {
+    const result = checkImmutableSkip({
+      provenance: { sourceSha256: 'abc', sourcePath: 'original/x.pdf' },
+      provenanceBackfill: undefined,
+    });
+    expect(result).to.deep.equal({
+      skip: true,
+      reason: 'provenance exists, provenanceBackfill absent',
+    });
+  });
+
+  it('provenance 不在 + provenanceBackfill 存在 → skip=false (異常状態、caller で対応)', () => {
+    // 通常は provenance + provenanceBackfill が atomic に書込まれるため発生しないが、
+    // 本 pure function は判定責務のみ。実害は caller (orchestrator) で別途検出する。
+    const result = checkImmutableSkip({
+      provenance: undefined,
+      provenanceBackfill: { method: 'legacy-observed' },
+    });
+    expect(result).to.deep.equal({ skip: false });
+  });
+
+  it('両 field 存在 → skip=false (既 backfilled、Phase A で除外済の前提)', () => {
+    const result = checkImmutableSkip({
+      provenance: { sourceSha256: 'abc' },
+      provenanceBackfill: { method: 'legacy-observed', confidence: 'derived-bytes-verified' },
+    });
+    expect(result).to.deep.equal({ skip: false });
+  });
+
+  it('provenanceBackfill が null → skip=false (Codex 3rd I3: null sentinel 禁止、明示書込で別意味)', () => {
+    const result = checkImmutableSkip({
+      provenance: { sourceSha256: 'abc' },
+      provenanceBackfill: null,
+    });
+    expect(result).to.deep.equal({ skip: false });
+  });
+
+  it('provenance が null + provenanceBackfill 不在 → skip=true (null も "exists" 扱い)', () => {
+    // Firestore SDK 上 null は field 存在 (data() で key 取得可)。
+    // 通常 PR-D2/D3 では null を書込まないが、外部介入で発生する可能性は排除しない。
+    const result = checkImmutableSkip({
+      provenance: null,
+      provenanceBackfill: undefined,
+    });
+    expect(result).to.deep.equal({
+      skip: true,
+      reason: 'provenance exists, provenanceBackfill absent',
+    });
+  });
+});

--- a/functions/test/prD4PhaseCImmutableSkipChecker.test.ts
+++ b/functions/test/prD4PhaseCImmutableSkipChecker.test.ts
@@ -28,22 +28,28 @@ describe('checkImmutableSkip (PR-D4 S1-4 Phase C BF14)', () => {
     });
   });
 
-  it('provenance 不在 + provenanceBackfill 存在 → skip=false (異常状態、caller で対応)', () => {
+  it('provenance 不在 + provenanceBackfill 存在 → skip=true reason="already backfilled" (Codex 6th Important)', () => {
     // 通常は provenance + provenanceBackfill が atomic に書込まれるため発生しないが、
-    // 本 pure function は判定責務のみ。実害は caller (orchestrator) で別途検出する。
+    // present check で防御 (caller-bug ガード)。
     const result = checkImmutableSkip({
       provenance: undefined,
       provenanceBackfill: { method: 'legacy-observed' },
     });
-    expect(result).to.deep.equal({ skip: false });
+    expect(result).to.deep.equal({
+      skip: true,
+      reason: 'already backfilled (provenanceBackfill present)',
+    });
   });
 
-  it('両 field 存在 → skip=false (既 backfilled、Phase A で除外済の前提)', () => {
+  it('両 field 存在 → skip=true reason="already backfilled" (Codex 6th Important、idempotency 保護)', () => {
     const result = checkImmutableSkip({
       provenance: { sourceSha256: 'abc' },
       provenanceBackfill: { method: 'legacy-observed', confidence: 'derived-bytes-verified' },
     });
-    expect(result).to.deep.equal({ skip: false });
+    expect(result).to.deep.equal({
+      skip: true,
+      reason: 'already backfilled (provenanceBackfill present)',
+    });
   });
 
   it('provenanceBackfill が null → skip=false (Codex 3rd I3: null sentinel 禁止、明示書込で別意味)', () => {

--- a/functions/test/prD4PhaseCIndividualRetryWriter.test.ts
+++ b/functions/test/prD4PhaseCIndividualRetryWriter.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Issue #445 PR-D4 S1-4: processFallback (Phase C BF18/BF23) テスト.
+ *
+ * batch 失敗時の doc 単位 fallback。precondition-failed / transient retry max / 隔離挙動。
+ */
+
+import { expect } from 'chai';
+import { Timestamp } from 'firebase-admin/firestore';
+import {
+  processFallback,
+  type FirestoreIndividualAdapter,
+  type IndividualUpdateInput,
+  type IndividualUpdateResult,
+} from '../../scripts/pr-d4-backfill/phase-c/individualRetryWriter';
+import type { RateLimiter } from '../../scripts/pr-d4-backfill/phase-c/rateLimiter';
+import type { PhaseBRevalidatedCandidate } from '../../scripts/pr-d4-backfill/types';
+
+class FakeRateLimiter implements RateLimiter {
+  public acquireCalls: number[] = [];
+  async acquire(tokens: number = 1): Promise<void> {
+    this.acquireCalls.push(tokens);
+  }
+}
+
+class FakeIndividualAdapter implements FirestoreIndividualAdapter {
+  public updateCalls: IndividualUpdateInput[] = [];
+  /** docId → 各 attempt の結果 (順次消費)。`[ok, ok]` ならどの attempt も ok */
+  public behavior = new Map<string, IndividualUpdateResult[]>();
+  /** behavior の現在 index */
+  private attemptIndex = new Map<string, number>();
+
+  async updateOne(input: IndividualUpdateInput): Promise<IndividualUpdateResult> {
+    this.updateCalls.push(input);
+    const scenarios = this.behavior.get(input.docId) ?? [
+      { kind: 'ok', updateTime: '2026-05-15T01:00:00.000Z' },
+    ];
+    const idx = this.attemptIndex.get(input.docId) ?? 0;
+    const scenario = scenarios[Math.min(idx, scenarios.length - 1)];
+    this.attemptIndex.set(input.docId, idx + 1);
+    return scenario;
+  }
+}
+
+function buildCandidate(docId: string): PhaseBRevalidatedCandidate {
+  return {
+    docId,
+    category: 'MatchedByHash',
+    computedConfidence: 'derived-bytes-verified',
+    computedProvenance: {
+      sourceGeneration: '1000',
+      sourceMetageneration: '1',
+      sourceSha256: 'a'.repeat(64),
+      sourcePath: 'original/parent.pdf',
+      sourceBucket: 'docsplit-dev-storage',
+      derivedObjectPath: `processed/${docId}.pdf`,
+      derivedGeneration: '2000',
+      derivedMetageneration: '1',
+      derivedSha256: 'b'.repeat(64),
+      createdAt: '2026-05-13T10:00:00.000Z',
+    },
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+  };
+}
+
+function preconditionMap(docIds: string[]): Map<string, string> {
+  return new Map(docIds.map((d) => [d, '2026-05-14T22:00:00.000Z']));
+}
+
+const BASE_INPUT = {
+  backfillScriptVersion: 'pr-d4-v1.0',
+  backfilledAt: Timestamp.fromDate(new Date('2026-05-15T00:00:00.000Z')),
+};
+
+describe('processFallback (PR-D4 S1-4 Phase C BF18/BF23)', () => {
+  describe('happy path', () => {
+    it('全 doc 1 attempt で成功 → writtenDocs 完備、preconditionFailedDocs 空', async () => {
+      const adapter = new FakeIndividualAdapter();
+      const rl = new FakeRateLimiter();
+      const candidates = [buildCandidate('a'), buildCandidate('b')];
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates,
+          lastUpdateTimePreconditions: preconditionMap(['a', 'b']),
+        },
+        adapter,
+        rl
+      );
+      expect(result.writtenDocs).to.have.length(2);
+      expect(result.preconditionFailedDocs).to.deep.equal([]);
+      expect(adapter.updateCalls).to.have.length(2);
+      expect(rl.acquireCalls).to.deep.equal([1, 1]);
+    });
+  });
+
+  describe('precondition-failed handling (BF18 drift 隔離)', () => {
+    it('precondition-failed は即終了 + preconditionFailedDocs に隔離 (retry なし)', async () => {
+      const adapter = new FakeIndividualAdapter();
+      adapter.behavior.set('drift', [{ kind: 'precondition-failed' }]);
+      const rl = new FakeRateLimiter();
+      const candidates = [buildCandidate('drift'), buildCandidate('ok')];
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates,
+          lastUpdateTimePreconditions: preconditionMap(['drift', 'ok']),
+        },
+        adapter,
+        rl
+      );
+      expect(result.writtenDocs.map((w) => w.docId)).to.deep.equal(['ok']);
+      expect(result.preconditionFailedDocs).to.deep.equal([
+        { docId: 'drift', reason: 'lastUpdateTime drift', retryCount: 1 },
+      ]);
+      // drift doc は 1 attempt のみ (retry なし)、ok doc は 1 attempt = 合計 2 update
+      expect(adapter.updateCalls).to.have.length(2);
+    });
+  });
+
+  describe('transient retry (max=3、BF23 rate limiter 通過)', () => {
+    it('transient 2 回 → 3 回目で ok → writtenDocs 1 件 + retryCount 反映なし (成功時は retryCount は記録対象外)', async () => {
+      const adapter = new FakeIndividualAdapter();
+      adapter.behavior.set('retry', [
+        { kind: 'transient', message: 'net 1' },
+        { kind: 'transient', message: 'net 2' },
+        { kind: 'ok', updateTime: '2026-05-15T01:00:00.000Z' },
+      ]);
+      const rl = new FakeRateLimiter();
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates: [buildCandidate('retry')],
+          lastUpdateTimePreconditions: preconditionMap(['retry']),
+        },
+        adapter,
+        rl
+      );
+      expect(result.writtenDocs).to.have.length(1);
+      expect(result.preconditionFailedDocs).to.deep.equal([]);
+      expect(adapter.updateCalls).to.have.length(3);
+      expect(rl.acquireCalls).to.deep.equal([1, 1, 1]);
+    });
+
+    it('transient 3 回連続 → retry exhausted で隔離 (retryCount=3)', async () => {
+      const adapter = new FakeIndividualAdapter();
+      adapter.behavior.set('flaky', [
+        { kind: 'transient', message: 'net 1' },
+        { kind: 'transient', message: 'net 2' },
+        { kind: 'transient', message: 'net 3' },
+      ]);
+      const rl = new FakeRateLimiter();
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates: [buildCandidate('flaky')],
+          lastUpdateTimePreconditions: preconditionMap(['flaky']),
+        },
+        adapter,
+        rl
+      );
+      expect(result.writtenDocs).to.deep.equal([]);
+      expect(result.preconditionFailedDocs).to.deep.equal([
+        { docId: 'flaky', reason: 'transient retry exhausted', retryCount: 3 },
+      ]);
+      expect(adapter.updateCalls).to.have.length(3);
+    });
+
+    it('retryMax を override 可能 (test 用、default=3)', async () => {
+      const adapter = new FakeIndividualAdapter();
+      adapter.behavior.set('flaky', [
+        { kind: 'transient', message: 'net 1' },
+        { kind: 'transient', message: 'net 2' },
+      ]);
+      const rl = new FakeRateLimiter();
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates: [buildCandidate('flaky')],
+          lastUpdateTimePreconditions: preconditionMap(['flaky']),
+          retryMax: 2,
+        },
+        adapter,
+        rl
+      );
+      expect(result.preconditionFailedDocs[0].retryCount).to.equal(2);
+    });
+  });
+
+  describe('precondition Map 不在 (defense in depth)', () => {
+    it('lastUpdateTimePreconditions に entry 不在 → 隔離 retryCount=0 (silent fail させない)', async () => {
+      const adapter = new FakeIndividualAdapter();
+      const rl = new FakeRateLimiter();
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates: [buildCandidate('orphan')],
+          lastUpdateTimePreconditions: new Map(),
+        },
+        adapter,
+        rl
+      );
+      expect(result.preconditionFailedDocs).to.deep.equal([
+        { docId: 'orphan', reason: 'lastUpdateTime drift', retryCount: 0 },
+      ]);
+      expect(adapter.updateCalls).to.have.length(0);
+    });
+  });
+
+  describe('rate limiter 1 token / attempt (BF23 lock-in)', () => {
+    it('複数 doc + 複数 retry でも 各 attempt = 1 token 消費', async () => {
+      const adapter = new FakeIndividualAdapter();
+      // a: 2 attempts (transient→ok), b: 1 attempt (ok)
+      adapter.behavior.set('a', [
+        { kind: 'transient', message: 'x' },
+        { kind: 'ok', updateTime: '2026-05-15T01:00:00.000Z' },
+      ]);
+      const rl = new FakeRateLimiter();
+      await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates: [buildCandidate('a'), buildCandidate('b')],
+          lastUpdateTimePreconditions: preconditionMap(['a', 'b']),
+        },
+        adapter,
+        rl
+      );
+      // a: 2 attempts → 2 tokens, b: 1 attempt → 1 token, 合計 3
+      expect(rl.acquireCalls).to.deep.equal([1, 1, 1]);
+    });
+  });
+});

--- a/functions/test/prD4PhaseCIndividualRetryWriter.test.ts
+++ b/functions/test/prD4PhaseCIndividualRetryWriter.test.ts
@@ -190,8 +190,8 @@ describe('processFallback (PR-D4 S1-4 Phase C BF18/BF23)', () => {
     });
   });
 
-  describe('precondition Map 不在 (defense in depth)', () => {
-    it('lastUpdateTimePreconditions に entry 不在 → 隔離 retryCount=0 (silent fail させない)', async () => {
+  describe('caller-bug paths (code-reviewer #3、observability 別軸)', () => {
+    it('lastUpdateTimePreconditions に entry 不在 → unprocessableDocs.reason="missing" に分類 (drift と混同しない)', async () => {
       const adapter = new FakeIndividualAdapter();
       const rl = new FakeRateLimiter();
       const result = await processFallback(
@@ -203,9 +203,32 @@ describe('processFallback (PR-D4 S1-4 Phase C BF18/BF23)', () => {
         adapter,
         rl
       );
-      expect(result.preconditionFailedDocs).to.deep.equal([
-        { docId: 'orphan', reason: 'lastUpdateTime drift', retryCount: 0 },
-      ]);
+      expect(result.preconditionFailedDocs).to.deep.equal([]);
+      expect(result.unprocessableDocs).to.have.length(1);
+      expect(result.unprocessableDocs[0].docId).to.equal('orphan');
+      expect(result.unprocessableDocs[0].reason).to.equal('missing');
+      expect(result.unprocessableDocs[0].message).to.match(/caller bug/);
+      expect(adapter.updateCalls).to.have.length(0);
+    });
+
+    it('provenance に invalid sha256 → unprocessableDocs.reason="validation" に分類', async () => {
+      const adapter = new FakeIndividualAdapter();
+      const rl = new FakeRateLimiter();
+      const broken = buildCandidate('broken');
+      broken.computedProvenance.derivedSha256 = 'not-a-sha256';
+      const result = await processFallback(
+        {
+          ...BASE_INPUT,
+          candidates: [broken],
+          lastUpdateTimePreconditions: preconditionMap(['broken']),
+        },
+        adapter,
+        rl
+      );
+      expect(result.preconditionFailedDocs).to.deep.equal([]);
+      expect(result.unprocessableDocs).to.have.length(1);
+      expect(result.unprocessableDocs[0].reason).to.equal('validation');
+      expect(result.unprocessableDocs[0].message).to.match(/derivedSha256/);
       expect(adapter.updateCalls).to.have.length(0);
     });
   });

--- a/functions/test/prD4PhaseCLockManager.test.ts
+++ b/functions/test/prD4PhaseCLockManager.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C lockManager (BF16/BF21) テスト.
+ *
+ * GCS sentinel object 排他 lock の取得 / 解放 / 並走検出 / generation mismatch 検証。
+ */
+
+import { expect } from 'chai';
+import {
+  acquirePhaseCLock,
+  buildPhaseCLockPath,
+  LockHeldByOthersError,
+  releasePhaseCLock,
+  type AcquireResult,
+  type LockObjectStore,
+} from '../../scripts/pr-d4-backfill/phase-c/lockManager';
+
+/**
+ * In-memory fake: 1 path につき 1 object。generation は increment。
+ */
+class FakeLockStore implements LockObjectStore {
+  private objects = new Map<string, { body: string; generation: number }>();
+  private nextGeneration = 1;
+  public acquireCalls: { path: string; body: string }[] = [];
+  public releaseCalls: { path: string; acquiredGeneration: string }[] = [];
+
+  async acquire(input: { path: string; body: string }): Promise<AcquireResult> {
+    this.acquireCalls.push(input);
+    const existing = this.objects.get(input.path);
+    if (existing) {
+      return {
+        acquired: false,
+        existing: { body: existing.body, generation: String(existing.generation) },
+      };
+    }
+    const generation = this.nextGeneration++;
+    this.objects.set(input.path, { body: input.body, generation });
+    return { acquired: true, generation: String(generation) };
+  }
+
+  async release(input: { path: string; acquiredGeneration: string }): Promise<void> {
+    this.releaseCalls.push(input);
+    const existing = this.objects.get(input.path);
+    if (!existing) {
+      throw new Error(`lock not found: ${input.path}`);
+    }
+    if (String(existing.generation) !== input.acquiredGeneration) {
+      throw new Error(
+        `generation mismatch: expected=${input.acquiredGeneration}, actual=${existing.generation}`
+      );
+    }
+    this.objects.delete(input.path);
+  }
+
+  // 試験用 helper
+  seedExistingLock(path: string, body: string): string {
+    const generation = this.nextGeneration++;
+    this.objects.set(path, { body, generation });
+    return String(generation);
+  }
+}
+
+function baseInput() {
+  return {
+    bucketName: 'docsplit-dev-pr-d4-artifacts',
+    env: 'dev' as const,
+    runId: '20260515T000000Z-dev-pr-d4-v1',
+    jobId: 'job-abc-001',
+    startedAt: '2026-05-15T00:00:00.000Z',
+    expectedDurationSec: 3600,
+    lockOwner: 'github-actions-run-100',
+  };
+}
+
+describe('lockManager (PR-D4 S1-4 Phase C BF16/BF21)', () => {
+  describe('buildPhaseCLockPath', () => {
+    it('expected GCS path 形式 (gs://{bucket}/pr-d4-backfill-locks/{env}-phase-c.lock)', () => {
+      const path = buildPhaseCLockPath('docsplit-dev-pr-d4-artifacts', 'dev');
+      expect(path).to.equal(
+        'gs://docsplit-dev-pr-d4-artifacts/pr-d4-backfill-locks/dev-phase-c.lock'
+      );
+    });
+    it('env が cocoro / kanameone でも path が正しく生成される', () => {
+      expect(buildPhaseCLockPath('b1', 'cocoro')).to.equal(
+        'gs://b1/pr-d4-backfill-locks/cocoro-phase-c.lock'
+      );
+      expect(buildPhaseCLockPath('b2', 'kanameone')).to.equal(
+        'gs://b2/pr-d4-backfill-locks/kanameone-phase-c.lock'
+      );
+    });
+  });
+
+  describe('acquirePhaseCLock', () => {
+    it('既存 lock なし → acquired=true + body 完備', async () => {
+      const store = new FakeLockStore();
+      const result = await acquirePhaseCLock(baseInput(), store);
+      expect(result.lockPath).to.equal(
+        'gs://docsplit-dev-pr-d4-artifacts/pr-d4-backfill-locks/dev-phase-c.lock'
+      );
+      expect(result.acquiredGeneration).to.equal('1');
+      expect(result.body.runId).to.equal('20260515T000000Z-dev-pr-d4-v1');
+      expect(result.body.lockOwner).to.equal('github-actions-run-100');
+      expect(result.body.lockSchemaVersion).to.equal('pr-d4-v1.0');
+    });
+
+    it('store に投げる body は JSON 文字列で PhaseCLockBody 全 field を含む', async () => {
+      const store = new FakeLockStore();
+      await acquirePhaseCLock(baseInput(), store);
+      expect(store.acquireCalls.length).to.equal(1);
+      const parsed = JSON.parse(store.acquireCalls[0].body);
+      expect(parsed).to.deep.equal({
+        lockSchemaVersion: 'pr-d4-v1.0',
+        runId: '20260515T000000Z-dev-pr-d4-v1',
+        jobId: 'job-abc-001',
+        startedAt: '2026-05-15T00:00:00.000Z',
+        expectedDurationSec: 3600,
+        lockOwner: 'github-actions-run-100',
+      });
+    });
+
+    it('既存 lock あり → LockHeldByOthersError throw + 既存 body / generation / parsed body を保持', async () => {
+      const store = new FakeLockStore();
+      const lockPath = buildPhaseCLockPath('docsplit-dev-pr-d4-artifacts', 'dev');
+      const existingBody = JSON.stringify({
+        lockSchemaVersion: 'pr-d4-v1.0',
+        runId: 'old-run-id',
+        jobId: 'old-job',
+        startedAt: '2026-05-14T00:00:00.000Z',
+        expectedDurationSec: 3600,
+        lockOwner: 'github-actions-run-99',
+      });
+      store.seedExistingLock(lockPath, existingBody);
+
+      let err: LockHeldByOthersError | null = null;
+      try {
+        await acquirePhaseCLock(baseInput(), store);
+      } catch (e) {
+        err = e as LockHeldByOthersError;
+      }
+      expect(err).to.be.instanceOf(LockHeldByOthersError);
+      expect(err!.lockPath).to.equal(lockPath);
+      expect(err!.existingBody).to.equal(existingBody);
+      expect(err!.existingGeneration).to.equal('1');
+      expect(err!.parsedExistingBody?.runId).to.equal('old-run-id');
+    });
+
+    it('既存 lock body が JSON parse 失敗 → parsedExistingBody=null (人間判断材料)', async () => {
+      const store = new FakeLockStore();
+      const lockPath = buildPhaseCLockPath('docsplit-dev-pr-d4-artifacts', 'dev');
+      store.seedExistingLock(lockPath, 'not a json {');
+
+      let err: LockHeldByOthersError | null = null;
+      try {
+        await acquirePhaseCLock(baseInput(), store);
+      } catch (e) {
+        err = e as LockHeldByOthersError;
+      }
+      expect(err).to.be.instanceOf(LockHeldByOthersError);
+      expect(err!.existingBody).to.equal('not a json {');
+      expect(err!.parsedExistingBody).to.be.null;
+    });
+  });
+
+  describe('releasePhaseCLock', () => {
+    it('acquire → release で lock 解放成功 (object 不在になる)', async () => {
+      const store = new FakeLockStore();
+      const acquired = await acquirePhaseCLock(baseInput(), store);
+      await releasePhaseCLock(
+        { lockPath: acquired.lockPath, acquiredGeneration: acquired.acquiredGeneration },
+        store
+      );
+      expect(store.releaseCalls.length).to.equal(1);
+      // 解放後は再 acquire 可能 (object 削除確認)
+      const reacquired = await acquirePhaseCLock(baseInput(), store);
+      expect(reacquired.acquiredGeneration).to.equal('2');
+    });
+
+    it('release で generation mismatch → error throw (stale lock 上書き事故防止 BF21)', async () => {
+      const store = new FakeLockStore();
+      const acquired = await acquirePhaseCLock(baseInput(), store);
+      let err: Error | null = null;
+      try {
+        await releasePhaseCLock(
+          { lockPath: acquired.lockPath, acquiredGeneration: '999' },
+          store
+        );
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.be.instanceOf(Error);
+      expect(err!.message).to.match(/generation mismatch/);
+    });
+
+    it('release で lock 不在 → error throw (二重 release / 既に release 済の検出)', async () => {
+      const store = new FakeLockStore();
+      const acquired = await acquirePhaseCLock(baseInput(), store);
+      await releasePhaseCLock(
+        { lockPath: acquired.lockPath, acquiredGeneration: acquired.acquiredGeneration },
+        store
+      );
+      let err: Error | null = null;
+      try {
+        await releasePhaseCLock(
+          { lockPath: acquired.lockPath, acquiredGeneration: acquired.acquiredGeneration },
+          store
+        );
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.be.instanceOf(Error);
+      expect(err!.message).to.match(/lock not found/);
+    });
+  });
+});

--- a/functions/test/prD4PhaseCRateLimiter.test.ts
+++ b/functions/test/prD4PhaseCRateLimiter.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Issue #445 PR-D4 S1-4: TokenBucketRateLimiter (Phase C BF23) テスト.
+ *
+ * batch / individual update 共通の global token bucket。
+ * Firestore write 100-200/sec 上限を守るための write rate 制御。
+ *
+ * fake clock を inject して時間依存ロジックを deterministic に検証する。
+ */
+
+import { expect } from 'chai';
+import {
+  TokenBucketRateLimiter,
+  type RateLimiterClock,
+} from '../../scripts/pr-d4-backfill/phase-c/rateLimiter';
+
+class FakeClock implements RateLimiterClock {
+  public currentMs = 0;
+  public sleepCalls: number[] = [];
+
+  now(): number {
+    return this.currentMs;
+  }
+
+  async sleep(ms: number): Promise<void> {
+    this.sleepCalls.push(ms);
+    this.currentMs += ms;
+  }
+
+  advance(ms: number): void {
+    this.currentMs += ms;
+  }
+}
+
+describe('TokenBucketRateLimiter (PR-D4 S1-4 Phase C BF23)', () => {
+  describe('constructor validation', () => {
+    it('tokensPerSecond <= 0 で error', () => {
+      const clock = new FakeClock();
+      expect(
+        () => new TokenBucketRateLimiter({ tokensPerSecond: 0, burstCapacity: 10 }, clock)
+      ).to.throw(/tokensPerSecond/);
+      expect(
+        () => new TokenBucketRateLimiter({ tokensPerSecond: -5, burstCapacity: 10 }, clock)
+      ).to.throw(/tokensPerSecond/);
+    });
+
+    it('burstCapacity <= 0 で error', () => {
+      const clock = new FakeClock();
+      expect(
+        () => new TokenBucketRateLimiter({ tokensPerSecond: 100, burstCapacity: 0 }, clock)
+      ).to.throw(/burstCapacity/);
+    });
+  });
+
+  describe('acquire input validation', () => {
+    it('tokens <= 0 で error', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 100 },
+        clock
+      );
+      let err: Error | null = null;
+      try {
+        await rl.acquire(0);
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.be.instanceOf(Error);
+      expect(err!.message).to.match(/tokens must be positive/);
+    });
+
+    it('tokens > burstCapacity で error', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 10 },
+        clock
+      );
+      let err: Error | null = null;
+      try {
+        await rl.acquire(11);
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).to.be.instanceOf(Error);
+      expect(err!.message).to.match(/exceeds burstCapacity/);
+    });
+  });
+
+  describe('burst behavior', () => {
+    it('burst capacity 上限まで即座に acquire 可能 (sleep なし)', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 100 },
+        clock
+      );
+      for (let i = 0; i < 100; i++) {
+        await rl.acquire(1);
+      }
+      expect(clock.sleepCalls).to.deep.equal([]);
+    });
+
+    it('burst 枯渇後の acquire は sleep 待ち (1 token = 1000/tokensPerSecond ms)', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 10 },
+        clock
+      );
+      // burst 10 を消費
+      for (let i = 0; i < 10; i++) {
+        await rl.acquire(1);
+      }
+      expect(clock.sleepCalls).to.deep.equal([]);
+      // 11 個目: 1 token 不足 → 10ms sleep 必要 (1 / 100 token/sec = 10 ms)
+      await rl.acquire(1);
+      expect(clock.sleepCalls).to.deep.equal([10]);
+    });
+  });
+
+  describe('refill timing', () => {
+    it('時間経過で token 補充される (clock 手動 advance + 再 acquire)', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 10 },
+        clock
+      );
+      // burst 10 全消費
+      for (let i = 0; i < 10; i++) {
+        await rl.acquire(1);
+      }
+      // 100ms 経過 = 10 token 補充
+      clock.advance(100);
+      // 10 token 即座に取得可能 (sleep 0)
+      const sleepCallsBefore = clock.sleepCalls.length;
+      for (let i = 0; i < 10; i++) {
+        await rl.acquire(1);
+      }
+      expect(clock.sleepCalls.length).to.equal(sleepCallsBefore);
+    });
+
+    it('burstCapacity を超えて補充されない', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 10 },
+        clock
+      );
+      // 1 秒経過 = 100 token 補充されるはずだが burstCapacity=10 で cap
+      clock.advance(1000);
+      // 10 token は即取得、11 個目は sleep 必要
+      for (let i = 0; i < 10; i++) {
+        await rl.acquire(1);
+      }
+      expect(clock.sleepCalls).to.deep.equal([]);
+      await rl.acquire(1);
+      expect(clock.sleepCalls).to.deep.equal([10]);
+    });
+  });
+
+  describe('concurrent callers (batch + individual の serialize)', () => {
+    it('並行 acquire 呼び出しが chain で順次処理され token race が発生しない', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 5 },
+        clock
+      );
+      // 10 並行 acquire を起動 (burst 5 → 残 5 は sleep 待ち)
+      const promises = Array.from({ length: 10 }, () => rl.acquire(1));
+      await Promise.all(promises);
+      // 後半 5 件は順次 1 token = 10ms sleep
+      expect(clock.sleepCalls.length).to.be.greaterThanOrEqual(1);
+      // 全 sleep 合計 = 各 1 token 補充ぶん (50ms 想定だが、refill が累積されるため正確値はテストではなく性質を検証)
+      const totalSleep = clock.sleepCalls.reduce((a, b) => a + b, 0);
+      expect(totalSleep).to.be.greaterThan(0);
+    });
+
+    it('acquire の chain は前回 error 後も維持される (後続 caller がブロックされない)', async () => {
+      const clock = new FakeClock();
+      const rl = new TokenBucketRateLimiter(
+        { tokensPerSecond: 100, burstCapacity: 5 },
+        clock
+      );
+      // 1 つ目: tokens=0 で error
+      let err1: Error | null = null;
+      try {
+        await rl.acquire(0);
+      } catch (e) {
+        err1 = e as Error;
+      }
+      expect(err1).to.be.instanceOf(Error);
+      // 2 つ目: 正常に acquire できる
+      await rl.acquire(1);
+      // 1 token consumed
+      expect(clock.sleepCalls).to.deep.equal([]);
+    });
+  });
+});

--- a/scripts/pr-d4-backfill/index.ts
+++ b/scripts/pr-d4-backfill/index.ts
@@ -33,6 +33,17 @@ import {
   GcsObjectDownloader,
   FirestoreReReaderImpl,
 } from './phase-b/adapters';
+import { runPhaseC } from './phase-c/backfillOrchestrator';
+import {
+  FirestoreBatchAdapterImpl,
+  FirestoreIndividualAdapterImpl,
+  GcsLockStoreImpl,
+} from './phase-c/adapters';
+import {
+  PR_D4_PHASE_C_DEFAULT_RATE_LIMITER,
+  PR_D4_SCRIPT_VERSION,
+} from './types';
+import { TokenBucketRateLimiter } from './phase-c/rateLimiter';
 
 function readArg(name: string, defaultValue?: string): string | undefined {
   const idx = process.argv.indexOf(name);
@@ -68,8 +79,10 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const phase = readArg('--phase', 'A');
-  if (phase !== 'A' && phase !== 'B') {
-    console.error(`FATAL: phase ${phase} not implemented (only Phase A / B are available in S1-3)`);
+  if (phase !== 'A' && phase !== 'B' && phase !== 'C') {
+    console.error(
+      `FATAL: phase ${phase} not implemented (only Phase A / B / C are available in S1-4)`
+    );
     process.exit(2);
   }
 
@@ -131,7 +144,7 @@ async function main(): Promise<void> {
     console.log(`  manifest: ${result.manifestPath}`);
     console.log(`  snapshotStartedAt: ${snapshotStartedAt}`);
     console.log(`  snapshotCompletedAt: ${result.snapshotCompletedAt}`);
-  } else {
+  } else if (phase === 'B') {
     // Phase B: Phase A artifact 経由 manifest を読み revalidation 実施
     const manifestPath = `gs://${artifactBucketName}/pr-d4-backfill-artifacts/${runId}/manifest.json`;
     console.log(`\nPhase B starting with manifest: ${manifestPath}`);
@@ -164,6 +177,56 @@ async function main(): Promise<void> {
     console.log(`  manifest: ${result.manifestPath}`);
     console.log(`  revalidationStartedAt: ${revalidationStartedAt}`);
     console.log(`  revalidationCompletedAt: ${result.revalidationCompletedAt}`);
+  } else {
+    // Phase C: Phase B artifact 経由 manifest を読み atomic backfill 実施 (本 PR S1-4)
+    const manifestPath = `gs://${artifactBucketName}/pr-d4-backfill-artifacts/${runId}/manifest.json`;
+    const jobId = readArg('--job-id', `job-${runId}`)!;
+    // lock owner: GitHub Actions 経由なら GITHUB_RUN_ID + GITHUB_REPOSITORY、ローカルなら 'manual-cli'
+    const githubRunId = process.env.GITHUB_RUN_ID;
+    const defaultLockOwner = githubRunId
+      ? `github-actions-run-${githubRunId}`
+      : 'manual-cli';
+    const lockOwner = readArg('--lock-owner', defaultLockOwner)!;
+    const expectedDurationSec = Number(readArg('--expected-duration-sec', '3600'));
+
+    console.log(`\nPhase C starting with manifest: ${manifestPath}`);
+    console.log(`  jobId: ${jobId}`);
+    console.log(`  lockOwner: ${lockOwner}`);
+    console.log(`  expectedDurationSec: ${expectedDurationSec}`);
+    console.log(
+      `  rateLimiter: ${PR_D4_PHASE_C_DEFAULT_RATE_LIMITER.tokensPerSecond} tokens/sec, burst ${PR_D4_PHASE_C_DEFAULT_RATE_LIMITER.burstCapacity}`
+    );
+
+    const rateLimiter = new TokenBucketRateLimiter(PR_D4_PHASE_C_DEFAULT_RATE_LIMITER);
+
+    const result = await runPhaseC({
+      env: envName,
+      runId,
+      jobId,
+      lockOwner,
+      artifactBucketName,
+      manifestPath,
+      artifactReader: new GcsArtifactReader(artifactBucketRef),
+      artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
+      lockStore: new GcsLockStoreImpl(artifactBucketRef),
+      batchAdapter: new FirestoreBatchAdapterImpl(db),
+      individualAdapter: new FirestoreIndividualAdapterImpl(db),
+      rateLimiter,
+      rateLimiterConfig: PR_D4_PHASE_C_DEFAULT_RATE_LIMITER,
+      backfillScriptVersion: PR_D4_SCRIPT_VERSION,
+      expectedDurationSec,
+    });
+
+    console.log('\nPhase C complete:');
+    console.log(`  candidatesIn: ${result.candidatesIn}`);
+    console.log(`  writtenDocs: ${result.writtenDocs}`);
+    console.log(`  preconditionFailedDocs: ${result.preconditionFailedDocs}`);
+    console.log(`  skippedImmutable: ${result.skippedImmutable}`);
+    console.log(`  lockAcquiredGeneration: ${result.lockAcquiredGeneration}`);
+    console.log(`  lockReleasedAt: ${result.lockReleasedAt}`);
+    console.log(`  mainArtifact: ${result.mainArtifactPath}`);
+    console.log(`  manifest: ${result.manifestPath}`);
+    console.log(`  backfillCompletedAt: ${result.backfillCompletedAt}`);
   }
 }
 

--- a/scripts/pr-d4-backfill/phase-c/adapters.ts
+++ b/scripts/pr-d4-backfill/phase-c/adapters.ts
@@ -60,8 +60,19 @@ export class GcsLockStoreImpl implements LockObjectStore {
         preconditionOpts: { ifGenerationMatch: 0 },
         metadata: { cacheControl: 'no-store' },
       });
+      // Codex 5th I1 反映 + code-reviewer suggestion: generation strict validation。
+      // save() と getMetadata() の間に他者が delete + 再 create する race window は理論上存在するが、
+      // ifGenerationMatch:0 で save 成功直後に delete + 別 owner save が起きる現実的シナリオは
+      // 極めて稀。defensive に generation が numeric digit string であることを runtime 検証し、
+      // 空文字 / 不正値の場合は throw して silent failure を避ける。
       const [metadata] = await file.getMetadata();
-      return { acquired: true, generation: String(metadata.generation ?? '') };
+      const generation = String(metadata.generation ?? '');
+      if (!/^[0-9]+$/.test(generation)) {
+        throw new Error(
+          `lock acquired but generation invalid (path=${input.path}, generation="${generation}")`
+        );
+      }
+      return { acquired: true, generation };
     } catch (err) {
       const code = (err as { code?: number }).code;
       if (code === 412) {

--- a/scripts/pr-d4-backfill/phase-c/adapters.ts
+++ b/scripts/pr-d4-backfill/phase-c/adapters.ts
@@ -1,0 +1,203 @@
+/**
+ * Issue #445 PR-D4 S1-4: production concrete adapters for Phase C.
+ *
+ * - GcsLockStoreImpl: GCS sentinel object 排他 lock (ifGenerationMatch:0 / ifGenerationMatch:<gen>)
+ * - FirestoreBatchAdapterImpl: documents collection への atomic batch update + lastUpdateTime precondition
+ * - FirestoreIndividualAdapterImpl: batch fallback の doc 単位 update
+ *
+ * unit test 対象外 (real SDK 接続のため)、dev rehearsal で動作検証。
+ * artifact reader / writer は phase-b / phase-a の既存 adapter を再利用する
+ * (GcsArtifactReader / GcsArtifactStorageWriter)。
+ */
+
+import * as admin from 'firebase-admin';
+import type { Bucket } from '@google-cloud/storage';
+import type {
+  BatchReReadResult,
+  BatchUpdateEntry,
+  CommitBatchResult,
+  FirestoreBatchAdapter,
+} from './batchWriter';
+import type {
+  FirestoreIndividualAdapter,
+  IndividualUpdateInput,
+  IndividualUpdateResult,
+} from './individualRetryWriter';
+import type { AcquireResult, LockObjectStore } from './lockManager';
+
+/**
+ * GCS sentinel object として lock を扱う production adapter (impl-plan §7.3 / §4.3 step 1)。
+ *
+ * - acquire: `file.save(body, { preconditionOpts: { ifGenerationMatch: 0 } })`
+ *   - 412 Precondition Failed → 既存 lock を read + AcquireResult.acquired=false で返却
+ * - release: `file.delete({ preconditionOpts: { ifGenerationMatch: <acquiredGen> } })`
+ *   - 412 / 404 は throw (caller 側で stale lock 解放手順を runbook 通り実行)
+ */
+export class GcsLockStoreImpl implements LockObjectStore {
+  constructor(private readonly artifactBucket: Bucket) {}
+
+  private parseAndValidatePath(objectPath: string): string {
+    const match = objectPath.match(/^gs:\/\/([^/]+)\/(.+)$/);
+    if (!match) {
+      throw new Error(`invalid GCS object path: ${objectPath}`);
+    }
+    const [, bucketName, path] = match;
+    if (bucketName !== this.artifactBucket.name) {
+      throw new Error(
+        `lock bucket mismatch: expected ${this.artifactBucket.name}, got ${bucketName} (path=${objectPath})`
+      );
+    }
+    return path;
+  }
+
+  async acquire(input: { path: string; body: string }): Promise<AcquireResult> {
+    const path = this.parseAndValidatePath(input.path);
+    const file = this.artifactBucket.file(path);
+    try {
+      await file.save(input.body, {
+        contentType: 'application/json',
+        resumable: false,
+        preconditionOpts: { ifGenerationMatch: 0 },
+        metadata: { cacheControl: 'no-store' },
+      });
+      const [metadata] = await file.getMetadata();
+      return { acquired: true, generation: String(metadata.generation ?? '') };
+    } catch (err) {
+      const code = (err as { code?: number }).code;
+      if (code === 412) {
+        // 既存 lock を取得して caller に返却 (人間判断材料)
+        const [contents] = await file.download();
+        const [metadata] = await file.getMetadata();
+        return {
+          acquired: false,
+          existing: {
+            body: contents.toString('utf8'),
+            generation: String(metadata.generation ?? ''),
+          },
+        };
+      }
+      throw err;
+    }
+  }
+
+  async release(input: { path: string; acquiredGeneration: string }): Promise<void> {
+    const path = this.parseAndValidatePath(input.path);
+    const file = this.artifactBucket.file(path);
+    await file.delete({
+      ignoreNotFound: false,
+      preconditionOpts: { ifGenerationMatch: Number(input.acquiredGeneration) },
+    });
+  }
+}
+
+/**
+ * Firestore atomic batch + lastUpdateTime precondition の production adapter。
+ *
+ * commitBatch error 分類 (Codex 1st Critical 4 → 本 PR 反映):
+ * - code === 9 (FAILED_PRECONDITION) → kind=batch-failed, reason='precondition'
+ * - その他 (UNAVAILABLE / DEADLINE_EXCEEDED 等) → kind=batch-failed, reason='transient'
+ *   → caller (orchestrator) が individualRetryWriter で doc 単位 retry / 隔離
+ */
+export class FirestoreBatchAdapterImpl implements FirestoreBatchAdapter {
+  constructor(private readonly db: admin.firestore.Firestore) {}
+
+  async reReadForBatch(docIds: string[]): Promise<Map<string, BatchReReadResult>> {
+    const result = new Map<string, BatchReReadResult>();
+    // 並行 read は本 PR では避け、順次 get で SDK 自動 throttle に委譲 (Phase A/B と一貫)
+    for (const docId of docIds) {
+      const snap = await this.db.collection('documents').doc(docId).get();
+      if (!snap.exists) {
+        result.set(docId, {
+          exists: false,
+          provenance: undefined,
+          provenanceBackfill: undefined,
+        });
+        continue;
+      }
+      const data = snap.data() ?? {};
+      const updateTimeIso = snap.updateTime?.toDate().toISOString();
+      result.set(docId, {
+        exists: true,
+        updateTime: updateTimeIso,
+        provenance: 'provenance' in data ? data.provenance : undefined,
+        provenanceBackfill:
+          'provenanceBackfill' in data ? data.provenanceBackfill : undefined,
+      });
+    }
+    return result;
+  }
+
+  async commitBatch(entries: BatchUpdateEntry[]): Promise<CommitBatchResult> {
+    const batch = this.db.batch();
+    for (const entry of entries) {
+      const docRef = this.db.collection('documents').doc(entry.docId);
+      batch.update(
+        docRef,
+        {
+          provenance: entry.provenance,
+          provenanceBackfill: entry.provenanceBackfill,
+        },
+        {
+          lastUpdateTime: admin.firestore.Timestamp.fromDate(
+            new Date(entry.lastUpdateTimePrecondition)
+          ),
+        }
+      );
+    }
+    try {
+      const writeResults = await batch.commit();
+      return {
+        kind: 'ok',
+        writeResults: entries.map((e, i) => ({
+          docId: e.docId,
+          updateTime: writeResults[i].writeTime.toDate().toISOString(),
+        })),
+      };
+    } catch (err) {
+      const code = (err as { code?: number }).code;
+      const message = (err as Error).message ?? String(err);
+      if (code === 9) {
+        return { kind: 'batch-failed', reason: 'precondition', message };
+      }
+      return { kind: 'batch-failed', reason: 'transient', message };
+    }
+  }
+}
+
+/**
+ * Firestore 個別 update + lastUpdateTime precondition の production adapter。
+ *
+ * updateOne error 分類:
+ * - code === 9 (FAILED_PRECONDITION) → kind=precondition-failed (drift 確定、retry 不要)
+ * - その他 → kind=transient, message (retry 対象)
+ */
+export class FirestoreIndividualAdapterImpl implements FirestoreIndividualAdapter {
+  constructor(private readonly db: admin.firestore.Firestore) {}
+
+  async updateOne(input: IndividualUpdateInput): Promise<IndividualUpdateResult> {
+    const docRef = this.db.collection('documents').doc(input.docId);
+    try {
+      const writeResult = await docRef.update(
+        {
+          provenance: input.provenance,
+          provenanceBackfill: input.provenanceBackfill,
+        },
+        {
+          lastUpdateTime: admin.firestore.Timestamp.fromDate(
+            new Date(input.lastUpdateTimePrecondition)
+          ),
+        }
+      );
+      return { kind: 'ok', updateTime: writeResult.writeTime.toDate().toISOString() };
+    } catch (err) {
+      const code = (err as { code?: number }).code;
+      if (code === 9) {
+        return { kind: 'precondition-failed' };
+      }
+      return {
+        kind: 'transient',
+        message: (err as Error).message ?? String(err),
+      };
+    }
+  }
+}

--- a/scripts/pr-d4-backfill/phase-c/artifactReader.ts
+++ b/scripts/pr-d4-backfill/phase-c/artifactReader.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase B artifact streaming reader (BF22 反映).
+ *
+ * Phase C が Phase B 出力を消費する経路:
+ *   1. manifest.json 読込 → phaseB section から main path + sha256 取得
+ *   2. main artifact 読込 + sha256 verify (不一致 → ArtifactIntegrityError)
+ *   3. main.chunks 配列を順次 1 chunk ずつ stream read + sha256 verify + revalidated yield
+ *
+ * caller (orchestrator) は AsyncIterable<PhaseBRevalidatedCandidate> を for-await で消費し、
+ * 全 chunk を一括メモリロードしない (BF22)。
+ */
+
+import * as crypto from 'crypto';
+import type {
+  BackfillManifest,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+} from '../types';
+import type { ArtifactStorageReader } from '../phase-b/artifactReader';
+import { ArtifactIntegrityError } from '../phase-b/artifactReader';
+
+export type { ArtifactStorageReader } from '../phase-b/artifactReader';
+export { ArtifactIntegrityError } from '../phase-b/artifactReader';
+
+export interface ReadPhaseBArtifactInput {
+  manifestPath: string;
+  reader: ArtifactStorageReader;
+}
+
+export interface PhaseBArtifactStream {
+  /** Phase B main artifact path (Phase C finalize 時に `phaseBArtifactRef` に記録) */
+  phaseBArtifactRef: string;
+  /** Phase B main artifact 内容の sha256 (= manifest.phaseB.mainArtifact.sha256) */
+  phaseBManifestSha256: string;
+  /** Phase B revalidated 候補件数 (chunks 配列の docCount 合計) */
+  candidatesIn: number;
+  /** Phase B 完了時点の manifest 全体 (Phase C finalize に existingManifest として渡す) */
+  manifest: BackfillManifest;
+  /** manifest.json の GCS generation (Phase C finalize で CAS update 用) */
+  manifestGeneration: number;
+  /** 全 candidate を順次 yield する AsyncIterable */
+  candidates(): AsyncIterable<PhaseBRevalidatedCandidate>;
+}
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export async function readPhaseBArtifact(
+  input: ReadPhaseBArtifactInput
+): Promise<PhaseBArtifactStream> {
+  const manifestRead = await input.reader.readJson(input.manifestPath);
+  const manifest = JSON.parse(manifestRead.content) as BackfillManifest;
+  if (!manifest.phaseB) {
+    throw new Error(
+      `manifest.phaseB section absent (Phase B artifact not finalized): ${input.manifestPath}`
+    );
+  }
+  const phaseBArtifactRef = manifest.phaseB.mainArtifact.path;
+  const phaseBManifestSha256 = manifest.phaseB.mainArtifact.sha256;
+
+  const mainRead = await input.reader.readJson(phaseBArtifactRef);
+  const mainContent = mainRead.content;
+  const actualMainSha = sha256Hex(mainContent);
+  if (actualMainSha !== phaseBManifestSha256) {
+    throw new ArtifactIntegrityError(
+      `Phase B main artifact sha256 mismatch: expected ${phaseBManifestSha256}, got ${actualMainSha} (path=${phaseBArtifactRef})`
+    );
+  }
+  const main = JSON.parse(mainContent) as PhaseBRevalidationSummary;
+  const chunkPointers = main.chunks;
+  const candidatesIn = chunkPointers.reduce((acc, c) => acc + c.docCount, 0);
+
+  async function* streamCandidates(): AsyncIterable<PhaseBRevalidatedCandidate> {
+    for (const pointer of chunkPointers) {
+      const chunkRead = await input.reader.readJson(pointer.path);
+      const chunkContent = chunkRead.content;
+      const actualSha = sha256Hex(chunkContent);
+      if (actualSha !== pointer.sha256) {
+        throw new ArtifactIntegrityError(
+          `Phase B chunk sha256 mismatch: expected ${pointer.sha256}, got ${actualSha} (path=${pointer.path})`
+        );
+      }
+      const chunk = JSON.parse(chunkContent) as PhaseBRevalidatedChunk;
+      for (const candidate of chunk.revalidated) yield candidate;
+    }
+  }
+
+  return {
+    phaseBArtifactRef,
+    phaseBManifestSha256,
+    candidatesIn,
+    manifest,
+    manifestGeneration: manifestRead.generation,
+    candidates: streamCandidates,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-c/artifactWriter.ts
+++ b/scripts/pr-d4-backfill/phase-c/artifactWriter.ts
@@ -18,8 +18,10 @@ import type {
   PhaseCBackfillChunk,
   PhaseCBackfillSummary,
   PhaseCImmutableSkippedDoc,
+  PhaseCOutOfScopeDoc,
   PhaseCPreconditionFailedDoc,
   PhaseCRateLimiterConfig,
+  PhaseCUnprocessableDoc,
   PhaseCWrittenDoc,
 } from '../types';
 import { PR_D4_ARTIFACT_SCHEMA_VERSION, PR_D4_SCRIPT_VERSION } from '../types';
@@ -41,12 +43,14 @@ export interface WritePhaseCChunkInput {
   writtenDocs: PhaseCWrittenDoc[];
   preconditionFailedDocs: PhaseCPreconditionFailedDoc[];
   immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
+  unprocessableDocs: PhaseCUnprocessableDoc[];
+  outOfScopeDocs: PhaseCOutOfScopeDoc[];
 }
 
 /**
  * 1 chunk 書込 (orchestrator が per-chunk flush で呼ぶ)。
- * chunk の docCount は writtenDocs.length を採用 (Phase A/B と同じ意味論)。
- * precondition / immutable skipped 件数は main artifact の集計値で別途記録される。
+ * Codex 5th I3 反映: chunk docCount は全カテゴリ合計 (BF22 artifact 完全性、運用者が
+ * 「この chunk で扱った全 doc 数」を pointer 単独で把握可能)。
  */
 export async function writePhaseCChunk(
   input: WritePhaseCChunkInput,
@@ -58,6 +62,8 @@ export async function writePhaseCChunk(
     writtenDocs: input.writtenDocs,
     preconditionFailedDocs: input.preconditionFailedDocs,
     immutableSkippedDocs: input.immutableSkippedDocs,
+    unprocessableDocs: input.unprocessableDocs,
+    outOfScopeDocs: input.outOfScopeDocs,
   };
   const chunkContent = JSON.stringify(chunkBody);
   const chunkPath = buildObjectPath(
@@ -66,10 +72,16 @@ export async function writePhaseCChunk(
     `phase-c-backfill-summary-chunk-${input.chunkIndex}.json`
   );
   await writer.writeJson(chunkPath, chunkContent);
+  const totalDocCount =
+    input.writtenDocs.length +
+    input.preconditionFailedDocs.length +
+    input.immutableSkippedDocs.length +
+    input.unprocessableDocs.length +
+    input.outOfScopeDocs.length;
   return {
     path: chunkPath,
     sha256: sha256Hex(chunkContent),
-    docCount: input.writtenDocs.length,
+    docCount: totalDocCount,
   };
 }
 
@@ -85,6 +97,10 @@ export interface FinalizePhaseCInput {
   writtenDocs: number;
   preconditionFailedDocs: number;
   skippedImmutable: number;
+  /** Codex 5th C2 反映: missing / validation 不能 doc の集計 */
+  unprocessableDocs: number;
+  /** Codex 5th C1 反映: hard-gate で除外された Phase C スコープ外 doc の集計 */
+  outOfScopeDocs: number;
   lockAcquiredGeneration: string;
   lockReleasedAt: string;
   rateLimiterConfig: PhaseCRateLimiterConfig;
@@ -121,6 +137,8 @@ export async function finalizePhaseCArtifact(
     writtenDocs: input.writtenDocs,
     preconditionFailedDocs: input.preconditionFailedDocs,
     skippedImmutable: input.skippedImmutable,
+    unprocessableDocs: input.unprocessableDocs,
+    outOfScopeDocs: input.outOfScopeDocs,
     lockAcquiredGeneration: input.lockAcquiredGeneration,
     lockReleasedAt: input.lockReleasedAt,
     rateLimiterConfig: input.rateLimiterConfig,

--- a/scripts/pr-d4-backfill/phase-c/artifactWriter.ts
+++ b/scripts/pr-d4-backfill/phase-c/artifactWriter.ts
@@ -1,0 +1,151 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C artifact writer (BF22 chunking + manifest CAS update).
+ *
+ * impl-plan §4.3 step 6 + Codex 2nd BF19 / 3rd BF22 反映:
+ *   phase-c-backfill-summary.json (main) + chunks (writtenDocs / preconditionFailedDocs /
+ *   immutableSkippedDocs) + manifest.json の phaseC section CAS update。
+ *
+ * 構造は Phase A/B writer と一貫。manifest update は existingManifest を base にして
+ * phaseC を additive で追記、ifGenerationMatch precondition 付き。
+ */
+
+import * as crypto from 'crypto';
+import type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  BackfillManifest,
+  PhaseCBackfillChunk,
+  PhaseCBackfillSummary,
+  PhaseCImmutableSkippedDoc,
+  PhaseCPreconditionFailedDoc,
+  PhaseCRateLimiterConfig,
+  PhaseCWrittenDoc,
+} from '../types';
+import { PR_D4_ARTIFACT_SCHEMA_VERSION, PR_D4_SCRIPT_VERSION } from '../types';
+
+export type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function buildObjectPath(bucketName: string, runId: string, fileName: string): string {
+  return `gs://${bucketName}/pr-d4-backfill-artifacts/${runId}/${fileName}`;
+}
+
+export interface WritePhaseCChunkInput {
+  bucketName: string;
+  runId: string;
+  chunkIndex: number;
+  writtenDocs: PhaseCWrittenDoc[];
+  preconditionFailedDocs: PhaseCPreconditionFailedDoc[];
+  immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
+}
+
+/**
+ * 1 chunk 書込 (orchestrator が per-chunk flush で呼ぶ)。
+ * chunk の docCount は writtenDocs.length を採用 (Phase A/B と同じ意味論)。
+ * precondition / immutable skipped 件数は main artifact の集計値で別途記録される。
+ */
+export async function writePhaseCChunk(
+  input: WritePhaseCChunkInput,
+  writer: ArtifactStorageWriter
+): Promise<ArtifactChunkPointer> {
+  const chunkBody: PhaseCBackfillChunk = {
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    chunkIndex: input.chunkIndex,
+    writtenDocs: input.writtenDocs,
+    preconditionFailedDocs: input.preconditionFailedDocs,
+    immutableSkippedDocs: input.immutableSkippedDocs,
+  };
+  const chunkContent = JSON.stringify(chunkBody);
+  const chunkPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    `phase-c-backfill-summary-chunk-${input.chunkIndex}.json`
+  );
+  await writer.writeJson(chunkPath, chunkContent);
+  return {
+    path: chunkPath,
+    sha256: sha256Hex(chunkContent),
+    docCount: input.writtenDocs.length,
+  };
+}
+
+export interface FinalizePhaseCInput {
+  bucketName: string;
+  runId: string;
+  env: BackfillEnvName;
+  backfillStartedAt: string;
+  backfillCompletedAt: string;
+  phaseBArtifactRef: string;
+  phaseBManifestSha256: string;
+  candidatesIn: number;
+  writtenDocs: number;
+  preconditionFailedDocs: number;
+  skippedImmutable: number;
+  lockAcquiredGeneration: string;
+  lockReleasedAt: string;
+  rateLimiterConfig: PhaseCRateLimiterConfig;
+  chunks: ArtifactChunkPointer[];
+  /** Phase B 完了時点の manifest (Phase C で phaseC section を追記) */
+  existingManifest: BackfillManifest;
+  /**
+   * existingManifest を read した時点の GCS generation。
+   * Phase C finalize で manifest を CAS update する precondition。
+   */
+  manifestGeneration: number;
+}
+
+export interface FinalizePhaseCResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+}
+
+export async function finalizePhaseCArtifact(
+  input: FinalizePhaseCInput,
+  writer: ArtifactStorageWriter
+): Promise<FinalizePhaseCResult> {
+  const mainBody: PhaseCBackfillSummary = {
+    phase: 'C',
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    scriptVersion: PR_D4_SCRIPT_VERSION,
+    env: input.env,
+    runId: input.runId,
+    phaseBArtifactRef: input.phaseBArtifactRef,
+    phaseBManifestSha256: input.phaseBManifestSha256,
+    backfillStartedAt: input.backfillStartedAt,
+    backfillCompletedAt: input.backfillCompletedAt,
+    candidatesIn: input.candidatesIn,
+    writtenDocs: input.writtenDocs,
+    preconditionFailedDocs: input.preconditionFailedDocs,
+    skippedImmutable: input.skippedImmutable,
+    lockAcquiredGeneration: input.lockAcquiredGeneration,
+    lockReleasedAt: input.lockReleasedAt,
+    rateLimiterConfig: input.rateLimiterConfig,
+    chunks: input.chunks,
+  };
+  const mainContent = JSON.stringify(mainBody);
+  const mainPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    'phase-c-backfill-summary.json'
+  );
+  await writer.writeJson(mainPath, mainContent);
+
+  const updatedManifest: BackfillManifest = {
+    ...input.existingManifest,
+    phaseC: {
+      mainArtifact: { path: mainPath, sha256: sha256Hex(mainContent) },
+      chunks: input.chunks,
+    },
+  };
+  const manifestContent = JSON.stringify(updatedManifest);
+  const manifestPath = buildObjectPath(input.bucketName, input.runId, 'manifest.json');
+  await writer.writeJson(manifestPath, manifestContent, {
+    ifGenerationMatch: input.manifestGeneration,
+  });
+
+  return { mainArtifactPath: mainPath, manifestPath };
+}

--- a/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
+++ b/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
@@ -248,18 +248,16 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
     // 残 buffer chunk 出力
     await flushChunkBuffersIfFull(true);
 
-    // (7) lock release は finalize 前に実行 (Evaluator MEDIUM 反映、lockReleasedAt が
-    // finalize 開始時刻になる問題を解消)。manifest CAS update は precondition で守られて
-    // いるため、lock 解放後でも並走による artifact 整合性破壊は発生しない。
-    await releasePhaseCLock(
-      {
-        lockPath: lockAcquired.lockPath,
-        acquiredGeneration: lockAcquired.acquiredGeneration,
-      },
-      input.lockStore
-    );
-    const lockReleasedAt = nowProvider();
-    const backfillCompletedAt = lockReleasedAt;
+    // Codex 6th Critical 反映: lock release は finalize の **後** に行う。
+    // 先に release すると finalize 失敗時に別 run が同 env lock を取得可能になり、
+    // 「Firestore writes は committed + manifest.phaseC 未反映」の中途半端な状態が
+    // 別 run に観測される (production-unsafe window)。
+    //
+    // `lockReleasedAt` field は **lock release を要求する直前の時刻** を記録する。
+    // 実際の release ACK 後の時刻は別途 `runPhaseC` 戻り値で追加観測することも
+    // 可能だが、artifact 完整性 (= lock 保護下で書込まれる) を優先する。
+    const backfillCompletedAt = nowProvider();
+    const lockReleasedAt = backfillCompletedAt;
 
     const finalize = await finalizePhaseCArtifact(
       {
@@ -284,6 +282,15 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
         manifestGeneration: stream.manifestGeneration,
       },
       input.artifactWriter
+    );
+
+    // finalize 完了後に lock release (Codex 6th Critical 反映)
+    await releasePhaseCLock(
+      {
+        lockPath: lockAcquired.lockPath,
+        acquiredGeneration: lockAcquired.acquiredGeneration,
+      },
+      input.lockStore
     );
 
     return {

--- a/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
+++ b/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
@@ -1,0 +1,284 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C orchestrator (atomic backfill verified docs).
+ *
+ * Phase B artifact streaming read → 各 candidate を ≤20 docs/batch にまとめて
+ * processBatch → 失敗時 processFallback → writtenDocs / preconditionFailedDocs /
+ * immutableSkippedDocs を per-chunk flush → finalize (main + manifest CAS) → lock 解放。
+ *
+ * 処理フロー (impl-plan §4.3):
+ *   1. lock acquire (lockManager) → existing lock 検出で即 abort
+ *   2. Phase B manifest 読込 + sha256 verify (artifactReader)
+ *   3. candidates AsyncIterable を for-await で消費し PR_D4_PHASE_C_BATCH_SIZE で grouping
+ *   4. processBatch (skip + commit)
+ *   5. outcome=batch-failed → processFallback (個別 retry + 隔離)
+ *   6. 結果を per-chunk buffer (PR_D4_CANDIDATES_PER_CHUNK 上限) で flush
+ *   7. finalize (main + manifest) → lock release
+ *
+ * lock 解放は try/finally で必ず実行 (中断 / error でも stale lock を残さない、Codex 2nd 反映)
+ */
+
+import { Timestamp } from 'firebase-admin/firestore';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  PhaseBRevalidatedCandidate,
+  PhaseCImmutableSkippedDoc,
+  PhaseCPreconditionFailedDoc,
+  PhaseCRateLimiterConfig,
+  PhaseCWrittenDoc,
+} from '../types';
+import {
+  PR_D4_CANDIDATES_PER_CHUNK,
+  PR_D4_PHASE_C_BATCH_SIZE,
+} from '../types';
+import { readPhaseBArtifact, type ArtifactStorageReader } from './artifactReader';
+import { finalizePhaseCArtifact, writePhaseCChunk } from './artifactWriter';
+import type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+import {
+  processBatch,
+  type FirestoreBatchAdapter,
+} from './batchWriter';
+import {
+  processFallback,
+  type FirestoreIndividualAdapter,
+} from './individualRetryWriter';
+import {
+  acquirePhaseCLock,
+  releasePhaseCLock,
+  type LockObjectStore,
+} from './lockManager';
+import type { RateLimiter } from './rateLimiter';
+
+export interface RunPhaseCInput {
+  env: BackfillEnvName;
+  runId: string;
+  jobId: string;
+  lockOwner: string;
+  artifactBucketName: string;
+  manifestPath: string;
+  artifactReader: ArtifactStorageReader;
+  artifactWriter: ArtifactStorageWriter;
+  lockStore: LockObjectStore;
+  batchAdapter: FirestoreBatchAdapter;
+  individualAdapter: FirestoreIndividualAdapter;
+  rateLimiter: RateLimiter;
+  rateLimiterConfig: PhaseCRateLimiterConfig;
+  backfillScriptVersion: string;
+  expectedDurationSec: number;
+  /** test 用 clock (ISO8601 を返す)。省略時 system clock */
+  nowProvider?: () => string;
+  /**
+   * test 用 backfilledAt Timestamp。省略時 nowProvider 由来。
+   * run 単位で 1 度生成し全 batch で共有 (観測一貫性)
+   */
+  backfilledAtProvider?: () => Timestamp;
+}
+
+export interface RunPhaseCResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+  candidatesIn: number;
+  writtenDocs: number;
+  preconditionFailedDocs: number;
+  skippedImmutable: number;
+  lockAcquiredGeneration: string;
+  lockReleasedAt: string;
+  backfillCompletedAt: string;
+}
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult> {
+  const nowProvider = input.nowProvider ?? defaultNow;
+  const backfilledAtProvider =
+    input.backfilledAtProvider ?? (() => Timestamp.fromDate(new Date(nowProvider())));
+
+  const backfillStartedAt = nowProvider();
+  const backfilledAt = backfilledAtProvider();
+
+  // (1) lock acquire — 既存 lock 検出で LockHeldByOthersError throw、orchestrator は呼出元へ伝播
+  const lockAcquired = await acquirePhaseCLock(
+    {
+      bucketName: input.artifactBucketName,
+      env: input.env,
+      runId: input.runId,
+      jobId: input.jobId,
+      startedAt: backfillStartedAt,
+      expectedDurationSec: input.expectedDurationSec,
+      lockOwner: input.lockOwner,
+    },
+    input.lockStore
+  );
+
+  try {
+    // (2) Phase B artifact read + sha256 verify
+    const stream = await readPhaseBArtifact({
+      manifestPath: input.manifestPath,
+      reader: input.artifactReader,
+    });
+    const existingManifest = stream.manifest;
+
+    let totalCandidatesIn = 0;
+    let totalWritten = 0;
+    let totalPreconditionFailed = 0;
+    let totalImmutableSkipped = 0;
+
+    const chunkPointers: ArtifactChunkPointer[] = [];
+    let writtenBuffer: PhaseCWrittenDoc[] = [];
+    let preconditionFailedBuffer: PhaseCPreconditionFailedDoc[] = [];
+    let immutableSkippedBuffer: PhaseCImmutableSkippedDoc[] = [];
+    let chunkIndex = 0;
+
+    /**
+     * buffer flush 判定:
+     *   - forceFlush=true (最終 flush): 残 buffer を空にする
+     *   - 各 buffer 数が PR_D4_CANDIDATES_PER_CHUNK 以上: 1 chunk 出力
+     *   - 全 buffer が空 / forceFlush=true でも 0 件: chunk 出力なし
+     */
+    async function flushChunkBuffersIfFull(forceFlush = false): Promise<void> {
+      const totalBuffered =
+        writtenBuffer.length + preconditionFailedBuffer.length + immutableSkippedBuffer.length;
+      const shouldFlush =
+        forceFlush ||
+        writtenBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK ||
+        preconditionFailedBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK ||
+        immutableSkippedBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK;
+      if (!shouldFlush || totalBuffered === 0) return;
+      const pointer = await writePhaseCChunk(
+        {
+          bucketName: input.artifactBucketName,
+          runId: input.runId,
+          chunkIndex,
+          writtenDocs: writtenBuffer,
+          preconditionFailedDocs: preconditionFailedBuffer,
+          immutableSkippedDocs: immutableSkippedBuffer,
+        },
+        input.artifactWriter
+      );
+      chunkPointers.push(pointer);
+      chunkIndex++;
+      writtenBuffer = [];
+      preconditionFailedBuffer = [];
+      immutableSkippedBuffer = [];
+    }
+
+    // (3) batch 単位 grouping (batch size = 20)
+    let batchAccumulator: PhaseBRevalidatedCandidate[] = [];
+
+    async function flushBatch(): Promise<void> {
+      if (batchAccumulator.length === 0) return;
+      const batchResult = await processBatch(
+        {
+          candidates: batchAccumulator,
+          backfillScriptVersion: input.backfillScriptVersion,
+          backfilledAt,
+        },
+        input.batchAdapter,
+        input.rateLimiter
+      );
+
+      if (batchResult.outcome === 'all-committed') {
+        writtenBuffer.push(...batchResult.writtenDocs);
+        totalWritten += batchResult.writtenDocs.length;
+        immutableSkippedBuffer.push(...batchResult.immutableSkippedDocs);
+        totalImmutableSkipped += batchResult.immutableSkippedDocs.length;
+      } else {
+        // (5) batch 失敗 → fallback
+        immutableSkippedBuffer.push(...batchResult.immutableSkippedDocs);
+        totalImmutableSkipped += batchResult.immutableSkippedDocs.length;
+        const fallback = await processFallback(
+          {
+            candidates: batchResult.candidatesForFallback,
+            lastUpdateTimePreconditions: batchResult.lastUpdateTimePreconditions,
+            backfillScriptVersion: input.backfillScriptVersion,
+            backfilledAt,
+          },
+          input.individualAdapter,
+          input.rateLimiter
+        );
+        writtenBuffer.push(...fallback.writtenDocs);
+        totalWritten += fallback.writtenDocs.length;
+        preconditionFailedBuffer.push(...fallback.preconditionFailedDocs);
+        totalPreconditionFailed += fallback.preconditionFailedDocs.length;
+      }
+
+      batchAccumulator = [];
+      await flushChunkBuffersIfFull(false);
+    }
+
+    for await (const candidate of stream.candidates()) {
+      totalCandidatesIn++;
+      batchAccumulator.push(candidate);
+      if (batchAccumulator.length >= PR_D4_PHASE_C_BATCH_SIZE) {
+        await flushBatch();
+      }
+    }
+    // 残 batch flush
+    await flushBatch();
+    // 残 buffer chunk 出力
+    await flushChunkBuffersIfFull(true);
+
+    const lockReleasedAt = nowProvider();
+    const backfillCompletedAt = lockReleasedAt;
+
+    const finalize = await finalizePhaseCArtifact(
+      {
+        bucketName: input.artifactBucketName,
+        runId: input.runId,
+        env: input.env,
+        backfillStartedAt,
+        backfillCompletedAt,
+        phaseBArtifactRef: stream.phaseBArtifactRef,
+        phaseBManifestSha256: stream.phaseBManifestSha256,
+        candidatesIn: totalCandidatesIn,
+        writtenDocs: totalWritten,
+        preconditionFailedDocs: totalPreconditionFailed,
+        skippedImmutable: totalImmutableSkipped,
+        lockAcquiredGeneration: lockAcquired.acquiredGeneration,
+        lockReleasedAt,
+        rateLimiterConfig: input.rateLimiterConfig,
+        chunks: chunkPointers,
+        existingManifest,
+        manifestGeneration: stream.manifestGeneration,
+      },
+      input.artifactWriter
+    );
+
+    // (7) lock release (必ず実行、generation precondition 付き)
+    await releasePhaseCLock(
+      {
+        lockPath: lockAcquired.lockPath,
+        acquiredGeneration: lockAcquired.acquiredGeneration,
+      },
+      input.lockStore
+    );
+
+    return {
+      mainArtifactPath: finalize.mainArtifactPath,
+      manifestPath: finalize.manifestPath,
+      candidatesIn: totalCandidatesIn,
+      writtenDocs: totalWritten,
+      preconditionFailedDocs: totalPreconditionFailed,
+      skippedImmutable: totalImmutableSkipped,
+      lockAcquiredGeneration: lockAcquired.acquiredGeneration,
+      lockReleasedAt,
+      backfillCompletedAt,
+    };
+  } catch (e) {
+    // 中断 / error 時は lock を best-effort で解放 (release 失敗は元 error 優先)
+    try {
+      await releasePhaseCLock(
+        {
+          lockPath: lockAcquired.lockPath,
+          acquiredGeneration: lockAcquired.acquiredGeneration,
+        },
+        input.lockStore
+      );
+    } catch {
+      /* swallow */
+    }
+    throw e;
+  }
+}

--- a/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
+++ b/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
@@ -14,7 +14,8 @@
  *   6. 結果を per-chunk buffer (PR_D4_CANDIDATES_PER_CHUNK 上限) で flush
  *   7. finalize (main + manifest) → lock release
  *
- * lock 解放は try/finally で必ず実行 (中断 / error でも stale lock を残さない、Codex 2nd 反映)
+ * lock 解放は finalize 後の最終操作。中断 / error 時は try/catch で best-effort 解放
+ * (release 失敗は console.error で運用者通知、元 error を伝播、Codex 2nd 反映)
  */
 
 import { Timestamp } from 'firebase-admin/firestore';

--- a/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
+++ b/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
@@ -23,8 +23,10 @@ import type {
   BackfillEnvName,
   PhaseBRevalidatedCandidate,
   PhaseCImmutableSkippedDoc,
+  PhaseCOutOfScopeDoc,
   PhaseCPreconditionFailedDoc,
   PhaseCRateLimiterConfig,
+  PhaseCUnprocessableDoc,
   PhaseCWrittenDoc,
 } from '../types';
 import {
@@ -77,10 +79,16 @@ export interface RunPhaseCInput {
 export interface RunPhaseCResult {
   mainArtifactPath: string;
   manifestPath: string;
+  /**
+   * 保全式: candidatesIn = writtenDocs + preconditionFailedDocs + skippedImmutable +
+   *                       unprocessableDocs + outOfScopeDocs (orchestrator が test でアサート)
+   */
   candidatesIn: number;
   writtenDocs: number;
   preconditionFailedDocs: number;
   skippedImmutable: number;
+  unprocessableDocs: number;
+  outOfScopeDocs: number;
   lockAcquiredGeneration: string;
   lockReleasedAt: string;
   backfillCompletedAt: string;
@@ -124,27 +132,37 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
     let totalWritten = 0;
     let totalPreconditionFailed = 0;
     let totalImmutableSkipped = 0;
+    let totalUnprocessable = 0;
+    let totalOutOfScope = 0;
 
     const chunkPointers: ArtifactChunkPointer[] = [];
     let writtenBuffer: PhaseCWrittenDoc[] = [];
     let preconditionFailedBuffer: PhaseCPreconditionFailedDoc[] = [];
     let immutableSkippedBuffer: PhaseCImmutableSkippedDoc[] = [];
+    let unprocessableBuffer: PhaseCUnprocessableDoc[] = [];
+    let outOfScopeBuffer: PhaseCOutOfScopeDoc[] = [];
     let chunkIndex = 0;
 
     /**
-     * buffer flush 判定:
+     * buffer flush 判定 (全カテゴリ対象):
      *   - forceFlush=true (最終 flush): 残 buffer を空にする
-     *   - 各 buffer 数が PR_D4_CANDIDATES_PER_CHUNK 以上: 1 chunk 出力
+     *   - いずれかの buffer 数が PR_D4_CANDIDATES_PER_CHUNK 以上: 1 chunk 出力
      *   - 全 buffer が空 / forceFlush=true でも 0 件: chunk 出力なし
      */
     async function flushChunkBuffersIfFull(forceFlush = false): Promise<void> {
       const totalBuffered =
-        writtenBuffer.length + preconditionFailedBuffer.length + immutableSkippedBuffer.length;
+        writtenBuffer.length +
+        preconditionFailedBuffer.length +
+        immutableSkippedBuffer.length +
+        unprocessableBuffer.length +
+        outOfScopeBuffer.length;
       const shouldFlush =
         forceFlush ||
         writtenBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK ||
         preconditionFailedBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK ||
-        immutableSkippedBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK;
+        immutableSkippedBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK ||
+        unprocessableBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK ||
+        outOfScopeBuffer.length >= PR_D4_CANDIDATES_PER_CHUNK;
       if (!shouldFlush || totalBuffered === 0) return;
       const pointer = await writePhaseCChunk(
         {
@@ -154,6 +172,8 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
           writtenDocs: writtenBuffer,
           preconditionFailedDocs: preconditionFailedBuffer,
           immutableSkippedDocs: immutableSkippedBuffer,
+          unprocessableDocs: unprocessableBuffer,
+          outOfScopeDocs: outOfScopeBuffer,
         },
         input.artifactWriter
       );
@@ -162,6 +182,8 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
       writtenBuffer = [];
       preconditionFailedBuffer = [];
       immutableSkippedBuffer = [];
+      unprocessableBuffer = [];
+      outOfScopeBuffer = [];
     }
 
     // (3) batch 単位 grouping (batch size = 20)
@@ -179,15 +201,19 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
         input.rateLimiter
       );
 
+      // batch 直前段で除外された immutable / unprocessable / out-of-scope を先に積む
+      immutableSkippedBuffer.push(...batchResult.immutableSkippedDocs);
+      totalImmutableSkipped += batchResult.immutableSkippedDocs.length;
+      unprocessableBuffer.push(...batchResult.unprocessableDocs);
+      totalUnprocessable += batchResult.unprocessableDocs.length;
+      outOfScopeBuffer.push(...batchResult.outOfScopeDocs);
+      totalOutOfScope += batchResult.outOfScopeDocs.length;
+
       if (batchResult.outcome === 'all-committed') {
         writtenBuffer.push(...batchResult.writtenDocs);
         totalWritten += batchResult.writtenDocs.length;
-        immutableSkippedBuffer.push(...batchResult.immutableSkippedDocs);
-        totalImmutableSkipped += batchResult.immutableSkippedDocs.length;
       } else {
-        // (5) batch 失敗 → fallback
-        immutableSkippedBuffer.push(...batchResult.immutableSkippedDocs);
-        totalImmutableSkipped += batchResult.immutableSkippedDocs.length;
+        // (5) batch 失敗 → fallback (immutable / unprocessable / out-of-scope は既に積み済)
         const fallback = await processFallback(
           {
             candidates: batchResult.candidatesForFallback,
@@ -202,6 +228,8 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
         totalWritten += fallback.writtenDocs.length;
         preconditionFailedBuffer.push(...fallback.preconditionFailedDocs);
         totalPreconditionFailed += fallback.preconditionFailedDocs.length;
+        unprocessableBuffer.push(...fallback.unprocessableDocs);
+        totalUnprocessable += fallback.unprocessableDocs.length;
       }
 
       batchAccumulator = [];
@@ -220,6 +248,16 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
     // 残 buffer chunk 出力
     await flushChunkBuffersIfFull(true);
 
+    // (7) lock release は finalize 前に実行 (Evaluator MEDIUM 反映、lockReleasedAt が
+    // finalize 開始時刻になる問題を解消)。manifest CAS update は precondition で守られて
+    // いるため、lock 解放後でも並走による artifact 整合性破壊は発生しない。
+    await releasePhaseCLock(
+      {
+        lockPath: lockAcquired.lockPath,
+        acquiredGeneration: lockAcquired.acquiredGeneration,
+      },
+      input.lockStore
+    );
     const lockReleasedAt = nowProvider();
     const backfillCompletedAt = lockReleasedAt;
 
@@ -236,6 +274,8 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
         writtenDocs: totalWritten,
         preconditionFailedDocs: totalPreconditionFailed,
         skippedImmutable: totalImmutableSkipped,
+        unprocessableDocs: totalUnprocessable,
+        outOfScopeDocs: totalOutOfScope,
         lockAcquiredGeneration: lockAcquired.acquiredGeneration,
         lockReleasedAt,
         rateLimiterConfig: input.rateLimiterConfig,
@@ -246,15 +286,6 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
       input.artifactWriter
     );
 
-    // (7) lock release (必ず実行、generation precondition 付き)
-    await releasePhaseCLock(
-      {
-        lockPath: lockAcquired.lockPath,
-        acquiredGeneration: lockAcquired.acquiredGeneration,
-      },
-      input.lockStore
-    );
-
     return {
       mainArtifactPath: finalize.mainArtifactPath,
       manifestPath: finalize.manifestPath,
@@ -262,12 +293,15 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
       writtenDocs: totalWritten,
       preconditionFailedDocs: totalPreconditionFailed,
       skippedImmutable: totalImmutableSkipped,
+      unprocessableDocs: totalUnprocessable,
+      outOfScopeDocs: totalOutOfScope,
       lockAcquiredGeneration: lockAcquired.acquiredGeneration,
       lockReleasedAt,
       backfillCompletedAt,
     };
   } catch (e) {
-    // 中断 / error 時は lock を best-effort で解放 (release 失敗は元 error 優先)
+    // 中断 / error 時は lock を best-effort で解放 (release 失敗は console.error で
+    // 通知、運用者が stale lock 解放手順を runbook 通り実行できるよう支援、Codex 5th I2 反映)。
     try {
       await releasePhaseCLock(
         {
@@ -276,8 +310,11 @@ export async function runPhaseC(input: RunPhaseCInput): Promise<RunPhaseCResult>
         },
         input.lockStore
       );
-    } catch {
-      /* swallow */
+    } catch (releaseErr) {
+      console.error(
+        `[PR-D4 Phase C] lock release failed during error recovery (lockPath=${lockAcquired.lockPath}, generation=${lockAcquired.acquiredGeneration}):`,
+        releaseErr
+      );
     }
     throw e;
   }

--- a/scripts/pr-d4-backfill/phase-c/batchWriter.ts
+++ b/scripts/pr-d4-backfill/phase-c/batchWriter.ts
@@ -1,0 +1,298 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C atomic batch writer (BF10/BF11/BF14/BF18/BF23).
+ *
+ * impl-plan §4.3 step 5 + Codex 2nd C3 + 3rd I3 反映:
+ *   20 docs/batch + 各 doc に `lastUpdateTime` precondition + batch 直前 immutable skip
+ *   再確認 + `provenance` 10 fields + `provenanceBackfill` metadata を atomic update。
+ *
+ * 設計判断:
+ * - 依存性逆転: `FirestoreBatchAdapter` interface 経由で Firestore SDK を受け取り、
+ *   unit test では in-memory fake で挙動を制御する (Phase A/B Writer pattern と同じ)
+ * - batch commit は **全体成功 / 全体失敗の二択** (Firestore atomic batch 仕様)。
+ *   precondition 失敗 / transient error 等で batch 全体が fail した場合、caller
+ *   (individualRetryWriter) が doc 単位 fallback で続行する (BF18)
+ * - immutable skip は batch 直前の再読込で field existence 判定 (BF14、null sentinel 禁止)
+ * - rate limiter は batch size 分の token を **commit 直前** に acquire
+ *   (canonical JSON 構築 / immutable skip filter の cost は token 消費前)
+ * - `backfilledAt` は orchestrator 側で 1 度生成し全 batch で共有 (run 単位の観測一貫性)
+ * - `lastUpdateTimeAfter` は commitBatch が返す writeResults から取得 (Firestore batch commit
+ *   の WriteResult.writeTime で十分、追加 read 不要)
+ *
+ * provenanceBackfill metadata の sha256 計算は canonical JSON (キー順固定の JSON.stringify
+ * は ECMA-262 で deterministic) ベース。Timestamp は { seconds, nanoseconds } で stringify
+ * されるため backfilledAt 含めて deterministic に sha256 が計算できる。
+ */
+
+import * as crypto from 'crypto';
+import { Timestamp } from 'firebase-admin/firestore';
+import type {
+  DocumentProvenance,
+  ProvenanceBackfillMetadata,
+} from '../../../shared/types';
+import {
+  createBackfillProvenance,
+  ProvenanceValidationError,
+} from '../../../functions/src/pdf/provenance';
+import type {
+  PhaseBRevalidatedCandidate,
+  PhaseCImmutableSkippedDoc,
+  PhaseCWrittenDoc,
+} from '../types';
+import { checkImmutableSkip } from './immutableSkipChecker';
+import type { RateLimiter } from './rateLimiter';
+
+export interface BatchReReadResult {
+  exists: boolean;
+  /** ISO8601 (Firestore updateTime) — doc 不在時 undefined */
+  updateTime?: string;
+  provenance: unknown;
+  provenanceBackfill: unknown;
+}
+
+export interface FirestoreBatchAdapter {
+  /**
+   * doc 単位で snapshot 再取得 (batch 直前 immutable skip + precondition 値取得用)。
+   * doc 不在は `exists: false` で返却 (caller が skip 候補から除外)。
+   */
+  reReadForBatch(docIds: string[]): Promise<Map<string, BatchReReadResult>>;
+  /**
+   * Firestore atomic batch commit。各 entry の `lastUpdateTimePrecondition` を precondition
+   * として渡し、全体成功 / 全体失敗で返却。
+   */
+  commitBatch(entries: BatchUpdateEntry[]): Promise<CommitBatchResult>;
+}
+
+export interface BatchUpdateEntry {
+  docId: string;
+  provenance: DocumentProvenance;
+  provenanceBackfill: ProvenanceBackfillMetadata;
+  /** ISO8601、batch precondition (lastUpdateTime drift で全体 fail) */
+  lastUpdateTimePrecondition: string;
+}
+
+export type CommitBatchResult =
+  | {
+      kind: 'ok';
+      /** 各 doc の commit 後 updateTime (ISO8601) */
+      writeResults: Array<{ docId: string; updateTime: string }>;
+    }
+  | {
+      kind: 'batch-failed';
+      /** 失敗種別: 'precondition' / 'transient' / 'unknown' */
+      reason: 'precondition' | 'transient' | 'unknown';
+      message: string;
+    };
+
+export interface ProcessBatchInput {
+  candidates: PhaseBRevalidatedCandidate[];
+  backfillScriptVersion: string;
+  /** backfilledAt: run 単位で 1 度生成し全 batch 共有 */
+  backfilledAt: Timestamp;
+}
+
+export type ProcessBatchOutcome =
+  | {
+      outcome: 'all-committed';
+      writtenDocs: PhaseCWrittenDoc[];
+      immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
+      /** doc 不在 / lookup 不能で skip された docs (caller が観測ログに残す) */
+      missingDocs: string[];
+    }
+  | {
+      outcome: 'batch-failed';
+      failureReason: string;
+      /** individualRetryWriter で fallback 対象 (immutable skip / missing は既に除外済) */
+      candidatesForFallback: PhaseBRevalidatedCandidate[];
+      /** 各 candidate に対応する precondition lastUpdateTime (再読込時の値) */
+      lastUpdateTimePreconditions: Map<string, string>;
+      immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
+      missingDocs: string[];
+    };
+
+/**
+ * provenanceBackfill metadata を canonical JSON で sha256 算出。
+ * Timestamp は { seconds, nanoseconds } へ展開 (admin SDK の Timestamp.toJSON 互換)。
+ *
+ * individualRetryWriter からも writtenDocs[].newProvenanceBackfillSha256 計算で利用するため
+ * export する (BF22 artifact 観測一貫性)。
+ */
+export function sha256ProvenanceBackfill(metadata: ProvenanceBackfillMetadata): string {
+  const canonical = JSON.stringify(metadata, (_key, value) => {
+    if (value instanceof Timestamp) {
+      return { seconds: value.seconds, nanoseconds: value.nanoseconds };
+    }
+    return value;
+  });
+  return crypto.createHash('sha256').update(canonical, 'utf8').digest('hex');
+}
+
+/**
+ * Phase B revalidated candidate から `createBackfillProvenance` 入力を構築する。
+ *
+ * - `createdAt` ISO string → admin SDK Timestamp 変換 (impl-plan §4.2 JSDoc 明文化済)
+ * - confidence は candidate.computedConfidence をそのまま採用
+ * - parent re-split 検証済 candidate (= MatchedByHash + derived-bytes-verified) は
+ *   `evidence.parentSha256MatchedAtBackfill = true`、それ以外 (child-snapshot-only fixture
+ *   等) は false / null。本 batch writer は candidate.evidence を信頼する
+ *   (Phase B で構築済 / classifierCategory ↔ confidence invariant は caller scope)
+ *
+ * individualRetryWriter (BF18 fallback) からも同入力を構築するため export する (DRY)。
+ */
+export function buildBackfillRecord(
+  candidate: PhaseBRevalidatedCandidate,
+  backfillScriptVersion: string,
+  backfilledAt: Timestamp
+): { provenance: DocumentProvenance; provenanceBackfill: ProvenanceBackfillMetadata } {
+  const createdAt = Timestamp.fromDate(new Date(candidate.computedProvenance.createdAt));
+  return createBackfillProvenance({
+    provenanceFields: {
+      sourceGeneration: candidate.computedProvenance.sourceGeneration,
+      sourceMetageneration: candidate.computedProvenance.sourceMetageneration,
+      sourceSha256: candidate.computedProvenance.sourceSha256,
+      sourcePath: candidate.computedProvenance.sourcePath,
+      sourceBucket: candidate.computedProvenance.sourceBucket,
+      derivedObjectPath: candidate.computedProvenance.derivedObjectPath,
+      derivedGeneration: candidate.computedProvenance.derivedGeneration,
+      derivedMetageneration: candidate.computedProvenance.derivedMetageneration,
+      derivedSha256: candidate.computedProvenance.derivedSha256,
+      createdAt,
+    },
+    confidence: candidate.computedConfidence,
+    classifierCategory: candidate.category,
+    evidence: {
+      parentExists: candidate.evidence.parentExists,
+      parentSha256MatchedAtBackfill: candidate.evidence.parentSha256MatchedAtBackfill,
+      childSha256ComputedAtBackfill: candidate.evidence.childSha256ComputedAtBackfill,
+    },
+    backfillScriptVersion,
+    backfilledAt,
+  });
+}
+
+/**
+ * 1 batch (≤20 docs) を処理する。
+ *
+ * 処理順:
+ *   1. reReadForBatch で snapshot 取得
+ *   2. immutable skip (BF14) / doc 不在 を除外
+ *   3. createBackfillProvenance で entries 構築 (validation error は doc 単位 skip)
+ *   4. rateLimiter.acquire (batch size 分の token、BF23)
+ *   5. commitBatch
+ *   6. 成功 → writtenDocs[]、失敗 → candidatesForFallback (immutable skip / missing 除外済)
+ */
+export async function processBatch(
+  input: ProcessBatchInput,
+  adapter: FirestoreBatchAdapter,
+  rateLimiter: RateLimiter
+): Promise<ProcessBatchOutcome> {
+  const { candidates, backfillScriptVersion, backfilledAt } = input;
+  if (candidates.length === 0) {
+    return {
+      outcome: 'all-committed',
+      writtenDocs: [],
+      immutableSkippedDocs: [],
+      missingDocs: [],
+    };
+  }
+
+  const snapshots = await adapter.reReadForBatch(candidates.map((c) => c.docId));
+  const immutableSkippedDocs: PhaseCImmutableSkippedDoc[] = [];
+  const missingDocs: string[] = [];
+  const eligible: Array<{
+    candidate: PhaseBRevalidatedCandidate;
+    record: { provenance: DocumentProvenance; provenanceBackfill: ProvenanceBackfillMetadata };
+    lastUpdateTimePrecondition: string;
+  }> = [];
+
+  for (const candidate of candidates) {
+    const snapshot = snapshots.get(candidate.docId);
+    if (!snapshot || !snapshot.exists || !snapshot.updateTime) {
+      missingDocs.push(candidate.docId);
+      continue;
+    }
+    const skipDecision = checkImmutableSkip({
+      provenance: snapshot.provenance,
+      provenanceBackfill: snapshot.provenanceBackfill,
+    });
+    if (skipDecision.skip) {
+      immutableSkippedDocs.push({ docId: candidate.docId, reason: skipDecision.reason });
+      continue;
+    }
+    let record;
+    try {
+      record = buildBackfillRecord(candidate, backfillScriptVersion, backfilledAt);
+    } catch (e) {
+      if (e instanceof ProvenanceValidationError) {
+        // validation error は doc 単位 skip (本 PR では missing 扱い、observability ログのみ)
+        missingDocs.push(candidate.docId);
+        continue;
+      }
+      throw e;
+    }
+    eligible.push({
+      candidate,
+      record,
+      lastUpdateTimePrecondition: snapshot.updateTime,
+    });
+  }
+
+  if (eligible.length === 0) {
+    return {
+      outcome: 'all-committed',
+      writtenDocs: [],
+      immutableSkippedDocs,
+      missingDocs,
+    };
+  }
+
+  // BF23: batch size 分の token を commit 直前 acquire
+  await rateLimiter.acquire(eligible.length);
+
+  const entries: BatchUpdateEntry[] = eligible.map((e) => ({
+    docId: e.candidate.docId,
+    provenance: e.record.provenance,
+    provenanceBackfill: e.record.provenanceBackfill,
+    lastUpdateTimePrecondition: e.lastUpdateTimePrecondition,
+  }));
+
+  const commitResult = await adapter.commitBatch(entries);
+
+  if (commitResult.kind === 'batch-failed') {
+    const lastUpdateTimePreconditions = new Map(
+      eligible.map((e) => [e.candidate.docId, e.lastUpdateTimePrecondition])
+    );
+    return {
+      outcome: 'batch-failed',
+      failureReason: `${commitResult.reason}: ${commitResult.message}`,
+      candidatesForFallback: eligible.map((e) => e.candidate),
+      lastUpdateTimePreconditions,
+      immutableSkippedDocs,
+      missingDocs,
+    };
+  }
+
+  const writeResultMap = new Map(
+    commitResult.writeResults.map((r) => [r.docId, r.updateTime])
+  );
+  const writtenDocs: PhaseCWrittenDoc[] = eligible.map((e) => {
+    const updateTimeAfter = writeResultMap.get(e.candidate.docId);
+    if (!updateTimeAfter) {
+      throw new Error(
+        `commit returned ok but writeResult missing for docId=${e.candidate.docId}`
+      );
+    }
+    return {
+      docId: e.candidate.docId,
+      writeStatus: 'ok',
+      newProvenanceBackfillSha256: sha256ProvenanceBackfill(e.record.provenanceBackfill),
+      lastUpdateTimeAfter: updateTimeAfter,
+    };
+  });
+
+  return {
+    outcome: 'all-committed',
+    writtenDocs,
+    immutableSkippedDocs,
+    missingDocs,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-c/batchWriter.ts
+++ b/scripts/pr-d4-backfill/phase-c/batchWriter.ts
@@ -36,6 +36,8 @@ import {
 import type {
   PhaseBRevalidatedCandidate,
   PhaseCImmutableSkippedDoc,
+  PhaseCOutOfScopeDoc,
+  PhaseCUnprocessableDoc,
   PhaseCWrittenDoc,
 } from '../types';
 import { checkImmutableSkip } from './immutableSkipChecker';
@@ -95,18 +97,19 @@ export type ProcessBatchOutcome =
       outcome: 'all-committed';
       writtenDocs: PhaseCWrittenDoc[];
       immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
-      /** doc 不在 / lookup 不能で skip された docs (caller が観測ログに残す) */
-      missingDocs: string[];
+      unprocessableDocs: PhaseCUnprocessableDoc[];
+      outOfScopeDocs: PhaseCOutOfScopeDoc[];
     }
   | {
       outcome: 'batch-failed';
       failureReason: string;
-      /** individualRetryWriter で fallback 対象 (immutable skip / missing は既に除外済) */
+      /** individualRetryWriter で fallback 対象 (immutable skip / unprocessable / out-of-scope は既に除外済) */
       candidatesForFallback: PhaseBRevalidatedCandidate[];
-      /** 各 candidate に対応する precondition lastUpdateTime (再読込時の値) */
+      /** 各 fallback candidate に対応する precondition lastUpdateTime (再読込時の値) */
       lastUpdateTimePreconditions: Map<string, string>;
       immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
-      missingDocs: string[];
+      unprocessableDocs: PhaseCUnprocessableDoc[];
+      outOfScopeDocs: PhaseCOutOfScopeDoc[];
     };
 
 /**
@@ -115,6 +118,19 @@ export type ProcessBatchOutcome =
  *
  * individualRetryWriter からも writtenDocs[].newProvenanceBackfillSha256 計算で利用するため
  * export する (BF22 artifact 観測一貫性)。
+ *
+ * **cross-process determinism の注意** (memory: feedback_deterministic_cross_process.md):
+ *   本関数は **同一 process 内で `createBackfillProvenance` factory 経由で構築された
+ *   metadata object** に対しては deterministic に sha256 を返す。
+ *   ECMA-262 で string (non-integer) key の object literal は insertion order を保持し、
+ *   `createBackfillProvenance` factory 内の field 構築順は固定。
+ *
+ *   一方、**Phase D で Firestore から `data().provenanceBackfill` を読んで再 sha256 計算**
+ *   する場合、Firestore admin SDK が返す object の key order は実装依存で insertion order
+ *   を保証しない可能性がある。Phase D verification では:
+ *     (a) `createBackfillProvenance` を再 invoke して metadata を再構築してから sha256 比較
+ *     (b) または field 単位 deep-equal で sha256 比較を回避
+ *   いずれかを採用すること (cross-process byte 一致は要求しない設計)。
  */
 export function sha256ProvenanceBackfill(metadata: ProvenanceBackfillMetadata): string {
   const canonical = JSON.stringify(metadata, (_key, value) => {
@@ -191,23 +207,63 @@ export async function processBatch(
       outcome: 'all-committed',
       writtenDocs: [],
       immutableSkippedDocs: [],
-      missingDocs: [],
+      unprocessableDocs: [],
+      outOfScopeDocs: [],
     };
   }
 
-  const snapshots = await adapter.reReadForBatch(candidates.map((c) => c.docId));
   const immutableSkippedDocs: PhaseCImmutableSkippedDoc[] = [];
-  const missingDocs: string[] = [];
+  const unprocessableDocs: PhaseCUnprocessableDoc[] = [];
+  const outOfScopeDocs: PhaseCOutOfScopeDoc[] = [];
+
+  // (Codex 5th C1 反映) impl-plan §4.0 hard-gate: 本番 Phase C 書込対象は
+  // category === 'MatchedByHash' かつ computedConfidence === 'derived-bytes-verified' のみ。
+  // Phase B 実装は MatchedByHash のみ revalidated[] に入れるが、dev fixture / 将来の
+  // Phase B 拡張 / 設計バグで異種 candidate が混入した場合に構造的にガードする。
+  const inScopeCandidates: PhaseBRevalidatedCandidate[] = [];
+  for (const candidate of candidates) {
+    if (candidate.category !== 'MatchedByHash') {
+      outOfScopeDocs.push({
+        docId: candidate.docId,
+        reason: 'category not MatchedByHash',
+        observedCategory: candidate.category,
+        observedConfidence: candidate.computedConfidence,
+      });
+      continue;
+    }
+    if (candidate.computedConfidence !== 'derived-bytes-verified') {
+      outOfScopeDocs.push({
+        docId: candidate.docId,
+        reason: 'confidence not derived-bytes-verified',
+        observedCategory: candidate.category,
+        observedConfidence: candidate.computedConfidence,
+      });
+      continue;
+    }
+    inScopeCandidates.push(candidate);
+  }
+
+  if (inScopeCandidates.length === 0) {
+    return {
+      outcome: 'all-committed',
+      writtenDocs: [],
+      immutableSkippedDocs,
+      unprocessableDocs,
+      outOfScopeDocs,
+    };
+  }
+
+  const snapshots = await adapter.reReadForBatch(inScopeCandidates.map((c) => c.docId));
   const eligible: Array<{
     candidate: PhaseBRevalidatedCandidate;
     record: { provenance: DocumentProvenance; provenanceBackfill: ProvenanceBackfillMetadata };
     lastUpdateTimePrecondition: string;
   }> = [];
 
-  for (const candidate of candidates) {
+  for (const candidate of inScopeCandidates) {
     const snapshot = snapshots.get(candidate.docId);
     if (!snapshot || !snapshot.exists || !snapshot.updateTime) {
-      missingDocs.push(candidate.docId);
+      unprocessableDocs.push({ docId: candidate.docId, reason: 'missing' });
       continue;
     }
     const skipDecision = checkImmutableSkip({
@@ -223,8 +279,12 @@ export async function processBatch(
       record = buildBackfillRecord(candidate, backfillScriptVersion, backfilledAt);
     } catch (e) {
       if (e instanceof ProvenanceValidationError) {
-        // validation error は doc 単位 skip (本 PR では missing 扱い、observability ログのみ)
-        missingDocs.push(candidate.docId);
+        // Codex 5th C2 反映: validation error は 'missing' とは区別して unprocessable に分類
+        unprocessableDocs.push({
+          docId: candidate.docId,
+          reason: 'validation',
+          message: e.message,
+        });
         continue;
       }
       throw e;
@@ -241,7 +301,8 @@ export async function processBatch(
       outcome: 'all-committed',
       writtenDocs: [],
       immutableSkippedDocs,
-      missingDocs,
+      unprocessableDocs,
+      outOfScopeDocs,
     };
   }
 
@@ -267,7 +328,8 @@ export async function processBatch(
       candidatesForFallback: eligible.map((e) => e.candidate),
       lastUpdateTimePreconditions,
       immutableSkippedDocs,
-      missingDocs,
+      unprocessableDocs,
+      outOfScopeDocs,
     };
   }
 
@@ -293,6 +355,7 @@ export async function processBatch(
     outcome: 'all-committed',
     writtenDocs,
     immutableSkippedDocs,
-    missingDocs,
+    unprocessableDocs,
+    outOfScopeDocs,
   };
 }

--- a/scripts/pr-d4-backfill/phase-c/immutableSkipChecker.ts
+++ b/scripts/pr-d4-backfill/phase-c/immutableSkipChecker.ts
@@ -39,8 +39,8 @@ export type ImmutableSkipDecision =
  *
  * - `provenance` 不在 + `provenanceBackfill` 不在 → skip しない (新規 backfill 対象)
  * - `provenance` 存在 + `provenanceBackfill` 不在 → skip='provenance exists, provenanceBackfill absent'
- * - `provenanceBackfill` 存在 (== !== undefined、null 含む)... ただし `null` は明示書込で
- *   別意味のため skip しない (Codex 3rd I3、null sentinel 禁止)
+ * - `provenanceBackfill` 存在 (== !== undefined、ただし `null` は **除外**) → skip='already backfilled'
+ *   (Codex 3rd I3、null は明示書込で別意味のため "present" 扱いしない)
  * - `provenance` 存在 + `provenanceBackfill` object/string/値 (null 以外) → skip='already backfilled'
  */
 export function checkImmutableSkip(

--- a/scripts/pr-d4-backfill/phase-c/immutableSkipChecker.ts
+++ b/scripts/pr-d4-backfill/phase-c/immutableSkipChecker.ts
@@ -1,0 +1,45 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C immutable skip checker (pure function, BF14).
+ *
+ * impl-plan §4.3 step 5 + ADR-0016 MUST 7 + Codex 3rd I3 反映:
+ *   batch 直前の再読込で `provenance` field exists && `provenanceBackfill` field is undefined
+ *   を検出 → skip (本 PR-D4 が既 verified provenance を上書きしないガード)。
+ *
+ * 設計判断:
+ * - **field existence で判定** (Codex 3rd I3): `null` sentinel は使わない。
+ *   Firestore で `undefined` (field absent) と `null` (明示書込) は別意味。
+ *   PR-D2/D3 で書込まれた verified provenance は `provenanceBackfill` field 自体が存在しない
+ *   (= absent / undefined) であり、`null` ではない。
+ * - caller (orchestrator) が再読込した Firestore data を渡し、本 pure function が判定のみ行う
+ *   (Firestore SDK に依存しない、test しやすい)
+ */
+
+export interface FirestoreDocSnapshotForSkipCheck {
+  /** Firestore doc.data() の結果 (undefined = doc 不在は caller でガード) */
+  provenance: unknown;
+  provenanceBackfill: unknown;
+}
+
+export type ImmutableSkipDecision =
+  | { skip: false }
+  | { skip: true; reason: 'provenance exists, provenanceBackfill absent' };
+
+/**
+ * BF14: `provenance` field exists && `provenanceBackfill` field absent (undefined) で skip。
+ *
+ * - `provenance` undefined → skip しない (新規 backfill 対象)
+ * - `provenance` 存在 + `provenanceBackfill` undefined → **skip** (verified existing、immutable)
+ * - `provenance` 存在 + `provenanceBackfill` null → skip しない (null は明示書込で別意味、I3)
+ * - `provenance` 存在 + `provenanceBackfill` object/string/任意の値 → skip しない (既 backfilled、
+ *   既存 backfill 上書きは別途 ADR で議論。本 PR-D4 では候補から除外済の前提)
+ */
+export function checkImmutableSkip(
+  snapshot: FirestoreDocSnapshotForSkipCheck
+): ImmutableSkipDecision {
+  const provenanceExists = snapshot.provenance !== undefined;
+  const provenanceBackfillAbsent = snapshot.provenanceBackfill === undefined;
+  if (provenanceExists && provenanceBackfillAbsent) {
+    return { skip: true, reason: 'provenance exists, provenanceBackfill absent' };
+  }
+  return { skip: false };
+}

--- a/scripts/pr-d4-backfill/phase-c/immutableSkipChecker.ts
+++ b/scripts/pr-d4-backfill/phase-c/immutableSkipChecker.ts
@@ -20,24 +20,41 @@ export interface FirestoreDocSnapshotForSkipCheck {
   provenanceBackfill: unknown;
 }
 
+export type ImmutableSkipReason =
+  | 'provenance exists, provenanceBackfill absent'
+  | 'already backfilled (provenanceBackfill present)';
+
 export type ImmutableSkipDecision =
   | { skip: false }
-  | { skip: true; reason: 'provenance exists, provenanceBackfill absent' };
+  | { skip: true; reason: ImmutableSkipReason };
 
 /**
- * BF14: `provenance` field exists && `provenanceBackfill` field absent (undefined) で skip。
+ * BF14 + Codex 6th Important: 2 種類の skip 判定で既存 doc の上書きを防止する。
  *
- * - `provenance` undefined → skip しない (新規 backfill 対象)
- * - `provenance` 存在 + `provenanceBackfill` undefined → **skip** (verified existing、immutable)
- * - `provenance` 存在 + `provenanceBackfill` null → skip しない (null は明示書込で別意味、I3)
- * - `provenance` 存在 + `provenanceBackfill` object/string/任意の値 → skip しない (既 backfilled、
- *   既存 backfill 上書きは別途 ADR で議論。本 PR-D4 では候補から除外済の前提)
+ * 1. `provenance exists, provenanceBackfill absent` (BF14 verified existing):
+ *    PR-D2/D3 で書込まれた split-time provenance を PR-D4 backfill が上書きしないガード
+ * 2. `already backfilled (provenanceBackfill present)`:
+ *    別 Phase C run / 同 run の retry で既 backfilled doc を再 backfill しないガード
+ *    (Phase A → C 間で別 run が backfill した場合の idempotency 保護)
+ *
+ * - `provenance` 不在 + `provenanceBackfill` 不在 → skip しない (新規 backfill 対象)
+ * - `provenance` 存在 + `provenanceBackfill` 不在 → skip='provenance exists, provenanceBackfill absent'
+ * - `provenanceBackfill` 存在 (== !== undefined、null 含む)... ただし `null` は明示書込で
+ *   別意味のため skip しない (Codex 3rd I3、null sentinel 禁止)
+ * - `provenance` 存在 + `provenanceBackfill` object/string/値 (null 以外) → skip='already backfilled'
  */
 export function checkImmutableSkip(
   snapshot: FirestoreDocSnapshotForSkipCheck
 ): ImmutableSkipDecision {
   const provenanceExists = snapshot.provenance !== undefined;
   const provenanceBackfillAbsent = snapshot.provenanceBackfill === undefined;
+  // null は明示書込で別意味 (Codex 3rd I3) → "present" 扱いしない
+  const provenanceBackfillPresent =
+    snapshot.provenanceBackfill !== undefined && snapshot.provenanceBackfill !== null;
+
+  if (provenanceBackfillPresent) {
+    return { skip: true, reason: 'already backfilled (provenanceBackfill present)' };
+  }
   if (provenanceExists && provenanceBackfillAbsent) {
     return { skip: true, reason: 'provenance exists, provenanceBackfill absent' };
   }

--- a/scripts/pr-d4-backfill/phase-c/individualRetryWriter.ts
+++ b/scripts/pr-d4-backfill/phase-c/individualRetryWriter.ts
@@ -23,6 +23,7 @@ import { ProvenanceValidationError } from '../../../functions/src/pdf/provenance
 import type {
   PhaseBRevalidatedCandidate,
   PhaseCPreconditionFailedDoc,
+  PhaseCUnprocessableDoc,
   PhaseCWrittenDoc,
 } from '../types';
 import { PR_D4_PHASE_C_INDIVIDUAL_RETRY_MAX } from '../types';
@@ -59,6 +60,11 @@ export interface ProcessFallbackInput {
 export interface ProcessFallbackOutcome {
   writtenDocs: PhaseCWrittenDoc[];
   preconditionFailedDocs: PhaseCPreconditionFailedDoc[];
+  /**
+   * caller-bug 経路 (lastUpdateTimePreconditions 不在 / ProvenanceValidationError) を
+   * 'lastUpdateTime drift' と混同せず、unprocessable に分類 (code-reviewer #3 反映)。
+   */
+  unprocessableDocs: PhaseCUnprocessableDoc[];
 }
 
 /**
@@ -114,16 +120,17 @@ export async function processFallback(
   const retryMax = input.retryMax ?? PR_D4_PHASE_C_INDIVIDUAL_RETRY_MAX;
   const writtenDocs: PhaseCWrittenDoc[] = [];
   const preconditionFailedDocs: PhaseCPreconditionFailedDoc[] = [];
+  const unprocessableDocs: PhaseCUnprocessableDoc[] = [];
 
   for (const candidate of input.candidates) {
     const lastUpdateTime = input.lastUpdateTimePreconditions.get(candidate.docId);
     if (!lastUpdateTime) {
       // batchWriter outcome から渡された Map に必ず entry がある前提だが、defense-in-depth:
-      // entry 不在は隔離 (= caller のバグだが silent fail させない)
-      preconditionFailedDocs.push({
+      // entry 不在は caller-bug = unprocessable に分類 (drift とは別観測軸、code-reviewer #3 反映)
+      unprocessableDocs.push({
         docId: candidate.docId,
-        reason: 'lastUpdateTime drift',
-        retryCount: 0,
+        reason: 'missing',
+        message: 'lastUpdateTimePreconditions entry absent (caller bug)',
       });
       continue;
     }
@@ -133,11 +140,11 @@ export async function processFallback(
     } catch (e) {
       if (e instanceof ProvenanceValidationError) {
         // validation error は batchWriter scope で既に除外済の前提だが、defense:
-        // skip 扱いではなく隔離 (caller observability)
-        preconditionFailedDocs.push({
+        // unprocessable に分類 (caller observability、drift とは別観測軸)
+        unprocessableDocs.push({
           docId: candidate.docId,
-          reason: 'lastUpdateTime drift',
-          retryCount: 0,
+          reason: 'validation',
+          message: e.message,
         });
         continue;
       }
@@ -175,5 +182,5 @@ export async function processFallback(
     }
   }
 
-  return { writtenDocs, preconditionFailedDocs };
+  return { writtenDocs, preconditionFailedDocs, unprocessableDocs };
 }

--- a/scripts/pr-d4-backfill/phase-c/individualRetryWriter.ts
+++ b/scripts/pr-d4-backfill/phase-c/individualRetryWriter.ts
@@ -1,0 +1,179 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C batch fallback individual retry writer (BF18/BF23).
+ *
+ * impl-plan §4.3 step 5 + Codex 2nd Critical 3 + 3rd L3/BF23 反映:
+ *   batch 全体が失敗した時、 doc 単位の個別 update に分解して再実行する。
+ *   - precondition 失敗 (drift あり) → `preconditionFailedDocs` に隔離 (retry しない)
+ *   - transient error (timeout / network) → max 3 回 retry → 超過で `preconditionFailedDocs` 隔離
+ *   - rate limiter は各 attempt で token 1 を acquire (BF23 lock-in、突発 rate 増加防止)
+ *
+ * 設計判断:
+ * - batchWriter と同じ `RateLimiter` interface + 同じ `buildBackfillRecord` factory を
+ *   共有する (DRY、provenanceBackfill metadata 構築の一貫性 = artifact 観測整合性)
+ * - 個別 adapter は `FirestoreIndividualAdapter` interface で抽象化 (batch とは別 SDK call)
+ * - immutable skip は batchWriter scope で既に除外済の前提 (本 module は eligible のみ受取)
+ */
+
+import { Timestamp } from 'firebase-admin/firestore';
+import type {
+  DocumentProvenance,
+  ProvenanceBackfillMetadata,
+} from '../../../shared/types';
+import { ProvenanceValidationError } from '../../../functions/src/pdf/provenance';
+import type {
+  PhaseBRevalidatedCandidate,
+  PhaseCPreconditionFailedDoc,
+  PhaseCWrittenDoc,
+} from '../types';
+import { PR_D4_PHASE_C_INDIVIDUAL_RETRY_MAX } from '../types';
+import { buildBackfillRecord, sha256ProvenanceBackfill } from './batchWriter';
+import type { RateLimiter } from './rateLimiter';
+
+export interface IndividualUpdateInput {
+  docId: string;
+  provenance: DocumentProvenance;
+  provenanceBackfill: ProvenanceBackfillMetadata;
+  /** ISO8601 precondition (Phase C reReadForBatch 時の updateTime) */
+  lastUpdateTimePrecondition: string;
+}
+
+export type IndividualUpdateResult =
+  | { kind: 'ok'; updateTime: string }
+  | { kind: 'precondition-failed' }
+  | { kind: 'transient'; message: string };
+
+export interface FirestoreIndividualAdapter {
+  updateOne(input: IndividualUpdateInput): Promise<IndividualUpdateResult>;
+}
+
+export interface ProcessFallbackInput {
+  candidates: PhaseBRevalidatedCandidate[];
+  /** docId → batchWriter reReadForBatch で取得した updateTime (precondition) */
+  lastUpdateTimePreconditions: Map<string, string>;
+  backfillScriptVersion: string;
+  backfilledAt: Timestamp;
+  /** default = PR_D4_PHASE_C_INDIVIDUAL_RETRY_MAX (=3) */
+  retryMax?: number;
+}
+
+export interface ProcessFallbackOutcome {
+  writtenDocs: PhaseCWrittenDoc[];
+  preconditionFailedDocs: PhaseCPreconditionFailedDoc[];
+}
+
+/**
+ * 1 doc を retryMax 回まで個別 update。
+ * - precondition-failed → 即終了 (drift 確定、retry 不要)
+ * - transient → 次 attempt、retryMax 到達で 'transient retry exhausted' 隔離
+ * - ok → 成功
+ */
+async function attemptOneDocWithRetry(
+  candidate: PhaseBRevalidatedCandidate,
+  record: { provenance: DocumentProvenance; provenanceBackfill: ProvenanceBackfillMetadata },
+  lastUpdateTimePrecondition: string,
+  adapter: FirestoreIndividualAdapter,
+  rateLimiter: RateLimiter,
+  retryMax: number
+): Promise<
+  | { kind: 'ok'; updateTime: string; retryCount: number }
+  | { kind: 'precondition-failed'; retryCount: number }
+  | { kind: 'transient-exhausted'; retryCount: number }
+> {
+  let attemptCount = 0;
+  for (let i = 0; i < retryMax; i++) {
+    attemptCount++;
+    await rateLimiter.acquire(1);
+    const result = await adapter.updateOne({
+      docId: candidate.docId,
+      provenance: record.provenance,
+      provenanceBackfill: record.provenanceBackfill,
+      lastUpdateTimePrecondition,
+    });
+    if (result.kind === 'ok') {
+      return { kind: 'ok', updateTime: result.updateTime, retryCount: attemptCount };
+    }
+    if (result.kind === 'precondition-failed') {
+      return { kind: 'precondition-failed', retryCount: attemptCount };
+    }
+    // transient: 次 attempt へ
+  }
+  return { kind: 'transient-exhausted', retryCount: attemptCount };
+}
+
+/**
+ * batch 失敗時の fallback: 各 doc を個別 update + retry max=3 + drift 確定で隔離。
+ *
+ * 注意: immutable skip / missing doc は batchWriter で既に除外済の前提。本 module は
+ * candidates の各 doc が更新候補であることを信頼する。
+ */
+export async function processFallback(
+  input: ProcessFallbackInput,
+  adapter: FirestoreIndividualAdapter,
+  rateLimiter: RateLimiter
+): Promise<ProcessFallbackOutcome> {
+  const retryMax = input.retryMax ?? PR_D4_PHASE_C_INDIVIDUAL_RETRY_MAX;
+  const writtenDocs: PhaseCWrittenDoc[] = [];
+  const preconditionFailedDocs: PhaseCPreconditionFailedDoc[] = [];
+
+  for (const candidate of input.candidates) {
+    const lastUpdateTime = input.lastUpdateTimePreconditions.get(candidate.docId);
+    if (!lastUpdateTime) {
+      // batchWriter outcome から渡された Map に必ず entry がある前提だが、defense-in-depth:
+      // entry 不在は隔離 (= caller のバグだが silent fail させない)
+      preconditionFailedDocs.push({
+        docId: candidate.docId,
+        reason: 'lastUpdateTime drift',
+        retryCount: 0,
+      });
+      continue;
+    }
+    let record;
+    try {
+      record = buildBackfillRecord(candidate, input.backfillScriptVersion, input.backfilledAt);
+    } catch (e) {
+      if (e instanceof ProvenanceValidationError) {
+        // validation error は batchWriter scope で既に除外済の前提だが、defense:
+        // skip 扱いではなく隔離 (caller observability)
+        preconditionFailedDocs.push({
+          docId: candidate.docId,
+          reason: 'lastUpdateTime drift',
+          retryCount: 0,
+        });
+        continue;
+      }
+      throw e;
+    }
+
+    const outcome = await attemptOneDocWithRetry(
+      candidate,
+      record,
+      lastUpdateTime,
+      adapter,
+      rateLimiter,
+      retryMax
+    );
+
+    if (outcome.kind === 'ok') {
+      writtenDocs.push({
+        docId: candidate.docId,
+        writeStatus: 'ok',
+        newProvenanceBackfillSha256: sha256ProvenanceBackfill(record.provenanceBackfill),
+        lastUpdateTimeAfter: outcome.updateTime,
+      });
+    } else if (outcome.kind === 'precondition-failed') {
+      preconditionFailedDocs.push({
+        docId: candidate.docId,
+        reason: 'lastUpdateTime drift',
+        retryCount: outcome.retryCount,
+      });
+    } else {
+      preconditionFailedDocs.push({
+        docId: candidate.docId,
+        reason: 'transient retry exhausted',
+        retryCount: outcome.retryCount,
+      });
+    }
+  }
+
+  return { writtenDocs, preconditionFailedDocs };
+}

--- a/scripts/pr-d4-backfill/phase-c/lockManager.ts
+++ b/scripts/pr-d4-backfill/phase-c/lockManager.ts
@@ -1,0 +1,142 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C GCS sentinel object 排他 lock (BF16/BF21).
+ *
+ * impl-plan §4.3 step 1-2 + §7.3 + Codex 2nd C2 / 3rd I1/I2 反映:
+ *   `gs://{env-bucket}/pr-d4-backfill-locks/{env}-phase-c.lock` を `ifGenerationMatch:0`
+ *   precondition で create。既存 lock 検出 → abort。release は acquired generation 付き
+ *   delete のみ許可 (stale lock 上書き事故防止)。
+ *
+ * 設計判断:
+ * - 依存性逆転: `LockObjectStore` interface 経由で GCS Bucket を受け取り、unit test では
+ *   in-memory fake で test 可能 (Phase A/B の Writer pattern と同じ)
+ * - lock body は `PhaseCLockBody` を JSON 化、`lockSchemaVersion` 付きで parse 失敗時の
+ *   人間判断材料を残す
+ * - lease 60 min は本 module では強制しない (impl-plan §4.3 step 2: 自動 takeover 禁止、
+ *   解放は runbook 経由の手動のみ)。lease タイムスタンプは body に記録するだけ
+ * - lockOwner は caller が指定 ('github-actions-run-{N}' / 'manual-cli' 等)
+ */
+
+import type { BackfillEnvName, PhaseCLockBody } from '../types';
+import { PR_D4_ARTIFACT_SCHEMA_VERSION } from '../types';
+
+/**
+ * GCS object として lock を扱うための interface (依存性逆転)。
+ *
+ * production 実装は `adapters.ts` で `@google-cloud/storage` Bucket を使う。
+ * unit test 用 fake 実装は in-memory map で十分。
+ */
+export interface LockObjectStore {
+  /**
+   * `ifGenerationMatch:0` で create を試行。
+   * - 成功 → { acquired: true, generation }
+   * - 既存 lock 検出 → { acquired: false, existing: { body, generation } } (caller が abort)
+   * その他の error (network 等) は throw。
+   */
+  acquire(input: { path: string; body: string }): Promise<AcquireResult>;
+  /**
+   * `ifGenerationMatch:<acquiredGeneration>` 付き delete。precondition 失敗 / network error は throw。
+   */
+  release(input: { path: string; acquiredGeneration: string }): Promise<void>;
+}
+
+export type AcquireResult =
+  | { acquired: true; generation: string }
+  | { acquired: false; existing: { body: string; generation: string } };
+
+/**
+ * `gs://{bucket}/pr-d4-backfill-locks/{env}-phase-c.lock` 形式の object path を構築。
+ */
+export function buildPhaseCLockPath(bucketName: string, env: BackfillEnvName): string {
+  return `gs://${bucketName}/pr-d4-backfill-locks/${env}-phase-c.lock`;
+}
+
+export interface AcquireLockInput {
+  bucketName: string;
+  env: BackfillEnvName;
+  runId: string;
+  jobId: string;
+  startedAt: string;
+  expectedDurationSec: number;
+  lockOwner: string;
+}
+
+export interface AcquireLockSuccess {
+  lockPath: string;
+  acquiredGeneration: string;
+  body: PhaseCLockBody;
+}
+
+/**
+ * Existing lock detection error.
+ * Orchestrator が catch して abort + 既存 lock body をログ記録 (人間判断材料)。
+ */
+export class LockHeldByOthersError extends Error {
+  constructor(
+    public readonly lockPath: string,
+    public readonly existingBody: string,
+    public readonly existingGeneration: string,
+    public readonly parsedExistingBody: PhaseCLockBody | null
+  ) {
+    super(
+      `Phase C lock held by another runner (path=${lockPath}, generation=${existingGeneration})`
+    );
+    this.name = 'LockHeldByOthersError';
+  }
+}
+
+/**
+ * Phase C 排他 lock 取得 (impl-plan §4.3 step 1)。
+ *
+ * 既存 lock 検出時は `LockHeldByOthersError` を throw し、orchestrator が既存 body を
+ * ログ出力した上で early abort する。
+ */
+export async function acquirePhaseCLock(
+  input: AcquireLockInput,
+  store: LockObjectStore
+): Promise<AcquireLockSuccess> {
+  const lockPath = buildPhaseCLockPath(input.bucketName, input.env);
+  const body: PhaseCLockBody = {
+    lockSchemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    runId: input.runId,
+    jobId: input.jobId,
+    startedAt: input.startedAt,
+    expectedDurationSec: input.expectedDurationSec,
+    lockOwner: input.lockOwner,
+  };
+  const bodyContent = JSON.stringify(body);
+  const result = await store.acquire({ path: lockPath, body: bodyContent });
+  if (!result.acquired) {
+    let parsed: PhaseCLockBody | null = null;
+    try {
+      parsed = JSON.parse(result.existing.body) as PhaseCLockBody;
+    } catch {
+      parsed = null;
+    }
+    throw new LockHeldByOthersError(
+      lockPath,
+      result.existing.body,
+      result.existing.generation,
+      parsed
+    );
+  }
+  return { lockPath, acquiredGeneration: result.generation, body };
+}
+
+export interface ReleaseLockInput {
+  lockPath: string;
+  acquiredGeneration: string;
+}
+
+/**
+ * Phase C 排他 lock 解放 (BF21)。`ifGenerationMatch:<acquiredGeneration>` 必須。
+ * stale lock 上書きで他 Job の lock を消す事故を防止。
+ */
+export async function releasePhaseCLock(
+  input: ReleaseLockInput,
+  store: LockObjectStore
+): Promise<void> {
+  await store.release({
+    path: input.lockPath,
+    acquiredGeneration: input.acquiredGeneration,
+  });
+}

--- a/scripts/pr-d4-backfill/phase-c/rateLimiter.ts
+++ b/scripts/pr-d4-backfill/phase-c/rateLimiter.ts
@@ -1,0 +1,101 @@
+/**
+ * Issue #445 PR-D4 S1-4: Phase C token bucket rate limiter (BF23, Codex 3rd I4 反映).
+ *
+ * impl-plan §4.3 step 5 + §4.2 rate limit:
+ *   batch update / individual update が **同一 global token bucket** を通過し、
+ *   突発書込 rate 増加を防止する (Firestore write 100-200/sec 上限を守る)。
+ *
+ * 設計判断:
+ * - 並行 caller (batch worker + individual retry worker が同時に呼ぶケース) を
+ *   chained promise でシリアル化し、token 二重消費の race を排除
+ * - clock を inject (test 用 fake clock + 本番用 system clock を切替可能)
+ * - sleep ms は deficit / tokensPerSecond で正確算出 (Codex L2 反映の正確性)
+ *
+ * 配置: scripts/pr-d4-backfill/phase-c/。Phase A/B と異なり caller 注入型ではなく
+ * single class export (state を持つため、orchestrator が 1 instance を共有して全 writer 経由)
+ */
+
+import type { PhaseCRateLimiterConfig } from '../types';
+
+export interface RateLimiterClock {
+  /** monotonic ms (Date.now ベースでも可、但し test では fake clock 推奨) */
+  now(): number;
+  /** ms 単位 sleep (テストでは fake clock の advance + resolve で代替) */
+  sleep(ms: number): Promise<void>;
+}
+
+/**
+ * 本番用 system clock (Date.now + setTimeout)。
+ */
+export const SYSTEM_CLOCK: RateLimiterClock = {
+  now: () => Date.now(),
+  sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+/**
+ * Phase C 内 caller (batchWriter / individualRetryWriter) が依存する rate limiter interface。
+ * unit test では fake 実装を渡せる (Phase A/B Writer pattern と同じ依存性逆転)。
+ */
+export interface RateLimiter {
+  acquire(tokens?: number): Promise<void>;
+}
+
+export class TokenBucketRateLimiter implements RateLimiter {
+  private currentTokens: number;
+  private lastRefillTimeMs: number;
+  private chain: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly config: PhaseCRateLimiterConfig,
+    private readonly clock: RateLimiterClock = SYSTEM_CLOCK
+  ) {
+    if (config.tokensPerSecond <= 0) {
+      throw new Error('tokensPerSecond must be positive');
+    }
+    if (config.burstCapacity <= 0) {
+      throw new Error('burstCapacity must be positive');
+    }
+    this.currentTokens = config.burstCapacity;
+    this.lastRefillTimeMs = clock.now();
+  }
+
+  /**
+   * 必要 tokens を acquire (不足時は自動 sleep + refill)。
+   * 並行 caller は内部 chain で順次処理されるため、token race は発生しない。
+   */
+  acquire(tokens: number = 1): Promise<void> {
+    if (tokens <= 0) {
+      return Promise.reject(new Error('tokens must be positive'));
+    }
+    if (tokens > this.config.burstCapacity) {
+      return Promise.reject(
+        new Error(`tokens (${tokens}) exceeds burstCapacity (${this.config.burstCapacity})`)
+      );
+    }
+    const result = this.chain.then(() => this.acquireOnce(tokens));
+    this.chain = result.catch(() => {
+      /* swallow to keep chain alive for subsequent callers */
+    });
+    return result;
+  }
+
+  private async acquireOnce(tokens: number): Promise<void> {
+    this.refill();
+    while (this.currentTokens < tokens) {
+      const deficit = tokens - this.currentTokens;
+      const waitMs = Math.ceil((deficit / this.config.tokensPerSecond) * 1000);
+      await this.clock.sleep(waitMs);
+      this.refill();
+    }
+    this.currentTokens -= tokens;
+  }
+
+  private refill(): void {
+    const now = this.clock.now();
+    const elapsedMs = now - this.lastRefillTimeMs;
+    if (elapsedMs <= 0) return;
+    const refilled = (elapsedMs / 1000) * this.config.tokensPerSecond;
+    this.currentTokens = Math.min(this.config.burstCapacity, this.currentTokens + refilled);
+    this.lastRefillTimeMs = now;
+  }
+}

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -332,14 +332,19 @@ export interface PhaseCPreconditionFailedDoc {
 }
 
 /**
- * Phase C immutable skip 記録 (BF14、impl-plan §4.3 step 5)。
+ * Phase C immutable skip 記録 (BF14 + Codex 6th Important、impl-plan §4.3 step 5)。
  *
- * batch 直前の再読込で `provenance` field exists && `provenanceBackfill` field undefined
- * を検出した doc。null sentinel は使わない (Codex 3rd I3)。
+ * 2 種類の skip reason:
+ * - `'provenance exists, provenanceBackfill absent'`: PR-D2/D3 で書込まれた verified
+ *   split-time provenance を本 PR-D4 backfill が上書きしないガード (BF14)
+ * - `'already backfilled (provenanceBackfill present)'`: 別 Phase C run / retry で
+ *   既 backfilled doc を再 backfill しない idempotency 保護 (Codex 6th)
  */
 export interface PhaseCImmutableSkippedDoc {
   docId: string;
-  reason: 'provenance exists, provenanceBackfill absent';
+  reason:
+    | 'provenance exists, provenanceBackfill absent'
+    | 'already backfilled (provenanceBackfill present)';
 }
 
 /**
@@ -434,7 +439,15 @@ export interface PhaseCBackfillSummary {
   /** Codex 5th C1 反映: hard-gate で除外された Phase C スコープ外 doc の集計 */
   outOfScopeDocs: number;
   lockAcquiredGeneration: string;
-  /** lock release 完了時刻 (releasePhaseCLock 成功直後の nowProvider 値、Evaluator MEDIUM 反映) */
+  /**
+   * lock release を要求する直前の時刻 (= finalize 直前の nowProvider 値、Codex 6th Critical 反映)。
+   *
+   * **重要**: 「実際の release ACK 完了時刻」ではない。Codex 6th Critical で指摘された
+   * 「lock release を finalize 前に行うと production-unsafe」を回避するため、
+   * 順序は finalize → release で固定し、artifact 内では release **要求** 時刻のみ
+   * 記録する。実 release ACK 後の時刻は orchestrator 戻り値 (RunPhaseCResult) でも
+   * 同値を返す (artifact 整合性優先)。
+   */
   lockReleasedAt: string;
   rateLimiterConfig: PhaseCRateLimiterConfig;
   chunks: ArtifactChunkPointer[];

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -263,3 +263,142 @@ export interface PhaseBRevalidationSummary {
   skippedNonMatchedByHash: number;
   chunks: ArtifactChunkPointer[];
 }
+
+// ============================================================================
+// Phase C types (impl-plan §4.3、AC BF10/BF11/BF14/BF16/BF18/BF21/BF22/BF23)
+// ============================================================================
+
+/**
+ * Phase C で取得する GCS sentinel lock の body (impl-plan §4.3 step 1)。
+ *
+ * 設計判断:
+ * - `runId`: Phase A/B/C で同一の runId を使う (manifest と整合)
+ * - `jobId`: Cloud Run Job execution ID (Phase C 起動側で生成、stale lock 解放時に
+ *   Cloud Run Console と照合する人間判断材料)
+ * - `startedAt`: lock 取得時刻 (lease 60 min 計算基準、stale 判定の参考)
+ * - `expectedDuration`: 計画見込み時間 (秒、観測用)
+ * - `lockOwner`: GitHub Actions run / 手動実行など lock 取得元 ('github-actions-run-{N}' 等)
+ * - `lockSchemaVersion`: lock body 互換性 (script 改修で bump、parse 失敗時の人間判断助け)
+ */
+export interface PhaseCLockBody {
+  lockSchemaVersion: PrD4ArtifactSchemaVersion;
+  runId: string;
+  jobId: string;
+  startedAt: string;
+  expectedDurationSec: number;
+  lockOwner: string;
+}
+
+/**
+ * Phase C rate limiter (token bucket) の設定 (BF23 + Codex 3rd I4 反映)。
+ *
+ * 設計:
+ * - batch / individual update 共通の global token bucket
+ * - `tokensPerSecond`: refill rate (100-200 / sec、Codex 2nd L2、dev rehearsal 実測で昇格判断)
+ * - `burstCapacity`: 一時的に許容する突発 (= tokensPerSecond 同値で安定運用、Codex 3rd I4)
+ * - 実装は monotonic clock + token refill で正確性を担保
+ */
+export interface PhaseCRateLimiterConfig {
+  tokensPerSecond: number;
+  burstCapacity: number;
+}
+
+/**
+ * Phase C 書込成功 1 doc の記録 (BF22 chunk 内)。
+ *
+ * - `writeStatus`: 'ok' = batch / individual で書込成功
+ * - `newProvenanceBackfillSha256`: 書込んだ provenanceBackfill metadata を canonical JSON
+ *   で sha256 した値 (Phase D verification の入力)
+ * - `lastUpdateTimeAfter`: 書込後の Firestore updateTime (ISO8601、後続 backfill の drift 検出用)
+ */
+export interface PhaseCWrittenDoc {
+  docId: string;
+  writeStatus: 'ok';
+  newProvenanceBackfillSha256: string;
+  lastUpdateTimeAfter: string;
+}
+
+/**
+ * Phase C precondition 失敗で隔離された 1 doc (BF18、impl-plan §4.3 step 5)。
+ *
+ * - `reason`: 'lastUpdateTime drift' (precondition 失敗時) / 'transient retry exhausted'
+ *   (network / timeout で max retry 超過)
+ * - `retryCount`: 個別 update での実行回数 (max=3、impl-plan §4.3 step 5)
+ */
+export interface PhaseCPreconditionFailedDoc {
+  docId: string;
+  reason: 'lastUpdateTime drift' | 'transient retry exhausted';
+  retryCount: number;
+}
+
+/**
+ * Phase C immutable skip 記録 (BF14、impl-plan §4.3 step 5)。
+ *
+ * batch 直前の再読込で `provenance` field exists && `provenanceBackfill` field undefined
+ * を検出した doc。null sentinel は使わない (Codex 3rd I3)。
+ */
+export interface PhaseCImmutableSkippedDoc {
+  docId: string;
+  reason: 'provenance exists, provenanceBackfill absent';
+}
+
+/**
+ * Phase C 書込 chunk file (BF22、1 chunk ≤ PR_D4_CANDIDATES_PER_CHUNK)。
+ *
+ * writtenDocs と preconditionFailedDocs を chunk 単位で分割保存し、全 chunk を
+ * 一括メモリロードしない (Phase A/B と同じ chunked streaming パターン)。
+ */
+export interface PhaseCBackfillChunk {
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  chunkIndex: number;
+  writtenDocs: PhaseCWrittenDoc[];
+  preconditionFailedDocs: PhaseCPreconditionFailedDoc[];
+  immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
+}
+
+/**
+ * Phase C main artifact 構造 (impl-plan §4.3 output)。
+ *
+ * 設計:
+ * - `candidatesIn`: Phase B revalidated[] 全件
+ * - `writtenDocs`: 書込成功合計 (chunks の writtenDocs.length 合計と一致)
+ * - `preconditionFailedDocs`: 隔離合計 (chunks の preconditionFailedDocs.length 合計と一致)
+ * - `skippedImmutable`: immutable skip 合計 (BF14 検証用)
+ * - `phaseBArtifactRef`: Phase B main artifact path (manifest chain 再構成可能)
+ * - `phaseBManifestSha256`: Phase C 起動時に検証した Phase B manifest sha256
+ * - `lockAcquiredGeneration`: 取得した GCS sentinel lock の generation (BF21、解放時に
+ *   ifGenerationMatch 必須 = 安全解放確認の証跡)
+ * - `lockReleasedAt`: lock 解放完了時刻 (ISO8601、stale lock detection の人間判断材料)
+ * - `rateLimiterConfig`: 使用した rate limiter 設定 (BF23、観測用)
+ */
+export interface PhaseCBackfillSummary {
+  phase: 'C';
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  scriptVersion: PrD4ScriptVersion;
+  env: BackfillEnvName;
+  runId: string;
+  phaseBArtifactRef: string;
+  phaseBManifestSha256: string;
+  backfillStartedAt: string;
+  backfillCompletedAt: string;
+  candidatesIn: number;
+  writtenDocs: number;
+  preconditionFailedDocs: number;
+  skippedImmutable: number;
+  lockAcquiredGeneration: string;
+  lockReleasedAt: string;
+  rateLimiterConfig: PhaseCRateLimiterConfig;
+  chunks: ArtifactChunkPointer[];
+}
+
+/** Phase C atomic batch 上限 (impl-plan §4.3 step 5、Firestore 上限 500 の余裕値) */
+export const PR_D4_PHASE_C_BATCH_SIZE = 20 as const;
+
+/** Phase C individual update retry max (impl-plan §4.3 step 5、transient error 対策) */
+export const PR_D4_PHASE_C_INDIVIDUAL_RETRY_MAX = 3 as const;
+
+/** Phase C rate limiter defaults (impl-plan §4.3 / §6.1、Codex 2nd L2) */
+export const PR_D4_PHASE_C_DEFAULT_RATE_LIMITER: PhaseCRateLimiterConfig = {
+  tokensPerSecond: 100,
+  burstCapacity: 100,
+} as const;

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -343,10 +343,47 @@ export interface PhaseCImmutableSkippedDoc {
 }
 
 /**
+ * Phase C 書込 scope 外 (Codex 5th C1 反映、impl-plan §4.0 hard-gate)。
+ *
+ * 本 PR Phase C 本番書込対象は `category === 'MatchedByHash' && computedConfidence ===
+ * 'derived-bytes-verified'` のみ。Phase B 実装は `MatchedByHash` のみ revalidated[] に入れる
+ * が、dev fixture / Phase B のバグ / 将来の Phase B 拡張で異種 candidate が混入した場合に
+ * 構造的にガードする。
+ *
+ * reason:
+ * - `'category not MatchedByHash'`: Phase B 出力で `category !== 'MatchedByHash'`
+ * - `'confidence not derived-bytes-verified'`: `MatchedByHash` だが confidence が
+ *   `child-snapshot-only` / `metadata-only` (dev fixture 用、本番書込禁止)
+ */
+export interface PhaseCOutOfScopeDoc {
+  docId: string;
+  reason: 'category not MatchedByHash' | 'confidence not derived-bytes-verified';
+  observedCategory: BackfillClassifierCategory;
+  observedConfidence: BackfillConfidence;
+}
+
+/**
+ * Phase C 処理不能 doc 記録 (Codex 5th C2 反映、observability)。
+ *
+ * 過去 `missingDocs` で扱われていたが、原因区別不能だったため reason 付きに統合。
+ * `validation`: `createBackfillProvenance` の runtime validation が throw (sha256 不正等)
+ * `missing`: Firestore re-read で doc 不在
+ */
+export interface PhaseCUnprocessableDoc {
+  docId: string;
+  reason: 'missing' | 'validation';
+  message?: string;
+}
+
+/**
  * Phase C 書込 chunk file (BF22、1 chunk ≤ PR_D4_CANDIDATES_PER_CHUNK)。
  *
- * writtenDocs と preconditionFailedDocs を chunk 単位で分割保存し、全 chunk を
- * 一括メモリロードしない (Phase A/B と同じ chunked streaming パターン)。
+ * 全カテゴリを chunk 単位で分割保存し、全 chunk を一括メモリロードしない。
+ * Codex 5th C2 反映で `unprocessableDocs` / `outOfScopeDocs` を追加 (運用観測完全性)。
+ *
+ * 保全式 (chunk 全件):
+ *   writtenDocs + preconditionFailedDocs + immutableSkippedDocs + unprocessableDocs +
+ *   outOfScopeDocs == 該当 chunk に渡された候補件数
  */
 export interface PhaseCBackfillChunk {
   schemaVersion: PrD4ArtifactSchemaVersion;
@@ -354,6 +391,8 @@ export interface PhaseCBackfillChunk {
   writtenDocs: PhaseCWrittenDoc[];
   preconditionFailedDocs: PhaseCPreconditionFailedDoc[];
   immutableSkippedDocs: PhaseCImmutableSkippedDoc[];
+  unprocessableDocs: PhaseCUnprocessableDoc[];
+  outOfScopeDocs: PhaseCOutOfScopeDoc[];
 }
 
 /**
@@ -381,11 +420,21 @@ export interface PhaseCBackfillSummary {
   phaseBManifestSha256: string;
   backfillStartedAt: string;
   backfillCompletedAt: string;
+  /**
+   * 保全式: candidatesIn = writtenDocs + preconditionFailedDocs + skippedImmutable +
+   *                       unprocessableDocs + outOfScopeDocs
+   * (orchestrator が test でアサート、observability 完全性)
+   */
   candidatesIn: number;
   writtenDocs: number;
   preconditionFailedDocs: number;
   skippedImmutable: number;
+  /** Codex 5th C2 反映: missing / validation 不能 doc の集計 (silent drop 防止) */
+  unprocessableDocs: number;
+  /** Codex 5th C1 反映: hard-gate で除外された Phase C スコープ外 doc の集計 */
+  outOfScopeDocs: number;
   lockAcquiredGeneration: string;
+  /** lock release 完了時刻 (releasePhaseCLock 成功直後の nowProvider 値、Evaluator MEDIUM 反映) */
   lockReleasedAt: string;
   rateLimiterConfig: PhaseCRateLimiterConfig;
   chunks: ArtifactChunkPointer[];


### PR DESCRIPTION
## Summary
Issue #445 PR-D4 S1-4: Phase B revalidated candidates を本番 Firestore に atomic batch で書込む Phase C の実装。GCS sentinel 排他 lock + 20 docs/batch + lastUpdateTime precondition + immutable skip (新規/既 backfilled 両方) + batch fallback の doc 単位 retry + global write rate limiter を含む **destructive migration** の本丸。

- 新規 9 source (`scripts/pr-d4-backfill/phase-c/`) + 7 test (`functions/test/prD4PhaseC*.test.ts`、60 unit tests)
- types.ts に Phase C 型追加 (PhaseCBackfillSummary / PhaseCBackfillChunk / PhaseCLockBody / PhaseCRateLimiterConfig + 5 doc カテゴリ + 定数)
- index.ts に `--phase C` ブランチ追加 (--job-id / --lock-owner / --expected-duration-sec)
- 全 1305 tests passing (+60)、tsc + lint 0 errors

## Acceptance Criteria
| AC | 内容 | 検証 |
|----|------|---------|
| BF10 | provenance.createdAt 不変 | buildBackfillRecord で document.createdAt 由来 |
| BF11 | provenanceBackfill.confidence 分布一致 | orchestrator test |
| BF14 | verified existing は immutable skip | immutableSkipChecker (`'provenance exists, provenanceBackfill absent'`) |
| BF16 | GCS sentinel lock で並走不可能 | lockManager (ifGenerationMatch:0 acquire) |
| BF18 | batch precondition failure は doc 単位隔離 | individualRetryWriter (retry max=3) |
| BF21 | release は取得 generation 付き ifGenerationMatch 必須 | lockManager + GcsLockStoreImpl |
| BF22 | Phase C artifact も chunked streaming + sha256 verify | artifactReader / artifactWriter |
| BF23 | batch fallback も同 global rate limiter 通過 | batchWriter + individualRetryWriter (RateLimiter interface DI) |

## 主要設計判断
- **Hard-gate** (impl-plan §4.0): batchWriter で `category === 'MatchedByHash' && computedConfidence === 'derived-bytes-verified'` 以外を `outOfScopeDocs` に分類 (本番書込しない構造的ガード、Phase B が異種候補を出しても安全)
- **Idempotency**: immutableSkipChecker が `provenanceBackfill !== undefined` (null 除く) → `'already backfilled'` で skip (別 run / 同 run retry で既 backfilled doc を再書込しない)
- **Lock 順序**: finalize (main + manifest CAS) → release (Codex 6th Critical 反映、release 前 finalize で artifact 整合性保証)
- **Observability 完全性**: 保全式 `candidatesIn = writtenDocs + preconditionFailedDocs + skippedImmutable + unprocessableDocs + outOfScopeDocs` を artifact + test でアサート (silent drop 防止)
- **`unprocessableDocs` vs `preconditionFailedDocs`**: `missing` (doc 不在) / `validation` (provenance 不正) は drift とは別観測軸 (code-reviewer #3 反映)
- **Cross-process determinism 注意**: sha256ProvenanceBackfill JSDoc に Phase D verification 時は factory 再 invoke 推奨と明記 (memory `feedback_deterministic_cross_process.md`)

## Quality Gate
- TDD Red→Green (60 tests、Phase A/B Writer pattern と一貫した依存性逆転)
- evaluator agent: AC 8 件 PASS + REQUEST_CHANGES → 反映
- pr-review-toolkit:code-reviewer: ratings reuse=8 / quality=7 / efficiency=8 → 反映
- **Codex MCP review** (destructive migration 必須、memory `feedback_destructive_migration_codex_review.md`):
  - 1st NO-GO: Critical 2 (hard-gate / unprocessableDocs 集計) + Important 3 → 反映 (commit 111b9d1)
  - 2nd NO-GO: Critical 1 (lock 順序) + Important 1 (idempotency) → 反映 (commit ce506a0)
  - **3rd GO**: Minor 2 件 (JSDoc 整合性) → 反映 (commit 828f4ae)

## Test plan
- [x] `npm test` (functions): 1305 passing / 0 failing
- [x] tsc --noEmit: 0 errors
- [x] eslint: 0 errors (Phase C 関連 warning 0 件)
- [x] 全 60 Phase C unit tests passing
- [x] Quality Gate 3 並列 review (evaluator / code-reviewer / Codex MCP) GO

## デプロイ計画
**本 PR は実装のみ**。dev / cocoro / kanameone 環境への適用は別フェーズ:
- S1-5: Phase D 実装 (verify + rotate gate test、本 PR では含まない)
- S1-6: Dockerfile + `.github/workflows/pr-d4-backfill.yml`
- S1-7: container build + push (dev) → S1 完了

Cloud Run Job 実行は S1-7 以降で別途承認を取得 (本番書込前に必ず dev rehearsal)。

## 次セッション着手予定
- PR-D4 S1-5 (Phase D verify + rotate gate behavior、BF12/BF13/BF15)
- 本 PR が main にマージされた後、Phase D を Phase C artifact 経由で実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Phase C backfill capability to the PR-D4 backfill workflow, enabling atomic batch processing and individual retry handling for verified document updates with GCS-backed lock management to prevent concurrent execution.
- Implemented token-bucket rate limiting to control backfill throughput.

**Tests**
- Added comprehensive test suites covering Phase C components including batch writing, artifact handling, lock management, rate limiting, and end-to-end orchestration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/469)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->