### PR TITLE
feat(pr-d4): S6 rollback script (phase=E) 実装 — dev fixture provenance + provenanceBackfill field-only delete

### DIFF
--- a/.github/workflows/pr-d4-backfill.yml
+++ b/.github/workflows/pr-d4-backfill.yml
@@ -26,7 +26,7 @@ on:
           - cocoro
           - kanameone
       phase:
-        description: 'PR-D4 phase (A=audit, B=preflight, C=atomic backfill, D=verify+rotate gate)'
+        description: 'PR-D4 phase (A=audit, B=preflight, C=atomic backfill, D=verify+rotate gate, E=rollback dev fixtures, S6/BF24, dev-only)'
         required: true
         type: choice
         options:
@@ -34,6 +34,7 @@ on:
           - B
           - C
           - D
+          - E
       run_id:
         description: 'Run ID (optional, auto-generated if empty; must match ^[A-Za-z0-9._-]+$)'
         required: false
@@ -41,6 +42,14 @@ on:
         default: ''
       rotate_fixture_mode:
         description: 'Phase D rotate gate fixture test (dev + phase=D only; prod では常に false 強制)'
+        required: true
+        type: choice
+        default: 'false'
+        options:
+          - 'false'
+          - 'true'
+      confirm:
+        description: 'Phase E rollback で実 FieldValue.delete() を発行 (phase=E + dev のみ true 許可、デフォルト false=dry-run)'
         required: true
         type: choice
         default: 'false'
