### PR TITLE
fix(pr-d4): Cloud Build を --async + polling に変更 (S1-7 rehearsal 発見)

### DIFF
--- a/.github/workflows/pr-d4-backfill.yml
+++ b/.github/workflows/pr-d4-backfill.yml
@@ -199,7 +199,7 @@ jobs:
             exit 1
           fi
 
-      - name: Build container image (Cloud Build) + digest pinning
+      - name: Build container image (Cloud Build, async + polling) + digest pinning
         id: build
         env:
           PROJECT_ID: ${{ steps.resolve.outputs.project_id }}
@@ -208,10 +208,54 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_URI="${CLOUD_RUN_LOCATION}-docker.pkg.dev/${PROJECT_ID}/pr-d4-backfill/pr-d4-backfill:${IMAGE_TAG}"
-          echo "Submitting Cloud Build: $IMAGE_URI"
-          gcloud builds submit \
+          echo "Submitting Cloud Build (async): $IMAGE_URI"
+          # S1-7 rehearsal: deploy SA が project Viewer 持っていても default logs bucket
+          # への stream は環境により fail しうるため --async submit + describe polling で
+          # log streaming を回避する。
+          BUILD_ID=$(gcloud builds submit \
             --tag="$IMAGE_URI" \
-            --project="$PROJECT_ID"
+            --project="$PROJECT_ID" \
+            --async \
+            --format='value(metadata.build.id)')
+          if [ -z "$BUILD_ID" ]; then
+            echo "ERROR: failed to obtain BUILD_ID" >&2
+            exit 1
+          fi
+          echo "BUILD_ID: $BUILD_ID"
+          # poll status (60min timeout = 240 iterations × 15s)
+          POLL_INTERVAL=15
+          MAX_ITERATIONS=240
+          ITERATION=0
+          while [ "$ITERATION" -lt "$MAX_ITERATIONS" ]; do
+            STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT_ID" --format='value(status)' 2>/dev/null || echo "UNKNOWN")
+            case "$STATUS" in
+              SUCCESS)
+                echo "Build succeeded after ${ITERATION} polls"
+                break
+                ;;
+              FAILURE|CANCELLED|TIMEOUT|EXPIRED|INTERNAL_ERROR)
+                echo "ERROR: Build failed with status: $STATUS" >&2
+                echo "Logs: https://console.cloud.google.com/cloud-build/builds/${BUILD_ID}?project=${PROJECT_ID}" >&2
+                exit 1
+                ;;
+              QUEUED|WORKING|PENDING)
+                echo "[${ITERATION}/${MAX_ITERATIONS}] Status: $STATUS, waiting ${POLL_INTERVAL}s..."
+                sleep "$POLL_INTERVAL"
+                ITERATION=$((ITERATION + 1))
+                ;;
+              *)
+                echo "WARN: Unexpected status '$STATUS', waiting ${POLL_INTERVAL}s and retrying..." >&2
+                sleep "$POLL_INTERVAL"
+                ITERATION=$((ITERATION + 1))
+                ;;
+            esac
+          done
+          if [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
+            echo "ERROR: Build polling timed out after $((MAX_ITERATIONS * POLL_INTERVAL))s" >&2
+            exit 1
+          fi
+          BUILD_SA=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT_ID" --format='value(serviceAccount)' 2>/dev/null || echo "unknown")
+          echo "actual Cloud Build SA: $BUILD_SA"
           # digest pinning (S2 suggestion 反映): tag は mutable のため digest を deploy に渡す
           IMAGE_DIGEST=$(gcloud artifacts docker images describe "$IMAGE_URI" \
             --format='value(image_summary.fully_qualified_digest)' \
@@ -408,7 +452,7 @@ jobs:
             echo "image_tag=$IMAGE_TAG"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build container image (Cloud Build) + digest pinning
+      - name: Build container image (Cloud Build, async + polling) + digest pinning
         id: build
         env:
           PROJECT_ID: ${{ steps.resolve.outputs.project_id }}
@@ -417,9 +461,37 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_URI="${CLOUD_RUN_LOCATION}-docker.pkg.dev/${PROJECT_ID}/pr-d4-backfill/pr-d4-backfill:${IMAGE_TAG}"
-          gcloud builds submit \
+          BUILD_ID=$(gcloud builds submit \
             --tag="$IMAGE_URI" \
-            --project="$PROJECT_ID"
+            --project="$PROJECT_ID" \
+            --async \
+            --format='value(metadata.build.id)')
+          if [ -z "$BUILD_ID" ]; then
+            echo "ERROR: failed to obtain BUILD_ID" >&2
+            exit 1
+          fi
+          POLL_INTERVAL=15
+          MAX_ITERATIONS=240
+          ITERATION=0
+          while [ "$ITERATION" -lt "$MAX_ITERATIONS" ]; do
+            STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT_ID" --format='value(status)' 2>/dev/null || echo "UNKNOWN")
+            case "$STATUS" in
+              SUCCESS) break ;;
+              FAILURE|CANCELLED|TIMEOUT|EXPIRED|INTERNAL_ERROR)
+                echo "ERROR: Build failed with status: $STATUS" >&2
+                echo "Logs: https://console.cloud.google.com/cloud-build/builds/${BUILD_ID}?project=${PROJECT_ID}" >&2
+                exit 1
+                ;;
+              QUEUED|WORKING|PENDING|*)
+                sleep "$POLL_INTERVAL"
+                ITERATION=$((ITERATION + 1))
+                ;;
+            esac
+          done
+          if [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
+            echo "ERROR: Build polling timed out" >&2
+            exit 1
+          fi
           IMAGE_DIGEST=$(gcloud artifacts docker images describe "$IMAGE_URI" \
             --format='value(image_summary.fully_qualified_digest)' \
             --project="$PROJECT_ID")


### PR DESCRIPTION
## Summary

S1-7 dev rehearsal で `gcloud builds submit` が default logs bucket への log stream に失敗し exit 1 を返す現象を確認。build 自体は **SUCCESS**（image は push 済）だが、log stream エラーで以降の deploy / execute step がスキップされる。

deploy SA `docsplit-cloud-build@doc-split-dev` に以下を付与しても再現:
- `roles/viewer`
- `roles/logging.viewer`
- `roles/cloudbuild.builds.viewer`

そのため log streaming 経路を回避する `--async` + describe polling パターンに変更。

## 主な変更

- `gcloud builds submit --async` で BUILD_ID 取得 (log streaming なし)
- `gcloud builds describe` で 15s 間隔 polling (60min timeout = 240 iterations)
- terminal status 識別 (`SUCCESS` / `FAILURE` / `CANCELLED` / `TIMEOUT` / `EXPIRED` / `INTERNAL_ERROR`)
- `BUILD_SA` を log 出力 (S1-7 rehearsal #6 README 更新の素材)
- deploy-dev / deploy-prod 両 job に同パターン適用

## S1-7 rehearsal 実証

| 試行 | run | 結果 | 原因 |
|---|---|---|---|
| 1 | `25916014272` | Cloud Build SUCCESS、gcloud exit 1 | log stream 失敗 |
| 2 | `25916182555` | 同上 (`logging.viewer` 付与後) | 同 |
| 3 | `25916347944` | 同上 (`roles/viewer` 付与後) | 同 |
| Build SUCCESS 確認 | `de0f4d3c-05b8-473d-a84a-19bdfaf44a45` | SA = `217393576593-compute@developer.gserviceaccount.com` | README §5 想定通り |

## Test plan

- [x] yaml syntax 検証 (`python3 -c yaml.safe_load`) pass
- [x] actionlint 0 exit
- [x] git diff 79+/7- 範囲確認、両 Build step (deploy-dev / deploy-prod) に同パターン
- [ ] Merge 後の S1-7 再 dispatch (env=dev, phase=A) で build + deploy + execute まで完走

## Net 計測

Before: open Issues = 4 (#432 P0, #402 P2, #251 P2, #238 P2)
After: open Issues = 4 (変化なし)
**Net 0** (Issue #432 P0 復旧経路 = PR-D4 S1-7 の不具合修正)

## References

- Issue #432 / #445
- session77 handoff (S1-6 main merge `4299ec8`)
- 公式: https://cloud.google.com/build/docs/securing-builds/use-custom-service-accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)