### PR TITLE
fix(pr-d4): location を env var 経由に変更 (gcloud --args 重複 reject 回避)

### DIFF
--- a/.github/workflows/pr-d4-backfill.yml
+++ b/.github/workflows/pr-d4-backfill.yml
@@ -318,8 +318,11 @@ jobs:
         run: |
           set -euo pipefail
           # Codex I1 反映: --update-env-vars は 1 回に統合 (base + fixture env を comma-separated に組み立て)
-          ENV_VARS="FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BUCKET=${STORAGE_BUCKET},ARTIFACT_BUCKET=${ARTIFACT_BUCKET}"
-          ARGS_CSV="--env,${ENVIRONMENT},--phase,${PHASE},--run-id,${RUN_ID},--cloud-run-location,${CLOUD_RUN_LOCATION},--bucket-location,${BUCKET_LOCATION}"
+          # S1-7 fix (PR #478 follow-up): gcloud run jobs execute --args は同一 value
+          # の複数回指定 ("asia-northeast1" 等) を reject するため、location は
+          # env var 経由で container に渡す (container 側は env fallback 対応済)
+          ENV_VARS="FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BUCKET=${STORAGE_BUCKET},ARTIFACT_BUCKET=${ARTIFACT_BUCKET},CLOUD_RUN_LOCATION=${CLOUD_RUN_LOCATION},BUCKET_LOCATION=${BUCKET_LOCATION}"
+          ARGS_CSV="--env,${ENVIRONMENT},--phase,${PHASE},--run-id,${RUN_ID}"
           if [ "$IS_DEV_FIXTURE_RUN" = "true" ]; then
             ENV_VARS="${ENV_VARS},PR_D4_ROTATE_URL=${PR_D4_ROTATE_URL}"
             ARGS_CSV="${ARGS_CSV},--phase-d-rotate-fixture-mode,true"
@@ -535,8 +538,9 @@ jobs:
           JOB_NAME: ${{ steps.compute.outputs.job_name }}
         run: |
           set -euo pipefail
-          ENV_VARS="FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BUCKET=${STORAGE_BUCKET},ARTIFACT_BUCKET=${ARTIFACT_BUCKET}"
-          ARGS_CSV="--env,${ENVIRONMENT},--phase,${PHASE},--run-id,${RUN_ID},--cloud-run-location,${CLOUD_RUN_LOCATION},--bucket-location,${BUCKET_LOCATION}"
+          # S1-7 fix: location は env var 経由 (PR #478 follow-up、--args 重複 reject 回避)
+          ENV_VARS="FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BUCKET=${STORAGE_BUCKET},ARTIFACT_BUCKET=${ARTIFACT_BUCKET},CLOUD_RUN_LOCATION=${CLOUD_RUN_LOCATION},BUCKET_LOCATION=${BUCKET_LOCATION}"
+          ARGS_CSV="--env,${ENVIRONMENT},--phase,${PHASE},--run-id,${RUN_ID}"
           echo "Executing: $JOB_NAME (env=$ENVIRONMENT phase=$PHASE run_id=$RUN_ID)"
           gcloud run jobs execute "$JOB_NAME" \
             --region="$CLOUD_RUN_LOCATION" \

--- a/scripts/pr-d4-backfill/index.ts
+++ b/scripts/pr-d4-backfill/index.ts
@@ -98,10 +98,21 @@ async function main(): Promise<void> {
   // --cloud-run-location / --bucket-location は **明示指定必須**。default を与えると、
   // 実 bucket location を確認せず "asia-northeast1" を assume してしまい、
   // 別 region に作られた bucket への cross-region egress を見逃す (Codex MCP Important 1)
-  const cloudRunLocation = readArg('--cloud-run-location');
-  const bucketLocation = readArg('--bucket-location');
+  // gcloud run jobs execute --args は同一 value を複数回禁ずる挙動があるため、
+  // workflow yaml では args 経由ではなく env var 経由で渡す (S1-7 rehearsal 発見、 PR #478 follow-up)。
+  // CLI 引数を優先、env var を fallback として受け付け、ローカル実行と CI 両方を維持する。
+  const cloudRunLocation = readArg('--cloud-run-location') || process.env.CLOUD_RUN_LOCATION;
+  const bucketLocation = readArg('--bucket-location') || process.env.BUCKET_LOCATION;
   if (!cloudRunLocation || !bucketLocation) {
-    console.error('FATAL: --cloud-run-location and --bucket-location are required (no default).');
+    console.error(
+      'FATAL: cloud-run-location and bucket-location are required (no default).'
+    );
+    console.error(
+      '       Specify via --cloud-run-location / --bucket-location CLI args'
+    );
+    console.error(
+      '       or CLOUD_RUN_LOCATION / BUCKET_LOCATION env vars.'
+    );
     console.error('       bucket location 確認は egress 課金前提のため明示指定必須');
     process.exit(2);
   }


### PR DESCRIPTION
## Summary

S1-7 dev rehearsal で `gcloud run jobs execute --args` が同一 value `asia-northeast1` の複数回指定を reject する挙動を確認。`CLOUD_RUN_LOCATION` と `BUCKET_LOCATION` がともに `asia-northeast1`（dev/cocoro/kanameone とも同 region）の場合に必ず発火。

```
ERROR: (gcloud.run.jobs.execute) argument --args:
  "asia-northeast1" cannot be specified multiple times
```

回避のため location は CLI args から外し env var 経由で渡す設計に変更。

## 変更

### `.github/workflows/pr-d4-backfill.yml` (deploy-dev + deploy-prod 両 Execute step)
- `ENV_VARS` に `CLOUD_RUN_LOCATION` と `BUCKET_LOCATION` を追加
- `ARGS_CSV` から `--cloud-run-location` `--bucket-location` を削除
- comment で root cause + PR #478 follow-up を明記

### `scripts/pr-d4-backfill/index.ts`
- CLI args (`--cloud-run-location` / `--bucket-location`) 優先
- env vars (`CLOUD_RUN_LOCATION` / `BUCKET_LOCATION`) を fallback として受け付け
- 両方とも欠落時の error message を更新（CLI / env 両方の入力経路を案内）

ローカル CLI 実行（既存 test）と CI execute（新規 env var 経路）両方を維持。

## S1-7 rehearsal 実証

| 試行 | run | 結果 |
|---|---|---|
| 4 | `25917691573` | Build ✅ / Deploy ✅ / **Execute X**（args duplicate） |

## Test plan

- [x] yaml syntax 検証 (`yaml.safe_load`) pass
- [x] 1370 functions tests pass (container test 不変)
- [x] CLI args 優先 → env var fallback の動作は container 内 OR 演算で確実
- [ ] Merge 後の S1-7 再 dispatch (env=dev, phase=A) で Build / Deploy / Execute 全通過 + Phase A artifact 出力確認

## Backward compatibility

- ローカル `npx ts-node scripts/pr-d4-backfill/index.ts --cloud-run-location ... --bucket-location ...` は引続き動作
- container 既存 test は CLI args 経路のままなので影響なし

## Net 計測

Before: open Issues = 4 (#432 P0, #402 P2, #251 P2, #238 P2)
After: open Issues = 4 (変化なし)
**Net 0** (Issue #432 P0 復旧経路 = PR-D4 S1-7 不具合修正、PR #477 #478 follow-up)

## References

- PR #477 (--async + polling 導入)
- PR #478 (format path 修正)
- Issue #432 / #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cloud Run Job execution parameter handling to prevent duplicate-value errors during deployment.
  * Improved environment variable handling for location configuration in backfill operations, supporting fallback values when CLI arguments are not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/479)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->