### PR TITLE
feat(pr-d4): PR-D4 S1-5 — Phase D verify + rotate gate 拡張 + 92 tests (#445)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -26,6 +26,7 @@ import { loadMasterData } from '../utils/loadMasterData';
 import { sanitizeFilenameForStorage } from '../utils/fileNaming';
 import { createSplitProvenance, createRotationProvenance } from './provenance';
 import { mergeRotations } from './rotationMerge';
+import { shouldRejectRotateForBackfill } from './rotateGate';
 import { randomUUID } from 'node:crypto';
 import type { DocumentProvenance } from '../../../shared/types';
 import {
@@ -878,6 +879,20 @@ export const rotatePdfPages = onCall(
         'failed-precondition',
         'Document is missing provenance fields; backfill required (Issue #445 PR-D4) before rotation'
       );
+    }
+
+    // PR-D4 BF12/BF13 (ADR-0016 MUST 3 拡張): backfilled doc は confidence 'derived-bytes-verified'
+    // のみ rotate 許可。malformed (null 含む) や低信頼度 confidence は failed-precondition で reject。
+    // 壊れた legacy bytes を正規 rotation 経路で昇格させる経路を構造的に閉鎖する (Codex 7th Critical 6)。
+    const backfillRejection = shouldRejectRotateForBackfill(startData.provenanceBackfill);
+    if (backfillRejection != null) {
+      console.warn('rotatePdfPages: backfill confidence guard rejected', {
+        operation: 'rotatePdfPages',
+        stage: 'backfill_confidence_check',
+        documentId,
+        rejection: backfillRejection,
+      });
+      throw new HttpsError('failed-precondition', backfillRejection);
     }
     const startUpdateTime = startSnapshot.updateTime;
     const fileUrl = startData.fileUrl as string;

--- a/functions/src/pdf/rotateGate.ts
+++ b/functions/src/pdf/rotateGate.ts
@@ -1,0 +1,117 @@
+/**
+ * Issue #445 PR-D4 S1-5: rotate gate helper (ADR-0016 MUST 3 拡張).
+ *
+ * PR-D4 backfilled doc の rotate を `confidence === 'derived-bytes-verified'` のみ allow
+ * する fail-closed ガード。`provenanceBackfill` が malformed / unknown / 低信頼度 confidence
+ * の場合は reject 理由文字列を返却し、callable 側で `failed-precondition` HttpsError に
+ * wrap する設計 (Codex MCP 2nd review Important 1 + Suggestion 1 反映で pure helper 化)。
+ *
+ * 検証スコープ (production gate = Phase D Stage 1 最小 invariant 共有):
+ * - 型: provenanceBackfill is undefined (absent) | plain object | それ以外で reject
+ * - method: 'legacy-observed' 固定値
+ * - confidence: 'derived-bytes-verified' allow / それ以外 reject
+ * - evidence: derived-bytes-verified の場合は parentExists / parentSha256MatchedAtBackfill /
+ *   childSha256ComputedAtBackfill 全 true (Codex 2nd review Important 1 反映、confidence
+ *   文字列だけで allow しない)
+ *
+ * 戻り値:
+ * - `null`: rotate 許可 (legacy verified / 完全な derived-bytes-verified)
+ * - `string`: rotate reject 理由 (failed-precondition で throw)
+ *
+ * 参照: docs/adr/0016-document-identity-and-provenance.md MUST 3 拡張 / shared/types.ts
+ * BackfillConfidence / ProvenanceBackfillMetadata
+ */
+
+/**
+ * provenanceBackfill が plain object かどうかを判定。
+ * array や Date / Buffer 等は plain object として扱わない (Firestore 経由 deserialize で
+ * plain object に正規化される前提だが防御的に判定)。
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * rotate gate: provenanceBackfill 存在時は confidence === 'derived-bytes-verified' + 完全
+ * evidence のみ allow。fail-closed 設計で malformed (null 含む) や未知 confidence は reject。
+ *
+ * @param raw - Firestore document.provenanceBackfill (unknown 型で受け取り runtime guard)
+ * @returns rotate 許可なら null、reject 理由文字列ならその内容
+ */
+export function shouldRejectRotateForBackfill(raw: unknown): string | null {
+  // 1. absent (undefined) = PR-D2/D3 verified split-time origin、allow
+  if (raw === undefined) return null;
+
+  // 2. null = malformed (古い書込経路 / 手動修復で混入の可能性)、fail-closed reject
+  if (raw === null) {
+    return 'provenanceBackfill is null (malformed); rotate requires either field absent (verified split-time origin) or a complete backfilled record with confidence "derived-bytes-verified"';
+  }
+
+  // 3. plain object 以外の型 (string / number / boolean / array / Buffer 等) は reject
+  if (!isPlainObject(raw)) {
+    return `provenanceBackfill has unexpected type "${typeof raw}"; rotate reject (malformed)`;
+  }
+
+  // 4. method 検証: 'legacy-observed' 固定値以外は reject
+  const method = raw.method;
+  if (typeof method !== 'string') {
+    return 'provenanceBackfill.method is missing or non-string; rotate reject (malformed)';
+  }
+  if (method !== 'legacy-observed') {
+    return `provenanceBackfill.method has unexpected value "${method}"; expected "legacy-observed"`;
+  }
+
+  // 5. confidence 検証: type guard + 'derived-bytes-verified' allow
+  const confidence = raw.confidence;
+  if (typeof confidence !== 'string') {
+    return `provenanceBackfill.confidence has unexpected type "${typeof confidence}"; rotate reject (malformed)`;
+  }
+  if (
+    confidence !== 'derived-bytes-verified' &&
+    confidence !== 'child-snapshot-only' &&
+    confidence !== 'metadata-only'
+  ) {
+    return `provenanceBackfill.confidence has unexpected value "${confidence}"; rotate reject (malformed, allowed: derived-bytes-verified | child-snapshot-only | metadata-only)`;
+  }
+  if (confidence !== 'derived-bytes-verified') {
+    return `Document was backfilled with confidence "${confidence}"; rotate requires "derived-bytes-verified" (壊れた legacy bytes を正規 rotation 経路で昇格させない、ADR-0016 MUST 3 拡張)`;
+  }
+
+  // 6. evidence 必須 + plain object
+  const evidence = raw.evidence;
+  if (!isPlainObject(evidence)) {
+    return 'provenanceBackfill.evidence is missing or non-object; derived-bytes-verified rotate requires complete evidence';
+  }
+
+  // 7. derived-bytes-verified では evidence 3 field を全 true 確認 (Codex 2nd Important 1)
+  const parentExists = evidence.parentExists;
+  if (typeof parentExists !== 'boolean') {
+    return 'provenanceBackfill.evidence.parentExists has unexpected type; expected boolean';
+  }
+  if (parentExists !== true) {
+    return 'provenanceBackfill.evidence.parentExists !== true; derived-bytes-verified requires parent現存';
+  }
+
+  const parentSha256Match = evidence.parentSha256MatchedAtBackfill;
+  // 型 union 上は boolean | null だが、derived-bytes-verified では true 必須 (null も reject)
+  if (parentSha256Match !== true && parentSha256Match !== false && parentSha256Match !== null) {
+    return 'provenanceBackfill.evidence.parentSha256MatchedAtBackfill has unexpected type; expected boolean | null';
+  }
+  if (parentSha256Match !== true) {
+    return 'provenanceBackfill.evidence.parentSha256MatchedAtBackfill !== true; derived-bytes-verified requires re-split sha256 match (null = unverified, false = mismatch)';
+  }
+
+  const childSha256Computed = evidence.childSha256ComputedAtBackfill;
+  if (typeof childSha256Computed !== 'boolean') {
+    return 'provenanceBackfill.evidence.childSha256ComputedAtBackfill has unexpected type; expected boolean';
+  }
+  if (childSha256Computed !== true) {
+    return 'provenanceBackfill.evidence.childSha256ComputedAtBackfill !== true; derived-bytes-verified requires child sha256 実計算';
+  }
+
+  // 8. 全 invariant 通過 → allow
+  return null;
+}

--- a/functions/test/prD4PhaseDArtifactReader.test.ts
+++ b/functions/test/prD4PhaseDArtifactReader.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D artifactReader unit test (BF22 + manifest chain authority).
+ *
+ * - readPhaseCArtifactFromManifest: manifest 経由 chain authority (phaseA/B/C ref を取得)
+ * - readPhaseBCandidatesIndex: Phase B chunks streaming → in-memory Map 構築
+ * - readPhaseACountReadOnly: Phase A summary から count 抽出
+ *
+ * Phase D は同 runId 強制ではなく Phase C manifest authority を採用 (Codex 8th 回答 5)。
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import type { ArtifactStorageReader } from '../../scripts/pr-d4-backfill/phase-b/artifactReader';
+import {
+  readPhaseACountReadOnly,
+  readPhaseBCandidatesIndex,
+  readPhaseCArtifactFromManifest,
+  ArtifactIntegrityError,
+} from '../../scripts/pr-d4-backfill/phase-d/artifactReader';
+import type {
+  BackfillManifest,
+  PhaseAClassifySummary,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+  PhaseCBackfillChunk,
+  PhaseCBackfillSummary,
+  PhaseCWrittenDoc,
+} from '../../scripts/pr-d4-backfill/types';
+
+function sha256Hex(s: string): string {
+  return crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+}
+
+const RUN_ID = '20260515T030000Z-dev-pr-d4-v1';
+const BUCKET = 'docsplit-dev-pr-d4-artifacts';
+const MANIFEST_PATH = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/manifest.json`;
+
+class FakeReader implements ArtifactStorageReader {
+  private store = new Map<string, { content: string; generation: number }>();
+  private nextGen = 100;
+  seed(path: string, content: string): number {
+    const generation = this.nextGen++;
+    this.store.set(path, { content, generation });
+    return generation;
+  }
+  async readJson(path: string): Promise<{ content: string; generation: number }> {
+    const obj = this.store.get(path);
+    if (!obj) throw new Error(`fake reader: object not found: ${path}`);
+    return obj;
+  }
+}
+
+describe('Phase D artifactReader (manifest chain authority、BF22 streaming)', () => {
+  describe('readPhaseCArtifactFromManifest', () => {
+    it('manifest 経由で phaseA/B/C 全 ref を取得 + writtenDocs streaming', async () => {
+      const reader = new FakeReader();
+      const phaseAMain: PhaseAClassifySummary = {
+        phase: 'A',
+        schemaVersion: 'pr-d4-v1.0',
+        scriptVersion: 'pr-d4-v1.0',
+        env: 'dev',
+        runId: RUN_ID,
+        snapshotStartedAt: '2026-05-15T00:00:00.000Z',
+        snapshotCompletedAt: '2026-05-15T00:01:00.000Z',
+        bucketLocation: 'asia-northeast1',
+        cloudRunJobLocation: 'asia-northeast1',
+        egressFreeAssertion: true,
+        totalDocs: 100,
+        categoryDistribution: {
+          MatchedByHash: 50,
+          RepairableMissingFile: 0,
+          Ambiguous: 0,
+          LostOrUnrecoverable: 0,
+          NeedsManualReview: 0,
+        },
+        alreadyBackfilled: 0,
+        verifiedExistingProvenance: 30,
+        chunks: [],
+      };
+      const phaseAPath = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-a.json`;
+      reader.seed(phaseAPath, JSON.stringify(phaseAMain));
+
+      const phaseBMain: PhaseBRevalidationSummary = {
+        phase: 'B',
+        schemaVersion: 'pr-d4-v1.0',
+        scriptVersion: 'pr-d4-v1.0',
+        env: 'dev',
+        runId: RUN_ID,
+        phaseAArtifactRef: phaseAPath,
+        phaseAManifestSha256: 'phaseA-sha',
+        revalidationStartedAt: '2026-05-15T01:00:00.000Z',
+        revalidationCompletedAt: '2026-05-15T01:30:00.000Z',
+        candidatesIn: 2,
+        candidatesOut: 2,
+        driftSkipped: { firestoreUpdateTimeChanged: 0, childGenerationChanged: 0, parentGenerationChanged: 0 },
+        verifyFailedMatchedByHash: 0,
+        skippedNonMatchedByHash: 0,
+        chunks: [],
+      };
+      const phaseBPath = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-b.json`;
+      reader.seed(phaseBPath, JSON.stringify(phaseBMain));
+
+      const writtenDocs: PhaseCWrittenDoc[] = [
+        {
+          docId: 'doc1',
+          writeStatus: 'ok',
+          newProvenanceBackfillSha256: 'sha-doc1',
+          lastUpdateTimeAfter: '2026-05-15T02:30:01.000Z',
+        },
+        {
+          docId: 'doc2',
+          writeStatus: 'ok',
+          newProvenanceBackfillSha256: 'sha-doc2',
+          lastUpdateTimeAfter: '2026-05-15T02:30:02.000Z',
+        },
+      ];
+      const phaseCChunk: PhaseCBackfillChunk = {
+        schemaVersion: 'pr-d4-v1.0',
+        chunkIndex: 0,
+        writtenDocs,
+        preconditionFailedDocs: [],
+        immutableSkippedDocs: [],
+        unprocessableDocs: [],
+        outOfScopeDocs: [],
+      };
+      const phaseCChunkContent = JSON.stringify(phaseCChunk);
+      const phaseCChunkPath = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-chunk-0.json`;
+      reader.seed(phaseCChunkPath, phaseCChunkContent);
+
+      const phaseCMain: PhaseCBackfillSummary = {
+        phase: 'C',
+        schemaVersion: 'pr-d4-v1.0',
+        scriptVersion: 'pr-d4-v1.0',
+        env: 'dev',
+        runId: RUN_ID,
+        phaseBArtifactRef: phaseBPath,
+        phaseBManifestSha256: 'phaseB-sha',
+        backfillStartedAt: '2026-05-15T02:00:00.000Z',
+        backfillCompletedAt: '2026-05-15T02:30:00.000Z',
+        candidatesIn: 2,
+        writtenDocs: 2,
+        preconditionFailedDocs: 0,
+        skippedImmutable: 0,
+        unprocessableDocs: 0,
+        outOfScopeDocs: 0,
+        lockAcquiredGeneration: '999',
+        lockReleasedAt: '2026-05-15T02:30:01.000Z',
+        rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },
+        chunks: [
+          { path: phaseCChunkPath, sha256: sha256Hex(phaseCChunkContent), docCount: 2 },
+        ],
+      };
+      const phaseCMainContent = JSON.stringify(phaseCMain);
+      const phaseCPath = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-main.json`;
+      reader.seed(phaseCPath, phaseCMainContent);
+
+      const manifest: BackfillManifest = {
+        schemaVersion: 'pr-d4-v1.0',
+        runId: RUN_ID,
+        env: 'dev',
+        phaseA: { mainArtifact: { path: phaseAPath, sha256: 'phaseA-sha' }, chunks: [] },
+        phaseB: { mainArtifact: { path: phaseBPath, sha256: 'phaseB-sha' }, chunks: [] },
+        phaseC: {
+          mainArtifact: { path: phaseCPath, sha256: sha256Hex(phaseCMainContent) },
+          chunks: phaseCMain.chunks,
+        },
+      };
+      const manifestGen = reader.seed(MANIFEST_PATH, JSON.stringify(manifest));
+
+      const stream = await readPhaseCArtifactFromManifest({
+        manifestPath: MANIFEST_PATH,
+        reader,
+      });
+
+      expect(stream.phaseAArtifactRef).to.equal(phaseAPath);
+      expect(stream.phaseBArtifactRef).to.equal(phaseBPath);
+      expect(stream.phaseCArtifactRef).to.equal(phaseCPath);
+      expect(stream.writtenDocsIn).to.equal(2);
+      expect(stream.manifestGeneration).to.equal(manifestGen);
+
+      const collected: PhaseCWrittenDoc[] = [];
+      for await (const doc of stream.writtenDocs()) {
+        collected.push(doc);
+      }
+      expect(collected).to.have.length(2);
+      expect(collected[0].docId).to.equal('doc1');
+      expect(collected[1].docId).to.equal('doc2');
+    });
+
+    it('manifest.phaseC absent → throw', async () => {
+      const reader = new FakeReader();
+      const manifest: BackfillManifest = {
+        schemaVersion: 'pr-d4-v1.0',
+        runId: RUN_ID,
+        env: 'dev',
+        phaseA: { mainArtifact: { path: 'a', sha256: 's' }, chunks: [] },
+      };
+      reader.seed(MANIFEST_PATH, JSON.stringify(manifest));
+      try {
+        await readPhaseCArtifactFromManifest({ manifestPath: MANIFEST_PATH, reader });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as Error).message).to.match(/phaseC section absent/);
+      }
+    });
+
+    it('main artifact sha256 mismatch → ArtifactIntegrityError', async () => {
+      const reader = new FakeReader();
+      const phaseAPath = 'phaseA';
+      const phaseBPath = 'phaseB';
+      const phaseCPath = 'phaseC';
+      reader.seed(phaseAPath, '{}');
+      reader.seed(phaseBPath, '{}');
+      reader.seed(phaseCPath, JSON.stringify({ phase: 'C', chunks: [] }));
+      const manifest: BackfillManifest = {
+        schemaVersion: 'pr-d4-v1.0',
+        runId: RUN_ID,
+        env: 'dev',
+        phaseA: { mainArtifact: { path: phaseAPath, sha256: 's' }, chunks: [] },
+        phaseB: { mainArtifact: { path: phaseBPath, sha256: 's' }, chunks: [] },
+        phaseC: { mainArtifact: { path: phaseCPath, sha256: 'wrong-sha' }, chunks: [] },
+      };
+      reader.seed(MANIFEST_PATH, JSON.stringify(manifest));
+      try {
+        await readPhaseCArtifactFromManifest({ manifestPath: MANIFEST_PATH, reader });
+        expect.fail('should throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(ArtifactIntegrityError);
+      }
+    });
+  });
+
+  describe('readPhaseBCandidatesIndex', () => {
+    it('全 chunks を docId 単位 Map に集約 + sha256 verify', async () => {
+      const reader = new FakeReader();
+      const cand1: PhaseBRevalidatedCandidate = {
+        docId: 'doc1',
+        category: 'MatchedByHash',
+        computedConfidence: 'derived-bytes-verified',
+        computedProvenance: {
+          sourceGeneration: '100',
+          sourceMetageneration: '1',
+          sourceSha256: 'a'.repeat(64),
+          sourcePath: 'parent.pdf',
+          sourceBucket: 'bucket',
+          derivedObjectPath: 'processed/doc1/doc1.pdf',
+          derivedGeneration: '200',
+          derivedMetageneration: '1',
+          derivedSha256: 'b'.repeat(64),
+          createdAt: '2026-05-13T10:00:00.000Z',
+        },
+        evidence: {
+          parentExists: true,
+          parentSha256MatchedAtBackfill: true,
+          childSha256ComputedAtBackfill: true,
+        },
+      };
+      const chunk: PhaseBRevalidatedChunk = {
+        schemaVersion: 'pr-d4-v1.0',
+        chunkIndex: 0,
+        revalidated: [cand1],
+      };
+      const chunkContent = JSON.stringify(chunk);
+      const chunkPath = `gs://${BUCKET}/phaseB-chunk-0.json`;
+      reader.seed(chunkPath, chunkContent);
+
+      const phaseBMain: PhaseBRevalidationSummary = {
+        phase: 'B',
+        schemaVersion: 'pr-d4-v1.0',
+        scriptVersion: 'pr-d4-v1.0',
+        env: 'dev',
+        runId: RUN_ID,
+        phaseAArtifactRef: 'phaseA',
+        phaseAManifestSha256: 's',
+        revalidationStartedAt: 'a',
+        revalidationCompletedAt: 'b',
+        candidatesIn: 1,
+        candidatesOut: 1,
+        driftSkipped: { firestoreUpdateTimeChanged: 0, childGenerationChanged: 0, parentGenerationChanged: 0 },
+        verifyFailedMatchedByHash: 0,
+        skippedNonMatchedByHash: 0,
+        chunks: [{ path: chunkPath, sha256: sha256Hex(chunkContent), docCount: 1 }],
+      };
+      const phaseBPath = `gs://${BUCKET}/phaseB-main.json`;
+      reader.seed(phaseBPath, JSON.stringify(phaseBMain));
+
+      const index = await readPhaseBCandidatesIndex(phaseBPath, sha256Hex(JSON.stringify(phaseBMain)), reader);
+      expect(index.size).to.equal(1);
+      expect(index.get('doc1')).to.not.be.undefined;
+      expect(index.get('doc1')!.computedConfidence).to.equal('derived-bytes-verified');
+    });
+  });
+
+  describe('readPhaseACountReadOnly', () => {
+    it('Phase A summary から totalDocs / alreadyBackfilled / verifiedExistingProvenance / categoryDistribution 抽出', async () => {
+      const reader = new FakeReader();
+      const phaseAMain: PhaseAClassifySummary = {
+        phase: 'A',
+        schemaVersion: 'pr-d4-v1.0',
+        scriptVersion: 'pr-d4-v1.0',
+        env: 'dev',
+        runId: RUN_ID,
+        snapshotStartedAt: 'a',
+        snapshotCompletedAt: 'b',
+        bucketLocation: 'asia-northeast1',
+        cloudRunJobLocation: 'asia-northeast1',
+        egressFreeAssertion: true,
+        totalDocs: 5725,
+        categoryDistribution: {
+          MatchedByHash: 4500,
+          RepairableMissingFile: 4,
+          Ambiguous: 135,
+          LostOrUnrecoverable: 86,
+          NeedsManualReview: 0,
+        },
+        alreadyBackfilled: 0,
+        verifiedExistingProvenance: 1000,
+        chunks: [],
+      };
+      const path = 'phaseA-main';
+      const phaseAContent = JSON.stringify(phaseAMain);
+      reader.seed(path, phaseAContent);
+      const count = await readPhaseACountReadOnly(path, sha256Hex(phaseAContent), reader);
+      expect(count.totalDocs).to.equal(5725);
+      expect(count.verifiedExistingProvenance).to.equal(1000);
+      expect(count.categoryDistribution.MatchedByHash).to.equal(4500);
+      expect(count.categoryDistribution.Ambiguous).to.equal(135);
+    });
+  });
+});