@@ -73,6 +82,7 @@ jobs:
           PHASE: ${{ github.event.inputs.phase }}
           RUN_ID: ${{ github.event.inputs.run_id }}
           ROTATE_FIXTURE_MODE: ${{ github.event.inputs.rotate_fixture_mode }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
         run: |
           set -euo pipefail
           # run_id 文字種 validate (Codex review I7 + 実装後 review: Docker tag 規約遵守)
@@ -96,7 +106,24 @@ jobs:
               exit 1
             fi
           fi
-          echo "Inputs validated: env=$ENVIRONMENT phase=$PHASE run_id=${RUN_ID:-<auto>} rotate_fixture_mode=$ROTATE_FIXTURE_MODE"
+          # Phase E (rollback) 制約 (S6 / BF24、Codex MCP 12th review I1 反映、env=dev 強制 + confirm 整合)
+          # deploy-dev job 自体が env=dev 限定なので env check は冗長だが defense in depth で明示
+          if [ "$PHASE" = "E" ]; then
+            if [ "$ENVIRONMENT" != "dev" ]; then
+              echo "ERROR: phase=E (rollback dev fixtures) requires environment=dev (got: env=$ENVIRONMENT)" >&2
+              exit 1
+            fi
+            if [ "$ROTATE_FIXTURE_MODE" = "true" ]; then
+              echo "ERROR: phase=E and rotate_fixture_mode=true are mutually exclusive" >&2
+              exit 1
+            fi
+          fi
+          # confirm=true は phase=E でのみ意味を持つ (他 phase で true を渡すと運用者誤認)
+          if [ "$CONFIRM" = "true" ] && [ "$PHASE" != "E" ]; then
+            echo "ERROR: confirm=true is only valid with phase=E (got: phase=$PHASE)" >&2
+            exit 1
+          fi
+          echo "Inputs validated: env=$ENVIRONMENT phase=$PHASE run_id=${RUN_ID:-<auto>} rotate_fixture_mode=$ROTATE_FIXTURE_MODE confirm=$CONFIRM"
 
       - uses: google-github-actions/auth@v2
         with:
@@ -309,6 +336,7 @@ jobs:
           BUCKET_LOCATION: ${{ steps.resolve.outputs.bucket_location }}
           ENVIRONMENT: ${{ github.event.inputs.environment }}
           PHASE: ${{ github.event.inputs.phase }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
           RUN_ID: ${{ steps.compute.outputs.run_id }}
           JOB_NAME: ${{ steps.compute.outputs.job_name }}
           IS_DEV_FIXTURE_RUN: ${{ steps.compute.outputs.is_dev_fixture_run }}
@@ -326,6 +354,10 @@ jobs:
           if [ "$IS_DEV_FIXTURE_RUN" = "true" ]; then
             ENV_VARS="${ENV_VARS},PR_D4_ROTATE_URL=${PR_D4_ROTATE_URL}"
             ARGS_CSV="${ARGS_CSV},--phase-d-rotate-fixture-mode,true"
+          fi
+          # Phase E (rollback) 専用: --confirm を args に追加 (S6 / BF24)
+          if [ "$PHASE" = "E" ]; then
+            ARGS_CSV="${ARGS_CSV},--confirm,${CONFIRM}"
           fi
           echo "Executing job: $JOB_NAME"
           echo "  args: $ARGS_CSV"
@@ -364,6 +396,7 @@ jobs:
           PHASE: ${{ github.event.inputs.phase }}
           RUN_ID: ${{ github.event.inputs.run_id }}
           ROTATE_FIXTURE_MODE: ${{ github.event.inputs.rotate_fixture_mode }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
         run: |
           set -euo pipefail
           if [ -n "$RUN_ID" ]; then
@@ -382,7 +415,18 @@ jobs:
             echo "ERROR: rotate_fixture_mode=true is dev-only (got env=$ENVIRONMENT)" >&2
             exit 1
           fi
-          echo "Inputs validated: env=$ENVIRONMENT phase=$PHASE run_id=${RUN_ID:-<auto>}"
+          # Phase E (rollback) は prod では一切実行禁止 (S6 / BF24、Codex MCP 12th review I1)
+          # workflow_dispatch.choice には残るが、deploy-prod job 側で hard reject。
+          # GitHub Environment reviewer も追加 gate になるが、本 step で先に止める (silent risk 排除)
+          if [ "$PHASE" = "E" ]; then
+            echo "ERROR: phase=E (rollback dev fixtures) is dev-only (got env=$ENVIRONMENT); workflow rejects on production envs" >&2
+            exit 1
+          fi
+          if [ "$CONFIRM" = "true" ]; then
+            echo "ERROR: confirm=true is only valid with phase=E (dev-only); rejected on production envs" >&2
+            exit 1
+          fi
+          echo "Inputs validated: env=$ENVIRONMENT phase=$PHASE run_id=${RUN_ID:-<auto>} confirm=$CONFIRM"
 
       - uses: google-github-actions/auth@v2
         with:

--- a/docs/specs/pr-d4-backfill-impl-plan.md
+++ b/docs/specs/pr-d4-backfill-impl-plan.md
@@ -629,7 +629,7 @@ PR-D2/D3 で integration fixtures が 28 件存在 (`scripts/fixtures/`)。PR-D4
 | S3 | Phase B 実行 (dev、dry-run なし) | `phase-b-revalidation-summary-dev-*.json` 生成、drift skip rate < 1% |
 | S4 | Phase C 実行 (dev、dry-run なし) | `phase-c-backfill-summary-dev-*.json` 生成、precondition 失敗 0 件 |
 | S5 | Phase D 実行 (dev、dry-run なし) | `phase-d-verify-summary-dev-*.json` 生成、rotate gate test 期待通り |
-| S6 (Codex 3rd I5/BF24 反映) | rollback rehearsal (dev): **PR-D4 が書いた fixture 限定** (`fixtureId.startsWith('BF_')` で query 限定) で `provenance` と `provenanceBackfill` の **両方を削除** + 再 Phase C → 同結果再現。**既存 verified provenance (`provenanceBackfill` absent) には適用しない** | rollback script 動作確認 + immutable skip 動作確認 |
+| S6 (Codex 3rd I5/BF24 + 12th I1 反映) | rollback rehearsal (dev): **PR-D4 が書いた fixture 限定** (`PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST = ['BF_', 'BF13_test_fixture_']`) で `provenance` と `provenanceBackfill` の **両方を `FieldValue.delete()` で field-only 削除** + 再 Phase C → 同結果再現。**既存 verified provenance (`provenanceBackfill` absent) には適用しない**。実装: `scripts/pr-d4-backfill/rollback/` 配下 + workflow yaml の `phase=E` + 3 段 hard gate (workflow + index.ts + orchestrator) + prefix allowlist 2 段適用 | rollback script (`phase=E`) 動作確認 + immutable skip 動作確認 + dry-run default + confirm 明示で実 delete |
 | S7 | 統合確認: Firestore Console で代表 doc 5 件目視 + GitHub Actions logs + GCS Console で artifact + manifest 目視 | ユーザー目視 OK |
 
 ### 9.2 2 周目 (1 周目で発覚した issue 修正後の再実行)

--- a/functions/test/prD4RollbackOrchestrator.test.ts
+++ b/functions/test/prD4RollbackOrchestrator.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Issue #445 PR-D4 S6: Rollback orchestrator 統合テスト.
+ *
+ * BF24 (Codex 3rd 追加) / Codex MCP 12th review I1 反映:
+ * dev fixture 限定 (prefix allowlist `BF_` / `BF13_test_fixture_`) で
+ * provenance + provenanceBackfill 双方を FieldValue.delete() し、既存 verified
+ * provenance (provenance exists && provenanceBackfill absent) は immutable skip する。
+ *
+ * AC1-AC6 を mocha + chai で網羅。AC7 (re-Phase C metric reproducibility) は
+ * dev rehearsal scope で本 unit test ではなく artifact diff で検証する。
+ */
+
+import { expect } from 'chai';
+import { runRollback } from '../../scripts/pr-d4-backfill/rollback/rollbackOrchestrator';
+import type {
+  DocRollbackSnapshot,
+  FirestoreRollbackReader,
+  FirestoreRollbackWriter,
+} from '../../scripts/pr-d4-backfill/rollback/rollbackOrchestrator';
+import type { ArtifactStorageWriter } from '../../scripts/pr-d4-backfill/phase-a/artifactWriter';
+import type {
+  BackfillEnvName,
+  PhaseRollbackSummary,
+} from '../../scripts/pr-d4-backfill/types';
+
+const RUN_ID = '20260516T010000Z-dev-pr-d4-rollback-v1';
+const ARTIFACT_BUCKET = 'doc-split-dev-pr-d4-artifacts';
+const EXPECTED_ARTIFACT_PATH =
+  `gs://${ARTIFACT_BUCKET}/pr-d4-backfill-artifacts/${RUN_ID}/phase-rollback-summary.json`;
+
+class FakeRollbackReader implements FirestoreRollbackReader {
+  private readonly docs: DocRollbackSnapshot[];
+
+  constructor(docs: DocRollbackSnapshot[]) {
+    this.docs = docs;
+  }
+
+  async *scanCandidateDocs(): AsyncIterable<DocRollbackSnapshot> {
+    for (const doc of this.docs) {
+      yield doc;
+    }
+  }
+}
+
+interface RecordedWriteCall {
+  docId: string;
+  deleteProvenance: boolean;
+  deleteProvenanceBackfill: boolean;
+}
+
+class RecordingRollbackWriter implements FirestoreRollbackWriter {
+  public calls: RecordedWriteCall[] = [];
+
+  async deleteProvenanceFields(input: {
+    docId: string;
+    deleteProvenance: boolean;
+    deleteProvenanceBackfill: boolean;
+  }): Promise<void> {
+    this.calls.push({ ...input });
+  }
+}
+
+interface RecordedArtifactCall {
+  path: string;
+  content: string;
+  precondition?: { ifGenerationMatch: number };
+}
+
+class RecordingArtifactWriter implements ArtifactStorageWriter {
+  public calls: RecordedArtifactCall[] = [];
+
+  async writeJson(
+    path: string,
+    content: string,
+    precondition?: { ifGenerationMatch: number }
+  ): Promise<void> {
+    this.calls.push({ path, content, precondition });
+  }
+}
+
+function snapshot(
+  docId: string,
+  hasProvenance: boolean,
+  hasProvenanceBackfill: boolean
+): DocRollbackSnapshot {
+  return { docId, hasProvenance, hasProvenanceBackfill };
+}
+
+function parseSummary(content: string): PhaseRollbackSummary {
+  return JSON.parse(content) as PhaseRollbackSummary;
+}
+
+describe('PR-D4 S6 rollback orchestrator (BF24 / Codex 12th I1)', () => {
+  describe('AC1: dev-only hard gate', () => {
+    it('env=cocoro で実行すると即 throw (cocoro/kanameone に rollback 適用しない、defense in depth)', async () => {
+      const reader = new FakeRollbackReader([]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      let caught: unknown;
+      try {
+        await runRollback({
+          env: 'cocoro' as BackfillEnvName,
+          runId: RUN_ID,
+          dryRun: true,
+          firestoreReader: reader,
+          firestoreWriter: writer,
+          artifactWriter,
+          artifactBucketName: ARTIFACT_BUCKET,
+          rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+          scriptVersion: 'pr-d4-v1.0',
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, 'cocoro で throw されなかった').to.exist;
+      expect((caught as Error).message).to.match(/dev-only/i);
+      // 副作用ゼロ確認 (writer / artifactWriter 未呼出)
+      expect(writer.calls).to.have.length(0);
+      expect(artifactWriter.calls).to.have.length(0);
+    });
+
+    it('env=kanameone で実行すると即 throw', async () => {
+      const reader = new FakeRollbackReader([]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      let caught: unknown;
+      try {
+        await runRollback({
+          env: 'kanameone' as BackfillEnvName,
+          runId: RUN_ID,
+          dryRun: true,
+          firestoreReader: reader,
+          firestoreWriter: writer,
+          artifactWriter,
+          artifactBucketName: ARTIFACT_BUCKET,
+          rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+          scriptVersion: 'pr-d4-v1.0',
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, 'kanameone で throw されなかった').to.exist;
+      expect((caught as Error).message).to.match(/dev-only/i);
+      expect(writer.calls).to.have.length(0);
+      expect(artifactWriter.calls).to.have.length(0);
+    });
+  });
+
+  describe('AC2: fixture prefix allowlist', () => {
+    it('BF_ / BF13_test_fixture_ / 任意 docId 混在で query → 前 2 つのみ target、その他は out-of-scope', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_alpha', true, true),
+        snapshot('BF13_test_fixture_beta', true, true),
+        snapshot('arbitrary_doc_gamma', true, true),
+        snapshot('another_random_id', true, true),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.scannedDocs).to.equal(4);
+      expect(summary.targetedDocs).to.equal(2);
+      expect(summary.skippedDocs).to.equal(2);
+      const outOfScopeIds = summary.skipped
+        .filter((s) => s.reason === 'out-of-scope')
+        .map((s) => s.docId)
+        .sort();
+      expect(outOfScopeIds).to.deep.equal(['another_random_id', 'arbitrary_doc_gamma']);
+
+      const targetIds = summary.targets.map((t) => t.docId).sort();
+      expect(targetIds).to.deep.equal(['BF13_test_fixture_beta', 'BF_alpha']);
+
+      // out-of-scope の writer 呼出ゼロ確認 (target 2 つのみ)
+      expect(writer.calls).to.have.length(2);
+      const writtenIds = writer.calls.map((c) => c.docId).sort();
+      expect(writtenIds).to.deep.equal(['BF13_test_fixture_beta', 'BF_alpha']);
+    });
+  });
+
+  describe('AC3: field-only delete (doc 自体は残存、他 fields 不変)', () => {
+    it('両 fields 存在 target で deleteProvenance=true + deleteProvenanceBackfill=true で writer 呼出', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_target_both', true, true),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      expect(writer.calls).to.deep.equal([
+        {
+          docId: 'BF_target_both',
+          deleteProvenance: true,
+          deleteProvenanceBackfill: true,
+        },
+      ]);
+
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.targets).to.deep.equal([
+        {
+          docId: 'BF_target_both',
+          status: 'executed',
+          deletedFields: ['provenance', 'provenanceBackfill'],
+        },
+      ]);
+    });
+
+    it('provenance のみ存在 (PR-D2/D3 split-time 由来) は immutable skip で writer 呼出ゼロ', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_only_provenance', true, false),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      expect(writer.calls).to.have.length(0);
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.skipped).to.deep.equal([
+        {
+          docId: 'BF_only_provenance',
+          reason: 'existing-verified-provenance',
+        },
+      ]);
+    });
+
+    it('provenanceBackfill のみ存在 (orphan PR-D4 残骸) は target、deletedFields=[provenanceBackfill]', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_only_backfill', false, true),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      expect(writer.calls).to.deep.equal([
+        {
+          docId: 'BF_only_backfill',
+          deleteProvenance: false,
+          deleteProvenanceBackfill: true,
+        },
+      ]);
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.targets[0]?.deletedFields).to.deep.equal(['provenanceBackfill']);
+    });
+  });
+
+  describe('AC4: immutable skip (existing verified provenance)', () => {
+    it('provenance exists && provenanceBackfill absent → existing-verified-provenance に分類', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_split_verified', true, false),
+        snapshot('BF13_test_fixture_split', true, false),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      expect(writer.calls).to.have.length(0);
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.targetedDocs).to.equal(0);
+      expect(summary.skippedDocs).to.equal(2);
+      const reasons = summary.skipped.map((s) => s.reason);
+      expect(reasons).to.deep.equal([
+        'existing-verified-provenance',
+        'existing-verified-provenance',
+      ]);
+    });
+
+    it('両 fields 不在 doc は no-provenance-fields に分類 (idempotent skip)', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_empty_doc', false, false),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      expect(writer.calls).to.have.length(0);
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.skipped).to.deep.equal([
+        { docId: 'BF_empty_doc', reason: 'no-provenance-fields' },
+      ]);
+    });
+  });
+
+  describe('AC5: dry-run (writer 呼出なし、artifact 記録あり)', () => {
+    it('dryRun=true なら target 識別はするが Firestore update は発行しない', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_target_a', true, true),
+        snapshot('BF13_test_fixture_b', true, true),
+        snapshot('random_x', true, true), // out-of-scope
+        snapshot('BF_split_only', true, false), // immutable skip
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: true,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      // writer 呼出ゼロ (核心)
+      expect(writer.calls).to.have.length(0);
+
+      // artifact には target / skip 判定を full 記録
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.dryRun).to.equal(true);
+      expect(summary.scannedDocs).to.equal(4);
+      expect(summary.targetedDocs).to.equal(2);
+      expect(summary.skippedDocs).to.equal(2);
+      // target.status 全 'dryRun'
+      expect(summary.targets.every((t) => t.status === 'dryRun')).to.equal(true);
+    });
+  });
+
+  describe('AC6: explicit confirm executes delete', () => {
+    it('dryRun=false なら target 全てで writer 呼出 + target.status=executed 記録', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_exec_a', true, true),
+        snapshot('BF13_test_fixture_exec_b', true, true),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+      });
+
+      expect(writer.calls).to.have.length(2);
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.dryRun).to.equal(false);
+      expect(summary.targets.every((t) => t.status === 'executed')).to.equal(true);
+    });
+  });
+
+  describe('artifact 構造 (schema + path) 検証', () => {
+    it('artifact path / phase / schemaVersion / scriptVersion / 保全式が impl-plan §4 と整合', async () => {
+      const reader = new FakeRollbackReader([
+        snapshot('BF_target', true, true),
+        snapshot('BF_skip_verified', true, false),
+        snapshot('outOfScope_x', true, true),
+      ]);
+      const writer = new RecordingRollbackWriter();
+      const artifactWriter = new RecordingArtifactWriter();
+
+      await runRollback({
+        env: 'dev',
+        runId: RUN_ID,
+        dryRun: false,
+        firestoreReader: reader,
+        firestoreWriter: writer,
+        artifactWriter,
+        artifactBucketName: ARTIFACT_BUCKET,
+        rollbackStartedAt: '2026-05-16T01:00:00.000Z',
+        scriptVersion: 'pr-d4-v1.0',
+        nowProvider: () => '2026-05-16T01:00:05.000Z',
+      });
+
+      expect(artifactWriter.calls).to.have.length(1);
+      expect(artifactWriter.calls[0]!.path).to.equal(EXPECTED_ARTIFACT_PATH);
+
+      const summary = parseSummary(artifactWriter.calls[0]!.content);
+      expect(summary.phase).to.equal('E');
+      expect(summary.schemaVersion).to.equal('pr-d4-v1.0');
+      expect(summary.scriptVersion).to.equal('pr-d4-v1.0');
+      expect(summary.env).to.equal('dev');
+      expect(summary.runId).to.equal(RUN_ID);
+      expect(summary.rollbackStartedAt).to.equal('2026-05-16T01:00:00.000Z');
+      expect(summary.rollbackCompletedAt).to.equal('2026-05-16T01:00:05.000Z');
+
+      // 保全式: targets.length + skipped.length === scannedDocs
+      expect(summary.targets.length + summary.skipped.length).to.equal(
+        summary.scannedDocs
+      );
+      // 保全式: targetedDocs === targets.length / skippedDocs === skipped.length
+      expect(summary.targetedDocs).to.equal(summary.targets.length);
+      expect(summary.skippedDocs).to.equal(summary.skipped.length);
+    });
+  });
+});

