### PR TITLE
fix(pr-d4): functions/src/pdf/provenance.ts を container に取り込む

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,8 +59,24 @@ frontend/tsconfig*.json
 frontend/postcss.config.*
 frontend/tailwind.config.*
 
-# functions (source 不要、PR-D4 backfill から依存なし)
-functions/src
+# functions (大半は source 不要だが PR-D4 backfill scripts は
+# `functions/src/pdf/provenance.ts` (factory + validation、shared/types 依存のみ) を import する。
+# pdf subdir を allowlist し、その中で provenance.ts のみ残す:
+functions/src/admin
+functions/src/documents
+functions/src/gmail
+functions/src/index.ts
+functions/src/ocr
+functions/src/search
+functions/src/storage
+functions/src/triggers
+functions/src/upload
+functions/src/utils
+functions/src/pdf/pdfOperations.ts
+functions/src/pdf/rotateGate.ts
+functions/src/pdf/rotationMerge.ts
+functions/src/pdf/splitDocumentBuilder.ts
+functions/src/pdf/splitSnapshot.ts
 functions/test
 functions/lib
 functions/tsconfig*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN npm ci \
 # source copy (functions/frontend の source は .dockerignore で排除)
 COPY scripts ./scripts
 COPY shared ./shared
+# PR-D4 backfill scripts は `functions/src/pdf/provenance.ts` を import するため、
+# 該当 file のみ allowlist で取り込む (.dockerignore で他 file は除外済)
+COPY functions/src/pdf/provenance.ts ./functions/src/pdf/provenance.ts
 # .firebaserc: container 内では project_id を env 経由で受け取るため runtime では不要だが、
 #   helpers/firebaserc-helper.js を将来 container 内で呼ぶ可能性に備えて copy
 COPY .firebaserc ./


### PR DESCRIPTION
## Summary

S1-7 dev rehearsal で Cloud Run Job 内で `MODULE_NOT_FOUND` を観測:

\`\`\`
Error: Cannot find module '../../../functions/src/pdf/provenance'
Require stack:
 - /app/scripts/pr-d4-backfill/phase-c/batchWriter.ts
 - /app/scripts/pr-d4-backfill/phase-c/backfillOrchestrator.ts
 - /app/scripts/pr-d4-backfill/index.ts
\`\`\`

S1-6 設計時に「functions/ source 不要」と誤判断したが、実際は PR-D4 scripts (phase-c batchWriter / individualRetryWriter + phase-d docVerifier) が `functions/src/pdf/provenance.ts` の factory + validation を import している。

## 変更

`functions/src/pdf/provenance.ts` の依存:
- `firebase-admin/firestore` (npm package)
- `../../../shared/types` (workspace)

他 functions source への依存はないため、最小限 allowlist で取り込む:

### `.dockerignore`
- `functions/src` 全体除外 → subdir 単位 (admin / documents / gmail / index.ts / ocr / search / storage / triggers / upload / utils) で除外
- `functions/src/pdf/` の 5 file (pdfOperations / rotateGate / rotationMerge / splitDocumentBuilder / splitSnapshot) は明示除外
- これにより `functions/src/pdf/provenance.ts` のみ container に取り込み可能

### `Dockerfile`
- `COPY functions/src/pdf/provenance.ts ./functions/src/pdf/provenance.ts` を追加

## S1-7 rehearsal 実証

| 試行 | run | 結果 |
|---|---|---|
| 5 | `25918338712` | Build ✅ / Deploy ✅ / **Execute X**（MODULE_NOT_FOUND） |

## Test plan

- [x] ローカル `docker build -t pr-d4-backfill:test .` 成功
- [x] container 内に `/app/functions/src/pdf/provenance.ts` 存在確認
- [x] container 内 `/app/functions/src/pdf/` には provenance.ts のみ（他 file は除外確認）
- [x] container 内 `/app/shared/` に types.ts 存在
- [x] 1370 functions tests pass (Dockerfile / .dockerignore のみ、test 不変)
- [ ] Merge 後の S1-7 再 dispatch (env=dev, phase=A) で Execute まで完走 + artifact 出力確認

## Backward compatibility

- container image size: provenance.ts (16KB) のみ追加、影響無視できる範囲
- container runtime 挙動: import path 解決のみ修正、business logic 不変

## Net 計測

Before: open Issues = 4 (#432 P0, #402 P2, #251 P2, #238 P2)
After: open Issues = 4 (変化なし)
**Net 0** (Issue #432 P0 復旧経路 = PR-D4 S1-7 不具合修正、PR #477 #478 #479 follow-up)

## References

- PR #477 / #478 / #479 (S1-7 rehearsal シリーズ)
- Issue #432 / #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)