--- a/functions/test/prD4PhaseDArtifactWriter.test.ts
+++ b/functions/test/prD4PhaseDArtifactWriter.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D artifactWriter unit test (BF22 + CAS update + status file).
+ *
+ * - writePhaseDChunk: 1 chunk 書込、sha256 計算、docCount は verifiedDocs + fieldsMismatchDocs 合計
+ * - finalizePhaseDArtifact:
+ *   - main artifact 書込 (manifestUpdateStatus: 'pending' 含む)
+ *   - manifest CAS update (ifGenerationMatch=manifestGeneration)
+ *   - CAS 失敗時 manifestUpdateStatus: 'failed' + status file 書込 (Codex 8th Important 3)
+ *   - 成功時 manifestUpdateStatus: 'ok' + status file 書込
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import {
+  writePhaseDChunk,
+  finalizePhaseDArtifact,
+  type ArtifactStorageWriter,
+} from '../../scripts/pr-d4-backfill/phase-d/artifactWriter';
+import type {
+  BackfillManifest,
+  PhaseDFieldMismatchDoc,
+  PhaseDVerifiedDoc,
+  PhaseDVerifyChunk,
+  PhaseDVerifySummary,
+  PhaseDFinalizeStatus,
+} from '../../scripts/pr-d4-backfill/types';
+
+function sha256Hex(s: string): string {
+  return crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+}
+
+class FakeWriter implements ArtifactStorageWriter {
+  private store = new Map<string, { content: string; generation: number }>();
+  private nextGen = 100;
+  /** Set path to fail CAS at */
+  failCASPath: string | null = null;
+
+  async writeJson(
+    path: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
+    if (this.failCASPath === path && precondition && precondition.ifGenerationMatch > 0) {
+      const err = new Error('412 PreconditionFailed (simulated)');
+      (err as Error & { code?: number }).code = 412;
+      throw err;
+    }
+    const ifGenMatch = precondition?.ifGenerationMatch;
+    if (ifGenMatch !== undefined) {
+      const existing = this.store.get(path);
+      if (ifGenMatch === 0 && existing) {
+        const err = new Error('412 PreconditionFailed: already exists');
+        (err as Error & { code?: number }).code = 412;
+        throw err;
+      }
+      if (ifGenMatch > 0) {
+        if (!existing || existing.generation !== ifGenMatch) {
+          const err = new Error(`412 PreconditionFailed: gen mismatch`);
+          (err as Error & { code?: number }).code = 412;
+          throw err;
+        }
+      }
+    }
+    this.store.set(path, { content, generation: this.nextGen++ });
+  }
+
+  seed(path: string, content: string, gen: number): void {
+    this.store.set(path, { content, generation: gen });
+    if (this.nextGen <= gen) this.nextGen = gen + 1;
+  }
+
+  get(path: string): { content: string; generation: number } | undefined {
+    return this.store.get(path);
+  }
+}
+
+const BUCKET = 'docsplit-dev-pr-d4-artifacts';
+const RUN_ID = '20260515T040000Z-dev-pr-d4-v1';
+const MANIFEST_PATH = `gs://${BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/manifest.json`;
+
+describe('Phase D artifactWriter', () => {
+  describe('writePhaseDChunk', () => {
+    it('chunk 書込 + sha256 + docCount = verifiedDocs + fieldsMismatchDocs 合計', async () => {
+      const writer = new FakeWriter();
+      const verifiedDocs: PhaseDVerifiedDoc[] = [
+        {
+          docId: 'doc1',
+          provenanceFieldsConsistent: true,
+          provenanceBackfillSha256Match: true,
+          observedConfidence: 'derived-bytes-verified',
+          observedCreatedAt: '2026-05-13T10:00:00.000Z',
+        },
+      ];
+      const mismatches: PhaseDFieldMismatchDoc[] = [
+        {
+          docId: 'doc2',
+          mismatchType: 'provenance-field',
+          field: 'sourceSha256',
+          observed: 'wrong',
+          expected: 'right',
+        },
+        {
+          docId: 'doc3',
+          mismatchType: 'sha256',
+          field: 'provenanceBackfill.sha256',
+          observed: 'sha-a',
+          expected: 'sha-b',
+        },
+      ];
+      const pointer = await writePhaseDChunk(
+        {
+          bucketName: BUCKET,
+          runId: RUN_ID,
+          chunkIndex: 0,
+          verifiedDocs,
+          fieldsMismatchDocs: mismatches,
+          mismatchedDocIds: ['doc2', 'doc3'],
+        },
+        writer
+      );
+      // docCount = verifiedDocs (1) + mismatchedDocIds.length (2) = 3 (doc 単位、Codex 9th C3)
+      expect(pointer.docCount).to.equal(3);
+      expect(pointer.path).to.match(/phase-d-verify-summary-chunk-0\.json$/);
+      const written = writer.get(pointer.path);
+      expect(written).to.not.be.undefined;
+      expect(pointer.sha256).to.equal(sha256Hex(written!.content));
+      const parsed = JSON.parse(written!.content) as PhaseDVerifyChunk;
+      expect(parsed.verifiedDocs).to.have.length(1);
+      expect(parsed.fieldsMismatchDocs).to.have.length(2);
+    });
+  });
+
+  describe('finalizePhaseDArtifact', () => {
+    function makeBaseInput(writer: FakeWriter) {
+      const manifest: BackfillManifest = {
+        schemaVersion: 'pr-d4-v1.0',
+        runId: RUN_ID,
+        env: 'dev',
+        phaseA: { mainArtifact: { path: 'a', sha256: 's' }, chunks: [] },
+        phaseB: { mainArtifact: { path: 'b', sha256: 's' }, chunks: [] },
+        phaseC: { mainArtifact: { path: 'c', sha256: 's' }, chunks: [] },
+      };
+      writer.seed(MANIFEST_PATH, JSON.stringify(manifest), 500);
+      return {
+        bucketName: BUCKET,
+        runId: RUN_ID,
+        env: 'dev' as const,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+        verifyCompletedAt: '2026-05-15T03:30:00.000Z',
+        phaseAArtifactRef: 'a',
+        phaseBArtifactRef: 'b',
+        phaseCArtifactRef: 'c',
+        phaseCManifestSha256: 's',
+        candidatesIn: 3,
+        verifiedDocs: 3,
+        fieldsConsistent: 3,
+        fieldsMismatch: [] as PhaseDFieldMismatchDoc[],
+        mismatchedDocCount: 0,
+        createdAtConsistent: 3,
+        createdAtMismatch: [] as PhaseDFieldMismatchDoc[],
+        confidenceDistribution: {
+          'derived-bytes-verified': 3,
+          'child-snapshot-only': 0,
+          'metadata-only': 0,
+        },
+        provenanceBackfillNullCount: 0,
+        provenanceBackfillAbsentCount: 0,
+        rotateGateTest: null,
+        coverageRatio: {
+          backfillAttemptCoverage: {
+            denominator: 3,
+            derivedBytesVerified: 1.0,
+            childSnapshotOnly: 0,
+            metadataOnly: 0,
+            preconditionFailed: 0,
+            immutableSkipped: 0,
+          },
+          estateRotateReadyCoverage: {
+            denominator: 100,
+            verifiedExisting: 0.5,
+            backfilledDerivedBytesVerified: 0.03,
+            rotateReadyTotal: 0.53,
+            notRotateReady: 0.47,
+          },
+        },
+        phaseACountReadOnly: {
+          totalDocs: 100,
+          alreadyBackfilled: 0,
+          verifiedExistingProvenance: 50,
+          categoryDistribution: {
+            MatchedByHash: 50,
+            RepairableMissingFile: 0,
+            Ambiguous: 0,
+            LostOrUnrecoverable: 0,
+            NeedsManualReview: 0,
+          },
+        },
+        chunks: [],
+        existingManifest: manifest,
+        manifestGeneration: 500,
+      };
+    }
+
+    it('CAS update 成功 → manifestUpdateStatus="ok" + main artifact に "pending" 残る', async () => {
+      const writer = new FakeWriter();
+      const result = await finalizePhaseDArtifact(makeBaseInput(writer), writer);
+      expect(result.manifestUpdateStatus).to.equal('ok');
+
+      const mainWritten = writer.get(result.mainArtifactPath);
+      expect(mainWritten).to.not.be.undefined;
+      const parsed = JSON.parse(mainWritten!.content) as PhaseDVerifySummary;
+      // Codex 8th Important 3: main は常に 'pending' で書込 (overwrite 回避)
+      expect(parsed.manifestUpdateStatus).to.equal('pending');
+      expect(parsed.phase).to.equal('D');
+      expect(parsed.candidatesIn).to.equal(3);
+
+      const statusWritten = writer.get(result.finalizeStatusPath);
+      expect(statusWritten).to.not.be.undefined;
+      const status = JSON.parse(statusWritten!.content) as PhaseDFinalizeStatus;
+      expect(status.manifestUpdateStatus).to.equal('ok');
+      expect(status.remediation).to.be.undefined;
+    });
+
+    it('CAS update 失敗 → manifestUpdateStatus="failed" + status file に remediation 記録', async () => {
+      const writer = new FakeWriter();
+      writer.failCASPath = MANIFEST_PATH;
+      const result = await finalizePhaseDArtifact(makeBaseInput(writer), writer);
+      expect(result.manifestUpdateStatus).to.equal('failed');
+
+      const statusWritten = writer.get(result.finalizeStatusPath);
+      expect(statusWritten).to.not.be.undefined;
+      const status = JSON.parse(statusWritten!.content) as PhaseDFinalizeStatus;
+      expect(status.manifestUpdateStatus).to.equal('failed');
+      expect(status.remediation).to.match(/CAS failed/i);
+      expect(status.remediation).to.match(/re-run Phase D/i);
+    });
+  });
+});

--- a/functions/test/prD4PhaseDDocVerifier.test.ts
+++ b/functions/test/prD4PhaseDDocVerifier.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D docVerifier unit test (Codex Critical 1/2 反映).
+ *
+ * Stage 1: observed field 単位検証 (factory 再 invoke なし)
+ * Stage 2: sha256 deterministic 確認 (Stage 1 pass のみ)
+ *
+ * verify 観点:
+ * - verified ケース (provenance 10 fields 一致 + Stage 1 pass + Stage 2 sha256 一致)
+ * - provenance mismatch (sourceSha256 不一致 / derivedSha256 不一致 / createdAt 不一致)
+ * - backfill-field mismatch (method 違反 / confidence 不正型 / evidence.* 不正値)
+ * - sha256 mismatch (Stage 2 で hash 不一致)
+ * - missing-expected (Phase B index に docId 不在)
+ * - BF10: provenance.createdAt vs document.createdAt 比較
+ */
+
+import { expect } from 'chai';
+import { Timestamp } from 'firebase-admin/firestore';
+import { verifyDoc, type ObservedDocState } from '../../scripts/pr-d4-backfill/phase-d/docVerifier';
+import { sha256ProvenanceBackfill } from '../../scripts/pr-d4-backfill/phase-c/batchWriter';
+import { createBackfillProvenance } from '../src/pdf/provenance';
+import type { PhaseBRevalidatedCandidate } from '../../scripts/pr-d4-backfill/types';
+
+// Test fixtures
+const BACKFILL_SCRIPT_VERSION = 'pr-d4-v1.0';
+const SHA_PARENT = 'a'.repeat(64);
+const SHA_CHILD = 'b'.repeat(64);
+
+function makeExpectedCandidate(docId: string): PhaseBRevalidatedCandidate {
+  return {
+    docId,
+    category: 'MatchedByHash',
+    computedConfidence: 'derived-bytes-verified',
+    computedProvenance: {
+      sourceGeneration: '1700000001',
+      sourceMetageneration: '1',
+      sourceSha256: SHA_PARENT,
+      sourcePath: 'sources/parent.pdf',
+      sourceBucket: 'doc-split-dev-data',
+      derivedObjectPath: `processed/${docId}/${docId}.pdf`,
+      derivedGeneration: '1700000002',
+      derivedMetageneration: '1',
+      derivedSha256: SHA_CHILD,
+      createdAt: '2025-01-01T00:00:00.000Z',
+    },
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+  };
+}
+
+function makeObservedAligned(docId: string, expected: PhaseBRevalidatedCandidate): {
+  observed: ObservedDocState;
+  expectedSha256: string;
+} {
+  const splitCreatedAt = Timestamp.fromDate(new Date(expected.computedProvenance.createdAt));
+  const backfilledAt = Timestamp.fromDate(new Date('2026-05-15T10:00:00.000Z'));
+  const built = createBackfillProvenance({
+    provenanceFields: {
+      sourceGeneration: expected.computedProvenance.sourceGeneration,
+      sourceMetageneration: expected.computedProvenance.sourceMetageneration,
+      sourceSha256: expected.computedProvenance.sourceSha256,
+      sourcePath: expected.computedProvenance.sourcePath,
+      sourceBucket: expected.computedProvenance.sourceBucket,
+      derivedObjectPath: expected.computedProvenance.derivedObjectPath,
+      derivedGeneration: expected.computedProvenance.derivedGeneration,
+      derivedMetageneration: expected.computedProvenance.derivedMetageneration,
+      derivedSha256: expected.computedProvenance.derivedSha256,
+      createdAt: splitCreatedAt,
+    },
+    confidence: 'derived-bytes-verified',
+    classifierCategory: 'MatchedByHash',
+    evidence: {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+    },
+    backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+    backfilledAt,
+  });
+  const expectedSha256 = sha256ProvenanceBackfill(built.provenanceBackfill);
+  return {
+    observed: {
+      docId,
+      documentCreatedAt: splitCreatedAt,
+      provenance: built.provenance,
+      provenanceBackfill: built.provenanceBackfill,
+      provenanceBackfillRaw: built.provenanceBackfill,
+    },
+    expectedSha256,
+  };
+}
+
+describe('verifyDoc - Phase D Stage 1 + Stage 2 (Codex Critical 1/2 反映)', () => {
+  describe('verified ケース', () => {
+    it('provenance 10 fields 一致 + Stage 1 pass + Stage 2 sha256 一致 → kind=verified', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('verified');
+      if (result.kind === 'verified') {
+        expect(result.provenanceFieldsConsistent).to.be.true;
+        expect(result.provenanceBackfillSha256Match).to.be.true;
+        expect(result.observedConfidence).to.equal('derived-bytes-verified');
+        expect(result.createdAtConsistent).to.be.true;
+      }
+    });
+  });
+
+  describe('missing-expected ケース', () => {
+    it('Phase B index に docId 不在 → mismatchType="missing-expected"', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: undefined,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        expect(result.mismatches[0].mismatchType).to.equal('missing-expected');
+        expect(result.mismatches[0].field).to.equal('__phaseBIndex');
+      }
+    });
+  });
+
+  describe('provenance-field mismatch ケース (Critical 1 反映)', () => {
+    it('observed.provenance.sourceSha256 不一致 → mismatchType="provenance-field" + field="sourceSha256"', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      // observed の sourceSha256 を別値に書換 (drift simulation)
+      observed.provenance!.sourceSha256 = 'c'.repeat(64);
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const sourceSha = result.mismatches.find((m) => m.field === 'sourceSha256');
+        expect(sourceSha).to.not.be.undefined;
+        expect(sourceSha!.mismatchType).to.equal('provenance-field');
+        expect(sourceSha!.observed).to.equal('c'.repeat(64));
+        expect(sourceSha!.expected).to.equal(SHA_PARENT);
+      }
+    });
+
+    it('observed.provenance.derivedSha256 不一致 → field="derivedSha256"', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      observed.provenance!.derivedSha256 = 'd'.repeat(64);
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const derivedSha = result.mismatches.find((m) => m.field === 'derivedSha256');
+        expect(derivedSha).to.not.be.undefined;
+      }
+    });
+
+    it('observed.provenance.createdAt が Timestamp でない → mismatch', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      (observed.provenance as unknown as Record<string, unknown>).createdAt = 'not-a-timestamp';
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+    });
+
+    it('observed.provenance null → field="provenance" mismatch', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const observed: ObservedDocState = {
+        docId: 'doc1',
+        documentCreatedAt: Timestamp.now(),
+        provenance: null,
+        provenanceBackfill: null,
+        provenanceBackfillRaw: undefined,
+      };
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: 'a'.repeat(64),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        expect(result.mismatches[0].field).to.equal('provenance');
+      }
+    });
+  });
+
+  describe('backfill-field mismatch ケース (Critical 2 反映 Stage 1)', () => {
+    it('provenanceBackfill.method !== "legacy-observed" → mismatchType="backfill-field"', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      (observed.provenanceBackfillRaw as Record<string, unknown>).method = 'future-method';
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const methodMismatch = result.mismatches.find((m) => m.field === 'provenanceBackfill.method');
+        expect(methodMismatch).to.not.be.undefined;
+        expect(methodMismatch!.mismatchType).to.equal('backfill-field');
+        expect(methodMismatch!.observed).to.equal('future-method');
+      }
+    });
+
+    it('provenanceBackfill.confidence が unknown 値 → mismatch', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      (observed.provenanceBackfillRaw as Record<string, unknown>).confidence = 'mystery';
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const confMismatch = result.mismatches.find((m) => m.field === 'provenanceBackfill.confidence');
+        expect(confMismatch).to.not.be.undefined;
+      }
+    });
+
+    it('provenanceBackfill.backfilledAt が Timestamp でない → mismatch', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      (observed.provenanceBackfillRaw as Record<string, unknown>).backfilledAt = 'not-a-timestamp';
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const backfilledAtMismatch = result.mismatches.find(
+          (m) => m.field === 'provenanceBackfill.backfilledAt'
+        );
+        expect(backfilledAtMismatch).to.not.be.undefined;
+      }
+    });
+
+    it('provenanceBackfill.evidence.parentExists が boolean でない → mismatch', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      const evidence = (observed.provenanceBackfillRaw as Record<string, unknown>).evidence as Record<
+        string,
+        unknown
+      >;
+      evidence.parentExists = 'yes';
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+    });
+
+    it('parentSha256MatchedAtBackfill が `boolean | null` 以外 → mismatch (Codex 8th Important 2)', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      const evidence = (observed.provenanceBackfillRaw as Record<string, unknown>).evidence as Record<
+        string,
+        unknown
+      >;
+      evidence.parentSha256MatchedAtBackfill = 'maybe';
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+    });
+
+    it('parentSha256MatchedAtBackfill が null → Stage 1 pass (一般 validator は null 許容)', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed } = makeObservedAligned('doc1', expected);
+      // null を入れて Stage 1 で fail しないことを確認
+      // (child-snapshot-only 経路で null が正当値、Codex 8th Important 2)
+      const evidence = (observed.provenanceBackfillRaw as Record<string, unknown>).evidence as Record<
+        string,
+        unknown
+      >;
+      evidence.parentSha256MatchedAtBackfill = null;
+      // confidence も child-snapshot-only に合わせる
+      (observed.provenanceBackfillRaw as Record<string, unknown>).confidence = 'child-snapshot-only';
+      // sha256 は別計算
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: 'unrelated',  // Stage 2 sha256 mismatch 想定
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      // Stage 1 は pass (mismatch type が 'backfill-field' でなく 'sha256' で出る)
+      if (result.kind === 'mismatch') {
+        const stage1Fail = result.mismatches.find((m) => m.mismatchType === 'backfill-field');
+        expect(stage1Fail, 'Stage 1 should pass when parentSha256MatchedAtBackfill is null').to.be
+          .undefined;
+      }
+    });
+  });
+
+  describe('sha256 mismatch ケース (Stage 2)', () => {
+    it('Phase C expectedSha256 と Stage 2 sha256 不一致 → mismatchType="sha256"', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed } = makeObservedAligned('doc1', expected);
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: 'f'.repeat(64),  // 全く別の hash
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const shaMismatch = result.mismatches.find((m) => m.mismatchType === 'sha256');
+        expect(shaMismatch).to.not.be.undefined;
+        expect(shaMismatch!.field).to.equal('provenanceBackfill.sha256');
+        expect(shaMismatch!.expected).to.equal('f'.repeat(64));
+      }
+    });
+  });
+
+  describe('BF10: provenance.createdAt vs document.createdAt 検証', () => {
+    it('document.createdAt と provenance.createdAt 一致 → createdAtConsistent=true', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('verified');
+      if (result.kind === 'verified') {
+        expect(result.createdAtConsistent).to.be.true;
+        expect(result.createdAtMismatch).to.be.null;
+      }
+    });
+
+    it('document.createdAt と provenance.createdAt 不一致 → createdAtConsistent=false + createdAtMismatch あり', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      observed.documentCreatedAt = Timestamp.fromDate(new Date('2030-01-01T00:00:00.000Z'));
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('verified');
+      if (result.kind === 'verified') {
+        expect(result.createdAtConsistent).to.be.false;
+        expect(result.createdAtMismatch).to.not.be.null;
+        expect(result.createdAtMismatch!.field).to.match(/createdAt/);
+      }
+    });
+
+    it('document.createdAt が null → createdAtConsistent=false + createdAtMismatch あり', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      observed.documentCreatedAt = null;
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      if (result.kind === 'verified') {
+        expect(result.createdAtConsistent).to.be.false;
+        expect(result.createdAtMismatch).to.not.be.null;
+      }
+    });
+  });
+
+  describe('provenanceBackfillRaw が null / undefined / array (Stage 1 防御)', () => {
+    it('provenanceBackfillRaw === null → mismatchType="backfill-field"', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      observed.provenanceBackfillRaw = null;
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+      if (result.kind === 'mismatch') {
+        const fieldMismatch = result.mismatches.find((m) => m.field === 'provenanceBackfill');
+        expect(fieldMismatch).to.not.be.undefined;
+        expect(fieldMismatch!.observed).to.be.null;
+      }
+    });
+
+    it('provenanceBackfillRaw === array → reject', () => {
+      const expected = makeExpectedCandidate('doc1');
+      const { observed, expectedSha256 } = makeObservedAligned('doc1', expected);
+      observed.provenanceBackfillRaw = [{ confidence: 'derived-bytes-verified' }];
+      const result = verifyDoc({
+        observed,
+        expectedFromPhaseB: expected,
+        expectedSha256FromPhaseC: expectedSha256,
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      });
+      expect(result.kind).to.equal('mismatch');
+    });
+  });
+});

--- a/functions/test/prD4PhaseDRotateGateFixtureTester.test.ts
+++ b/functions/test/prD4PhaseDRotateGateFixtureTester.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Issue #445 PR-D4 S1-5: rotateGateFixtureTester unit test (Codex 8th Important 2).
+ *
+ * - dev hard gate (env !== 'dev' で throw)
+ * - fixture docId 形式 (`BF13_test_fixture_${runId}_${kind}_${uuid}`)
+ * - cleanup hook が try / finally で必ず実行 (rotate API 成否に関わらず)
+ * - cleanup 失敗を `fixtureCleanupFailures[]` に記録
+ * - prefix 違反 docId を cleanup hook が refuse (defense in depth)
+ */
+
+import { expect } from 'chai';
+import {
+  buildFixtureDocId,
+  isFixtureDocId,
+  runRotateGateFixtureTest,
+  type FixtureStore,
+  type RotateApiCaller,
+} from '../../scripts/pr-d4-backfill/phase-d/rotateGateFixtureTester';
+
+describe('rotateGateFixtureTester (Codex 8th Important 2 反映)', () => {
+  describe('buildFixtureDocId / isFixtureDocId', () => {
+    it('prefix + runId + kind + uuid を含む', () => {
+      const docId = buildFixtureDocId('run-123', 'verified');
+      expect(docId).to.match(/^BF13_test_fixture_run-123_verified_/);
+      expect(isFixtureDocId(docId)).to.be.true;
+    });
+
+    it('uuid 部分で 2 回の呼出が衝突しない', () => {
+      const a = buildFixtureDocId('run-1', 'child_snapshot_only');
+      const b = buildFixtureDocId('run-1', 'child_snapshot_only');
+      expect(a).to.not.equal(b);
+    });
+
+    it('prefix 違反 docId は isFixtureDocId=false', () => {
+      expect(isFixtureDocId('production-doc-id')).to.be.false;
+      expect(isFixtureDocId('something-else-BF13_test_fixture')).to.be.false;
+    });
+  });
+
+  describe('dev hard gate', () => {
+    it('env !== "dev" で throw', async () => {
+      const fakeStore: FixtureStore = {
+        async createFixture() {
+          return { objectPath: 'x', objectGeneration: '1' };
+        },
+        async cleanupFixture() {},
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate() {
+          return { kind: 'rejected', rejectionMessage: 'never' };
+        },
+      };
+      try {
+        await runRotateGateFixtureTest({
+          env: 'cocoro',
+          runId: 'r1',
+          pdfBytesVerified: Buffer.from('a'),
+          pdfBytesChildSnapshotOnly: Buffer.from('b'),
+          fixtureStore: fakeStore,
+          rotateApiCaller: fakeRotate,
+        });
+        expect.fail('should throw');
+      } catch (err) {
+        expect((err as Error).message).to.match(/dev-only/);
+      }
+    });
+  });
+
+  describe('正常系: BF12 success + BF13 rejected', () => {
+    it('verified rotate success + child_snapshot_only rejected + cleanup 2 件成功', async () => {
+      const createCalls: string[] = [];
+      const cleanupCalls: string[] = [];
+      const fakeStore: FixtureStore = {
+        async createFixture(input) {
+          createCalls.push(input.docId);
+          return { objectPath: `processed/${input.docId}/p.pdf`, objectGeneration: '100' };
+        },
+        async cleanupFixture(input) {
+          cleanupCalls.push(input.docId);
+        },
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate(input) {
+          if (input.docId.includes('child_snapshot_only')) {
+            return { kind: 'rejected', rejectionMessage: 'failed-precondition' };
+          }
+          return {
+            kind: 'success',
+            rotatedAt: '2026-05-15T10:00:00.000Z',
+            newRotationObjectPath: `processed/${input.docId}/rotations/u.pdf`,
+            newRotationObjectGeneration: '200',
+          };
+        },
+      };
+      const result = await runRotateGateFixtureTest({
+        env: 'dev',
+        runId: 'run-1',
+        pdfBytesVerified: Buffer.from('verified-pdf'),
+        pdfBytesChildSnapshotOnly: Buffer.from('child-snapshot-pdf'),
+        fixtureStore: fakeStore,
+        rotateApiCaller: fakeRotate,
+      });
+      expect(result.derivedBytesVerified.rotateApiResult).to.equal('success');
+      expect(result.childSnapshotOnly.rotateApiResult).to.equal('rejected');
+      expect(result.fixtureCleanupFailures).to.have.length(0);
+      expect(createCalls).to.have.length(2);
+      expect(cleanupCalls).to.have.length(2);
+    });
+  });
+
+  describe('異常系: rotate gate leak (BF13 FAIL) を artifact に記録', () => {
+    it('child_snapshot_only が success → result に "BF13 FAILED" 残し cleanup は実行', async () => {
+      const fakeStore: FixtureStore = {
+        async createFixture(input) {
+          return { objectPath: `p/${input.docId}.pdf`, objectGeneration: '50' };
+        },
+        async cleanupFixture() {},
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate() {
+          return {
+            kind: 'success',
+            rotatedAt: '2026-05-15T10:00:00.000Z',
+            newRotationObjectPath: 'p/r.pdf',
+            newRotationObjectGeneration: '60',
+          };
+        },
+      };
+      const result = await runRotateGateFixtureTest({
+        env: 'dev',
+        runId: 'run-2',
+        pdfBytesVerified: Buffer.from('v'),
+        pdfBytesChildSnapshotOnly: Buffer.from('c'),
+        fixtureStore: fakeStore,
+        rotateApiCaller: fakeRotate,
+      });
+      expect(result.childSnapshotOnly.rotateApiResult).to.equal('success');
+      expect(result.childSnapshotOnly.rejectionMessage).to.match(/BF13 FAILED/i);
+    });
+  });
+
+  describe('cleanup hook 失敗 → fixtureCleanupFailures[] に記録', () => {
+    it('cleanupFixture が throw → fixtureCleanupFailures に error 記録', async () => {
+      const fakeStore: FixtureStore = {
+        async createFixture(input) {
+          return { objectPath: `p/${input.docId}.pdf`, objectGeneration: '70' };
+        },
+        async cleanupFixture(input) {
+          if (input.docId.includes('child_snapshot_only')) {
+            throw new Error('GCS 412 PreconditionFailed (simulated)');
+          }
+        },
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate(input) {
+          if (input.docId.includes('child_snapshot_only')) {
+            return { kind: 'rejected', rejectionMessage: 'failed-precondition' };
+          }
+          return {
+            kind: 'success',
+            rotatedAt: 'now',
+            newRotationObjectPath: 'p/r.pdf',
+            newRotationObjectGeneration: '80',
+          };
+        },
+      };
+      const result = await runRotateGateFixtureTest({
+        env: 'dev',
+        runId: 'run-3',
+        pdfBytesVerified: Buffer.from('v'),
+        pdfBytesChildSnapshotOnly: Buffer.from('c'),
+        fixtureStore: fakeStore,
+        rotateApiCaller: fakeRotate,
+      });
+      expect(result.fixtureCleanupFailures).to.have.length(1);
+      expect(result.fixtureCleanupFailures[0].fixtureDocId).to.match(/child_snapshot_only/);
+      expect(result.fixtureCleanupFailures[0].error).to.match(/GCS 412/);
+    });
+  });
+
+  describe('rotate API error → kind=error を rejected 扱い (defense in depth)', () => {
+    it('rotate API が error 返却 → result.rotateApiResult=rejected + cleanup 実行', async () => {
+      let createCount = 0;
+      let cleanupCount = 0;
+      const fakeStore: FixtureStore = {
+        async createFixture(input) {
+          createCount++;
+          return { objectPath: `p/${input.docId}.pdf`, objectGeneration: '99' };
+        },
+        async cleanupFixture() {
+          cleanupCount++;
+        },
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate() {
+          return { kind: 'error', message: 'network timeout' };
+        },
+      };
+      const result = await runRotateGateFixtureTest({
+        env: 'dev',
+        runId: 'run-4',
+        pdfBytesVerified: Buffer.from('v'),
+        pdfBytesChildSnapshotOnly: Buffer.from('c'),
+        fixtureStore: fakeStore,
+        rotateApiCaller: fakeRotate,
+      });
+      // BF12 verified: error は rejected 扱い (verifiedDocs.rotateApiResult=rejected)
+      expect(result.derivedBytesVerified.rotateApiResult).to.equal('rejected');
+      // BF13 child-snapshot-only: error も rejected (safety side)
+      expect(result.childSnapshotOnly.rotateApiResult).to.equal('rejected');
+      expect(createCount).to.equal(2);
+      expect(cleanupCount).to.equal(2);
+    });
+  });
+});

