### PR TITLE
fix(pr-d4): --async build の format を metadata.build.id → id に修正

### DIFF
--- a/.github/workflows/pr-d4-backfill.yml
+++ b/.github/workflows/pr-d4-backfill.yml
@@ -216,7 +216,7 @@ jobs:
             --tag="$IMAGE_URI" \
             --project="$PROJECT_ID" \
             --async \
-            --format='value(metadata.build.id)')
+            --format='value(id)')
           if [ -z "$BUILD_ID" ]; then
             echo "ERROR: failed to obtain BUILD_ID" >&2
             exit 1
@@ -465,7 +465,7 @@ jobs:
             --tag="$IMAGE_URI" \
             --project="$PROJECT_ID" \
             --async \
-            --format='value(metadata.build.id)')
+            --format='value(id)')
           if [ -z "$BUILD_ID" ]; then
             echo "ERROR: failed to obtain BUILD_ID" >&2
             exit 1


### PR DESCRIPTION
## Summary

PR #477 で導入した `gcloud builds submit --async --format='value(metadata.build.id)'` が空文字列を返す問題を修正。

`metadata.build.id` は long-running operation の output schema であり、`--async` で直接返される Build resource には適用されない。正しい format は `value(id)`。

## 検証

| 項目 | コマンド | 結果 |
|---|---|---|
| 旧 format | `gcloud builds submit --async --format='value(metadata.build.id)'` | 空文字列 → exit 1 |
| 新 format | `gcloud builds list --format='value(id)'` で同 build を取得 | `5ba0e52f-5c76-4305-a649-458b3ff9bd57` ✅ |
| 実 build (前回 run の async submit) | `gcloud builds describe ... --format='value(status,id)'` | `WORKING` + id 取得可 |

## 変更範囲

| File | 変更 |
|---|---|
| `.github/workflows/pr-d4-backfill.yml` | +2/-2 (deploy-dev + deploy-prod 両 Build step) |

## Test plan

- [x] yaml syntax 検証 pass
- [x] git diff: 2 occurrences (deploy-dev L219 + deploy-prod L468) を `value(id)` に変更
- [ ] Merge 後の S1-7 再 dispatch (env=dev, phase=A) で BUILD_ID 取得 + polling + build success まで完走

## Net 計測

Before: open Issues = 4 (#432 P0, #402 P2, #251 P2, #238 P2)
After: open Issues = 4 (変化なし)
**Net 0** (Issue #432 P0 復旧経路 = PR-D4 S1-7 の不具合修正、PR #477 直接 follow-up)

## References

- PR #477 (1段階前の修正、--async + polling 導入)
- Issue #432 / #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)