--- a/scripts/pr-d4-backfill/README.md
+++ b/scripts/pr-d4-backfill/README.md
@@ -10,6 +10,7 @@ Issue #445 PR-D4 series。Issue #432 P0 collision の構造的予防 (新規 spl
 | **B** | MatchedByHash 候補に対し parent 再 download + 再 split + child sha256 verify | なし | read-only |
 | **C** | Phase B verified (derived-bytes-verified) docs に `provenance` 10 fields + `provenanceBackfill` metadata を atomic batch write (GCS sentinel lock + lastUpdateTime precondition + max 100-200 tps) | あり | destructive |
 | **D** | Phase C 書込 doc を re-read + 10 fields field-by-field verify (Stage 1) + factory 再 invoke sha256 比較 (Stage 2) + (dev のみ) rotate fixture test | なし (verify のみ) | dev fixture 副作用は env hard gate で構造的排除 |
+| **E** | dev fixture (`BF_` / `BF13_test_fixture_` prefix) の `provenance` + `provenanceBackfill` を `FieldValue.delete()` で field-only 削除 (S6 / BF24、Codex MCP 12th review I1)。`confirm=true` で実 delete、それ以外は dry-run | あり (`confirm=true` のみ) | dev-only。workflow + index + orchestrator の 3 段 hard gate |
 
 ## 起動方法
 