--- a/functions/test/prD4PhaseDVerifyOrchestrator.test.ts
+++ b/functions/test/prD4PhaseDVerifyOrchestrator.test.ts
@@ -1,0 +1,690 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D verifyOrchestrator 統合テスト.
+ *
+ * Phase C manifest 読込 → Phase A read-only count + Phase B index 構築 → writtenDocs streaming
+ * verify → coverage 算出 → finalize (main + manifest CAS) の統合動作検証。
+ *
+ * fake adapters で in-memory artifact bucket + Firestore re-read を seed して run。
+ *
+ * 検証観点:
+ * - 正常系 (全 verified、保全式アサート)
+ * - sha256 mismatch / provenance-field mismatch / missing-expected の混在
+ * - per-chunk flush (BF22 streaming、chunk size > buffer threshold)
+ * - rotate gate fixture test (dev 環境 enabled / 本番相当 disabled)
+ * - manifest CAS 失敗時の status file 書込 (Codex 8th Important 3)
+ * - 2 系統 coverage ratio (Codex 7th Important 4)
+ * - provenanceBackfillNullCount (Codex 8th 回答 4)
+ */
+
+import { expect } from 'chai';
+import * as crypto from 'crypto';
+import { Timestamp } from 'firebase-admin/firestore';
+import { runPhaseD } from '../../scripts/pr-d4-backfill/phase-d/verifyOrchestrator';
+import type {
+  PhaseDDocReader,
+} from '../../scripts/pr-d4-backfill/phase-d/verifyOrchestrator';
+import type { ObservedDocState } from '../../scripts/pr-d4-backfill/phase-d/docVerifier';
+import type {
+  ArtifactStorageReader,
+} from '../../scripts/pr-d4-backfill/phase-b/artifactReader';
+import type { ArtifactStorageWriter } from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import { sha256ProvenanceBackfill } from '../../scripts/pr-d4-backfill/phase-c/batchWriter';
+import { createBackfillProvenance } from '../src/pdf/provenance';
+import type {
+  BackfillManifest,
+  PhaseAClassifySummary,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+  PhaseCBackfillChunk,
+  PhaseCBackfillSummary,
+  PhaseCWrittenDoc,
+} from '../../scripts/pr-d4-backfill/types';
+import type {
+  FixtureStore,
+  RotateApiCaller,
+} from '../../scripts/pr-d4-backfill/phase-d/rotateGateFixtureTester';
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+const RUN_ID = '20260515T020000Z-dev-pr-d4-v1';
+const ARTIFACT_BUCKET = 'docsplit-dev-pr-d4-artifacts';
+const BACKFILL_SCRIPT_VERSION = 'pr-d4-v1.0';
+const MANIFEST_PATH = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/manifest.json`;
+const PHASE_A_MAIN = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-a-classify-summary.json`;
+const PHASE_B_MAIN = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-b-revalidation-summary.json`;
+const PHASE_C_MAIN = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-backfill-summary.json`;
+
+interface FakeArtifactObject {
+  content: string;
+  generation: number;
+}
+
+class FakeInMemoryStorage {
+  private store = new Map<string, FakeArtifactObject>();
+  private nextGen = 100;
+  /** Set to true to simulate manifest CAS failure (412 PreconditionFailed) */
+  failManifestCAS = false;
+
+  reader: ArtifactStorageReader = {
+    readJson: async (path: string) => {
+      const obj = this.store.get(path);
+      if (!obj) throw new Error(`fake storage: object not found: ${path}`);
+      return { content: obj.content, generation: obj.generation };
+    },
+  };
+
+  writer: ArtifactStorageWriter = {
+    writeJson: async (
+      path: string,
+      content: string,
+      precondition?: { ifGenerationMatch: number }
+    ) => {
+      if (this.failManifestCAS && path === MANIFEST_PATH && precondition && precondition.ifGenerationMatch > 0) {
+        const err = new Error('412 PreconditionFailed (simulated)');
+        (err as Error & { code?: number }).code = 412;
+        throw err;
+      }
+      const ifGenMatch = precondition?.ifGenerationMatch;
+      if (ifGenMatch !== undefined) {
+        const existing = this.store.get(path);
+        if (ifGenMatch === 0) {
+          if (existing) {
+            const err = new Error('412 PreconditionFailed: object already exists');
+            (err as Error & { code?: number }).code = 412;
+            throw err;
+          }
+        } else {
+          if (!existing) {
+            const err = new Error('412 PreconditionFailed: object missing for CAS');
+            (err as Error & { code?: number }).code = 412;
+            throw err;
+          }
+          if (existing.generation !== ifGenMatch) {
+            const err = new Error(
+              `412 PreconditionFailed: expected gen ${ifGenMatch}, got ${existing.generation}`
+            );
+            (err as Error & { code?: number }).code = 412;
+            throw err;
+          }
+        }
+      }
+      this.store.set(path, { content, generation: this.nextGen++ });
+    },
+  };
+
+  seed(path: string, content: string, generation?: number): void {
+    this.store.set(path, { content, generation: generation ?? this.nextGen++ });
+  }
+  get(path: string): FakeArtifactObject | undefined {
+    return this.store.get(path);
+  }
+}
+
+let docCounter = 0;
+function makeCandidate(docId: string, confidence: 'derived-bytes-verified' | 'child-snapshot-only'): PhaseBRevalidatedCandidate {
+  docCounter += 1;
+  const gen = String(1700000000 + docCounter);
+  return {
+    docId,
+    category: confidence === 'derived-bytes-verified' ? 'MatchedByHash' : 'Ambiguous',
+    computedConfidence: confidence,
+    computedProvenance: {
+      sourceGeneration: gen,
+      sourceMetageneration: '1',
+      // 64-char hex (a-f only)
+      sourceSha256: ('a' + (docCounter % 16).toString(16)).repeat(32),
+      sourcePath: `original/${docId}-parent.pdf`,
+      sourceBucket: 'docsplit-dev-storage',
+      derivedObjectPath: `processed/${docId}/${docId}.pdf`,
+      derivedGeneration: String(2700000000 + docCounter),
+      derivedMetageneration: '1',
+      derivedSha256: ('b' + (docCounter % 16).toString(16)).repeat(32),
+      createdAt: '2026-05-13T10:00:00.000Z',
+    },
+    evidence: {
+      parentExists: confidence === 'derived-bytes-verified',
+      parentSha256MatchedAtBackfill: confidence === 'derived-bytes-verified',
+      childSha256ComputedAtBackfill: true,
+    },
+  };
+}
+
+/**
+ * Phase D test seed builder: Phase A summary + Phase B chunks + Phase C chunks + manifest を構築。
+ *
+ * computedProvenance + createBackfillProvenance を経由して `newProvenanceBackfillSha256` を計算し、
+ * Phase C writtenDocs に格納 + observed (Firestore re-read fake) も同 metadata を返す。
+ */
+function seedArtifacts(
+  storage: FakeInMemoryStorage,
+  options: {
+    candidates: PhaseBRevalidatedCandidate[];
+    phaseATotalDocs: number;
+    phaseAVerifiedExisting: number;
+  }
+): {
+  manifest: BackfillManifest;
+  manifestGeneration: number;
+  observedMap: Map<string, ObservedDocState>;
+  expectedSha256Map: Map<string, string>;
+} {
+  const observedMap = new Map<string, ObservedDocState>();
+  const expectedSha256Map = new Map<string, string>();
+  const writtenDocs: PhaseCWrittenDoc[] = [];
+
+  for (const cand of options.candidates) {
+    const splitCreatedAt = Timestamp.fromDate(new Date(cand.computedProvenance.createdAt));
+    const backfilledAt = Timestamp.fromDate(new Date('2026-05-15T10:00:00.000Z'));
+    const built = createBackfillProvenance({
+      provenanceFields: {
+        sourceGeneration: cand.computedProvenance.sourceGeneration,
+        sourceMetageneration: cand.computedProvenance.sourceMetageneration,
+        sourceSha256: cand.computedProvenance.sourceSha256,
+        sourcePath: cand.computedProvenance.sourcePath,
+        sourceBucket: cand.computedProvenance.sourceBucket,
+        derivedObjectPath: cand.computedProvenance.derivedObjectPath,
+        derivedGeneration: cand.computedProvenance.derivedGeneration,
+        derivedMetageneration: cand.computedProvenance.derivedMetageneration,
+        derivedSha256: cand.computedProvenance.derivedSha256,
+        createdAt: splitCreatedAt,
+      },
+      confidence: cand.computedConfidence,
+      classifierCategory: cand.category,
+      evidence: {
+        parentExists: cand.evidence.parentExists,
+        parentSha256MatchedAtBackfill: cand.evidence.parentSha256MatchedAtBackfill,
+        childSha256ComputedAtBackfill: cand.evidence.childSha256ComputedAtBackfill,
+      },
+      backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+      backfilledAt,
+    });
+    const sha = sha256ProvenanceBackfill(built.provenanceBackfill);
+    expectedSha256Map.set(cand.docId, sha);
+    writtenDocs.push({
+      docId: cand.docId,
+      writeStatus: 'ok',
+      newProvenanceBackfillSha256: sha,
+      lastUpdateTimeAfter: '2026-05-15T10:00:01.000Z',
+    });
+    observedMap.set(cand.docId, {
+      docId: cand.docId,
+      documentCreatedAt: splitCreatedAt,
+      provenance: built.provenance,
+      provenanceBackfill: built.provenanceBackfill,
+      provenanceBackfillRaw: built.provenanceBackfill,
+    });
+  }
+
+  // Phase A summary
+  const phaseAMain: PhaseAClassifySummary = {
+    phase: 'A',
+    schemaVersion: 'pr-d4-v1.0',
+    scriptVersion: 'pr-d4-v1.0',
+    env: 'dev',
+    runId: RUN_ID,
+    snapshotStartedAt: '2026-05-15T00:00:00.000Z',
+    snapshotCompletedAt: '2026-05-15T00:01:00.000Z',
+    bucketLocation: 'asia-northeast1',
+    cloudRunJobLocation: 'asia-northeast1',
+    egressFreeAssertion: true,
+    totalDocs: options.phaseATotalDocs,
+    categoryDistribution: {
+      MatchedByHash: options.candidates.length,
+      RepairableMissingFile: 0,
+      Ambiguous: 0,
+      LostOrUnrecoverable: 0,
+      NeedsManualReview: 0,
+    },
+    alreadyBackfilled: 0,
+    verifiedExistingProvenance: options.phaseAVerifiedExisting,
+    chunks: [],
+  };
+  const phaseAMainContent = JSON.stringify(phaseAMain);
+  storage.seed(PHASE_A_MAIN, phaseAMainContent);
+
+  // Phase B chunk + main
+  const phaseBChunk: PhaseBRevalidatedChunk = {
+    schemaVersion: 'pr-d4-v1.0',
+    chunkIndex: 0,
+    revalidated: options.candidates,
+  };
+  const phaseBChunkContent = JSON.stringify(phaseBChunk);
+  const phaseBChunkPath = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-b-chunk-0.json`;
+  storage.seed(phaseBChunkPath, phaseBChunkContent);
+  const phaseBMain: PhaseBRevalidationSummary = {
+    phase: 'B',
+    schemaVersion: 'pr-d4-v1.0',
+    scriptVersion: 'pr-d4-v1.0',
+    env: 'dev',
+    runId: RUN_ID,
+    phaseAArtifactRef: PHASE_A_MAIN,
+    phaseAManifestSha256: 'phaseA-sha-fake',
+    revalidationStartedAt: '2026-05-15T01:00:00.000Z',
+    revalidationCompletedAt: '2026-05-15T01:30:00.000Z',
+    candidatesIn: options.candidates.length,
+    candidatesOut: options.candidates.length,
+    driftSkipped: { firestoreUpdateTimeChanged: 0, childGenerationChanged: 0, parentGenerationChanged: 0 },
+    verifyFailedMatchedByHash: 0,
+    skippedNonMatchedByHash: 0,
+    chunks: [{ path: phaseBChunkPath, sha256: sha256Hex(phaseBChunkContent), docCount: options.candidates.length }],
+  };
+  const phaseBMainContent = JSON.stringify(phaseBMain);
+  storage.seed(PHASE_B_MAIN, phaseBMainContent);
+
+  // Phase C chunk + main
+  const phaseCChunk: PhaseCBackfillChunk = {
+    schemaVersion: 'pr-d4-v1.0',
+    chunkIndex: 0,
+    writtenDocs,
+    preconditionFailedDocs: [],
+    immutableSkippedDocs: [],
+    unprocessableDocs: [],
+    outOfScopeDocs: [],
+  };
+  const phaseCChunkContent = JSON.stringify(phaseCChunk);
+  const phaseCChunkPath = `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-c-chunk-0.json`;
+  storage.seed(phaseCChunkPath, phaseCChunkContent);
+  const phaseCMain: PhaseCBackfillSummary = {
+    phase: 'C',
+    schemaVersion: 'pr-d4-v1.0',
+    scriptVersion: 'pr-d4-v1.0',
+    env: 'dev',
+    runId: RUN_ID,
+    phaseBArtifactRef: PHASE_B_MAIN,
+    phaseBManifestSha256: 'phaseB-sha-fake',
+    backfillStartedAt: '2026-05-15T02:00:00.000Z',
+    backfillCompletedAt: '2026-05-15T02:30:00.000Z',
+    candidatesIn: options.candidates.length,
+    writtenDocs: writtenDocs.length,
+    preconditionFailedDocs: 0,
+    skippedImmutable: 0,
+    unprocessableDocs: 0,
+    outOfScopeDocs: 0,
+    lockAcquiredGeneration: '999',
+    lockReleasedAt: '2026-05-15T02:30:01.000Z',
+    rateLimiterConfig: { tokensPerSecond: 100, burstCapacity: 100 },
+    chunks: [{ path: phaseCChunkPath, sha256: sha256Hex(phaseCChunkContent), docCount: writtenDocs.length }],
+  };
+  const phaseCMainContent = JSON.stringify(phaseCMain);
+  storage.seed(PHASE_C_MAIN, phaseCMainContent);
+
+  // manifest
+  const manifest: BackfillManifest = {
+    schemaVersion: 'pr-d4-v1.0',
+    runId: RUN_ID,
+    env: 'dev',
+    phaseA: { mainArtifact: { path: PHASE_A_MAIN, sha256: sha256Hex(phaseAMainContent) }, chunks: [] },
+    phaseB: {
+      mainArtifact: { path: PHASE_B_MAIN, sha256: sha256Hex(phaseBMainContent) },
+      chunks: phaseBMain.chunks,
+    },
+    phaseC: {
+      mainArtifact: { path: PHASE_C_MAIN, sha256: sha256Hex(phaseCMainContent) },
+      chunks: phaseCMain.chunks,
+    },
+  };
+  const manifestContent = JSON.stringify(manifest);
+  const manifestGen = 500;
+  storage.seed(MANIFEST_PATH, manifestContent, manifestGen);
+
+  return { manifest, manifestGeneration: manifestGen, observedMap, expectedSha256Map };
+}
+
+class FakeDocReader implements PhaseDDocReader {
+  private map: Map<string, ObservedDocState>;
+  constructor(map: Map<string, ObservedDocState>) {
+    this.map = map;
+  }
+  async readDoc(docId: string): Promise<ObservedDocState> {
+    const obs = this.map.get(docId);
+    if (!obs) {
+      return {
+        docId,
+        documentCreatedAt: null,
+        provenance: null,
+        provenanceBackfill: null,
+        provenanceBackfillRaw: undefined,
+      };
+    }
+    return obs;
+  }
+}
+
+describe('runPhaseD - verify orchestrator (Codex 8th GO 反映)', () => {
+  describe('正常系: 全 verified + 保全式 + coverage 算出', () => {
+    it('全 3 docs verified + coverage 2 系統 + provenanceBackfillNullCount=0', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [
+        makeCandidate('doc1', 'derived-bytes-verified'),
+        makeCandidate('doc2', 'derived-bytes-verified'),
+        makeCandidate('doc3', 'derived-bytes-verified'),
+      ];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 100,
+        phaseAVerifiedExisting: 50,
+      });
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+        nowProvider: () => new Date('2026-05-15T03:30:00.000Z'),
+      });
+      expect(result.candidatesIn).to.equal(3);
+      expect(result.verifiedDocs).to.equal(3);
+      expect(result.fieldsConsistent).to.equal(3);
+      expect(result.fieldsMismatchCount).to.equal(0);
+      expect(result.createdAtConsistent).to.equal(3);
+      expect(result.createdAtMismatchCount).to.equal(0);
+      expect(result.provenanceBackfillNullCount).to.equal(0);
+      expect(result.confidenceDistribution['derived-bytes-verified']).to.equal(3);
+      expect(result.rotateGateTest).to.be.null;
+      expect(result.manifestUpdateStatus).to.equal('ok');
+      // 2 系統 coverage
+      expect(result.coverageRatio.backfillAttemptCoverage.denominator).to.equal(3);
+      expect(result.coverageRatio.backfillAttemptCoverage.derivedBytesVerified).to.equal(1.0);
+      expect(result.coverageRatio.estateRotateReadyCoverage.denominator).to.equal(100);
+      // verifiedExisting(50) + backfilledDerivedBytesVerified(3) = 53 / 100 = 0.53
+      expect(result.coverageRatio.estateRotateReadyCoverage.rotateReadyTotal).to.be.closeTo(0.53, 0.001);
+      // 保全式: rotateReadyTotal + notRotateReady === 1.0
+      const sumCov =
+        result.coverageRatio.estateRotateReadyCoverage.rotateReadyTotal +
+        result.coverageRatio.estateRotateReadyCoverage.notRotateReady;
+      expect(sumCov).to.be.closeTo(1.0, 0.001);
+    });
+  });
+
+  describe('mismatch 検出ケース', () => {
+    it('observed.provenance.sourceSha256 drift → fieldsMismatch に sourceSha256 含まれる', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('doc1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      // observed の sourceSha256 を強制改竄
+      const obs = seeded.observedMap.get('doc1')!;
+      obs.provenance!.sourceSha256 = 'z'.repeat(64);
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+        nowProvider: () => new Date('2026-05-15T03:30:00.000Z'),
+      });
+      expect(result.fieldsMismatchCount).to.be.greaterThan(0);
+      expect(result.fieldsConsistent).to.equal(0);
+    });
+
+    it('provenanceBackfillRaw が null の doc → provenanceBackfillNullCount=1 (Codex 8th 回答 4)', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('doc1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      const obs = seeded.observedMap.get('doc1')!;
+      obs.provenanceBackfillRaw = null;
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      expect(result.provenanceBackfillNullCount).to.equal(1);
+      expect(result.fieldsMismatchCount).to.be.greaterThan(0);
+    });
+  });
+
+  describe('rotate gate fixture test (dev only、Codex 7th Important 2)', () => {
+    it('rotateGateFixtureEnabled=true で derived-bytes-verified success + child-snapshot-only reject', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('doc1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      const cleanupCalls: string[] = [];
+      const fakeFixtureStore: FixtureStore = {
+        async createFixture(input) {
+          return { objectPath: `processed/${input.docId}/${input.docId}.pdf`, objectGeneration: '777' };
+        },
+        async cleanupFixture(input) {
+          cleanupCalls.push(input.docId);
+        },
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate(input) {
+          if (input.docId.includes('child_snapshot_only')) {
+            return { kind: 'rejected', rejectionMessage: 'failed-precondition: confidence' };
+          }
+          return {
+            kind: 'success',
+            rotatedAt: '2026-05-15T03:30:00.000Z',
+            newRotationObjectPath: `processed/${input.docId}/rotations/uuid.pdf`,
+            newRotationObjectGeneration: '888',
+          };
+        },
+      };
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: true,
+        fixtureStore: fakeFixtureStore,
+        rotateApiCaller: fakeRotate,
+        fixturePdfBytesVerified: Buffer.from('verified-pdf'),
+        fixturePdfBytesChildSnapshotOnly: Buffer.from('child-snapshot-pdf'),
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      expect(result.rotateGateTest).to.not.be.null;
+      expect(result.rotateGateTest!.derivedBytesVerified.rotateApiResult).to.equal('success');
+      expect(result.rotateGateTest!.childSnapshotOnly.rotateApiResult).to.equal('rejected');
+      expect(result.rotateGateTest!.fixtureCleanupFailures).to.have.length(0);
+      // cleanup hook 2 件呼出 (verified + child_snapshot_only)
+      expect(cleanupCalls).to.have.length(2);
+      expect(cleanupCalls[0]).to.match(/BF13_test_fixture_/);
+    });
+
+    it('本番相当 (rotateGateFixtureEnabled=false) で rotateGateTest=null + 副作用なし', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('doc1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      let createCalls = 0;
+      const fakeFixtureStore: FixtureStore = {
+        async createFixture() {
+          createCalls++;
+          return { objectPath: 'should-not-be-called', objectGeneration: '0' };
+        },
+        async cleanupFixture() {},
+      };
+      const fakeRotate: RotateApiCaller = {
+        async callRotate() {
+          return { kind: 'error', message: 'should-not-be-called' };
+        },
+      };
+      const result = await runPhaseD({
+        env: 'cocoro',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        fixtureStore: fakeFixtureStore,
+        rotateApiCaller: fakeRotate,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      expect(result.rotateGateTest).to.be.null;
+      expect(createCalls).to.equal(0);  // 本番副作用ゼロ
+    });
+  });
+
+  describe('Codex 10th: hasVerificationFailure 判定 + exit non-zero 用フラグ', () => {
+    it('mismatch あり → hasVerificationFailure=true', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('docA1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      seeded.observedMap.get('docA1')!.provenance!.sourceSha256 = 'x'.repeat(64);
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      expect(result.hasVerificationFailure).to.be.true;
+      expect(result.mismatchedDocCount).to.equal(1);
+    });
+
+    it('all clean + no fixture → hasVerificationFailure=false', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('docB1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      expect(result.hasVerificationFailure).to.be.false;
+      expect(result.mismatchedDocCount).to.equal(0);
+    });
+  });
+
+  describe('Codex 10th: BF15 backfillAttemptCoverage の正しい分母 (phaseC.candidatesIn)', () => {
+    it('phaseC summary に preconditionFailed=2 / skippedImmutable=3 がある場合、分母は writtenDocs ではなく candidatesIn', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [
+        makeCandidate('docC1', 'derived-bytes-verified'),
+        makeCandidate('docC2', 'derived-bytes-verified'),
+      ];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 100,
+        phaseAVerifiedExisting: 0,
+      });
+      // Phase C main artifact を改竄して preconditionFailed=2, skippedImmutable=3, candidatesIn=7 (= 2 + 2 + 3) にする
+      const phaseCMainObj = storage.get(PHASE_C_MAIN)!;
+      const phaseCMain = JSON.parse(phaseCMainObj.content) as PhaseCBackfillSummary;
+      phaseCMain.candidatesIn = 7;
+      phaseCMain.preconditionFailedDocs = 2;
+      phaseCMain.skippedImmutable = 3;
+      const newContent = JSON.stringify(phaseCMain);
+      storage.seed(PHASE_C_MAIN, newContent, phaseCMainObj.generation);
+      // manifest の phaseC sha256 も再計算
+      const manifestObj = storage.get(MANIFEST_PATH)!;
+      const manifest = JSON.parse(manifestObj.content) as BackfillManifest;
+      manifest.phaseC!.mainArtifact.sha256 = sha256Hex(newContent);
+      storage.seed(MANIFEST_PATH, JSON.stringify(manifest), manifestObj.generation);
+
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      // 分母 = candidatesIn = 7 (writtenDocs=2 ではない)
+      expect(result.coverageRatio.backfillAttemptCoverage.denominator).to.equal(7);
+      // derivedBytesVerified = 2 / 7
+      expect(result.coverageRatio.backfillAttemptCoverage.derivedBytesVerified).to.be.closeTo(2 / 7, 0.001);
+      // preconditionFailed = 2 / 7
+      expect(result.coverageRatio.backfillAttemptCoverage.preconditionFailed).to.be.closeTo(2 / 7, 0.001);
+      // immutableSkipped = 3 / 7
+      expect(result.coverageRatio.backfillAttemptCoverage.immutableSkipped).to.be.closeTo(3 / 7, 0.001);
+    });
+  });
+
+  describe('manifest CAS 失敗 (Codex 8th Important 3)', () => {
+    it('CAS 失敗時 manifestUpdateStatus="failed" + finalize status file 書込', async () => {
+      const storage = new FakeInMemoryStorage();
+      const candidates = [makeCandidate('doc1', 'derived-bytes-verified')];
+      const seeded = seedArtifacts(storage, {
+        candidates,
+        phaseATotalDocs: 10,
+        phaseAVerifiedExisting: 0,
+      });
+      storage.failManifestCAS = true;
+      const result = await runPhaseD({
+        env: 'dev',
+        runId: RUN_ID,
+        artifactBucketName: ARTIFACT_BUCKET,
+        manifestPath: MANIFEST_PATH,
+        artifactReader: storage.reader,
+        artifactWriter: storage.writer,
+        docReader: new FakeDocReader(seeded.observedMap),
+        backfillScriptVersion: BACKFILL_SCRIPT_VERSION,
+        rotateGateFixtureEnabled: false,
+        verifyStartedAt: '2026-05-15T03:00:00.000Z',
+      });
+      expect(result.manifestUpdateStatus).to.equal('failed');
+      // finalize status file は書込まれている
+      const statusObj = storage.get(result.finalizeStatusPath);
+      expect(statusObj).to.not.be.undefined;
+      const status = JSON.parse(statusObj!.content);
+      expect(status.manifestUpdateStatus).to.equal('failed');
+      expect(status.remediation).to.match(/CAS failed/i);
+    });
+  });
+});

--- a/functions/test/rotateGate.test.ts
+++ b/functions/test/rotateGate.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Issue #445 PR-D4 S1-5: rotate gate helper unit test (BF12/BF13/BF17 構造的 lock-in).
+ *
+ * `shouldRejectRotateForBackfill(raw: unknown)` の fail-closed 挙動を検証する。
+ *
+ * ADR-0016 MUST 3 拡張 (Codex 7th Critical 6 反映):
+ * - `provenanceBackfill` field absent (PR-D2/D3 verified split-time origin) → allow (null 返却)
+ * - `provenanceBackfill.confidence === 'derived-bytes-verified'` + evidence 整合 → allow
+ * - `provenanceBackfill === null` (malformed) → fail-closed reject
+ * - `provenanceBackfill.confidence !== 'derived-bytes-verified'` → reject
+ * - method !== 'legacy-observed' / evidence 欠落 / 不正型 → reject
+ *
+ * Codex MCP 2nd review Important 1 反映: helper は Phase D Stage 1 と同じ最小 invariant を共有。
+ * `confidence: 'derived-bytes-verified'` 単独で allow せず、derived 経路の場合は evidence 3 field
+ * (parentExists / parentSha256MatchedAtBackfill / childSha256ComputedAtBackfill) を all true 検証。
+ *
+ * Codex MCP 2nd review Important 2 反映: `parentSha256MatchedAtBackfill` 型は `boolean | null`。
+ * derived-bytes-verified の場合は true 必須、child-snapshot-only/metadata-only の場合は null 許容。
+ */
+
+import { expect } from 'chai';
+import { shouldRejectRotateForBackfill } from '../src/pdf/rotateGate';
+
+describe('shouldRejectRotateForBackfill (rotate gate helper)', () => {
+  describe('allow ケース', () => {
+    it('absent (undefined) → null 返却 = allow (PR-D2/D3 verified split-time origin)', () => {
+      expect(shouldRejectRotateForBackfill(undefined)).to.be.null;
+    });
+
+    it('derived-bytes-verified + 完全な evidence + method legacy-observed → null 返却 = allow', () => {
+      const raw = {
+        method: 'legacy-observed',
+        confidence: 'derived-bytes-verified',
+        backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+        evidence: {
+          parentExists: true,
+          parentSha256MatchedAtBackfill: true,
+          childSha256ComputedAtBackfill: true,
+          backfillScriptVersion: 'pr-d4-v1.0',
+          classifierCategory: 'MatchedByHash',
+        },
+      };
+      expect(shouldRejectRotateForBackfill(raw)).to.be.null;
+    });
+  });
+
+  describe('reject ケース (malformed)', () => {
+    it('null → reject (malformed、Codex Important 1 fail-closed)', () => {
+      const result = shouldRejectRotateForBackfill(null);
+      expect(result).to.match(/malformed/i);
+      expect(result).to.match(/null/i);
+    });
+
+    it('string 型 → reject (object 期待)', () => {
+      const result = shouldRejectRotateForBackfill('legacy');
+      expect(result).to.match(/unexpected type/i);
+    });
+
+    it('number 型 → reject (object 期待)', () => {
+      const result = shouldRejectRotateForBackfill(42);
+      expect(result).to.match(/unexpected type/i);
+    });
+
+    it('array → reject (plain object 期待)', () => {
+      const result = shouldRejectRotateForBackfill(['legacy-observed']);
+      expect(result).to.match(/malformed|unexpected/i);
+    });
+  });
+
+  describe('reject ケース (confidence 違反)', () => {
+    const baseEvidence = {
+      parentExists: true,
+      parentSha256MatchedAtBackfill: true,
+      childSha256ComputedAtBackfill: true,
+      backfillScriptVersion: 'pr-d4-v1.0',
+      classifierCategory: 'MatchedByHash',
+    };
+
+    it('confidence === "child-snapshot-only" → reject (BF13)', () => {
+      const raw = {
+        method: 'legacy-observed',
+        confidence: 'child-snapshot-only',
+        backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+        evidence: { ...baseEvidence, parentSha256MatchedAtBackfill: null },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/derived-bytes-verified/);
+      expect(result).to.include('child-snapshot-only');
+    });
+
+    it('confidence === "metadata-only" → reject', () => {
+      const raw = {
+        method: 'legacy-observed',
+        confidence: 'metadata-only',
+        backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+        evidence: { ...baseEvidence, childSha256ComputedAtBackfill: false },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/metadata-only/);
+    });
+
+    it('confidence が unknown 文字列 → reject (fail-closed)', () => {
+      const raw = {
+        method: 'legacy-observed',
+        confidence: 'mystery-confidence',
+        backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+        evidence: baseEvidence,
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/mystery-confidence|malformed|unexpected/i);
+    });
+
+    it('confidence が number 型 → reject (fail-closed)', () => {
+      const raw = {
+        method: 'legacy-observed',
+        confidence: 1,
+        backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+        evidence: baseEvidence,
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/unexpected type/i);
+    });
+
+    it('confidence missing → reject (fail-closed)', () => {
+      const raw = {
+        method: 'legacy-observed',
+        backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+        evidence: baseEvidence,
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/confidence/i);
+    });
+  });
+
+  describe('reject ケース (method / evidence 違反、Codex Important 1 反映)', () => {
+    const baseRaw = {
+      confidence: 'derived-bytes-verified' as const,
+      backfilledAt: { _seconds: 1700000000, _nanoseconds: 0 },
+      evidence: {
+        parentExists: true,
+        parentSha256MatchedAtBackfill: true,
+        childSha256ComputedAtBackfill: true,
+        backfillScriptVersion: 'pr-d4-v1.0',
+        classifierCategory: 'MatchedByHash',
+      },
+    };
+
+    it('method !== "legacy-observed" → reject (固定値違反)', () => {
+      const raw = { ...baseRaw, method: 'future-method' };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/method/i);
+    });
+
+    it('method missing → reject', () => {
+      const raw = { confidence: 'derived-bytes-verified', backfilledAt: baseRaw.backfilledAt, evidence: baseRaw.evidence };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/method/i);
+    });
+
+    it('evidence missing → reject (derived-bytes-verified では evidence 必須)', () => {
+      const raw = { method: 'legacy-observed', confidence: 'derived-bytes-verified', backfilledAt: baseRaw.backfilledAt };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/evidence/i);
+    });
+
+    it('evidence が object でない → reject', () => {
+      const raw = { ...baseRaw, method: 'legacy-observed', evidence: 'not-object' };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/evidence/i);
+    });
+
+    it('derived-bytes-verified で parentExists !== true → reject (Codex Important 1)', () => {
+      const raw = {
+        ...baseRaw,
+        method: 'legacy-observed',
+        evidence: { ...baseRaw.evidence, parentExists: false },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/parentExists/i);
+    });
+
+    it('derived-bytes-verified で parentSha256MatchedAtBackfill !== true → reject', () => {
+      const raw = {
+        ...baseRaw,
+        method: 'legacy-observed',
+        evidence: { ...baseRaw.evidence, parentSha256MatchedAtBackfill: false },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/parentSha256MatchedAtBackfill/i);
+    });
+
+    it('derived-bytes-verified で parentSha256MatchedAtBackfill === null → reject (null は未検証扱い)', () => {
+      const raw = {
+        ...baseRaw,
+        method: 'legacy-observed',
+        evidence: { ...baseRaw.evidence, parentSha256MatchedAtBackfill: null },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/parentSha256MatchedAtBackfill/i);
+    });
+
+    it('derived-bytes-verified で childSha256ComputedAtBackfill !== true → reject', () => {
+      const raw = {
+        ...baseRaw,
+        method: 'legacy-observed',
+        evidence: { ...baseRaw.evidence, childSha256ComputedAtBackfill: false },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/childSha256ComputedAtBackfill/i);
+    });
+
+    it('evidence.parentExists が boolean でない → reject (型違反)', () => {
+      const raw = {
+        ...baseRaw,
+        method: 'legacy-observed',
+        evidence: { ...baseRaw.evidence, parentExists: 'yes' },
+      };
+      const result = shouldRejectRotateForBackfill(raw);
+      expect(result).to.match(/parentExists|type/i);
+    });
+  });
+});

--- a/functions/test/rotatePdfPagesContract.test.ts
+++ b/functions/test/rotatePdfPagesContract.test.ts
@@ -208,6 +208,23 @@ describe('rotatePdfPages source code grep contract (PR-D3 AC3 拡張)', () => {
       expect(rotateBody).to.match(/baseProvenance\.derivedSha256\.toLowerCase\(\)/);
       expect(rotateBody).to.match(/bytes identity drift detected/i);
     });
+
+    it('PR-D4 BF12/BF13: shouldRejectRotateForBackfill helper で provenanceBackfill gate を実装', () => {
+      // ADR-0016 MUST 3 拡張: backfilled doc は confidence === derived-bytes-verified のみ allow。
+      // pure helper 化 (Codex MCP 2nd review Suggestion 1 反映) で test/contract と production を共通化。
+      expect(rotateBody).to.include('shouldRejectRotateForBackfill(');
+      expect(rotateBody).to.include('startData.provenanceBackfill');
+      expect(rotateBody).to.match(/backfill_confidence_check/);
+    });
+
+    it('PR-D4 Suggestion 2: rotate の docRef.update payload は provenanceBackfill を含まない (preserve contract)', () => {
+      // update 対象 fields: fileUrl / pageRotations / rotatedAt / provenance のみ。
+      // provenanceBackfill を update payload に入れると既存値を破壊するため、
+      // 「rotate は provenanceBackfill を保持する (= update 対象外)」を構造的に契約化。
+      const updateMatch = rotateBody.match(/docRef\.update\(\s*\{[\s\S]*?\}\s*,\s*\{\s*lastUpdateTime/);
+      expect(updateMatch, 'docRef.update 呼出が見つからない').to.not.be.null;
+      expect(updateMatch![0]).to.not.include('provenanceBackfill');
+    });
   });
 });
 

--- a/scripts/pr-d4-backfill/index.ts
+++ b/scripts/pr-d4-backfill/index.ts
@@ -44,6 +44,12 @@ import {
   PR_D4_SCRIPT_VERSION,
 } from './types';
 import { TokenBucketRateLimiter } from './phase-c/rateLimiter';
+import { runPhaseD } from './phase-d/verifyOrchestrator';
+import {
+  FirestoreDocReaderImpl,
+  GcsFixtureStoreImpl,
+  HttpsRotateApiCallerImpl,
+} from './phase-d/adapters';
 
 function readArg(name: string, defaultValue?: string): string | undefined {
   const idx = process.argv.indexOf(name);
@@ -79,9 +85,9 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const phase = readArg('--phase', 'A');
-  if (phase !== 'A' && phase !== 'B' && phase !== 'C') {
+  if (phase !== 'A' && phase !== 'B' && phase !== 'C' && phase !== 'D') {
     console.error(
-      `FATAL: phase ${phase} not implemented (only Phase A / B / C are available in S1-4)`
+      `FATAL: phase ${phase} not implemented (only Phase A / B / C / D are available in S1-5)`
     );
     process.exit(2);
   }
@@ -114,6 +120,9 @@ async function main(): Promise<void> {
   const db = admin.firestore();
   const productionBucketRef = admin.storage().bucket(productionBucket);
   const artifactBucketRef = admin.storage().bucket(artifactBucketName);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _phaseGuard: 'A' | 'B' | 'C' | 'D' = phase;
 
   if (phase === 'A') {
     const snapshotStartedAt = new Date().toISOString();
@@ -177,8 +186,8 @@ async function main(): Promise<void> {
     console.log(`  manifest: ${result.manifestPath}`);
     console.log(`  revalidationStartedAt: ${revalidationStartedAt}`);
     console.log(`  revalidationCompletedAt: ${result.revalidationCompletedAt}`);
-  } else {
-    // Phase C: Phase B artifact 経由 manifest を読み atomic backfill 実施 (本 PR S1-4)
+  } else if (phase === 'C') {
+    // Phase C: Phase B artifact 経由 manifest を読み atomic backfill 実施 (S1-4)
     const manifestPath = `gs://${artifactBucketName}/pr-d4-backfill-artifacts/${runId}/manifest.json`;
     const jobId = readArg('--job-id', `job-${runId}`)!;
     // lock owner: GitHub Actions 経由なら GITHUB_RUN_ID + GITHUB_REPOSITORY、ローカルなら 'manual-cli'
@@ -227,6 +236,120 @@ async function main(): Promise<void> {
     console.log(`  mainArtifact: ${result.mainArtifactPath}`);
     console.log(`  manifest: ${result.manifestPath}`);
     console.log(`  backfillCompletedAt: ${result.backfillCompletedAt}`);
+  } else {
+    // Phase D: Phase C artifact 経由 manifest を読み verify + rotate gate test 実施 (本 PR S1-5)
+    const manifestPath = `gs://${artifactBucketName}/pr-d4-backfill-artifacts/${runId}/manifest.json`;
+    // dev 環境のみ rotate gate fixture test 実行可、cocoro/kanameone は強制 false (Codex 3rd I6)
+    const rotateGateFixtureEnabledArg = readArg('--phase-d-rotate-fixture-mode', 'false');
+    const rotateGateFixtureEnabled =
+      envName === 'dev' && rotateGateFixtureEnabledArg === 'true';
+    if (rotateGateFixtureEnabledArg === 'true' && envName !== 'dev') {
+      console.error(
+        `FATAL: --phase-d-rotate-fixture-mode=true is dev-only; received env=${envName}`
+      );
+      process.exit(2);
+    }
+
+    console.log(`\nPhase D starting with manifest: ${manifestPath}`);
+    console.log(`  rotateGateFixtureEnabled: ${rotateGateFixtureEnabled}`);
+
+    const verifyStartedAt = new Date().toISOString();
+
+    // fixture mode 起動時: rotate URL + auth token を env 経由で受け取る
+    let fixtureStore;
+    let rotateApiCaller;
+    let fixturePdfBytesVerified;
+    let fixturePdfBytesChildSnapshotOnly;
+    if (rotateGateFixtureEnabled) {
+      const rotateUrl = process.env.PR_D4_ROTATE_URL;
+      const authToken = process.env.PR_D4_ROTATE_AUTH_TOKEN;
+      if (!rotateUrl || !authToken) {
+        console.error(
+          'FATAL: rotateGateFixtureEnabled=true requires PR_D4_ROTATE_URL + PR_D4_ROTATE_AUTH_TOKEN env'
+        );
+        process.exit(2);
+      }
+      // fixture PDF bytes: 最小の valid PDF (test caller が fixture bucket に事前 upload 想定だが、
+      // dev rehearsal では本 CLI が直接生成する。最小 1-page PDF を pdf-lib で構築)
+      const { PDFDocument } = await import('pdf-lib');
+      const docVerified = await PDFDocument.create();
+      docVerified.addPage();
+      fixturePdfBytesVerified = Buffer.from(await docVerified.save());
+      const docChild = await PDFDocument.create();
+      docChild.addPage();
+      docChild.addPage();
+      fixturePdfBytesChildSnapshotOnly = Buffer.from(await docChild.save());
+
+      fixtureStore = new GcsFixtureStoreImpl(db, productionBucketRef, productionBucket);
+      // Codex 9th Critical 2 反映: rotate 後 Firestore re-read で実 path + generation 取得するため db を渡す
+      rotateApiCaller = new HttpsRotateApiCallerImpl(rotateUrl, authToken, db, productionBucketRef);
+    }
+
+    const result = await runPhaseD({
+      env: envName,
+      runId,
+      artifactBucketName,
+      manifestPath,
+      artifactReader: new GcsArtifactReader(artifactBucketRef),
+      artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
+      docReader: new FirestoreDocReaderImpl(db),
+      backfillScriptVersion: PR_D4_SCRIPT_VERSION,
+      rotateGateFixtureEnabled,
+      fixtureStore,
+      rotateApiCaller,
+      fixturePdfBytesVerified,
+      fixturePdfBytesChildSnapshotOnly,
+      verifyStartedAt,
+    });
+
+    console.log('\nPhase D complete:');
+    console.log(`  candidatesIn: ${result.candidatesIn}`);
+    console.log(`  verifiedDocs: ${result.verifiedDocs}`);
+    console.log(`  fieldsConsistent: ${result.fieldsConsistent}`);
+    console.log(`  fieldsMismatchCount (field 単位): ${result.fieldsMismatchCount}`);
+    console.log(`  mismatchedDocCount (doc 単位): ${result.mismatchedDocCount}`);
+    console.log(`  createdAtConsistent: ${result.createdAtConsistent}`);
+    console.log(`  createdAtMismatchCount: ${result.createdAtMismatchCount}`);
+    console.log(`  provenanceBackfillNullCount: ${result.provenanceBackfillNullCount}`);
+    console.log(`  provenanceBackfillAbsentCount: ${result.provenanceBackfillAbsentCount}`);
+    console.log(`  confidenceDistribution: ${JSON.stringify(result.confidenceDistribution)}`);
+    console.log(`  rotateGateTest: ${result.rotateGateTest ? 'executed' : 'skipped (production)'}`);
+    if (result.rotateGateTest) {
+      console.log(
+        `    derivedBytesVerified: ${result.rotateGateTest.derivedBytesVerified.rotateApiResult}`
+      );
+      console.log(
+        `    childSnapshotOnly: ${result.rotateGateTest.childSnapshotOnly.rotateApiResult}`
+      );
+      console.log(
+        `    fixtureCleanupFailures: ${result.rotateGateTest.fixtureCleanupFailures.length}`
+      );
+    }
+    console.log('  coverage:');
+    console.log(`    backfillAttempt.derivedBytesVerified: ${result.coverageRatio.backfillAttemptCoverage.derivedBytesVerified.toFixed(4)}`);
+    console.log(`    estateRotateReady.rotateReadyTotal: ${result.coverageRatio.estateRotateReadyCoverage.rotateReadyTotal.toFixed(4)} (BF15 主指標)`);
+    console.log(`  mainArtifact: ${result.mainArtifactPath}`);
+    console.log(`  manifest: ${result.manifestPath}`);
+    console.log(`  finalizeStatus: ${result.finalizeStatusPath}`);
+    console.log(`  manifestUpdateStatus: ${result.manifestUpdateStatus}`);
+    console.log(`  hasVerificationFailure: ${result.hasVerificationFailure}`);
+    console.log(`  verifyCompletedAt: ${result.verifyCompletedAt}`);
+
+    // exit code policy (Codex 9th Important 3 反映)
+    if (result.manifestUpdateStatus === 'failed') {
+      console.error('FATAL: manifest CAS failed; phase-d artifact not authoritative (exit 3)');
+      process.exit(3);
+    }
+    if (result.hasVerificationFailure) {
+      console.error(
+        `FATAL: Phase D verification failure detected ` +
+          `(mismatchedDocCount=${result.mismatchedDocCount}, ` +
+          `createdAtMismatchCount=${result.createdAtMismatchCount}, ` +
+          `provenanceBackfillNullCount=${result.provenanceBackfillNullCount}, ` +
+          `rotateGate=${result.rotateGateTest ? 'tested' : 'skipped'}); exit 4`
+      );
+      process.exit(4);
+    }
   }
 }
 

