### PR TITLE
feat(audit): audit-storage-mismatch --show-creation-times option (Issue #432 session82)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -56,6 +56,7 @@ on:
           - audit-storage-mismatch
           - audit-storage-mismatch --no-orphans
           - audit-storage-mismatch --no-collisions
+          - audit-storage-mismatch --show-creation-times
           - audit-session61-parent-provenance
           - classify-collision-docs
           - setup-collision-fixture --dev

--- a/scripts/audit-storage-mismatch.js
+++ b/scripts/audit-storage-mismatch.js
@@ -21,6 +21,8 @@
  *   --no-orphans             fileUrl 孤児チェック (Firestore→Storage) を省略
  *   --no-collisions          fileName 衝突チェックを省略
  *   --no-reverse-orphans     reverse orphan チェック (Storage→Firestore) を省略
+ *   --show-creation-times    collision 出力に createdAt を含める (PR-B/D2 等 deploy 反映前後の
+ *                            切り分け用、Issue #432 session82 で導入)
  */
 
 const admin = require('firebase-admin');
@@ -48,6 +50,7 @@ const prefix = getOpt('--prefix', 'processed/');
 const skipOrphans = process.argv.includes('--no-orphans');
 const skipCollisions = process.argv.includes('--no-collisions');
 const skipReverseOrphans = process.argv.includes('--no-reverse-orphans');
+const showCreationTimes = process.argv.includes('--show-creation-times');
 
 admin.initializeApp({ projectId, storageBucket });
 const db = admin.firestore();
@@ -124,6 +127,7 @@ async function main() {
       rotatedAt: tsToIso(data.rotatedAt),
       processedAt: tsToIso(data.processedAt),
       updatedAt: tsToIso(data.updatedAt),
+      createdAt: tsToIso(data.createdAt),
       lastErrorMessage: data.lastErrorMessage,
     });
   });
@@ -261,7 +265,12 @@ async function main() {
     for (const [fileName, docs] of collisions) {
       console.log(`\n-- ${fileName} (${docs.length} docs) --`);
       for (const d of docs) {
-        console.log(`  ${d.id} | status=${d.status} | rotatedAt=${d.rotatedAt} | fileUrl=${d.fileUrl}`);
+        const base = `  ${d.id} | status=${d.status} | rotatedAt=${d.rotatedAt} | fileUrl=${d.fileUrl}`;
+        if (showCreationTimes) {
+          console.log(`${base} | createdAt=${d.createdAt} | processedAt=${d.processedAt}`);
+        } else {
+          console.log(base);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Issue #432 session82 で kanameone collision audit (run `25953739315`) を実行し、5/11 → 5/16 audit 差分で **+23 docs が旧形式 path に新規書き込まれた**事実を確定。本 PR は **+23 docs の発生時系列を確定する** ために、既存 `audit-storage-mismatch.js` に `--show-creation-times` option を追加する小規模拡張。

## Context

### session82 で確定済の事実

| 項目 | 値 |
|---|---|
| 5/11 audit (run `25644961557`) collision groups | 39 |
| 5/16 audit (run `25953739315`) collision groups | 47 (= 真 45 + audit false positive 2) |
| 5/11→5/16 純増 | **+23 docs** (8 新規 + 5 既存 groups への +15 docs、全 fileName 日付 = `20260511`) |
| splitPdf Cloud Run revision | `splitpdf-00041-dac` = **2026-05-11T03:27:43Z deploy** (PR-B #435 反映) |
| PR-B 修正範囲 (git diff) | `splitPdf` の `newFilePath` のみ。`processed/${fileName}` → `processed/${newDocRef.id}/${fileName}` |

### 切り分けたい仮説 (本 PR の目的)

- **H9 (有力)**: +23 docs の createdAt がすべて **5/11 03:27Z より前** → PR-B deploy 前の旧 code 稼働期間に集中処理されただけ、構造的予防に漏れなし
- **H10 (要検証)**: +23 docs の一部 createdAt が **5/11 03:27Z 以降** → PR-B deploy 後も旧 path で書き込む経路が残存、復旧前に追加修正必須

## Changes

- `scripts/audit-storage-mismatch.js`:
  - allDocs に `createdAt` field を保持 (常時、boundary cost ~0)
  - `--show-creation-times` option flag 追加 (`process.argv.includes`)
  - collision 出力に option 有効時のみ `createdAt` と `processedAt` を追記 (デフォルト出力は既存と完全一致 = regression なし)
- `.github/workflows/run-ops-script.yml`:
  - choice options に `audit-storage-mismatch --show-creation-times` を追加

## Test plan

- [x] node syntax check (`node --check scripts/audit-storage-mismatch.js`) PASS
- [x] yaml syntax check (`python3 -c yaml.safe_load`) PASS
- [ ] merge 後、user 番号認可下で kanameone へ workflow_dispatch:
  ```
  gh workflow run run-ops-script.yml -f environment=kanameone -f script="audit-storage-mismatch --show-creation-times"
  ```
- [ ] 出力の collision groups で 47 groups 全 doc の `createdAt` 表示確認
- [ ] +23 新規 docs (session82 .artifacts/session82/leakage-analysis.md 記載の docId 群) の createdAt vs `2026-05-11T03:27:43Z` 比較で H9/H10 切り分け

## Scope

- read-only (Firestore read のみ、Storage write なし)
- regression なし (既存出力形式は default で完全一致)
- 環境別影響なし (script 改修のみ、コード本体に影響なし)
- `dev` / `kanameone` / `cocoro` 全環境で安全に dispatch 可

## Related

Refs #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--show-creation-times` option to the storage audit script, enabling creation timestamp information in collision output. The new flag is now available as a choice in the workflow dispatch interface, allowing users to include creation timestamps when running the audit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->