@@ -18,11 +19,12 @@ GitHub Actions UI → Actions → "PR-D4 Backfill (Issue #445)" → "Run workflo
 | 入力 | 説明 | 例 |
 |---|---|---|
 | environment | dev / cocoro / kanameone | dev |
-| phase | A / B / C / D | A |
+| phase | A / B / C / D / E | A |
 | run_id | optional (auto-generated if empty), must match `^[A-Za-z0-9._-]+$` | `20260515T143000Z-dev-pr-d4-v1` |
 | rotate_fixture_mode | dev + phase=D のみ true 許可、prod では常に false 強制 | false |
+| confirm | phase=E + dev のみ true 許可で実 `FieldValue.delete()` 発行、それ以外 default false (dry-run) | false |
 
-dev → 即実行 (GitHub Environment なし)。cocoro/kanameone → GitHub Environment `pr-d4-prod-{env}` で manual approval。
+dev → 即実行 (GitHub Environment なし)。cocoro/kanameone → GitHub Environment `pr-d4-prod-{env}` で manual approval。`phase=E` は **dev 専用** (deploy-prod の Validate inputs で hard reject)。
 
 ## 設計判断
 
@@ -37,6 +39,21 @@ workflow に `concurrency.group: pr-d4-backfill-${env}` + `cancel-in-progress: f
 
 ### dev fixture 専用 job (Codex review I9)
 phase=D + env=dev + rotate_fixture_mode=true のときのみ `pr-d4-backfill-dev-fixture` (Secret bind 付き) を使用。通常 job には `PR_D4_ROTATE_AUTH_TOKEN` を bind しないことで state leak を構造的に排除。
+
+### Phase E rollback の 3 段 hard gate (S6 / BF24、Codex 12th I1)
+1. **workflow yaml**: deploy-dev で `phase=E` かつ `env=dev` 強制、deploy-prod で `phase=E` を hard reject
+2. **container CLI** (`scripts/pr-d4-backfill/index.ts`): `phase=E` かつ `env=dev` 強制、それ以外で exit 2
+3. **orchestrator** (`scripts/pr-d4-backfill/rollback/rollbackOrchestrator.ts`): `env !== 'dev'` で `throw new Error`
+
+加えて **fixture prefix allowlist** (`BF_` / `BF13_test_fixture_`) を orchestrator と Firestore adapter (`startAt/endAt` prefix-bounded query) で 2 段適用。本番に該当 prefix の doc が存在しないため、仮に 3 段 gate を全突破しても query 結果ゼロで silent (副作用ゼロ)。
+
+### Phase E delete スコープ (ADR-0008 整合)
+- 対象: `provenance` と `provenanceBackfill` の **field のみ** を `FieldValue.delete()` で削除
+- 非対象: doc 自体、他 fields (createdAt 等)、Storage object はすべて残存
+- ADR-0008 (Firestore 削除禁止) は doc/collection delete を禁ずるもので、本 PR の field delete はガード対象外
+
+### Phase E 既存 verified provenance immutable skip (BF24)
+`provenance` exists かつ `provenanceBackfill` absent (= PR-D2/D3 split-time provenance、ADR MUST 7) は rollback 対象外として skip artifact (`existing-verified-provenance`) に記録。PR-D4 が書いた fixture のみを巻き戻し、PR-D2/D3 で生成された verified provenance を失わない。
 
 ## exit code 一覧
 
@@ -266,6 +283,39 @@ Codex 12th verdict に基づく phase 別 GO 状態:
 1. `<TBD>` placeholder を実値で埋める PR (cocoro/kanameone の ARTIFACT_BUCKET / CLOUD_RUN_LOCATION / BUCKET_LOCATION)
 2. GitHub Environment `pr-d4-prod-<env>` で required reviewers ≥ 1 事前確認 (§8 の `gh api` コマンド)
 3. Phase A/B は本 amendment 状態でも即実行可、Phase C/D は S6 + #12 + Codex 13th review 後
+
+## Phase E (S6 / BF24 rollback) 使い方
+
+Codex MCP 12th review I1 で要求された stand-alone rollback の dev rehearsal 用 phase。dev fixture (`BF_` / `BF13_test_fixture_`) の `provenance` + `provenanceBackfill` を `FieldValue.delete()` で field-only 削除する (doc 自体は残存)。
+
+### 通常フロー (dev rehearsal 用)
+1. fixture 作成: `#12 Phase D rotate_fixture_mode=true` で `BF13_test_fixture_*` 作成
+2. dry-run 確認 (`confirm=false` default、Firestore 副作用ゼロ):
+   ```bash
+   gh workflow run pr-d4-backfill.yml \
+     -f environment=dev -f phase=E \
+     -f run_id='20260516T120000Z-dev-pr-d4-rollback-v1' \
+     -f rotate_fixture_mode=false -f confirm=false
+   ```
+   → artifact `phase-rollback-summary.json` で target/skip 判定を事前確認
+3. 番号認可下で実行 (`confirm=true`、実 `FieldValue.delete()` 発行):
+   ```bash
+   gh workflow run pr-d4-backfill.yml \
+     -f environment=dev -f phase=E \
+     -f run_id='20260516T120100Z-dev-pr-d4-rollback-v1' \
+     -f rotate_fixture_mode=false -f confirm=true
+   ```
+4. 後続: 別 run_id で `phase=C` 起動 → Round 1/2 と同 metrics 再現を artifact diff で確認 (BF24)
+
+### 安全装置 (3 段 hard gate)
+- workflow Validate inputs: `phase=E` かつ `env=dev` 強制、`confirm=true` の他 phase 拒否、deploy-prod は `phase=E` 自体を hard reject
+- container CLI: `phase=E` かつ `env=dev` 強制 (`scripts/pr-d4-backfill/index.ts`)
+- orchestrator: `env !== 'dev'` で `throw` (`scripts/pr-d4-backfill/rollback/rollbackOrchestrator.ts`)
+- prefix allowlist: `BF_` / `BF13_test_fixture_` のみ target、本番には該当 prefix の doc 不在
+
+### artifact 出力
+- main: `gs://<artifact-bucket>/pr-d4-backfill-artifacts/<run_id>/phase-rollback-summary.json`
+- 構造: `PhaseRollbackSummary` (types.ts 参照)。保全式: `targets.length + skipped.length === scannedDocs`、`targets[*].status === 'executed' ⇔ dryRun === false`
 
 ## Phase 間連携: run_id 継承 (session78 rehearsal で発見)
 

--- a/scripts/pr-d4-backfill/README.md
+++ b/scripts/pr-d4-backfill/README.md
@@ -316,6 +316,7 @@ Codex MCP 12th review I1 で要求された stand-alone rollback の dev rehears
 ### artifact 出力
 - main: `gs://<artifact-bucket>/pr-d4-backfill-artifacts/<run_id>/phase-rollback-summary.json`
 - 構造: `PhaseRollbackSummary` (types.ts 参照)。保全式: `targets.length + skipped.length === scannedDocs`、`targets[*].status === 'executed' ⇔ dryRun === false`