--- a/scripts/pr-d4-backfill/phase-d/adapters.ts
+++ b/scripts/pr-d4-backfill/phase-d/adapters.ts
@@ -1,0 +1,291 @@
+/**
+ * Issue #445 PR-D4 S1-5: production concrete adapters for Phase D.
+ *
+ * - FirestoreDocReaderImpl: documents collection re-read (provenance + provenanceBackfill + createdAt 取得)
+ * - GcsFixtureStoreImpl: dev fixture doc + Storage object 作成 / cleanup (dev のみ起動)
+ * - HttpsRotateApiCallerImpl: 実 rotatePdfPages callable 呼出 (dev fixture rotate test 用)
+ *
+ * unit test 対象外 (real SDK 接続のため)。artifact reader / writer は phase-a / phase-b 由来の
+ * 既存 adapter を再利用 (GcsArtifactReader / GcsArtifactStorageWriter)。
+ */
+
+import * as admin from 'firebase-admin';
+import * as crypto from 'node:crypto';
+import { Timestamp } from 'firebase-admin/firestore';
+import type { Bucket } from '@google-cloud/storage';
+import type { Firestore } from 'firebase-admin/firestore';
+import type {
+  DocumentProvenance,
+  ProvenanceBackfillMetadata,
+} from '../../../shared/types';
+import type { ObservedDocState, PhaseDDocReader } from './verifyOrchestrator';
+import type { FixtureStore, RotateApiCaller } from './rotateGateFixtureTester';
+
+/**
+ * Firestore documents collection 再読込 adapter (Phase D verify 用)。
+ */
+export class FirestoreDocReaderImpl implements PhaseDDocReader {
+  constructor(private readonly db: Firestore) {}
+
+  async readDoc(docId: string): Promise<ObservedDocState> {
+    const docRef = this.db.collection('documents').doc(docId);
+    const snap = await docRef.get();
+    if (!snap.exists) {
+      return {
+        docId,
+        documentCreatedAt: null,
+        provenance: null,
+        provenanceBackfill: null,
+        provenanceBackfillRaw: undefined,
+      };
+    }
+    const data = snap.data() as Record<string, unknown>;
+    const documentCreatedAt =
+      data.createdAt instanceof Timestamp ? data.createdAt : null;
+    const provenance =
+      data.provenance && typeof data.provenance === 'object'
+        ? (data.provenance as DocumentProvenance)
+        : null;
+    const provenanceBackfillRaw = data.provenanceBackfill;
+    // Stage 1 validator が型を判定するため、ここでは typed only な値も提供。
+    // null は raw とは別 (provenanceBackfillRaw 経由で null 判定)。
+    const provenanceBackfill =
+      provenanceBackfillRaw != null && typeof provenanceBackfillRaw === 'object'
+        ? (provenanceBackfillRaw as ProvenanceBackfillMetadata)
+        : null;
+    return {
+      docId,
+      documentCreatedAt,
+      provenance,
+      provenanceBackfill,
+      provenanceBackfillRaw,
+    };
+  }
+}
+
+/**
+ * dev fixture store: docId namespace = `processed/{docId}/...`、provenance/provenanceBackfill
+ * を直接書込んだ fixture doc を Firestore + Storage に作成。
+ *
+ * 注意: 本実装は **dev 環境のみで動作**。env hard gate は orchestrator / fixture tester 側で
+ * 1 段、本 module 内では fixture docId prefix 検証 (defense in depth) で 2 段ガード。
+ *
+ * cleanup は ADR-0008 削除制約と整合 (特定 doc delete のみ、`--all-collections` 等は使わない)。
+ */
+export class GcsFixtureStoreImpl implements FixtureStore {
+  constructor(
+    private readonly db: Firestore,
+    private readonly productionBucket: Bucket,
+    private readonly fixtureSourceBucket: string
+  ) {}
+
+  async createFixture(input: {
+    docId: string;
+    confidence: 'derived-bytes-verified' | 'child-snapshot-only';
+    pdfBytes: Buffer;
+  }): Promise<{ objectPath: string; objectGeneration: string }> {
+    // docId namespace path (PR-D2/D3 と同等)
+    const objectName = `processed/${input.docId}/${input.docId}.pdf`;
+    const file = this.productionBucket.file(objectName);
+    await file.save(input.pdfBytes, {
+      contentType: 'application/pdf',
+      resumable: false,
+      preconditionOpts: { ifGenerationMatch: 0 },
+      metadata: { cacheControl: 'no-store' },
+    });
+    const [metadata] = await file.getMetadata();
+    const generation = String(metadata.generation ?? '');
+    const metageneration = String(metadata.metageneration ?? '');
+    if (!/^[0-9]+$/.test(generation) || !/^[0-9]+$/.test(metageneration)) {
+      throw new Error(
+        `fixture object save: generation/metageneration invalid (path=${objectName}, generation="${generation}", metageneration="${metageneration}")`
+      );
+    }
+    // sha256 を簡易計算 (実 PDF bytes、test caller は予め固定済 pdfBytes を渡す)
+    // code-reviewer L2 反映: static import (node:crypto は内蔵モジュール、dynamic import 不要)
+    const sha256 = crypto.createHash('sha256').update(input.pdfBytes).digest('hex');
+
+    const fixtureCreatedAt = Timestamp.now();
+    const provenance: DocumentProvenance = {
+      sourceGeneration: '0',
+      sourceMetageneration: '0',
+      sourceSha256: sha256,
+      sourcePath: `fixtures/${input.docId}/parent.pdf`,
+      sourceBucket: this.fixtureSourceBucket,
+      derivedObjectPath: objectName,
+      derivedGeneration: generation,
+      derivedMetageneration: metageneration,
+      derivedSha256: sha256,
+      createdAt: fixtureCreatedAt,
+    };
+    const provenanceBackfill: ProvenanceBackfillMetadata = {
+      method: 'legacy-observed',
+      confidence: input.confidence,
+      backfilledAt: fixtureCreatedAt,
+      evidence: {
+        parentExists: input.confidence === 'derived-bytes-verified',
+        parentSha256MatchedAtBackfill:
+          input.confidence === 'derived-bytes-verified' ? true : null,
+        childSha256ComputedAtBackfill: true,
+        backfillScriptVersion: 'pr-d4-fixture-v1.0',
+        classifierCategory:
+          input.confidence === 'derived-bytes-verified' ? 'MatchedByHash' : 'Ambiguous',
+      },
+    };
+    const fileUrl = `gs://${this.productionBucket.name}/${objectName}`;
+    await this.db
+      .collection('documents')
+      .doc(input.docId)
+      .set({
+        documentId: input.docId,
+        fileName: `${input.docId}.pdf`,
+        fileUrl,
+        status: 'completed',
+        createdAt: fixtureCreatedAt,
+        provenance,
+        provenanceBackfill,
+        // fixture 識別 marker (cleanup hook の二重ガード補強)
+        _fixtureMarker: 'BF13_test_fixture',
+      });
+    return { objectPath: objectName, objectGeneration: generation };
+  }
+
+  async cleanupFixture(input: {
+    docId: string;
+    objects: Array<{ path: string; generation: string }>;
+  }): Promise<void> {
+    // GCS delete (Codex 9th Important 1 + code-reviewer M1 反映: preconditionOpts pattern で既存実装と統一)
+    // generation === '0' は fallback で生成された値 (path 取得不能等)、ifGenerationMatch=0 は
+    // 「object 不存在」セマンティクスで通常の delete とは異なる → そのケースは throw して
+    // fixtureCleanupFailures に記録させる (silent skip 回避)
+    for (const obj of input.objects) {
+      const generationNum = Number(obj.generation);
+      if (!Number.isFinite(generationNum) || generationNum <= 0) {
+        throw new Error(
+          `cleanup fixture: generation must be positive integer (got "${obj.generation}" for path=${obj.path})`
+        );
+      }
+      const file = this.productionBucket.file(obj.path);
+      await file.delete({
+        preconditionOpts: { ifGenerationMatch: generationNum },
+        ignoreNotFound: false,
+      } as { preconditionOpts: { ifGenerationMatch: number }; ignoreNotFound: boolean });
+    }
+    // Firestore doc delete (特定 doc delete、ADR-0008 削除制約と整合)
+    await this.db.collection('documents').doc(input.docId).delete();
+  }
+}
+
+/**
+ * 実 rotatePdfPages callable を呼ぶ adapter (dev fixture rotate test 用)。
+ *
+ * production wire は Firebase Functions emulator または dev project 上の deployed callable を
+ * 呼ぶ。test では fake (in-memory rotate emulation) を使う。
+ *
+ * ※ 本 adapter は Phase D verify 中の dev 環境のみで invoke される。本番 (cocoro/kanameone) では
+ * orchestrator 側で `rotateGateFixtureEnabled: false` 渡しで本 adapter は一切呼ばれない。
+ */
+export class HttpsRotateApiCallerImpl implements RotateApiCaller {
+  /**
+   * rotateUrl: dev project の callable URL (e.g. https://asia-northeast1-doc-split-dev.cloudfunctions.net/rotatePdfPages)
+   * authToken: dev project の有効な Firebase ID token (test fixture user で取得)
+   * db: Firestore (rotate 成功後 documents コレクションを再 read して新 fileUrl から canonical path 抽出)
+   * productionBucket: GCS bucket (新 rotation object の generation 取得)
+   *
+   * Codex 9th Critical 2 + code-reviewer M1 反映: rotatePdfPages callable は現在 success
+   * payload に rotation object path を含まないため、Firestore 再 read + GCS metadata で
+   * 確実に取得する設計に変更 (fixture cleanup orphan 防止)。
+   */
+  constructor(
+    private readonly rotateUrl: string,
+    private readonly authToken: string,
+    private readonly db: Firestore,
+    private readonly productionBucket: Bucket
+  ) {}
+
+  async callRotate(input: {
+    docId: string;
+  }): Promise<
+    | { kind: 'success'; rotatedAt: string; newRotationObjectPath: string; newRotationObjectGeneration: string }
+    | { kind: 'rejected'; rejectionMessage: string }
+    | { kind: 'error'; message: string }
+  > {
+    try {
+      const response = await fetch(this.rotateUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.authToken}`,
+        },
+        body: JSON.stringify({
+          data: {
+            documentId: input.docId,
+            rotations: [{ pageNumber: 1, degrees: 90 }],
+          },
+        }),
+      });
+      const bodyText = await response.text();
+      if (!response.ok) {
+        return { kind: 'error', message: `HTTP ${response.status}: ${bodyText}` };
+      }
+      let body: unknown;
+      try {
+        body = JSON.parse(bodyText);
+      } catch {
+        return { kind: 'error', message: `non-JSON response: ${bodyText}` };
+      }
+      if (body && typeof body === 'object' && 'error' in body) {
+        const errorObj = (body as { error?: { status?: string; message?: string } }).error;
+        if (errorObj?.status === 'FAILED_PRECONDITION' || errorObj?.status === 'failed-precondition') {
+          return { kind: 'rejected', rejectionMessage: errorObj.message ?? 'failed-precondition' };
+        }
+        return { kind: 'error', message: errorObj?.message ?? 'unknown callable error' };
+      }
+      // success: Firestore 再 read で新 fileUrl 取得 → canonical path 抽出 → GCS metadata で generation 取得
+      const rotatedAt = new Date().toISOString();
+      const docSnap = await this.db.collection('documents').doc(input.docId).get();
+      if (!docSnap.exists) {
+        return {
+          kind: 'error',
+          message: `rotate succeeded but doc not found in Firestore re-read (docId=${input.docId})`,
+        };
+      }
+      const fileUrl = docSnap.data()?.fileUrl as string | undefined;
+      if (!fileUrl || typeof fileUrl !== 'string') {
+        return {
+          kind: 'error',
+          message: `rotate succeeded but fileUrl absent or non-string (docId=${input.docId})`,
+        };
+      }
+      // fileUrl format: gs://{bucket}/processed/{docId}/rotations/{rotationId}.pdf
+      const match = fileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/);
+      if (!match || match[1] !== this.productionBucket.name) {
+        return {
+          kind: 'error',
+          message: `rotate succeeded but fileUrl bucket mismatch: expected ${this.productionBucket.name}, got "${fileUrl}"`,
+        };
+      }
+      const objectPath = match[2];
+      const [meta] = await this.productionBucket.file(objectPath).getMetadata();
+      const generation = String(meta.generation ?? '');
+      if (!/^[0-9]+$/.test(generation)) {
+        return {
+          kind: 'error',
+          message: `rotate succeeded but rotation object generation invalid (path=${objectPath}, generation="${generation}")`,
+        };
+      }
+      return {
+        kind: 'success',
+        rotatedAt,
+        newRotationObjectPath: objectPath,
+        newRotationObjectGeneration: generation,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { kind: 'error', message };
+    }
+  }
+}
+
+// re-export for index.ts integration
+export { admin };

--- a/scripts/pr-d4-backfill/phase-d/artifactReader.ts
+++ b/scripts/pr-d4-backfill/phase-d/artifactReader.ts
@@ -1,0 +1,217 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D artifact streaming reader (BF22 + manifest chain authority).
+ *
+ * Phase D は Phase C `writtenDocs[]` の verify が主目的だが、verify の expected source は
+ * Phase B `computedProvenance` (10 fields)。manifest chain (phaseA → phaseB → phaseC) を
+ * authority として、Phase B/C 両 artifact + Phase A summary を読み込む。
+ *
+ * Codex MCP 8th review 回答 5 反映: 同 runId 強制ではなく Phase C manifest authority。CLI は
+ * `--phase-c-artifact-ref` (= manifest path) を起点とし、そこから phaseA/B/C を辿る。
+ *
+ * 設計:
+ * - readPhaseCArtifactFromManifest: Phase D 起動時に Phase C main artifact + manifest を読み込み、
+ *   `writtenDocs[]` streaming を提供 (chunks の writtenDocs のみ yield、他カテゴリは skip)
+ * - readPhaseBCandidatesIndex: Phase B 全 chunks を in-memory Map<docId, computedProvenance> 化
+ *   (Codex 7th 回答 1 + 8th 回答 1 反映、6,238 件 × ~500 bytes = ~3MB、OK)
+ * - readPhaseACountReadOnly: Phase A main artifact から totalDocs / categoryDistribution 等を read-only
+ *   抽出 (Codex 7th Important 5)
+ */
+
+import * as crypto from 'crypto';
+import type {
+  BackfillManifest,
+  PhaseAClassifySummary,
+  PhaseBRevalidatedCandidate,
+  PhaseBRevalidatedChunk,
+  PhaseBRevalidationSummary,
+  PhaseCBackfillChunk,
+  PhaseCBackfillSummary,
+  PhaseCWrittenDoc,
+} from '../types';
+import type { ArtifactStorageReader } from '../phase-b/artifactReader';
+import { ArtifactIntegrityError } from '../phase-b/artifactReader';
+
+export type { ArtifactStorageReader } from '../phase-b/artifactReader';
+export { ArtifactIntegrityError } from '../phase-b/artifactReader';
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export interface ReadPhaseCArtifactInput {
+  manifestPath: string;
+  reader: ArtifactStorageReader;
+}
+
+export interface PhaseCArtifactStream {
+  phaseCArtifactRef: string;
+  phaseCManifestSha256: string;
+  /** Phase C writtenDocs 件数 (chunks 内 writtenDocs.length 合計、Phase D candidatesIn) */
+  writtenDocsIn: number;
+  /** Phase B main artifact path (Phase D が Phase B index を読む authority) */
+  phaseBArtifactRef: string;
+  /** Phase A main artifact path (Phase D が summary を read-only 抽出する authority) */
+  phaseAArtifactRef: string;
+  /**
+   * Phase C main artifact 全体 (Codex 9th Important 4 + code-reviewer L1 反映で expose、
+   * preconditionFailedDocs / skippedImmutable / unprocessableDocs / outOfScopeDocs を
+   * Phase D coverage 算出で利用)。
+   */
+  phaseCSummary: PhaseCBackfillSummary;
+  manifest: BackfillManifest;
+  manifestGeneration: number;
+  /** Phase C 全 chunks の writtenDocs のみを順次 yield (他カテゴリは skip) */
+  writtenDocs(): AsyncIterable<PhaseCWrittenDoc>;
+}
+
+/**
+ * Phase C manifest を起点に main artifact + writtenDocs stream を構築。
+ *
+ * Codex 7th 回答 5 反映: 同 runId 強制ではなく phaseC manifest authority。
+ */
+export async function readPhaseCArtifactFromManifest(
+  input: ReadPhaseCArtifactInput
+): Promise<PhaseCArtifactStream> {
+  const manifestRead = await input.reader.readJson(input.manifestPath);
+  const manifest = JSON.parse(manifestRead.content) as BackfillManifest;
+  if (!manifest.phaseC) {
+    throw new Error(
+      `manifest.phaseC section absent (Phase C artifact not finalized): ${input.manifestPath}`
+    );
+  }
+  if (!manifest.phaseB) {
+    throw new Error(
+      `manifest.phaseB section absent (Phase D requires Phase B index): ${input.manifestPath}`
+    );
+  }
+  if (!manifest.phaseA) {
+    throw new Error(
+      `manifest.phaseA section absent (Phase D requires Phase A summary): ${input.manifestPath}`
+    );
+  }
+  const phaseCArtifactRef = manifest.phaseC.mainArtifact.path;
+  const phaseCManifestSha256 = manifest.phaseC.mainArtifact.sha256;
+
+  const mainRead = await input.reader.readJson(phaseCArtifactRef);
+  const mainContent = mainRead.content;
+  const actualMainSha = sha256Hex(mainContent);
+  if (actualMainSha !== phaseCManifestSha256) {
+    throw new ArtifactIntegrityError(
+      `Phase C main artifact sha256 mismatch: expected ${phaseCManifestSha256}, got ${actualMainSha} (path=${phaseCArtifactRef})`
+    );
+  }
+  const main = JSON.parse(mainContent) as PhaseCBackfillSummary;
+  const chunkPointers = main.chunks;
+
+  // writtenDocs 件数を chunks streaming 前に確定するため、Phase C summary の writtenDocs を使う。
+  // (chunks の writtenDocs.length 合計と一致する設計、Phase C orchestrator が保全式で保証済)
+  const writtenDocsIn = main.writtenDocs;
+
+  async function* streamWrittenDocs(): AsyncIterable<PhaseCWrittenDoc> {
+    for (const pointer of chunkPointers) {
+      const chunkRead = await input.reader.readJson(pointer.path);
+      const chunkContent = chunkRead.content;
+      const actualSha = sha256Hex(chunkContent);
+      if (actualSha !== pointer.sha256) {
+        throw new ArtifactIntegrityError(
+          `Phase C chunk sha256 mismatch: expected ${pointer.sha256}, got ${actualSha} (path=${pointer.path})`
+        );
+      }
+      const chunk = JSON.parse(chunkContent) as PhaseCBackfillChunk;
+      for (const writtenDoc of chunk.writtenDocs) yield writtenDoc;
+    }
+  }
+
+  return {
+    phaseCArtifactRef,
+    phaseCManifestSha256,
+    writtenDocsIn,
+    phaseBArtifactRef: manifest.phaseB.mainArtifact.path,
+    phaseAArtifactRef: manifest.phaseA.mainArtifact.path,
+    phaseCSummary: main,
+    manifest,
+    manifestGeneration: manifestRead.generation,
+    writtenDocs: streamWrittenDocs,
+  };
+}
+
+/**
+ * Phase B chunks を in-memory Map に load (Codex 7th 回答 1 + 8th 回答 1 反映)。
+ *
+ * 6,238 件 × computedProvenance 10 fields (~80 bytes/field) = ~5MB rough。constant-memory
+ * 設計よりも index look-up 計算量 O(1) を優先 (Phase D は per-doc に Phase B candidate を
+ * 引きたいため)。
+ *
+ * Codex 9th Important 2 + code-reviewer M2 反映: Phase B main artifact の sha256 も
+ * manifest と照合 (Phase C と同等の chain authority に揃える)。
+ *
+ * 注意: Map<docId, PhaseBRevalidatedCandidate>。docId 重複時は **後者で上書き**する設計 (Phase B
+ * が同 docId を 2 回 revalidated[] に入れる仕様はないが、防御として一応 last-write 動作明文化)。
+ */
+export async function readPhaseBCandidatesIndex(
+  phaseBArtifactRef: string,
+  expectedMainSha256: string,
+  reader: ArtifactStorageReader
+): Promise<Map<string, PhaseBRevalidatedCandidate>> {
+  const mainRead = await reader.readJson(phaseBArtifactRef);
+  const mainContent = mainRead.content;
+  const actualMainSha = sha256Hex(mainContent);
+  if (actualMainSha !== expectedMainSha256) {
+    throw new ArtifactIntegrityError(
+      `Phase B main artifact sha256 mismatch: expected ${expectedMainSha256}, got ${actualMainSha} (path=${phaseBArtifactRef})`
+    );
+  }
+  const main = JSON.parse(mainContent) as PhaseBRevalidationSummary;
+
+  const index = new Map<string, PhaseBRevalidatedCandidate>();
+  for (const pointer of main.chunks) {
+    const chunkRead = await reader.readJson(pointer.path);
+    const chunkContent = chunkRead.content;
+    const actualSha = sha256Hex(chunkContent);
+    if (actualSha !== pointer.sha256) {
+      throw new ArtifactIntegrityError(
+        `Phase B chunk sha256 mismatch (Phase D index 構築中): expected ${pointer.sha256}, got ${actualSha} (path=${pointer.path})`
+      );
+    }
+    const chunk = JSON.parse(chunkContent) as PhaseBRevalidatedChunk;
+    for (const candidate of chunk.revalidated) {
+      index.set(candidate.docId, candidate);
+    }
+  }
+  return index;
+}
+
+/**
+ * Phase A main artifact から read-only count を抽出 (Codex 7th Important 5)。
+ */
+export interface PhaseACountReadOnlyResult {
+  totalDocs: number;
+  alreadyBackfilled: number;
+  verifiedExistingProvenance: number;
+  categoryDistribution: PhaseAClassifySummary['categoryDistribution'];
+}
+
+/**
+ * Codex 9th Important 2 + code-reviewer M2 反映: Phase A main artifact の sha256 も manifest と
+ * 照合 (chain authority 完全性)。
+ */
+export async function readPhaseACountReadOnly(
+  phaseAArtifactRef: string,
+  expectedMainSha256: string,
+  reader: ArtifactStorageReader
+): Promise<PhaseACountReadOnlyResult> {
+  const mainRead = await reader.readJson(phaseAArtifactRef);
+  const actualMainSha = sha256Hex(mainRead.content);
+  if (actualMainSha !== expectedMainSha256) {
+    throw new ArtifactIntegrityError(
+      `Phase A main artifact sha256 mismatch: expected ${expectedMainSha256}, got ${actualMainSha} (path=${phaseAArtifactRef})`
+    );
+  }
+  const main = JSON.parse(mainRead.content) as PhaseAClassifySummary;
+  return {
+    totalDocs: main.totalDocs,
+    alreadyBackfilled: main.alreadyBackfilled,
+    verifiedExistingProvenance: main.verifiedExistingProvenance,
+    categoryDistribution: main.categoryDistribution,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-d/artifactWriter.ts
+++ b/scripts/pr-d4-backfill/phase-d/artifactWriter.ts
@@ -1,0 +1,223 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D artifact writer (BF22 chunking + Codex 8th Important 3 反映).
+ *
+ * Phase D の特殊性: CAS update 失敗時に main artifact を上書きすると `ifGenerationMatch: 0`
+ * semantics と衝突する。設計は以下:
+ *   1. main artifact は `manifestUpdateStatus: 'pending'` で書込 (新規 only、412 回避)
+ *   2. CAS update を試行
+ *   3. 結果 (ok / failed) を別 file (`phase-d-finalize-status.json`) に書込
+ *   4. main artifact 自体は CAS 結果に関わらず authoritative 判定材料を残す
+ *
+ * 効果: CAS 失敗時に operator が `phase-d-finalize-status.json` を見て main artifact の
+ * 信頼性を判断可能。main artifact 自体は overwrite せず GCS 上で 1 度だけ書込まれる。
+ */
+
+import * as crypto from 'crypto';
+import type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  BackfillManifest,
+  PhaseDFieldMismatchDoc,
+  PhaseDVerifyChunk,
+  PhaseDVerifySummary,
+  PhaseDVerifiedDoc,
+  PhaseDRotateGateTestResult,
+  PhaseDCoverageRatio,
+  PhaseDFinalizeStatus,
+} from '../types';
+import { PR_D4_ARTIFACT_SCHEMA_VERSION, PR_D4_SCRIPT_VERSION } from '../types';
+import type { BackfillConfidence, BackfillClassifierCategory } from '../../../shared/types';
+
+export type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function buildObjectPath(bucketName: string, runId: string, fileName: string): string {
+  return `gs://${bucketName}/pr-d4-backfill-artifacts/${runId}/${fileName}`;
+}
+
+export interface WritePhaseDChunkInput {
+  bucketName: string;
+  runId: string;
+  chunkIndex: number;
+  verifiedDocs: PhaseDVerifiedDoc[];
+  fieldsMismatchDocs: PhaseDFieldMismatchDoc[];
+  /** Codex 9th Critical 3 反映: doc 単位 mismatch ID 集合 (保全式の doc 数算出用) */
+  mismatchedDocIds: string[];
+}
+
+/**
+ * 1 chunk 書込 (orchestrator が per-chunk flush で呼ぶ)。
+ * docCount は verifiedDocs + mismatchedDocIds 合計 (Codex 9th Critical 3 反映、doc 単位)。
+ */
+export async function writePhaseDChunk(
+  input: WritePhaseDChunkInput,
+  writer: ArtifactStorageWriter
+): Promise<ArtifactChunkPointer> {
+  const chunkBody: PhaseDVerifyChunk = {
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    chunkIndex: input.chunkIndex,
+    verifiedDocs: input.verifiedDocs,
+    fieldsMismatchDocs: input.fieldsMismatchDocs,
+    mismatchedDocIds: input.mismatchedDocIds,
+  };
+  const chunkContent = JSON.stringify(chunkBody);
+  const chunkPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    `phase-d-verify-summary-chunk-${input.chunkIndex}.json`
+  );
+  await writer.writeJson(chunkPath, chunkContent);
+  return {
+    path: chunkPath,
+    sha256: sha256Hex(chunkContent),
+    docCount: input.verifiedDocs.length + input.mismatchedDocIds.length,
+  };
+}
+
+export interface FinalizePhaseDInput {
+  bucketName: string;
+  runId: string;
+  env: BackfillEnvName;
+  verifyStartedAt: string;
+  verifyCompletedAt: string;
+  phaseAArtifactRef: string;
+  phaseBArtifactRef: string;
+  phaseCArtifactRef: string;
+  phaseCManifestSha256: string;
+  candidatesIn: number;
+  verifiedDocs: number;
+  fieldsConsistent: number;
+  fieldsMismatch: PhaseDFieldMismatchDoc[];
+  mismatchedDocCount: number;
+  createdAtConsistent: number;
+  createdAtMismatch: PhaseDFieldMismatchDoc[];
+  confidenceDistribution: Record<BackfillConfidence, number>;
+  provenanceBackfillNullCount: number;
+  /** Codex 9th Evaluator エッジケース 1 反映: field absent (undefined) を null と別軸で集計 */
+  provenanceBackfillAbsentCount: number;
+  rotateGateTest: PhaseDRotateGateTestResult | null;
+  coverageRatio: PhaseDCoverageRatio;
+  phaseACountReadOnly: {
+    totalDocs: number;
+    alreadyBackfilled: number;
+    verifiedExistingProvenance: number;
+    categoryDistribution: Record<BackfillClassifierCategory, number>;
+  };
+  chunks: ArtifactChunkPointer[];
+  existingManifest: BackfillManifest;
+  manifestGeneration: number;
+}
+
+export interface FinalizePhaseDResult {
+  mainArtifactPath: string;
+  manifestPath: string;
+  manifestUpdateStatus: 'ok' | 'failed';
+  finalizeStatusPath: string;
+}
+
+/**
+ * Phase D finalize: main 書込 → CAS update 試行 → status file 書込。
+ *
+ * Codex 8th Important 3 反映:
+ * - main artifact は `manifestUpdateStatus: 'pending'` で書込 (overwrite なし)
+ * - CAS update を try / catch で wrap、412 検出時は `manifestUpdateStatus: 'failed'` で status file 書込
+ * - 戻り値の `manifestUpdateStatus` を caller (orchestrator) が判定し、exit code 3 で終了させる
+ */
+export async function finalizePhaseDArtifact(
+  input: FinalizePhaseDInput,
+  writer: ArtifactStorageWriter
+): Promise<FinalizePhaseDResult> {
+  const mainBody: PhaseDVerifySummary = {
+    phase: 'D',
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    scriptVersion: PR_D4_SCRIPT_VERSION,
+    env: input.env,
+    runId: input.runId,
+    phaseAArtifactRef: input.phaseAArtifactRef,
+    phaseBArtifactRef: input.phaseBArtifactRef,
+    phaseCArtifactRef: input.phaseCArtifactRef,
+    phaseCManifestSha256: input.phaseCManifestSha256,
+    verifyStartedAt: input.verifyStartedAt,
+    verifyCompletedAt: input.verifyCompletedAt,
+    candidatesIn: input.candidatesIn,
+    verifiedDocs: input.verifiedDocs,
+    fieldsConsistent: input.fieldsConsistent,
+    fieldsMismatch: input.fieldsMismatch,
+    mismatchedDocCount: input.mismatchedDocCount,
+    createdAtConsistent: input.createdAtConsistent,
+    createdAtMismatch: input.createdAtMismatch,
+    confidenceDistribution: input.confidenceDistribution,
+    provenanceBackfillNullCount: input.provenanceBackfillNullCount,
+    provenanceBackfillAbsentCount: input.provenanceBackfillAbsentCount,
+    rotateGateTest: input.rotateGateTest,
+    coverageRatio: input.coverageRatio,
+    phaseACountReadOnly: input.phaseACountReadOnly,
+    manifestUpdateStatus: 'pending',
+    chunks: input.chunks,
+  };
+  const mainContent = JSON.stringify(mainBody);
+  const mainPath = buildObjectPath(input.bucketName, input.runId, 'phase-d-verify-summary.json');
+  await writer.writeJson(mainPath, mainContent);
+
+  const updatedManifest: BackfillManifest = {
+    ...input.existingManifest,
+    phaseD: {
+      mainArtifact: { path: mainPath, sha256: sha256Hex(mainContent) },
+      chunks: input.chunks,
+    },
+  };
+  const manifestContent = JSON.stringify(updatedManifest);
+  const manifestPath = buildObjectPath(input.bucketName, input.runId, 'manifest.json');
+
+  let manifestUpdateStatus: 'ok' | 'failed' = 'ok';
+  let remediation: string | undefined;
+  try {
+    await writer.writeJson(manifestPath, manifestContent, {
+      ifGenerationMatch: input.manifestGeneration,
+    });
+  } catch (err) {
+    manifestUpdateStatus = 'failed';
+    const message = err instanceof Error ? err.message : String(err);
+    remediation =
+      `manifest CAS failed (expectedGeneration=${input.manifestGeneration}); phase-d artifact ` +
+      `not authoritative. Remediation: re-run Phase D with fresh manifestGeneration after ` +
+      `confirming concurrent Phase D / retry is stopped. Original error: ${message}`;
+    console.error('manifest CAS failed; phase-d artifact not authoritative', {
+      runId: input.runId,
+      expectedGeneration: input.manifestGeneration,
+      observedAt: new Date().toISOString(),
+      remediation,
+    });
+  }
+
+  // status file 書込 (main artifact とは独立、`ifGenerationMatch: 0` で新規 only)
+  const statusBody: PhaseDFinalizeStatus = {
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    runId: input.runId,
+    env: input.env,
+    finalizedAt: new Date().toISOString(),
+    manifestUpdateStatus,
+    expectedGeneration: String(input.manifestGeneration),
+    remediation,
+  };
+  const statusContent = JSON.stringify(statusBody);
+  const statusPath = buildObjectPath(
+    input.bucketName,
+    input.runId,
+    'phase-d-finalize-status.json'
+  );
+  // code-reviewer L3 反映: 新規 only を明示 (Phase D retry 時に status file 既存なら 412 で
+  // operator が「同 runId で Phase D が既に走った」を即把握できる)
+  await writer.writeJson(statusPath, statusContent, { ifGenerationMatch: 0 });
+
+  return {
+    mainArtifactPath: mainPath,
+    manifestPath,
+    manifestUpdateStatus,
+    finalizeStatusPath: statusPath,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-d/docVerifier.ts
+++ b/scripts/pr-d4-backfill/phase-d/docVerifier.ts
@@ -1,0 +1,462 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D doc-level verifier (Codex Critical 1/2 + Stage 1/2 設計).
+ *
+ * Stage 1: observed field 単位検証 (factory 再 invoke なし、Codex 7th Critical 2 反映)
+ *   - provenance 10 fields を Phase B `computedProvenance` と field-by-field 比較 (Critical 1 反映)
+ *   - provenanceBackfill の method / confidence / backfilledAt / evidence.* を type + invariant 検証
+ *   - `createBackfillProvenance` factory が固定生成する `method: 'legacy-observed'` の false positive
+ *     を構造的に検出 (factory 再 invoke 前に observed を直接読む)
+ *
+ * Stage 2: sha256 deterministic 確認 (Stage 1 pass のみ)
+ *   - observed metadata を `createBackfillProvenance` factory に再投入 (observed `backfilledAt`
+ *     必須、省略すると Timestamp.now() で sha256 が一致しない)
+ *   - 出力 metadata を `sha256ProvenanceBackfill` で hash 化 → Phase C `newProvenanceBackfillSha256`
+ *     と比較
+ *
+ * `feedback_deterministic_cross_process.md` 反映: Firestore data() 直 stringify は key 順序
+ * cross-process 不安定。factory 再 invoke で metadata 再構築してから sha256 化。
+ */
+
+import { Timestamp } from 'firebase-admin/firestore';
+import type {
+  BackfillConfidence,
+  BackfillClassifierCategory,
+  DocumentProvenance,
+  ProvenanceBackfillMetadata,
+} from '../../../shared/types';
+import type { PhaseBRevalidatedCandidate, PhaseDFieldMismatchDoc } from '../types';
+import { createBackfillProvenance } from '../../../functions/src/pdf/provenance';
+import { sha256ProvenanceBackfill } from '../phase-c/batchWriter';
+
+/**
+ * Firestore document から読んだ observed の状態。
+ *
+ * `provenance` / `provenanceBackfill` は admin SDK 経由で取得した raw object (Timestamp 含む)。
+ * `null` は absent / 取得不能。`undefined` は field 不在を表す。
+ */
+export interface ObservedDocState {
+  docId: string;
+  /** Firestore document.createdAt (BF10 検証で provenance.createdAt と比較) */
+  documentCreatedAt: Timestamp | null;
+  provenance: DocumentProvenance | null;
+  provenanceBackfill: ProvenanceBackfillMetadata | null;
+  /** Firestore 経由 raw object (null と undefined を区別するため別 field) */
+  provenanceBackfillRaw: unknown;
+}
+
+export type VerifyDocResult =
+  | {
+      kind: 'verified';
+      docId: string;
+      provenanceFieldsConsistent: true;
+      provenanceBackfillSha256Match: boolean;
+      observedConfidence: BackfillConfidence;
+      observedCreatedAt: string;
+      /** BF10 検証結果: provenance.createdAt === document.createdAt */
+      createdAtConsistent: boolean;
+      /** createdAt 不一致時、observed と expected を残す (mismatch doc 構築用) */
+      createdAtMismatch: PhaseDFieldMismatchDoc | null;
+    }
+  | {
+      kind: 'mismatch';
+      docId: string;
+      mismatches: PhaseDFieldMismatchDoc[];
+    };
+
+/**
+ * provenance 10 fields の field-by-field 比較 (Critical 1 反映)。
+ *
+ * 文字列 9 fields は厳密一致 (`===`)、createdAt は Timestamp → ISO8601 化して expected の
+ * ISO string (Phase B computedProvenance.createdAt) と比較。
+ */
+function compareProvenanceFields(
+  docId: string,
+  observed: DocumentProvenance,
+  expected: PhaseBRevalidatedCandidate['computedProvenance']
+): PhaseDFieldMismatchDoc[] {
+  const mismatches: PhaseDFieldMismatchDoc[] = [];
+  const stringFields: Array<keyof DocumentProvenance> = [
+    'sourceGeneration',
+    'sourceMetageneration',
+    'sourceSha256',
+    'sourcePath',
+    'sourceBucket',
+    'derivedObjectPath',
+    'derivedGeneration',
+    'derivedMetageneration',
+    'derivedSha256',
+  ];
+  for (const field of stringFields) {
+    const observedValue = observed[field];
+    const expectedValue = expected[field as keyof typeof expected];
+    if (typeof observedValue !== 'string') {
+      mismatches.push({
+        docId,
+        mismatchType: 'provenance-field',
+        field,
+        observed: observedValue == null ? null : String(observedValue),
+        expected: typeof expectedValue === 'string' ? expectedValue : null,
+      });
+      continue;
+    }
+    if (observedValue !== expectedValue) {
+      mismatches.push({
+        docId,
+        mismatchType: 'provenance-field',
+        field,
+        observed: observedValue,
+        expected: typeof expectedValue === 'string' ? expectedValue : null,
+      });
+    }
+  }
+  // createdAt (Timestamp → ISO 比較)
+  if (!(observed.createdAt instanceof Timestamp)) {
+    mismatches.push({
+      docId,
+      mismatchType: 'provenance-field',
+      field: 'createdAt',
+      observed: observed.createdAt == null ? null : String(observed.createdAt),
+      expected: expected.createdAt,
+    });
+  } else {
+    const observedIso = observed.createdAt.toDate().toISOString();
+    if (observedIso !== expected.createdAt) {
+      mismatches.push({
+        docId,
+        mismatchType: 'provenance-field',
+        field: 'createdAt',
+        observed: observedIso,
+        expected: expected.createdAt,
+      });
+    }
+  }
+  return mismatches;
+}
+
+/**
+ * provenanceBackfill の Stage 1 field 単位検証 (Codex Critical 2 反映)。
+ *
+ * factory 再 invoke 前に observed を直接読み、`method: 'legacy-observed'` 等の固定値が
+ * 壊れていないかを type + invariant 検証する。Stage 2 sha256 比較の前に false positive を
+ * 検出する。
+ *
+ * Codex 8th Important 2 反映: `parentSha256MatchedAtBackfill` 型は `boolean | null`
+ * を一般 validator では許容、confidence-specific invariant で derived-bytes-verified は true 必須。
+ */
+function validateBackfillMetadataStage1(
+  docId: string,
+  raw: unknown
+): { ok: true; metadata: ProvenanceBackfillMetadata } | { ok: false; mismatches: PhaseDFieldMismatchDoc[] } {
+  const mismatches: PhaseDFieldMismatchDoc[] = [];
+  if (raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray(raw)) {
+    mismatches.push({
+      docId,
+      mismatchType: 'backfill-field',
+      field: 'provenanceBackfill',
+      observed: raw === null ? null : typeof raw,
+      expected: 'object',
+    });
+    return { ok: false, mismatches };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (obj.method !== 'legacy-observed') {
+    mismatches.push({
+      docId,
+      mismatchType: 'backfill-field',
+      field: 'provenanceBackfill.method',
+      observed: typeof obj.method === 'string' ? obj.method : null,
+      expected: 'legacy-observed',
+    });
+  }
+  const allowedConfidence: BackfillConfidence[] = [
+    'derived-bytes-verified',
+    'child-snapshot-only',
+    'metadata-only',
+  ];
+  if (typeof obj.confidence !== 'string' || !allowedConfidence.includes(obj.confidence as BackfillConfidence)) {
+    mismatches.push({
+      docId,
+      mismatchType: 'backfill-field',
+      field: 'provenanceBackfill.confidence',
+      observed: typeof obj.confidence === 'string' ? obj.confidence : null,
+      expected: 'derived-bytes-verified | child-snapshot-only | metadata-only',
+    });
+  }
+  if (!(obj.backfilledAt instanceof Timestamp)) {
+    mismatches.push({
+      docId,
+      mismatchType: 'backfill-field',
+      field: 'provenanceBackfill.backfilledAt',
+      observed: obj.backfilledAt == null ? null : typeof obj.backfilledAt,
+      expected: 'Timestamp',
+    });
+  }
+  const evidenceRaw = obj.evidence;
+  if (
+    evidenceRaw === null ||
+    typeof evidenceRaw !== 'object' ||
+    Array.isArray(evidenceRaw)
+  ) {
+    mismatches.push({
+      docId,
+      mismatchType: 'backfill-field',
+      field: 'provenanceBackfill.evidence',
+      observed: evidenceRaw == null ? null : typeof evidenceRaw,
+      expected: 'object',
+    });
+  } else {
+    const ev = evidenceRaw as Record<string, unknown>;
+    if (typeof ev.parentExists !== 'boolean') {
+      mismatches.push({
+        docId,
+        mismatchType: 'backfill-field',
+        field: 'provenanceBackfill.evidence.parentExists',
+        observed: typeof ev.parentExists === 'boolean' ? ev.parentExists : null,
+        expected: 'boolean',
+      });
+    }
+    // boolean | null 許容 (Codex 8th Important 2)
+    if (
+      ev.parentSha256MatchedAtBackfill !== true &&
+      ev.parentSha256MatchedAtBackfill !== false &&
+      ev.parentSha256MatchedAtBackfill !== null
+    ) {
+      mismatches.push({
+        docId,
+        mismatchType: 'backfill-field',
+        field: 'provenanceBackfill.evidence.parentSha256MatchedAtBackfill',
+        observed: typeof ev.parentSha256MatchedAtBackfill,
+        expected: 'boolean | null',
+      });
+    }
+    if (typeof ev.childSha256ComputedAtBackfill !== 'boolean') {
+      mismatches.push({
+        docId,
+        mismatchType: 'backfill-field',
+        field: 'provenanceBackfill.evidence.childSha256ComputedAtBackfill',
+        observed: typeof ev.childSha256ComputedAtBackfill === 'boolean' ? ev.childSha256ComputedAtBackfill : null,
+        expected: 'boolean',
+      });
+    }
+    if (typeof ev.backfillScriptVersion !== 'string' || ev.backfillScriptVersion.length === 0) {
+      mismatches.push({
+        docId,
+        mismatchType: 'backfill-field',
+        field: 'provenanceBackfill.evidence.backfillScriptVersion',
+        observed: typeof ev.backfillScriptVersion === 'string' ? ev.backfillScriptVersion : null,
+        expected: 'non-empty string',
+      });
+    }
+    const allowedCategories: BackfillClassifierCategory[] = [
+      'MatchedByHash',
+      'RepairableMissingFile',
+      'Ambiguous',
+      'LostOrUnrecoverable',
+      'NeedsManualReview',
+    ];
+    if (
+      typeof ev.classifierCategory !== 'string' ||
+      !allowedCategories.includes(ev.classifierCategory as BackfillClassifierCategory)
+    ) {
+      mismatches.push({
+        docId,
+        mismatchType: 'backfill-field',
+        field: 'provenanceBackfill.evidence.classifierCategory',
+        observed: typeof ev.classifierCategory === 'string' ? ev.classifierCategory : null,
+        expected: 'MatchedByHash | RepairableMissingFile | Ambiguous | LostOrUnrecoverable | NeedsManualReview',
+      });
+    }
+  }
+  if (mismatches.length > 0) return { ok: false, mismatches };
+  return { ok: true, metadata: obj as unknown as ProvenanceBackfillMetadata };
+}
+
+/**
+ * Stage 2: sha256 deterministic 確認 (Stage 1 pass のみ)。
+ *
+ * observed metadata の `backfilledAt` を input.backfilledAt として factory 再 invoke → sha256
+ * → Phase C `newProvenanceBackfillSha256` と比較。Codex Critical 2 反映で observed backfilledAt
+ * を必ず渡す (省略すると Timestamp.now() で hash 一致しない)。
+ */
+function compareBackfillSha256(
+  docId: string,
+  observedMetadata: ProvenanceBackfillMetadata,
+  observedProvenance: DocumentProvenance,
+  expectedSha256: string,
+  backfillScriptVersion: string
+): PhaseDFieldMismatchDoc | null {
+  const expectedSplitCreatedAt = observedProvenance.createdAt;
+  if (!(expectedSplitCreatedAt instanceof Timestamp)) {
+    return {
+      docId,
+      mismatchType: 'sha256',
+      field: 'provenanceBackfill.sha256',
+      observed: 'observed.provenance.createdAt is not Timestamp; sha256 比較スキップ',
+      expected: expectedSha256,
+    };
+  }
+  // observed metadata を factory に再投入 (Codex Critical 2 反映: backfilledAt は observed 値)
+  let rebuilt;
+  try {
+    rebuilt = createBackfillProvenance({
+      provenanceFields: {
+        sourceGeneration: observedProvenance.sourceGeneration,
+        sourceMetageneration: observedProvenance.sourceMetageneration,
+        sourceSha256: observedProvenance.sourceSha256,
+        sourcePath: observedProvenance.sourcePath,
+        sourceBucket: observedProvenance.sourceBucket,
+        derivedObjectPath: observedProvenance.derivedObjectPath,
+        derivedGeneration: observedProvenance.derivedGeneration,
+        derivedMetageneration: observedProvenance.derivedMetageneration,
+        derivedSha256: observedProvenance.derivedSha256,
+        createdAt: expectedSplitCreatedAt,
+      },
+      confidence: observedMetadata.confidence,
+      classifierCategory: observedMetadata.evidence.classifierCategory,
+      evidence: {
+        parentExists: observedMetadata.evidence.parentExists,
+        parentSha256MatchedAtBackfill: observedMetadata.evidence.parentSha256MatchedAtBackfill,
+        childSha256ComputedAtBackfill: observedMetadata.evidence.childSha256ComputedAtBackfill,
+      },
+      backfillScriptVersion,
+      backfilledAt: observedMetadata.backfilledAt,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      docId,
+      mismatchType: 'sha256',
+      field: 'provenanceBackfill.sha256',
+      observed: `factory re-invoke failed: ${message}`,
+      expected: expectedSha256,
+    };
+  }
+  const observedSha = sha256ProvenanceBackfill(rebuilt.provenanceBackfill);
+  if (observedSha !== expectedSha256) {
+    return {
+      docId,
+      mismatchType: 'sha256',
+      field: 'provenanceBackfill.sha256',
+      observed: observedSha,
+      expected: expectedSha256,
+    };
+  }
+  return null;
+}
+
+export interface VerifyDocInput {
+  observed: ObservedDocState;
+  expectedFromPhaseB: PhaseBRevalidatedCandidate | undefined;
+  expectedSha256FromPhaseC: string;
+  backfillScriptVersion: string;
+}
+
+/**
+ * 1 doc の verify (Stage 1 + Stage 2)。
+ *
+ * 戻り値:
+ * - kind=verified: provenance 10 fields 一致 + Stage 1 pass。Stage 2 sha256 一致を
+ *   `provenanceBackfillSha256Match` で表現 (true/false)
+ * - kind=mismatch: いずれかの段階で fail
+ *
+ * BF10 `provenance.createdAt === document.createdAt` 検証も含む (createdAtConsistent field)。
+ */
+export function verifyDoc(input: VerifyDocInput): VerifyDocResult {
+  const docId = input.observed.docId;
+  const mismatches: PhaseDFieldMismatchDoc[] = [];
+
+  // Phase B index に該当 docId が無い場合 (Phase C と Phase B の同期ズレ、Codex Suggestion 1)
+  if (!input.expectedFromPhaseB) {
+    mismatches.push({
+      docId,
+      mismatchType: 'missing-expected',
+      field: '__phaseBIndex',
+      observed: null,
+      expected: 'Phase B candidate entry',
+    });
+    return { kind: 'mismatch', docId, mismatches };
+  }
+
+  if (input.observed.provenance === null) {
+    mismatches.push({
+      docId,
+      mismatchType: 'provenance-field',
+      field: 'provenance',
+      observed: null,
+      expected: 'DocumentProvenance object',
+    });
+    return { kind: 'mismatch', docId, mismatches };
+  }
+
+  // Stage 1a: provenance 10 fields 比較
+  const provMismatches = compareProvenanceFields(
+    docId,
+    input.observed.provenance,
+    input.expectedFromPhaseB.computedProvenance
+  );
+  mismatches.push(...provMismatches);
+
+  // Stage 1b: provenanceBackfill field 単位検証
+  const stage1 = validateBackfillMetadataStage1(docId, input.observed.provenanceBackfillRaw);
+  if (!stage1.ok) {
+    mismatches.push(...stage1.mismatches);
+    return { kind: 'mismatch', docId, mismatches };
+  }
+  if (provMismatches.length > 0) {
+    return { kind: 'mismatch', docId, mismatches };
+  }
+
+  // Stage 2: sha256 deterministic 比較
+  const sha256Mismatch = compareBackfillSha256(
+    docId,
+    stage1.metadata,
+    input.observed.provenance,
+    input.expectedSha256FromPhaseC,
+    input.backfillScriptVersion
+  );
+  const provenanceBackfillSha256Match = sha256Mismatch === null;
+
+  // BF10: provenance.createdAt === document.createdAt
+  const observedCreatedAtIso = input.observed.provenance.createdAt.toDate().toISOString();
+  let createdAtConsistent = false;
+  let createdAtMismatch: PhaseDFieldMismatchDoc | null = null;
+  if (input.observed.documentCreatedAt instanceof Timestamp) {
+    const docCreatedAtIso = input.observed.documentCreatedAt.toDate().toISOString();
+    createdAtConsistent = observedCreatedAtIso === docCreatedAtIso;
+    if (!createdAtConsistent) {
+      createdAtMismatch = {
+        docId,
+        mismatchType: 'provenance-field',
+        field: 'createdAt[BF10:document.createdAt]',
+        observed: observedCreatedAtIso,
+        expected: docCreatedAtIso,
+      };
+    }
+  } else {
+    createdAtMismatch = {
+      docId,
+      mismatchType: 'provenance-field',
+      field: 'createdAt[BF10:document.createdAt]',
+      observed: input.observed.documentCreatedAt == null ? null : typeof input.observed.documentCreatedAt,
+      expected: 'Timestamp',
+    };
+  }
+
+  if (sha256Mismatch) {
+    mismatches.push(sha256Mismatch);
+    return { kind: 'mismatch', docId, mismatches };
+  }
+
+  return {
+    kind: 'verified',
+    docId,
+    provenanceFieldsConsistent: true,
+    provenanceBackfillSha256Match,
+    observedConfidence: stage1.metadata.confidence,
+    observedCreatedAt: observedCreatedAtIso,
+    createdAtConsistent,
+    createdAtMismatch,
+  };
+}
+

--- a/scripts/pr-d4-backfill/phase-d/rotateGateFixtureTester.ts
+++ b/scripts/pr-d4-backfill/phase-d/rotateGateFixtureTester.ts
@@ -1,0 +1,255 @@
+/**
+ * Issue #445 PR-D4 S1-5: dev 環境 rotate gate fixture tester (BF12 / BF13、Codex 8th Important 2).
+ *
+ * impl-plan §4.4 step 2 + Codex 7th Important 2 反映の cleanup hook 必須条件:
+ *   - **env hard gate**: env !== 'dev' で throw (test caller 側で更に保証)
+ *   - **fixture docId prefix allowlist**: `BF13_test_fixture_${runId}_${kind}_${uuid}` 形式以外は cleanup refuse
+ *   - **GCS delete scope**: fixture original object + rotate 結果 object のみ (Codex 8th 回答 3 反映)
+ *   - **generation precondition**: delete 時に `ifGenerationMatch: <作成時 generation>` 付与
+ *   - **try / finally**: rotate 成否に関わらず cleanup 強制実行
+ *   - **cleanup 失敗 artifact 記録**: `fixtureCleanupFailures[]` に operator 目視削除を明示
+ *
+ * **本 module は dev 環境のみで起動される**。本番 (cocoro/kanameone) では orchestrator が
+ * `rotateGateTest: null` を返し本 module を一切 invoke しない (Codex 3rd I6 反映、本番 doc に
+ * rotate side effect ゼロ)。
+ *
+ * 設計: rotate API は callable function 直接呼出ではなく、DI 経由の `RotateApiCaller` interface
+ * を通じる。production wire (adapters.ts) で実 `rotatePdfPages` を呼ぶ実装を提供。test では
+ * fake で in-memory rotate emulation 可能。
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { BackfillEnvName, PhaseDRotateGateTestResult } from '../types';
+
+/**
+ * fixture 作成 / cleanup の Firestore + GCS adapter (DI、production wire は adapters.ts)。
+ */
+export interface FixtureStore {
+  /**
+   * fixture doc を Firestore に作成し、Storage に PDF object を 1 件 save。
+   * 戻り値の `objectGeneration` は cleanup の precondition に使う。
+   */
+  createFixture(input: {
+    docId: string;
+    confidence: 'derived-bytes-verified' | 'child-snapshot-only';
+    /** Phase B から流用する parent PDF bytes (sha256 計算済 derived bytes) */
+    pdfBytes: Buffer;
+  }): Promise<{ objectPath: string; objectGeneration: string }>;
+  /**
+   * fixture doc を Firestore + Storage から削除。
+   * Storage delete は `ifGenerationMatch: <objectGeneration>` 付与 (誤削除防止)。
+   * doc 削除は ADR-0008 削除制約と整合 (特定 doc delete は許可、--all-collections は使わない)。
+   */
+  cleanupFixture(input: {
+    docId: string;
+    /** original object + rotate 結果 object (path + generation の組) */
+    objects: Array<{ path: string; generation: string }>;
+  }): Promise<void>;
+}
+
+/**
+ * rotate API caller の DI (production = 実 rotatePdfPages、test = fake)。
+ *
+ * 戻り値:
+ * - kind=success: rotate API が success を返した (BF12 verified の期待動作)
+ * - kind=rejected: failed-precondition で reject (BF13 child-snapshot-only の期待動作)
+ * - kind=error: それ以外の error (test を fail 扱いに分類)
+ */
+export interface RotateApiCaller {
+  callRotate(input: {
+    docId: string;
+  }): Promise<
+    | { kind: 'success'; rotatedAt: string; newRotationObjectPath: string; newRotationObjectGeneration: string }
+    | { kind: 'rejected'; rejectionMessage: string }
+    | { kind: 'error'; message: string }
+  >;
+}
+
+/**
+ * dev fixture docId 命名規則 (Codex 8th 回答 3 反映: prefix + UUID 二重識別)。
+ *
+ * 形式: `BF13_test_fixture_${runId}_${kind}_${uuid}`
+ * - prefix `BF13_test_fixture_` は cleanup allowlist で前方一致確認
+ * - kind ∈ 'verified' | 'child_snapshot_only'
+ * - uuid は randomUUID() で衝突回避
+ */
+const FIXTURE_PREFIX = 'BF13_test_fixture_';
+
+export function buildFixtureDocId(
+  runId: string,
+  kind: 'verified' | 'child_snapshot_only'
+): string {
+  const uuid = randomUUID();
+  return `${FIXTURE_PREFIX}${runId}_${kind}_${uuid}`;
+}
+
+/**
+ * cleanup allowlist 判定 (defense in depth、本 module 外で呼ばれた場合の保護)。
+ */
+export function isFixtureDocId(docId: string): boolean {
+  return docId.startsWith(FIXTURE_PREFIX);
+}
+
+export interface RunRotateGateFixtureTestInput {
+  env: BackfillEnvName;
+  runId: string;
+  /** BF12 test fixture 用の verified PDF bytes (Phase B 由来など、test caller が用意) */
+  pdfBytesVerified: Buffer;
+  /** BF13 test fixture 用の child-snapshot-only PDF bytes */
+  pdfBytesChildSnapshotOnly: Buffer;
+  fixtureStore: FixtureStore;
+  rotateApiCaller: RotateApiCaller;
+}
+
+/**
+ * BF12 + BF13 rotate gate test を dev 環境のみで実行。
+ *
+ * Codex 8th Important 2 反映:
+ * - env !== 'dev' で hard fail (test caller 側で更に env check 二重)
+ * - try / finally で cleanup 強制
+ * - cleanup 失敗を `fixtureCleanupFailures[]` に記録 (rotate test 結果と分離)
+ */
+export async function runRotateGateFixtureTest(
+  input: RunRotateGateFixtureTestInput
+): Promise<PhaseDRotateGateTestResult> {
+  if (input.env !== 'dev') {
+    throw new Error(
+      `rotate gate fixture test is dev-only; received env=${input.env} (Codex 7th Important 2 / ADR-0008 削除制約 遵守)`
+    );
+  }
+
+  const verifiedDocId = buildFixtureDocId(input.runId, 'verified');
+  const childSnapshotDocId = buildFixtureDocId(input.runId, 'child_snapshot_only');
+
+  const objectsToCleanup: Array<{
+    docId: string;
+    objects: Array<{ path: string; generation: string }>;
+  }> = [];
+
+  const fixtureCleanupFailures: PhaseDRotateGateTestResult['fixtureCleanupFailures'] = [];
+
+  let derivedBytesVerifiedResult: PhaseDRotateGateTestResult['derivedBytesVerified'] = {
+    fixtureDocId: verifiedDocId,
+    rotateApiResult: 'rejected',
+    rotatedAt: null,
+    rejectionMessage: 'fixture creation failed',
+  };
+
+  let childSnapshotResult: PhaseDRotateGateTestResult['childSnapshotOnly'] = {
+    fixtureDocId: childSnapshotDocId,
+    rotateApiResult: 'rejected',
+    rotatedAt: null,
+    rejectionMessage: 'fixture creation failed',
+  };
+
+  try {
+    // BF12: derived-bytes-verified fixture → rotate 成功期待
+    const verifiedFix = await input.fixtureStore.createFixture({
+      docId: verifiedDocId,
+      confidence: 'derived-bytes-verified',
+      pdfBytes: input.pdfBytesVerified,
+    });
+    objectsToCleanup.push({
+      docId: verifiedDocId,
+      objects: [{ path: verifiedFix.objectPath, generation: verifiedFix.objectGeneration }],
+    });
+    const verifiedRotate = await input.rotateApiCaller.callRotate({ docId: verifiedDocId });
+    if (verifiedRotate.kind === 'success') {
+      derivedBytesVerifiedResult = {
+        fixtureDocId: verifiedDocId,
+        rotateApiResult: 'success',
+        rotatedAt: verifiedRotate.rotatedAt,
+        rejectionMessage: null,
+      };
+      // rotate で生成された新 object も cleanup 対象 (Codex 8th Important 2)
+      objectsToCleanup[objectsToCleanup.length - 1].objects.push({
+        path: verifiedRotate.newRotationObjectPath,
+        generation: verifiedRotate.newRotationObjectGeneration,
+      });
+    } else if (verifiedRotate.kind === 'rejected') {
+      derivedBytesVerifiedResult = {
+        fixtureDocId: verifiedDocId,
+        rotateApiResult: 'rejected',
+        rotatedAt: null,
+        rejectionMessage: `BF12 FAILED: derived-bytes-verified rotate was rejected: ${verifiedRotate.rejectionMessage}`,
+      };
+    } else {
+      derivedBytesVerifiedResult = {
+        fixtureDocId: verifiedDocId,
+        rotateApiResult: 'rejected',
+        rotatedAt: null,
+        rejectionMessage: `BF12 FAILED: rotate error: ${verifiedRotate.message}`,
+      };
+    }
+
+    // BF13: child-snapshot-only fixture → failed-precondition reject 期待
+    const childFix = await input.fixtureStore.createFixture({
+      docId: childSnapshotDocId,
+      confidence: 'child-snapshot-only',
+      pdfBytes: input.pdfBytesChildSnapshotOnly,
+    });
+    objectsToCleanup.push({
+      docId: childSnapshotDocId,
+      objects: [{ path: childFix.objectPath, generation: childFix.objectGeneration }],
+    });
+    const childRotate = await input.rotateApiCaller.callRotate({ docId: childSnapshotDocId });
+    if (childRotate.kind === 'rejected') {
+      childSnapshotResult = {
+        fixtureDocId: childSnapshotDocId,
+        rotateApiResult: 'rejected',
+        rotatedAt: null,
+        rejectionMessage: childRotate.rejectionMessage,
+      };
+    } else if (childRotate.kind === 'success') {
+      // BF13 FAIL: gate がリーク
+      childSnapshotResult = {
+        fixtureDocId: childSnapshotDocId,
+        rotateApiResult: 'success',
+        rotatedAt: childRotate.rotatedAt,
+        rejectionMessage: 'BF13 FAILED: child-snapshot-only rotate succeeded; gate leakage detected',
+      };
+      objectsToCleanup[objectsToCleanup.length - 1].objects.push({
+        path: childRotate.newRotationObjectPath,
+        generation: childRotate.newRotationObjectGeneration,
+      });
+    } else {
+      childSnapshotResult = {
+        fixtureDocId: childSnapshotDocId,
+        rotateApiResult: 'rejected',
+        rotatedAt: null,
+        rejectionMessage: `BF13: rotate error treated as reject for safety: ${childRotate.message}`,
+      };
+    }
+  } finally {
+    // cleanup hook (try / finally で必ず実行、Codex 8th Important 2)
+    for (const entry of objectsToCleanup) {
+      if (!isFixtureDocId(entry.docId)) {
+        fixtureCleanupFailures.push({
+          fixtureDocId: entry.docId,
+          objectPath: null,
+          error: `docId does not match fixture allowlist prefix ${FIXTURE_PREFIX}; refused to cleanup`,
+        });
+        continue;
+      }
+      try {
+        await input.fixtureStore.cleanupFixture({
+          docId: entry.docId,
+          objects: entry.objects,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        fixtureCleanupFailures.push({
+          fixtureDocId: entry.docId,
+          objectPath: entry.objects.map((o) => o.path).join(','),
+          error: `cleanup failed: ${message}`,
+        });
+      }
+    }
+  }
+
+  return {
+    derivedBytesVerified: derivedBytesVerifiedResult,
+    childSnapshotOnly: childSnapshotResult,
+    fixtureCleanupFailures,
+  };
+}

--- a/scripts/pr-d4-backfill/phase-d/verifyOrchestrator.ts
+++ b/scripts/pr-d4-backfill/phase-d/verifyOrchestrator.ts
@@ -1,0 +1,380 @@
+/**
+ * Issue #445 PR-D4 S1-5: Phase D verify orchestrator (impl-plan §4.4).
+ *
+ * フロー:
+ *   1. Phase C manifest 読込 → manifest chain authority (phaseA / phaseB / phaseC ref を取得)
+ *   2. Phase A read-only count を抽出 (Codex 7th Important 5)
+ *   3. Phase B candidates を in-memory index 化 (Codex 7th 回答 1)
+ *   4. Phase C writtenDocs を streaming で順次 verify
+ *      - 各 doc を Firestore re-read → docVerifier.verifyDoc (Stage 1 / Stage 2)
+ *      - per-chunk buffer flush + provenanceBackfillNullCount 集計
+ *   5. dev 環境のみ rotate gate fixture test 起動 (BF12/BF13、Codex 7th Important 2)
+ *   6. coverage 比率算出 (2 系統、Codex 7th Important 4)
+ *   7. finalize (BF22 + manifest CAS、Codex 8th Important 3)
+ *
+ * 保全式 (orchestrator test でアサート):
+ *   verifiedDocs === fieldsConsistent + fieldsMismatch.length
+ *   createdAtConsistent + createdAtMismatch.length === verifiedDocs
+ *   estateRotateReadyCoverage.rotateReadyTotal + notRotateReady === phaseA.totalDocs
+ */
+
+import { PR_D4_CANDIDATES_PER_CHUNK } from '../types';
+import type {
+  ArtifactChunkPointer,
+  BackfillEnvName,
+  PhaseDCoverageRatio,
+  PhaseDFieldMismatchDoc,
+  PhaseDRotateGateTestResult,
+  PhaseDVerifiedDoc,
+} from '../types';
+import type { BackfillConfidence } from '../../../shared/types';
+import {
+  readPhaseACountReadOnly,
+  readPhaseBCandidatesIndex,
+  readPhaseCArtifactFromManifest,
+  type ArtifactStorageReader,
+} from './artifactReader';
+import type { ArtifactStorageWriter } from './artifactWriter';
+import { writePhaseDChunk, finalizePhaseDArtifact } from './artifactWriter';
+import { verifyDoc, type ObservedDocState } from './docVerifier';
+import { runRotateGateFixtureTest, type FixtureStore, type RotateApiCaller } from './rotateGateFixtureTester';
+
+/**
+ * Firestore document を Phase D 用に read する adapter (DI、production wire は adapters.ts)。
+ *
+ * 返却値 (ObservedDocState):
+ * - docId, documentCreatedAt, provenance (typed), provenanceBackfill (typed or null)
+ * - provenanceBackfillRaw: raw unknown (null / undefined / malformed の区別に必要)
+ */
+export interface PhaseDDocReader {
+  readDoc(docId: string): Promise<ObservedDocState>;
+}
+
+export interface RunPhaseDInput {
+  env: BackfillEnvName;
+  runId: string;
+  artifactBucketName: string;
+  manifestPath: string;
+  artifactReader: ArtifactStorageReader;
+  artifactWriter: ArtifactStorageWriter;
+  docReader: PhaseDDocReader;
+  backfillScriptVersion: string;
+  /** dev 環境で rotate gate fixture test を起動するか (本番では false 固定、Codex 3rd I6) */
+  rotateGateFixtureEnabled: boolean;
+  /** dev fixture test 用 (rotateGateFixtureEnabled=true 時のみ参照) */
+  fixtureStore?: FixtureStore;
+  rotateApiCaller?: RotateApiCaller;
+  fixturePdfBytesVerified?: Buffer;
+  fixturePdfBytesChildSnapshotOnly?: Buffer;
+  verifyStartedAt: string;
+  /** test の deterministic 時刻注入 (production は Date.now()) */
+  nowProvider?: () => Date;
+}
+
+export interface RunPhaseDResult {
+  candidatesIn: number;
+  verifiedDocs: number;
+  fieldsConsistent: number;
+  fieldsMismatchCount: number;
+  /** doc 単位 mismatch 数 (Codex 9th Critical 3 反映、保全式: verifiedDocs + mismatchedDocCount === candidatesIn) */
+  mismatchedDocCount: number;
+  createdAtConsistent: number;
+  createdAtMismatchCount: number;
+  provenanceBackfillNullCount: number;
+  /** Codex 9th Evaluator エッジケース 1 反映: field absent (undefined) を null とは別軸で集計 */
+  provenanceBackfillAbsentCount: number;
+  confidenceDistribution: Record<BackfillConfidence, number>;
+  rotateGateTest: PhaseDRotateGateTestResult | null;
+  coverageRatio: PhaseDCoverageRatio;
+  mainArtifactPath: string;
+  manifestPath: string;
+  finalizeStatusPath: string;
+  manifestUpdateStatus: 'ok' | 'failed';
+  /** いずれかの検証 fail があったか (CLI exit non-zero 判定用、Codex 9th Important 3) */
+  hasVerificationFailure: boolean;
+  verifyCompletedAt: string;
+}
+
+/**
+ * Phase D verify を実行。
+ *
+ * fixture test は env === 'dev' && rotateGateFixtureEnabled の両方で true の場合のみ起動。
+ * 本番 (cocoro / kanameone) では `rotateGateFixtureEnabled: false` を渡し、`rotateGateTest: null`
+ * を artifact に記録 (本番 doc に rotate side effect ゼロ、Codex 3rd I6)。
+ */
+export async function runPhaseD(input: RunPhaseDInput): Promise<RunPhaseDResult> {
+  const now = input.nowProvider ?? (() => new Date());
+
+  const phaseCStream = await readPhaseCArtifactFromManifest({
+    manifestPath: input.manifestPath,
+    reader: input.artifactReader,
+  });
+  // Codex 9th Important 2 反映: Phase A/B main artifact も sha256 verify (chain authority)
+  const phaseAExpectedSha = phaseCStream.manifest.phaseA!.mainArtifact.sha256;
+  const phaseBExpectedSha = phaseCStream.manifest.phaseB!.mainArtifact.sha256;
+  const phaseACount = await readPhaseACountReadOnly(
+    phaseCStream.phaseAArtifactRef,
+    phaseAExpectedSha,
+    input.artifactReader
+  );
+  const phaseBIndex = await readPhaseBCandidatesIndex(
+    phaseCStream.phaseBArtifactRef,
+    phaseBExpectedSha,
+    input.artifactReader
+  );
+
+  let verifiedDocsBuffer: PhaseDVerifiedDoc[] = [];
+  let fieldsMismatchBuffer: PhaseDFieldMismatchDoc[] = [];
+  let mismatchedDocIdsBuffer = new Set<string>();
+  const chunks: ArtifactChunkPointer[] = [];
+
+  let verifiedDocsTotal = 0;
+  let fieldsConsistent = 0;
+  const allFieldsMismatch: PhaseDFieldMismatchDoc[] = [];
+  const allMismatchedDocIds = new Set<string>();
+  let createdAtConsistent = 0;
+  const allCreatedAtMismatch: PhaseDFieldMismatchDoc[] = [];
+  let provenanceBackfillNullCount = 0;
+  let provenanceBackfillAbsentCount = 0;
+  const confidenceDistribution: Record<BackfillConfidence, number> = {
+    'derived-bytes-verified': 0,
+    'child-snapshot-only': 0,
+    'metadata-only': 0,
+  };
+  /** Codex 9th Evaluator エッジケース 2 反映: streaming yield count を計測し candidatesIn と照合 */
+  let streamingDocsObserved = 0;
+
+  let chunkIndex = 0;
+
+  async function flushChunk(): Promise<void> {
+    if (verifiedDocsBuffer.length === 0 && fieldsMismatchBuffer.length === 0) return;
+    const pointer = await writePhaseDChunk(
+      {
+        bucketName: input.artifactBucketName,
+        runId: input.runId,
+        chunkIndex,
+        verifiedDocs: verifiedDocsBuffer,
+        fieldsMismatchDocs: fieldsMismatchBuffer,
+        mismatchedDocIds: Array.from(mismatchedDocIdsBuffer),
+      },
+      input.artifactWriter
+    );
+    chunks.push(pointer);
+    verifiedDocsBuffer = [];
+    fieldsMismatchBuffer = [];
+    mismatchedDocIdsBuffer = new Set<string>();
+    chunkIndex += 1;
+  }
+
+  for await (const writtenDoc of phaseCStream.writtenDocs()) {
+    streamingDocsObserved += 1;
+    const observed = await input.docReader.readDoc(writtenDoc.docId);
+    if (observed.provenanceBackfillRaw === null) {
+      provenanceBackfillNullCount += 1;
+    } else if (observed.provenanceBackfillRaw === undefined) {
+      // field 不在 = backfill が書込まれていない doc (Codex 9th Evaluator エッジケース 1)
+      provenanceBackfillAbsentCount += 1;
+    }
+
+    const result = verifyDoc({
+      observed,
+      expectedFromPhaseB: phaseBIndex.get(writtenDoc.docId),
+      expectedSha256FromPhaseC: writtenDoc.newProvenanceBackfillSha256,
+      backfillScriptVersion: input.backfillScriptVersion,
+    });
+
+    if (result.kind === 'verified') {
+      verifiedDocsBuffer.push({
+        docId: result.docId,
+        provenanceFieldsConsistent: result.provenanceFieldsConsistent,
+        provenanceBackfillSha256Match: result.provenanceBackfillSha256Match,
+        observedConfidence: result.observedConfidence,
+        observedCreatedAt: result.observedCreatedAt,
+      });
+      verifiedDocsTotal += 1;
+      confidenceDistribution[result.observedConfidence] += 1;
+      // Codex Critical 3 + code-reviewer H1 反映: verifyDoc 仕様上 verified ⇒ sha256Match=true 必須
+      if (!result.provenanceBackfillSha256Match) {
+        // 到達不能 (verifyDoc は sha256 mismatch を kind:mismatch で返す) だが防御
+        throw new Error(
+          `invariant violation: verifyDoc returned kind=verified with provenanceBackfillSha256Match=false (docId=${result.docId})`
+        );
+      }
+      if (result.provenanceFieldsConsistent) {
+        fieldsConsistent += 1;
+      }
+      if (result.createdAtConsistent) {
+        createdAtConsistent += 1;
+      } else if (result.createdAtMismatch) {
+        allCreatedAtMismatch.push(result.createdAtMismatch);
+      }
+    } else {
+      // mismatch case: field 単位レコード + doc 単位 Set
+      fieldsMismatchBuffer.push(...result.mismatches);
+      allFieldsMismatch.push(...result.mismatches);
+      mismatchedDocIdsBuffer.add(result.docId);
+      allMismatchedDocIds.add(result.docId);
+    }
+
+    if (
+      verifiedDocsBuffer.length + fieldsMismatchBuffer.length >=
+      PR_D4_CANDIDATES_PER_CHUNK
+    ) {
+      await flushChunk();
+    }
+  }
+  await flushChunk();
+
+  // rotate gate fixture test (dev のみ)
+  let rotateGateTest: PhaseDRotateGateTestResult | null = null;
+  if (input.env === 'dev' && input.rotateGateFixtureEnabled) {
+    if (
+      !input.fixtureStore ||
+      !input.rotateApiCaller ||
+      !input.fixturePdfBytesVerified ||
+      !input.fixturePdfBytesChildSnapshotOnly
+    ) {
+      throw new Error(
+        'rotateGateFixtureEnabled=true requires fixtureStore + rotateApiCaller + fixturePdfBytesVerified + fixturePdfBytesChildSnapshotOnly'
+      );
+    }
+    rotateGateTest = await runRotateGateFixtureTest({
+      env: input.env,
+      runId: input.runId,
+      pdfBytesVerified: input.fixturePdfBytesVerified,
+      pdfBytesChildSnapshotOnly: input.fixturePdfBytesChildSnapshotOnly,
+      fixtureStore: input.fixtureStore,
+      rotateApiCaller: input.rotateApiCaller,
+    });
+  }
+
+  // Phase D の "verify 対象" = Phase C writtenDocs (= Phase D が再読込 + verify した doc 数)
+  // Phase C "backfillAttempt 母集団" = Phase C candidatesIn (= Phase B revalidated 全件、書込試行した母集団)
+  // Codex 10th Important 1 反映: backfillAttemptCoverage 分母は phaseCSummary.candidatesIn が正しい
+  const verifyTargetDocs = phaseCStream.writtenDocsIn;
+  const phaseCSummary = phaseCStream.phaseCSummary;
+  const backfillAttemptDenominator = phaseCSummary.candidatesIn;
+
+  // streaming yield count vs verify 対象 doc 数 保全式 (Codex 9th Evaluator エッジケース 2)
+  if (streamingDocsObserved !== verifyTargetDocs) {
+    throw new Error(
+      `invariant violation: streaming yielded ${streamingDocsObserved} docs but Phase C summary writtenDocs=${verifyTargetDocs} (chunk truncation 可能性)`
+    );
+  }
+
+  // doc 単位保全式 (Codex 9th Critical 3): verifyTargetDocs 内訳
+  const mismatchedDocCount = allMismatchedDocIds.size;
+  if (verifiedDocsTotal + mismatchedDocCount !== verifyTargetDocs) {
+    throw new Error(
+      `invariant violation: verifiedDocs(${verifiedDocsTotal}) + mismatchedDocCount(${mismatchedDocCount}) !== verifyTargetDocs(${verifyTargetDocs})`
+    );
+  }
+
+  // coverage 比率算出 (Codex 7th Important 4 + 10th Important 1 反映)
+  // - backfillAttemptCoverage: Phase B revalidated 全件 (= phaseC.candidatesIn) を母集団とする
+  //   「backfill 試行した全 docs に対する各 outcome の比率」
+  // - estateRotateReadyCoverage: Phase A totalDocs を母集団とする「env 全体で rotate 可能な比率」(BF15 主指標)
+  const verifiedConfidenceCount = confidenceDistribution['derived-bytes-verified'];
+  const childSnapshotCount = confidenceDistribution['child-snapshot-only'];
+  const metadataOnlyCount = confidenceDistribution['metadata-only'];
+  const safeDiv = (numer: number, denom: number): number => (denom === 0 ? 0 : numer / denom);
+  const preconditionFailedCount = phaseCSummary.preconditionFailedDocs;
+  const immutableSkippedCount = phaseCSummary.skippedImmutable;
+
+  const coverageRatio: PhaseDCoverageRatio = {
+    backfillAttemptCoverage: {
+      // Codex 10th Important 1 反映: 分母は phaseC.candidatesIn (Phase B revalidated 全件)
+      denominator: backfillAttemptDenominator,
+      derivedBytesVerified: safeDiv(verifiedConfidenceCount, backfillAttemptDenominator),
+      childSnapshotOnly: safeDiv(childSnapshotCount, backfillAttemptDenominator),
+      metadataOnly: safeDiv(metadataOnlyCount, backfillAttemptDenominator),
+      preconditionFailed: safeDiv(preconditionFailedCount, backfillAttemptDenominator),
+      immutableSkipped: safeDiv(immutableSkippedCount, backfillAttemptDenominator),
+    },
+    estateRotateReadyCoverage: {
+      denominator: phaseACount.totalDocs,
+      verifiedExisting: safeDiv(phaseACount.verifiedExistingProvenance, phaseACount.totalDocs),
+      backfilledDerivedBytesVerified: safeDiv(verifiedConfidenceCount, phaseACount.totalDocs),
+      rotateReadyTotal: safeDiv(
+        phaseACount.verifiedExistingProvenance + verifiedConfidenceCount,
+        phaseACount.totalDocs
+      ),
+      notRotateReady: safeDiv(
+        phaseACount.totalDocs - (phaseACount.verifiedExistingProvenance + verifiedConfidenceCount),
+        phaseACount.totalDocs
+      ),
+    },
+  };
+
+  const verifyCompletedAt = now().toISOString();
+  const fieldsMismatchCount = allFieldsMismatch.length;
+  const createdAtMismatchCount = allCreatedAtMismatch.length;
+
+  // 検証失敗判定 (Codex 9th Important 3 反映、CLI exit non-zero 用)
+  const fixtureFailure =
+    rotateGateTest !== null &&
+    (rotateGateTest.derivedBytesVerified.rotateApiResult !== 'success' ||
+      rotateGateTest.childSnapshotOnly.rotateApiResult !== 'rejected' ||
+      rotateGateTest.fixtureCleanupFailures.length > 0);
+  const hasVerificationFailure =
+    mismatchedDocCount > 0 ||
+    createdAtMismatchCount > 0 ||
+    provenanceBackfillNullCount > 0 ||
+    fixtureFailure;
+
+  const finalizeResult = await finalizePhaseDArtifact(
+    {
+      bucketName: input.artifactBucketName,
+      runId: input.runId,
+      env: input.env,
+      verifyStartedAt: input.verifyStartedAt,
+      verifyCompletedAt,
+      phaseAArtifactRef: phaseCStream.phaseAArtifactRef,
+      phaseBArtifactRef: phaseCStream.phaseBArtifactRef,
+      phaseCArtifactRef: phaseCStream.phaseCArtifactRef,
+      phaseCManifestSha256: phaseCStream.phaseCManifestSha256,
+      candidatesIn: verifyTargetDocs,
+      verifiedDocs: verifiedDocsTotal,
+      fieldsConsistent,
+      fieldsMismatch: allFieldsMismatch,
+      mismatchedDocCount,
+      createdAtConsistent,
+      createdAtMismatch: allCreatedAtMismatch,
+      confidenceDistribution,
+      provenanceBackfillNullCount,
+      provenanceBackfillAbsentCount,
+      rotateGateTest,
+      coverageRatio,
+      phaseACountReadOnly: phaseACount,
+      chunks,
+      existingManifest: phaseCStream.manifest,
+      manifestGeneration: phaseCStream.manifestGeneration,
+    },
+    input.artifactWriter
+  );
+
+  return {
+    candidatesIn: verifyTargetDocs,
+    verifiedDocs: verifiedDocsTotal,
+    fieldsConsistent,
+    fieldsMismatchCount,
+    mismatchedDocCount,
+    createdAtConsistent,
+    createdAtMismatchCount,
+    provenanceBackfillNullCount,
+    provenanceBackfillAbsentCount,
+    confidenceDistribution,
+    rotateGateTest,
+    coverageRatio,
+    mainArtifactPath: finalizeResult.mainArtifactPath,
+    manifestPath: finalizeResult.manifestPath,
+    finalizeStatusPath: finalizeResult.finalizeStatusPath,
+    manifestUpdateStatus: finalizeResult.manifestUpdateStatus,
+    hasVerificationFailure,
+    verifyCompletedAt,
+  };
+}
+
+// re-exports for adapters.ts / index.ts
+export type { ObservedDocState } from './docVerifier';
+export type { FixtureStore, RotateApiCaller } from './rotateGateFixtureTester';

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -464,3 +464,243 @@ export const PR_D4_PHASE_C_DEFAULT_RATE_LIMITER: PhaseCRateLimiterConfig = {
   tokensPerSecond: 100,
   burstCapacity: 100,
 } as const;
+
+// ============================================================================
+// Phase D types (impl-plan §4.4、AC BF10/BF11/BF12/BF13/BF15、Codex MCP 8th review GO 反映)
+// ============================================================================
+
+/**
+ * Phase D verify で検出した field mismatch 1 件 (impl-plan §4.4 + Codex 8th Suggestion 1)。
+ *
+ * `mismatchType` で運用切り分けを高速化:
+ * - `'provenance-field'`: `provenance` 10 fields のいずれか不一致 (e.g. sourceSha256 / derivedSha256)
+ * - `'backfill-field'`: `provenanceBackfill` Stage 1 field 単位検証で fail (method / confidence /
+ *   backfilledAt / evidence.*)
+ * - `'sha256'`: Stage 2 deterministic hash 比較で fail (factory 再 invoke 後の sha256 が Phase C
+ *   `newProvenanceBackfillSha256` と不一致)
+ * - `'missing-expected'`: Phase B candidate index に docId が無い (Phase C と Phase B の同期ズレ)
+ *
+ * Codex 8th Suggestion 2 反映: observed/expected は JSON scalar union + null。Timestamp や
+ * malformed object を記録するため、unknown を許容する側に振る (string 化された JSON 表現 OK)。
+ */
+export type PhaseDMismatchType =
+  | 'provenance-field'
+  | 'backfill-field'
+  | 'sha256'
+  | 'missing-expected';
+
+export interface PhaseDFieldMismatchDoc {
+  docId: string;
+  mismatchType: PhaseDMismatchType;
+  /**
+   * 不一致 field 名 (DocumentProvenance 10 keys + provenanceBackfill subfield、sha256 比較時は
+   * `'provenanceBackfill.sha256'`、missing-expected 時は `'__phaseBIndex'`)。
+   */
+  field: string;
+  /** observed value (Firestore document から取得)。`null` は不在 / 取得不能 */
+  observed: string | number | boolean | null;
+  /** expected value (Phase B computedProvenance / Phase C newProvenanceBackfillSha256 由来) */
+  expected: string | number | boolean | null;
+}
+
+/**
+ * Phase D で verify した 1 doc の成功記録 (Codex 8th Critical 1/2 反映)。
+ *
+ * - `provenanceFieldsConsistent`: provenance 10 fields すべて Phase B `computedProvenance` と一致
+ * - `provenanceBackfillSha256Match`: observed metadata を factory 再 invoke して sha256 化した結果が
+ *   Phase C `newProvenanceBackfillSha256` と一致 (Stage 2、deterministic hash 二重 validation)
+ * - `observedConfidence`: 取得した `provenanceBackfill.confidence` (`BackfillConfidence` の literal)
+ * - `observedCreatedAt`: provenance.createdAt の ISO8601 表現 (BF10 検証で document.createdAt と比較)
+ */
+export interface PhaseDVerifiedDoc {
+  docId: string;
+  provenanceFieldsConsistent: boolean;
+  provenanceBackfillSha256Match: boolean;
+  observedConfidence: BackfillConfidence;
+  observedCreatedAt: string;
+}
+
+/**
+ * dev 環境 rotate gate fixture test 結果 (BF12 / BF13)。
+ *
+ * fixture docId 形式 (Codex 8th 残課題回答 3 反映): `BF13_test_fixture_${runId}_${kind}_${uuid}`
+ * (kind = 'verified' | 'child_snapshot_only'、uuid = randomUUID()、prefix + UUID 二重識別)。
+ *
+ * 本番環境 (cocoro / kanameone) では本 field は `null` (read-only verification のみ、Codex 3rd I6
+ * + 7th 回答 6 反映、本番に rotate side effect ゼロを保証)。
+ */
+export interface PhaseDRotateGateTestResult {
+  /** `derived-bytes-verified` fixture で rotate 成功 (BF12) */
+  derivedBytesVerified: {
+    fixtureDocId: string;
+    rotateApiResult: 'success' | 'rejected';
+    rotatedAt: string | null;
+    rejectionMessage: string | null;
+  };
+  /** `child-snapshot-only` fixture で failed-precondition reject (BF13) */
+  childSnapshotOnly: {
+    fixtureDocId: string;
+    rotateApiResult: 'success' | 'rejected';
+    rotatedAt: string | null;
+    rejectionMessage: string | null;
+  };
+  /**
+   * cleanup hook で削除しきれなかった fixture (operator 目視削除を artifact に明示、
+   * Codex 8th Important 2 反映)。
+   */
+  fixtureCleanupFailures: Array<{
+    fixtureDocId: string;
+    objectPath: string | null;
+    error: string;
+  }>;
+}
+
+/**
+ * Phase D coverage 比率 (2 系統、BF15 主指標 + 補助指標、Codex 7th Important 4 反映)。
+ *
+ * 設計:
+ * - `backfillAttemptCoverage`: Phase C candidatesIn (本 run で backfill 試行した母集団) 基準。
+ *   分母 = `phaseC.candidatesIn`、各カテゴリの ratio (0.0-1.0)
+ * - `estateRotateReadyCoverage`: Phase A totalDocs (env 全 documents) 基準。**BF15 主指標**。
+ *   分母 = `phaseA.totalDocs`、kanameone 全体で rotate 可能な状態の比率を直接表現
+ *
+ * 保全式: `estateRotateReadyCoverage.rotateReadyTotal + notRotateReady === totalDocs`
+ */
+export interface PhaseDCoverageRatio {
+  backfillAttemptCoverage: {
+    denominator: number;
+    derivedBytesVerified: number;
+    childSnapshotOnly: number;
+    metadataOnly: number;
+    preconditionFailed: number;
+    immutableSkipped: number;
+  };
+  estateRotateReadyCoverage: {
+    denominator: number;
+    verifiedExisting: number;
+    backfilledDerivedBytesVerified: number;
+    rotateReadyTotal: number;
+    notRotateReady: number;
+  };
+}
+
+/**
+ * Phase D verify 1 chunk (BF22、1 chunk ≤ PR_D4_CANDIDATES_PER_CHUNK)。
+ *
+ * Codex 9th Critical 3 / Evaluator HIGH / code-reviewer H1 反映:
+ * `fieldsMismatch` は **field 単位レコード** 配列。1 doc に複数 field mismatch がある場合、複数件記録される。
+ * doc 数の保全式には `mismatchedDocIds` (Set 由来の集計、type は string[]) を使う。
+ *
+ * 保全式 (chunk 全件、doc 単位):
+ *   verifiedDocs.length + uniqueMismatchedDocIds.length === 該当 chunk に渡された Phase C
+ *   writtenDocs 件数
+ */
+export interface PhaseDVerifyChunk {
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  chunkIndex: number;
+  verifiedDocs: PhaseDVerifiedDoc[];
+  fieldsMismatchDocs: PhaseDFieldMismatchDoc[];
+  /** chunk 内で mismatch を起こした unique docId 集合 (doc 単位保全式の検証用) */
+  mismatchedDocIds: string[];
+}
+
+/**
+ * Phase D main artifact 構造 (impl-plan §4.4 + Codex 7th/8th review 反映)。
+ *
+ * 設計:
+ * - `candidatesIn`: Phase C writtenDocs 総数 (Phase D verify 対象)
+ * - `verifiedDocs`: Phase D で再読込 + field 整合 verify 成功した件数 (= chunks の verifiedDocs 合計)
+ * - `fieldsConsistent`: provenance 10 fields + provenanceBackfill 全 verify 成功
+ * - `fieldsMismatch`: chunks の fieldsMismatchDocs 全件 (BF11 違反の集計)
+ * - `createdAtConsistent`: `provenance.createdAt === document.createdAt` を満たした件数 (BF10)
+ * - `confidenceDistribution`: observed confidence の集計 (BF11、Phase B 期待と比較)
+ * - `provenanceBackfillNullCount`: Codex 8th 回答 4 反映、`provenanceBackfill === null` 件数を
+ *   事前検知 (fail-closed 変更前の影響予測)
+ * - `rotateGateTest`: dev のみ存在、cocoro/kanameone は `null`
+ * - `coverageRatio`: 2 系統 (Codex 7th Important 4)
+ * - `phaseACountReadOnly`: Phase A summary を Phase D が取り込む (Codex 7th Important 5)
+ * - `phaseBArtifactRef` / `phaseCArtifactRef`: manifest chain authority (Codex 8th 回答 5 反映)
+ * - `manifestUpdateStatus`: CAS update 結果 (Codex 8th Important 3 反映、`'pending'` で main 書込、
+ *   CAS 後別 status file で結果記録)
+ *
+ * 保全式 (top-level、Codex 10th Important 2 反映で doc 単位に修正):
+ *   verifiedDocs + mismatchedDocCount === candidatesIn (= Phase C writtenDocs、Phase D verify 対象)
+ *   createdAtConsistent + createdAtMismatch.length === verifiedDocs (verified 内訳)
+ *   streamingDocsObserved === candidatesIn (chunk truncation 検出、orchestrator runtime check)
+ *   result.kind === 'verified' ⇒ provenanceBackfillSha256Match === true (verifyDoc 仕様、defensive throw)
+ *   estateRotateReadyCoverage.rotateReadyTotal + notRotateReady === 1.0
+ *
+ * 注: `fieldsConsistent` は「provenance 10 fields + provenanceBackfill Stage 1/2 全 pass」の doc 数。
+ *     `mismatchedDocCount` (doc 単位) と `fieldsMismatch.length` (field 単位レコード合計) は別概念。
+ *     1 doc が複数 field mismatch を起こすと fieldsMismatch.length > mismatchedDocCount となる。
+ */
+export interface PhaseDVerifySummary {
+  phase: 'D';
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  scriptVersion: PrD4ScriptVersion;
+  env: BackfillEnvName;
+  runId: string;
+  phaseAArtifactRef: string;
+  phaseBArtifactRef: string;
+  phaseCArtifactRef: string;
+  phaseCManifestSha256: string;
+  verifyStartedAt: string;
+  verifyCompletedAt: string;
+  candidatesIn: number;
+  /**
+   * verifyDoc が verified を返却した doc 数 (sha256 only mismatch 含まず、mismatch 経路は別途集計)。
+   * Codex 9th Critical 3 + Evaluator HIGH 反映で doc 単位カウントを厳密化。
+   */
+  verifiedDocs: number;
+  /** 完全一致 doc 数 (provenance 10 fields + provenanceBackfill Stage 1/2 全 pass) */
+  fieldsConsistent: number;
+  /**
+   * field 単位 mismatch レコード (1 doc に複数 field mismatch あれば複数件)。
+   * doc 数の集計は `mismatchedDocCount` で別途保持。
+   */
+  fieldsMismatch: PhaseDFieldMismatchDoc[];
+  /** field 単位 mismatch を起こした unique doc 数 (保全式: verifiedDocs + mismatchedDocCount === candidatesIn) */
+  mismatchedDocCount: number;
+  createdAtConsistent: number;
+  createdAtMismatch: PhaseDFieldMismatchDoc[];
+  confidenceDistribution: Record<BackfillConfidence, number>;
+  /** Codex 8th 回答 4: provenanceBackfill === null の件数 (fail-closed 変更前影響予測) */
+  provenanceBackfillNullCount: number;
+  /** Codex 9th Evaluator エッジケース 1: provenanceBackfill field absent (undefined) の件数 */
+  provenanceBackfillAbsentCount: number;
+  rotateGateTest: PhaseDRotateGateTestResult | null;
+  coverageRatio: PhaseDCoverageRatio;
+  /** Codex 7th Important 5: Phase A read-only count を Phase D summary に統合 */
+  phaseACountReadOnly: {
+    totalDocs: number;
+    alreadyBackfilled: number;
+    verifiedExistingProvenance: number;
+    categoryDistribution: Record<BackfillClassifierCategory, number>;
+  };
+  /**
+   * Codex 8th Important 3 反映: main artifact 書込 → CAS update の 2 段階で行うため、main
+   * 書込時点では `'pending'` を入れる。CAS 結果は別 status file (`phase-d-finalize-status.json`)
+   * に記録し、main artifact は overwrite しない (artifact writer の `ifGenerationMatch: 0` semantics
+   * 維持)。
+   */
+  manifestUpdateStatus: 'pending';
+  chunks: ArtifactChunkPointer[];
+}
+
+/**
+ * Phase D finalize 結果ステータス (Codex 8th Important 3 反映)。
+ *
+ * main artifact とは独立した別 file に書込 (`phase-d-finalize-status.json`)。CAS 失敗時に main
+ * artifact を上書きせず、operator が「main artifact は authoritative ではない」を判断する材料。
+ */
+export interface PhaseDFinalizeStatus {
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  runId: string;
+  env: BackfillEnvName;
+  finalizedAt: string;
+  /** 'ok' = CAS 成功、'failed' = CAS で 412 PreconditionFailed (別 process が manifest 書換) */
+  manifestUpdateStatus: 'ok' | 'failed';
+  expectedGeneration: string;
+  /** CAS 失敗時のリトライ手順 (operator 用) */
+  remediation?: string;
+}


### PR DESCRIPTION
## Summary

Issue #445 PR-D4 S1-5 (Phase D 実装) = backfill 後の Firestore + GCS 整合確認 + rotate gate behavior 拡張 (BF12/BF13/BF15)。

PR-D4 series で **本番 callable `rotatePdfPages` の挙動を変更する最初の PR**。Codex MCP review 11 round (impl-plan 段階 7 + 実装段階 4) で Critical 8 + Important 12 + Suggestion 全件反映、11th = GO 判定取得。

- **rotate gate 拡張**: `shouldRejectRotateForBackfill` pure helper (functions/src/pdf/rotateGate.ts) で provenanceBackfill fail-closed gate。`null` / malformed / 不明 confidence / 低 confidence 全 reject。derived-bytes-verified では evidence 3 field 全 true 必須 (ADR-0016 MUST 3 拡張)
- **Phase D verify**: Stage 1 (provenance 10 fields field-by-field + provenanceBackfill 単位検証) + Stage 2 (factory 再 invoke で sha256 比較、cross-process determinism 反映) で false positive 構造的排除
- **manifest chain authority**: Phase C manifest 起点で phaseA/B/C 全 main artifact sha256 verify、Phase B in-memory index 構築
- **2 系統 coverage**: `backfillAttemptCoverage` (Phase C candidatesIn 分母) + `estateRotateReadyCoverage` (Phase A totalDocs 分母、BF15 主指標)
- **dev fixture rotate test**: disposable fixture + try/finally cleanup hook (dev hard gate + prefix allowlist + generation precondition + cleanup 失敗 artifact 記録)、本番では `null` で副作用ゼロ
- **CAS update 3 段構造**: main artifact (manifestUpdateStatus: 'pending') → manifest CAS → 別 status file (`phase-d-finalize-status.json`)

## 変更ファイル (17 files / +4470/-4)

- `functions/src/pdf/rotateGate.ts` (新規 117 LoC) — pure helper
- `functions/src/pdf/pdfOperations.ts` (+15 LoC) — rotate gate guard 追加
- `scripts/pr-d4-backfill/phase-d/` (7 新規 module、+2095 LoC)
- `scripts/pr-d4-backfill/types.ts` (+240 LoC) — Phase D schemas
- `scripts/pr-d4-backfill/index.ts` (+131/-4) — `--phase D` CLI + exit code policy
- Tests: 92 件新規 (rotateGate 20 + docVerifier 18 + artifactReader 5 + artifactWriter 3 + rotateGateFixtureTester 8 + verifyOrchestrator 9 + rotatePdfPagesContract grep 2)

## Acceptance Criteria

| AC | 内容 | 判定 |
|---|---|:--:|
| BF10 | provenance.createdAt === document.createdAt | PASS |
| BF11 | confidence 分布 artifact 化 | PASS (Phase B 期待との自動比較は将来課題) |
| BF12 | derived-bytes-verified で rotate 成功 | PASS |
| BF13 | child-snapshot-only で failed-precondition reject | PASS |
| BF15 | 2 系統 coverage を artifact 化 | PASS |
| BF22 | chunked streaming + manifest sha256 verify | PASS |

## 保全式 (orchestrator runtime throw)

\`\`\`
verifiedDocs + mismatchedDocCount === candidatesIn (= Phase C writtenDocs)
streamingDocsObserved === candidatesIn (chunk truncation 検出)
result.kind === 'verified' ⇒ provenanceBackfillSha256Match === true (defensive)
estateRotateReadyCoverage.rotateReadyTotal + notRotateReady === 1.0
\`\`\`

## Quality Gate

- TDD (RED→GREEN→REFACTOR) 各 module
- `/simplify` + `/safe-refactor`: lint clean
- evaluator (AC strict 評価): REQUEST_CHANGES → 全件反映後 PASS
- pr-review-toolkit:code-reviewer: HIGH 2 + MEDIUM 4 + LOW 4 → 全件反映
- Codex MCP review (impl-plan 7 round + 実装 4 round): NO-GO → GO with fixes → **11th GO**

## Test plan

- [x] `npm test` (functions): 1370 passing (前 1305 → +65)
- [x] `npm run build` (functions): tsc pass
- [x] `npm run lint` (functions): 0 errors / 25 warnings (既存)
- [x] frontend `tsc --noEmit`: pass
- [x] CLI `ts-node --transpile-only scripts/pr-d4-backfill/index.ts` 起動確認 (引数不足 FATAL まで到達)
- [ ] **PR merge 後**: S1-6 (Dockerfile + workflow) で `ts-node --transpile-only` 固定運用を lock
- [ ] **PR merge 後**: S1-7 (container build/push、dev) で image tag 取得
- [ ] **S2 stage 以降**: dev rehearsal 7-stage × 2 周 で実 rotate fixture cleanup 実測
- [ ] **Codex 11th 注記**: PR 作成前の 12th review 不要、次に必要な review は S1-6 Dockerfile/workflow

## 既存 verified doc への影響

legacy provenance (provenance あり + provenanceBackfill 無し = PR-D2/D3 verified) は **引続き rotate 可能**:
- `shouldRejectRotateForBackfill(undefined)` → null 返却 → allow
- 既存 AC12 guard (provenance 不在 → reject) は維持

## 関連

- Refs #445 (PR-D4 series Phase D)
- Refs #432 (P0 silent corruption 構造的閉鎖)
- ADR-0016 MUST 3 拡張 + MUST 6 / MUST 7
- impl-plan: docs/specs/pr-d4-backfill-impl-plan.md §4.4 + §5
- 既存 PR-D4 series: PR #462 (S1-1) / #464 (S1-2) / #466 (S1-3) / #469 (S1-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)