+- **manifest 非更新**: Phase E は **standalone rollback artifact** であり、Phase A/B/C/D の `manifest.json` には書き込まない (本 PR では `BackfillManifest.phaseRollback?` 型のみ将来拡張用に予約)。理由: rollback は通常 Phase C と異なる `run_id` で起動し artifact chain を共有しないため。Codex MCP 13th review (Low 1) 反映
 
 ## Phase 間連携: run_id 継承 (session78 rehearsal で発見)
 

--- a/scripts/pr-d4-backfill/index.ts
+++ b/scripts/pr-d4-backfill/index.ts
@@ -50,6 +50,12 @@ import {
   GcsFixtureStoreImpl,
   HttpsRotateApiCallerImpl,
 } from './phase-d/adapters';
+import { runRollback } from './rollback/rollbackOrchestrator';
+import {
+  FirestoreRollbackReaderImpl,
+  FirestoreRollbackWriterImpl,
+} from './rollback/adapters';
+import { PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST } from './types';
 
 function readArg(name: string, defaultValue?: string): string | undefined {
   const idx = process.argv.indexOf(name);
@@ -85,9 +91,9 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const phase = readArg('--phase', 'A');
-  if (phase !== 'A' && phase !== 'B' && phase !== 'C' && phase !== 'D') {
+  if (phase !== 'A' && phase !== 'B' && phase !== 'C' && phase !== 'D' && phase !== 'E') {
     console.error(
-      `FATAL: phase ${phase} not implemented (only Phase A / B / C / D are available in S1-5)`
+      `FATAL: phase ${phase} not implemented (Phase A / B / C / D / E (rollback dev fixtures) only)`
     );
     process.exit(2);
   }
@@ -118,7 +124,7 @@ async function main(): Promise<void> {
   }
   const runId = readArg('--run-id', generateRunId(envName))!;
 
-  console.log('Phase A (PR-D4 S1-2) starting:');
+  console.log(`Phase ${phase} (PR-D4) starting:`);
   console.log(`  env: ${envName}`);
   console.log(`  projectId: ${projectId}`);
   console.log(`  productionBucket: ${productionBucket}`);
@@ -133,7 +139,7 @@ async function main(): Promise<void> {
   const artifactBucketRef = admin.storage().bucket(artifactBucketName);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _phaseGuard: 'A' | 'B' | 'C' | 'D' = phase;
+  const _phaseGuard: 'A' | 'B' | 'C' | 'D' | 'E' = phase;
 
   if (phase === 'A') {
     const snapshotStartedAt = new Date().toISOString();
@@ -247,7 +253,7 @@ async function main(): Promise<void> {
     console.log(`  mainArtifact: ${result.mainArtifactPath}`);
     console.log(`  manifest: ${result.manifestPath}`);
     console.log(`  backfillCompletedAt: ${result.backfillCompletedAt}`);
-  } else {
+  } else if (phase === 'D') {
     // Phase D: Phase C artifact 経由 manifest を読み verify + rotate gate test 実施 (本 PR S1-5)
     const manifestPath = `gs://${artifactBucketName}/pr-d4-backfill-artifacts/${runId}/manifest.json`;
     // dev 環境のみ rotate gate fixture test 実行可、cocoro/kanameone は強制 false (Codex 3rd I6)
@@ -363,6 +369,48 @@ async function main(): Promise<void> {
       );
       process.exit(4);
     }
+  } else if (phase === 'E') {
+    // Phase E: dev fixture rollback (S6 / BF24、Codex MCP 12th review I1 反映)
+    // env=dev hard gate を container 側でも明示 (workflow + index + orchestrator の 3 段 defense in depth の 2nd layer)
+    if (envName !== 'dev') {
+      console.error(
+        `FATAL: phase=E (rollback dev fixtures) requires env=dev; received env=${envName}`
+      );
+      process.exit(2);
+    }
+
+    // dry-run default true、`--confirm true` で実 delete
+    const confirmArg = readArg('--confirm', 'false');
+    const dryRun = confirmArg !== 'true';
+
+    console.log('\nPhase E (rollback dev fixtures) starting:');
+    console.log(`  prefixes: ${PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST.join(', ')}`);
+    console.log(`  dryRun: ${dryRun} (confirm=${confirmArg})`);
+
+    const rollbackStartedAt = new Date().toISOString();
+    const rollbackResult = await runRollback({
+      env: envName,
+      runId,
+      dryRun,
+      firestoreReader: new FirestoreRollbackReaderImpl(
+        db,
+        PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST
+      ),
+      firestoreWriter: new FirestoreRollbackWriterImpl(db),
+      artifactWriter: new GcsArtifactStorageWriter(artifactBucketRef),
+      artifactBucketName,
+      rollbackStartedAt,
+      scriptVersion: PR_D4_SCRIPT_VERSION,
+    });
+
+    console.log('\nPhase E complete:');
+    console.log(`  scannedDocs: ${rollbackResult.summary.scannedDocs}`);
+    console.log(`  targetedDocs: ${rollbackResult.summary.targetedDocs}`);
+    console.log(`  skippedDocs: ${rollbackResult.summary.skippedDocs}`);
+    console.log(`  dryRun: ${rollbackResult.summary.dryRun}`);
+    console.log(`  mainArtifact: ${rollbackResult.mainArtifactPath}`);
+    console.log(`  rollbackStartedAt: ${rollbackStartedAt}`);
+    console.log(`  rollbackCompletedAt: ${rollbackResult.summary.rollbackCompletedAt}`);
   }
 }
 

--- a/scripts/pr-d4-backfill/rollback/adapters.ts
+++ b/scripts/pr-d4-backfill/rollback/adapters.ts
@@ -1,0 +1,95 @@
+/**
+ * Issue #445 PR-D4 S6: Rollback adapters (Firestore implementation).
+ *
+ * BF24 (Codex 3rd 追加) / Codex MCP 12th review I1 反映:
+ * - FirestoreRollbackReaderImpl: documents collection を prefix-bounded query で scan
+ * - FirestoreRollbackWriterImpl: provenance / provenanceBackfill を FieldValue.delete() で削除
+ *
+ * 設計:
+ * - prefix-bounded query: `orderBy('__name__').startAt(prefix).endAt(prefix + '')`。
+ *   `` は Unicode の private use area 最後で、Firestore prefix 検索の慣習 (公式 docs 推奨)
+ * - 各 prefix 別 query → orchestrator 側で順次 yield (merge は不要、出力順は仕様外)
+ * - field-only delete: `doc.update({field: FieldValue.delete()})`。doc 自体や他 fields は不変
+ *   (ADR-0008 削除制約と整合、本 PR は doc/collection delete を一切しない)
+ *
+ * cocoro/kanameone 万一実行された場合の二重防御:
+ * - 本 adapter は env=dev hard gate を含まない (orchestrator + index.ts + workflow yaml で実施)
+ * - prefix allowlist (`BF_` / `BF13_test_fixture_`) は本番に存在しないため、仮に走っても
+ *   query 結果ゼロで silent (副作用ゼロ)。orchestrator が `out-of-scope` 判定する前に
+ *   そもそも doc が返らない
+ */
+
+import { FieldValue, type Firestore } from 'firebase-admin/firestore';
+import type {
+  DocRollbackSnapshot,
+  FirestoreRollbackReader,
+  FirestoreRollbackWriter,
+} from './rollbackOrchestrator';
+
+/**
+ * Firestore documents collection から prefix-bounded query で fixture 候補を scan。
+ *
+ * 注意: __name__ orderBy で startAt/endAt が docId に対して適用される。
+ *  は range 末端の慣習。
+ */
+export class FirestoreRollbackReaderImpl implements FirestoreRollbackReader {
+  private readonly db: Firestore;
+  private readonly prefixes: readonly string[];
+
+  constructor(db: Firestore, prefixes: readonly string[]) {
+    this.db = db;
+    this.prefixes = prefixes;
+  }
+
+  async *scanCandidateDocs(): AsyncIterable<DocRollbackSnapshot> {
+    for (const prefix of this.prefixes) {
+      const snap = await this.db
+        .collection('documents')
+        .orderBy('__name__')
+        .startAt(prefix)
+        .endAt(`${prefix}`)
+        .get();
+      for (const doc of snap.docs) {
+        const data = doc.data();
+        yield {
+          docId: doc.id,
+          hasProvenance: data['provenance'] !== undefined,
+          hasProvenanceBackfill: data['provenanceBackfill'] !== undefined,
+        };
+      }
+    }
+  }
+}
+
+/**
+ * Firestore documents.doc(docId).update() で provenance / provenanceBackfill を field-delete。
+ *
+ * `FieldValue.delete()` は doc 内の指定 field のみ除去し、他 fields (createdAt 等) と doc 自体は
+ * 残存させる (`.update()` semantics)。`set({merge:true})` ではないため新 field 追加リスクなし。
+ */
+export class FirestoreRollbackWriterImpl implements FirestoreRollbackWriter {
+  private readonly db: Firestore;
+
+  constructor(db: Firestore) {
+    this.db = db;
+  }
+
+  async deleteProvenanceFields(input: {
+    docId: string;
+    deleteProvenance: boolean;
+    deleteProvenanceBackfill: boolean;
+  }): Promise<void> {
+    const update: Record<string, FieldValue> = {};
+    if (input.deleteProvenance) {
+      update['provenance'] = FieldValue.delete();
+    }
+    if (input.deleteProvenanceBackfill) {
+      update['provenanceBackfill'] = FieldValue.delete();
+    }
+    if (Object.keys(update).length === 0) {
+      // 両 false なら no-op (orchestrator は呼ばない前提だが defensive)
+      return;
+    }
+    await this.db.collection('documents').doc(input.docId).update(update);
+  }
+}

--- a/scripts/pr-d4-backfill/rollback/rollbackOrchestrator.ts
+++ b/scripts/pr-d4-backfill/rollback/rollbackOrchestrator.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #445 PR-D4 S6: Rollback orchestrator (dev fixture 限定 provenance + provenanceBackfill delete).
+ *
+ * BF24 (Codex 3rd 追加) / Codex MCP 12th review I1 反映:
+ * - dev fixture 限定 (prefix allowlist `BF_` / `BF13_test_fixture_`) で
+ *   `provenance` と `provenanceBackfill` の両方を `FieldValue.delete()` で削除
+ * - 既存 verified provenance (provenance exists && provenanceBackfill absent) は
+ *   immutable skip (PR-D2/D3 split-time provenance を rollback で失わない、ADR MUST 7)
+ * - dry-run default、明示 confirm (CLI `--confirm` / workflow input `confirm=true`) で実 delete
+ *
+ * 設計 (Codex 12th I1 specific guidance):
+ * - dev-only hard gate (本 orchestrator + index.ts + workflow yaml の 3 段 defense in depth)
+ * - doc delete / GCS object delete は **行わない** (cleanup と区別)。field 削除のみで doc 残存
+ * - 既存 verified provenance には適用しない (`existing-verified-provenance` skip artifact 記録)
+ * - artifact: `phase-rollback-summary.json` のみ (chunks なし、fixture 件数少ない)
+ *
+ * 処理フロー:
+ *   1. env hard gate (dev 以外は throw)
+ *   2. firestoreReader.scanCandidateDocs() で documents collection scan
+ *   3. 各 doc を prefix allowlist で分類: target / out-of-scope skip
+ *   4. target を fields 存在で分類: target (要 delete) / existing-verified-provenance / no-provenance-fields
+ *   5. dry-run なら writer 呼出スキップ、それ以外は FieldValue.delete() 発行
+ *   6. artifact (PhaseRollbackSummary) を artifact bucket に書込
+ */
+
+import type { ArtifactStorageWriter } from '../phase-a/artifactWriter';
+import {
+  PR_D4_ARTIFACT_SCHEMA_VERSION,
+  PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST,
+  type BackfillEnvName,
+  type PhaseRollbackSkippedDoc,
+  type PhaseRollbackSummary,
+  type PhaseRollbackTargetDoc,
+  type PrD4ScriptVersion,
+} from '../types';
+
+/**
+ * documents collection scan 経由で取得した 1 doc の rollback 判定材料。
+ *
+ * 設計:
+ * - `hasProvenance` / `hasProvenanceBackfill`: Firestore document 上の field 有無
+ *   (`undefined` でも値 `null` でも present 扱いにするかは adapter 側の責任、orchestrator は
+ *   field 値ではなく「set されている / されていない」だけを使う)
+ */
+export interface DocRollbackSnapshot {
+  docId: string;
+  hasProvenance: boolean;
+  hasProvenanceBackfill: boolean;
+}
+
+/**
+ * Firestore documents collection を scan する責務 (adapter 抽象)。
+ *
+ * 実 adapter は prefix-bounded query (`startAt`/`endAt`) で対象を絞り込む。
+ * orchestrator 側でも prefix allowlist による 2 段 filter を行う (defense in depth、
+ * AC2 で adapter から非 prefix doc が来た場合の挙動を test で検証)。
+ */
+export interface FirestoreRollbackReader {
+  scanCandidateDocs(): AsyncIterable<DocRollbackSnapshot>;
+}
+
+/**
+ * Firestore に field-only delete を発行する責務 (adapter 抽象)。
+ *
+ * - `deleteProvenance` / `deleteProvenanceBackfill`: 片方だけ true でも OK
+ *   (orphan provenanceBackfill のみ rollback したいケース等)
+ * - 両方 false なら no-op (orchestrator 側で 0 件 update を回避するため呼ばないこと)
+ * - 実装は `db.collection('documents').doc(docId).update({field: FieldValue.delete()})` で
+ *   他 fields (createdAt 等) は変更しないこと (ADR-0008 整合)
+ */
+export interface FirestoreRollbackWriter {
+  deleteProvenanceFields(input: {
+    docId: string;
+    deleteProvenance: boolean;
+    deleteProvenanceBackfill: boolean;
+  }): Promise<void>;
+}
+
+export interface RunRollbackInput {
+  env: BackfillEnvName;
+  runId: string;
+  /** true = artifact のみ書込 (Firestore update 発行ゼロ)、false = 実 delete */
+  dryRun: boolean;
+  firestoreReader: FirestoreRollbackReader;
+  firestoreWriter: FirestoreRollbackWriter;
+  artifactWriter: ArtifactStorageWriter;
+  artifactBucketName: string;
+  rollbackStartedAt: string;
+  scriptVersion: string;
+  /** test 用 clock (ISO8601 を返す)。省略時 system clock */
+  nowProvider?: () => string;
+}
+
+export interface RunRollbackResult {
+  summary: PhaseRollbackSummary;
+  mainArtifactPath: string;
+}
+
+function matchesAllowlist(docId: string): boolean {
+  for (const prefix of PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST) {
+    if (docId.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+export async function runRollback(input: RunRollbackInput): Promise<RunRollbackResult> {
+  // AC1: dev-only hard gate (orchestrator level、defense in depth の 3rd layer)
+  if (input.env !== 'dev') {
+    throw new Error(
+      `rollback is dev-only (env=${input.env}); workflow + index.ts + orchestrator の 3 段 hard gate のうち 3rd で reject`
+    );
+  }
+
+  const targets: PhaseRollbackTargetDoc[] = [];
+  const skipped: PhaseRollbackSkippedDoc[] = [];
+  let scanned = 0;
+
+  for await (const doc of input.firestoreReader.scanCandidateDocs()) {
+    scanned++;
+
+    // AC2: prefix allowlist filter (2nd layer、adapter 側でも prefix-bounded query するが
+    // orchestrator も独立判定して silent drop を防ぐ)
+    if (!matchesAllowlist(doc.docId)) {
+      skipped.push({ docId: doc.docId, reason: 'out-of-scope' });
+      continue;
+    }
+
+    // AC4: immutable skip - PR-D2/D3 split-time provenance (provenanceBackfill 不在)
+    if (doc.hasProvenance && !doc.hasProvenanceBackfill) {
+      skipped.push({ docId: doc.docId, reason: 'existing-verified-provenance' });
+      continue;
+    }
+
+    // 両 fields 不在 → idempotent skip (既 rollback 済 or 元から無い)
+    if (!doc.hasProvenance && !doc.hasProvenanceBackfill) {
+      skipped.push({ docId: doc.docId, reason: 'no-provenance-fields' });
+      continue;
+    }
+
+    // target: provenanceBackfill 存在 (provenance は両 OK)
+    const deletedFields: Array<'provenance' | 'provenanceBackfill'> = [];
+    if (doc.hasProvenance) deletedFields.push('provenance');
+    if (doc.hasProvenanceBackfill) deletedFields.push('provenanceBackfill');
+
+    if (!input.dryRun) {
+      // AC3 / AC6: field-only delete (doc 自体は残存)
+      await input.firestoreWriter.deleteProvenanceFields({
+        docId: doc.docId,
+        deleteProvenance: doc.hasProvenance,
+        deleteProvenanceBackfill: doc.hasProvenanceBackfill,
+      });
+    }
+
+    targets.push({
+      docId: doc.docId,
+      status: input.dryRun ? 'dryRun' : 'executed',
+      deletedFields,
+    });
+  }
+
+  const now = input.nowProvider ?? (() => new Date().toISOString());
+  const summary: PhaseRollbackSummary = {
+    phase: 'E',
+    schemaVersion: PR_D4_ARTIFACT_SCHEMA_VERSION,
+    scriptVersion: input.scriptVersion as PrD4ScriptVersion,
+    env: input.env,
+    runId: input.runId,
+    rollbackStartedAt: input.rollbackStartedAt,
+    rollbackCompletedAt: now(),
+    scannedDocs: scanned,
+    targetedDocs: targets.length,
+    skippedDocs: skipped.length,
+    dryRun: input.dryRun,
+    targets,
+    skipped,
+  };
+
+  const mainArtifactPath = `gs://${input.artifactBucketName}/pr-d4-backfill-artifacts/${input.runId}/phase-rollback-summary.json`;
+  const content = JSON.stringify(summary);
+  await input.artifactWriter.writeJson(mainArtifactPath, content);
+
+  return { summary, mainArtifactPath };
+}

--- a/scripts/pr-d4-backfill/types.ts
+++ b/scripts/pr-d4-backfill/types.ts
@@ -160,6 +160,13 @@ export interface BackfillManifest {
     mainArtifact: { path: string; sha256: string };
     chunks: ArtifactChunkPointer[];
   };
+  /**
+   * rollback artifact (S6 / BF24、Codex MCP 12th review I1 反映)。
+   * dev fixture rollback summary を chain。chunks なし (fixture 件数少なく chunking 不要)。
+   */
+  phaseRollback?: {
+    mainArtifact: { path: string; sha256: string };
+  };
 }
 
 /** chunk 1 件あたり最大件数 (impl-plan §4.1 BF19 / BF22 反映) */
@@ -703,4 +710,98 @@ export interface PhaseDFinalizeStatus {
   expectedGeneration: string;
   /** CAS 失敗時のリトライ手順 (operator 用) */
   remediation?: string;
+}
+
+// ============================================================================
+// Rollback types (S6 / BF24、Codex MCP 12th review I1 反映)
+// ============================================================================
+
+/**
+ * dev fixture rollback の対象 prefix allowlist (BF24)。
+ *
+ * PR-D4 が書いた fixture のみを rollback 対象とするための docId prefix 集合。
+ * - `BF_`: 将来追加 fixture / 一般 PR-D4 fixture 用 prefix
+ * - `BF13_test_fixture_`: Phase D rotate gate fixture (BF13) と一致 (実装済)
+ *
+ * 設計 (Codex 12th I1 反映):
+ * - 本番環境 (cocoro/kanameone) には本 prefix の doc が存在しないことを前提
+ *   (Phase A/B/C/D 通常運用で BF_ prefix を生成しない、PR-D2/D3 split も同様)
+ * - workflow + container 双方で env=dev hard gate を入れ、cocoro/kanameone での
+ *   rollback 起動を構造的に排除する (defense in depth)
+ * - rollback orchestrator は本 allowlist に match しない docId を `out-of-scope`
+ *   として skip artifact に記録 (silent drop しない、観測完全性)
+ */
+export const PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST = [
+  'BF_',
+  'BF13_test_fixture_',
+] as const;
+
+/**
+ * rollback の target に分類された 1 doc (実 delete または dry-run 想定)。
+ *
+ * `provenance` + `provenanceBackfill` 双方を `FieldValue.delete()` で削除する候補。
+ * AC3 (doc delete はしない、field-only) に従い、doc 自体および他 fields (createdAt 等)
+ * は残存。ADR-0008 (Firestore 削除禁止) は doc/collection delete を禁ずるもので、本 PR
+ * の field delete はガード対象外。
+ *
+ * - `executed`: dry-run=false で実 `FieldValue.delete()` を発行
+ * - `dryRun`: dry-run=true で実 update は発行せず、想定 delete のみ記録
+ */
+export interface PhaseRollbackTargetDoc {
+  docId: string;
+  status: 'executed' | 'dryRun';
+  /** 削除予定 (または実行済) field 名 (両 fields 不在のときは [], 通常は両方記載) */
+  deletedFields: Array<'provenance' | 'provenanceBackfill'>;
+}
+
+/**
+ * rollback で skip された 1 doc。
+ *
+ * - `reason='out-of-scope'`: docId が PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST に
+ *   match しない (AC2、BF24 fixture 限定、cocoro/kanameone 万一混入時の二重防御)
+ * - `reason='existing-verified-provenance'`: provenance exists && provenanceBackfill
+ *   absent (= PR-D2/D3 split-time provenance、ADR MUST 7 immutable skip + BF24)
+ * - `reason='no-provenance-fields'`: provenance も provenanceBackfill も存在しない
+ *   (既 rollback 済 / 元から無い fixture、idempotent skip)
+ */
+export interface PhaseRollbackSkippedDoc {
+  docId: string;
+  reason:
+    | 'out-of-scope'
+    | 'existing-verified-provenance'
+    | 'no-provenance-fields';
+}
+
+/**
+ * rollback 操作の summary artifact (main file、chunks なし)。
+ *
+ * 設計:
+ * - rollback 対象は dev fixture のみで件数が少ない (典型: ~10 docs) ため chunking 不要
+ * - `dryRun=true`: Firestore update 発行ゼロ、artifact に scope-out / immutable skip
+ *   判定結果のみ記録 (operator が target 範囲を事前確認するための材料)
+ * - `dryRun=false`: 実 `FieldValue.delete()` を発行し、targets[*].status='executed'
+ *
+ * 保全式:
+ *   targets.length + skipped.length === scannedDocs
+ *   targets[*].status === 'executed' ⇔ dryRun === false
+ *   targets[*].status === 'dryRun'   ⇔ dryRun === true
+ */
+export interface PhaseRollbackSummary {
+  phase: 'E';
+  schemaVersion: PrD4ArtifactSchemaVersion;
+  scriptVersion: PrD4ScriptVersion;
+  env: BackfillEnvName;
+  runId: string;
+  rollbackStartedAt: string;
+  rollbackCompletedAt: string;
+  /** documents collection を scan し prefix match で抽出した件数 (skip 含む) */
+  scannedDocs: number;
+  /** rollback 対象に分類された件数 (= targets.length) */
+  targetedDocs: number;
+  /** skip された件数 (= skipped.length) */
+  skippedDocs: number;
+  /** dry-run 動作フラグ (true = Firestore update なし) */
+  dryRun: boolean;
+  targets: PhaseRollbackTargetDoc[];
+  skipped: PhaseRollbackSkippedDoc[];
 }


### PR DESCRIPTION
## Summary

Codex MCP 12th review (thread `019e2d49-0b38-7ea2-bcd7-15af13bcb73b`) I1 (GO with required amendments) を反映。BF24 で要求された stand-alone rollback script を実装し、cocoro/kanameone Phase C/D 本番展開の prerequisite を満たす。

- **新規 phase=E** (rollback dev fixtures): `BF_` / `BF13_test_fixture_` prefix の dev fixture を `FieldValue.delete()` で field-only 削除
- **3 段 hard gate**: workflow yaml + index.ts + orchestrator で env=dev 強制、本番誤起動を構造的排除
- **immutable skip**: PR-D2/D3 split-time provenance (provenanceBackfill absent) は保護、ADR MUST 7 整合
- **dry-run default**: `confirm=true` 明示でのみ実 delete、artifact に判定理由を full 記録
- **doc 残存**: ADR-0008 整合、`set()` でなく `update()` で他 fields 不変

## 主要変更内容

### 新規ファイル (3 個)

- `scripts/pr-d4-backfill/rollback/rollbackOrchestrator.ts` (~210 LOC): runRollback + FirestoreRollbackReader/Writer 抽象 + 3rd-layer hard gate
- `scripts/pr-d4-backfill/rollback/adapters.ts` (~95 LOC): FirestoreRollbackReaderImpl (prefix-bounded query) + FirestoreRollbackWriterImpl (FieldValue.delete)
- `functions/test/prD4RollbackOrchestrator.test.ts` (~460 LOC): 11 tests covering AC1-AC6 + artifact 構造

### 修正ファイル (5 個)

- `scripts/pr-d4-backfill/types.ts` (+101 LOC): PhaseRollback{Target,Skipped,Summary}Doc + PR_D4_ROLLBACK_FIXTURE_PREFIX_ALLOWLIST + BackfillManifest.phaseRollback
- `scripts/pr-d4-backfill/index.ts` (+58/-11 LOC): phase=E branch、env=dev hard gate、--confirm 引数、**else-if chain 修正 (Evaluator HIGH)**
- `.github/workflows/pr-d4-backfill.yml` (+50 LOC): phase=E choice + confirm choice + Validate inputs (deploy-dev + deploy-prod 両方で拒否)
- `scripts/pr-d4-backfill/README.md` (+54 LOC): §Phase E 追加 (3 段 gate / scope / immutable skip / 使い方)
- `docs/specs/pr-d4-backfill-impl-plan.md` (+2/-2): §9.1 S6 行を実装済表記に更新

合計: 8 files / +992/-11

## Acceptance Criteria

| # | 基準 | 検証 |
|---|------|------|
| AC1 | dev-only hard gate (env=cocoro/kanameone reject) | unit test 2 ケース、副作用ゼロ確認 |
| AC2 | fixture prefix allowlist (BF_ / BF13_test_fixture_ のみ target) | unit test 1 ケース (3 種混在 → 2 target / 2 out-of-scope) |
| AC3 | field-only delete (doc + 他 fields 残存) | unit test 3 ケース (両方 / provenance のみ / provenanceBackfill のみ) |
| AC4 | immutable skip (existing-verified-provenance) | unit test 2 ケース (両 fixture + 両 fields 不在 idempotent skip) |
| AC5 | dry-run default (writer 呼出ゼロ) | unit test 1 ケース |
| AC6 | explicit confirm required (target.status=executed) | unit test 1 ケース |
| AC7 | re-Phase C reproducibility | dev rehearsal 別 PR で artifact diff 検証 (本 PR スコープ外) |

## Test plan

- [x] unit tests 11 件全 PASS
- [x] 全 functions test suite 1381 件 PASS (regression なし)
- [x] type-check: clean
- [x] build (tsc): success
- [x] lint: 0 errors (25 pre-existing warnings)
- [x] yaml syntax: OK
- [x] /simplify (3 並列): 1 quality finding fix 適用 (scriptVersion cast)
- [x] /safe-refactor: 0 issues
- [x] Evaluator: 1 HIGH (制御フローバグ) + 1 LOW (log message) 修正、1 MEDIUM (null provenance) 設計コメント明示済として保留
- [ ] CI lint-build-test pass (PR 起動後)
- [ ] CodeRabbit / GitGuardian pass
- [ ] dev rehearsal (rollback → 再 Phase C → metric reproducibility): 本 PR merge 後の別 session で実施

## 次ステップ (本 PR merge 後)

1. **dev rehearsal** (本 PR merge 後): #12 Firebase login (user task) → fixture 作成 → workflow_dispatch phase=E dry-run → confirm=true 実行 → 再 Phase C → metric 再現を artifact diff で確認 (AC7)
2. **Codex MCP 13th review**: 本 PR diff + dev rehearsal artifact を提示し cocoro/kanameone Phase C/D GO 取得
3. **cocoro/kanameone 本番展開**: 各 phase 番号認可下で Phase A → B → C → D 順次起動

## Rollout

- merge 後即座に main 反映 (CI 自動 dev deploy なし、container は workflow_dispatch 起動時に build される設計)
- dev rehearsal は user authorization 必要 (#12 Firebase login user task + phase=E confirm=true は番号認可必須)
- cocoro/kanameone 本番には影響しない (deploy-prod が phase=E を outright reject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase E: dev-only rollback to selectively remove provenance fields from allowed dev fixtures
  * `confirm` input and dry-run support to preview vs execute destructive rollback
  * Scoped targeting via prefix allowlist and a rollback summary artifact written on run
  * Production runs now reject Phase E/confirm to prevent rollback in prod

* **Documentation**
  * Expanded docs with Phase E usage, safety gates, and example workflow commands

* **Tests**
  * Added integration tests covering gating, allowlist behavior, dry-run vs execute, and summary reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->