### PR TITLE
perf(search): searchDocuments OOM ガード暫定 (Issue #402 段階2)

### DIFF
--- a/functions/src/search/searchDocuments.ts
+++ b/functions/src/search/searchDocuments.ts
@@ -79,6 +79,11 @@ interface CacheEntry {
 const CACHE_TTL_MS = 10 * 60 * 1000;  // 10分
 const cache = new Map<string, CacheEntry>();
 
+// OOM ガード上限 (Issue #402 段階2)。256MiB Functions で db.getAll() の戻りを安全に
+// 保持できる件数の暫定値。document 1 件 ~ 数 KB × 500 = 数 MB 程度。段階1 計測ログの
+// N 分布から見直す前提の暫定値で、段階3 (posting に fileDate 内包) まで保持する。
+const MAX_GETALL = 500;
+
 function getCacheKey(query: string, limit: number, offset: number): string {
   return `${query}:${limit}:${offset}`;
 }
@@ -267,6 +272,25 @@ export const searchDocuments = onCall<SearchRequest>(
       return result;
     }
 
+    // OOM ガード暫定 (Issue #402 段階2)。256MiB Functions で getAll の戻りメモリを
+    // 安全圏に抑えるため、マッチ全件が MAX_GETALL を超えた場合は score 降順で上位 N
+    // 件のみ getAll する。fileDate ソートは MAX_GETALL 件の範囲内に限定 (= 全体ソート
+    // の部分犠牲)。query は PII リスク (顧客名・ファイル名等) のため warn 出力に含めず
+    // queryLength のみ記録 (段階1 perf ログと整合)。真の対応 (段階3 = posting に
+    // fileDate 内包) は段階1 計測ログの N 分布データに基づき後続 Issue で判断する。
+    const truncatedBeforeCount = filteredDocs.length;
+    let truncated = false;
+    if (truncatedBeforeCount > MAX_GETALL) {
+      filteredDocs.sort((a, b) => b.score - a.score);
+      filteredDocs.length = MAX_GETALL;
+      truncated = true;
+      console.warn('[searchDocuments] filteredDocs exceeds safe getAll limit', {
+        queryLength: query.length,
+        matchedCount: truncatedBeforeCount,
+        limit: MAX_GETALL,
+      });
+    }
+
     // マッチ全件の documents を取得（fileDate / processedAt をソートキーに使用するため）
     // db.getAll() の戻り順は ref 渡し順と一致するため、filteredDocs と index で対応する
     const allDocRefs = filteredDocs.map(d => db.collection('documents').doc(d.docId));
@@ -324,14 +348,17 @@ export const searchDocuments = onCall<SearchRequest>(
 
     // perf observability ログ (Issue #402 段階1)
     // 閾値超過時のみ出力。query 自体は PII リスク (顧客名・ファイル名等が含まれ得る) のため
-    // queryLength のみ記録。N の分布・elapsedMs から OOM ガード移行判断 (#402 段階2/3) を行う。
+    // queryLength のみ記録。N の分布・elapsedMs から OOM ガード移行判断 (#402 段階3) を行う。
+    // matchedCount は OOM ガード暫定 (段階2) 発動後の値ではなく実マッチ件数 (truncatedBeforeCount)
+    // を記録し、N 分布の正確な観測を継続する。truncated=true は段階2 ガード発動を示す。
     const elapsedMs = Date.now() - startMs;
-    if (filteredDocs.length > 100 || elapsedMs > 1000) {
+    if (truncatedBeforeCount > 100 || elapsedMs > 1000) {
       console.info('[searchDocuments] perf', {
         queryLength: query.length,
-        matchedCount: filteredDocs.length,
+        matchedCount: truncatedBeforeCount,
         fetchedCount: sortableDocs.length,
         orphanCount: orphanedDocIds.length,
+        truncated,
         elapsedMs,
       });
     }

--- a/functions/src/search/searchDocuments.ts
+++ b/functions/src/search/searchDocuments.ts
@@ -39,6 +39,16 @@ interface SearchResult {
   documents: SearchResultDocument[];
   total: number;
   hasMore: boolean;
+  /**
+   * Issue #402 段階2 OOM ガード発動時のみ true。FE は未読でも互換 (optional)。
+   * true のとき total = MAX_GETALL (取得件数) で実マッチ件数は actualMatchedCount を参照。
+   */
+  truncated?: boolean;
+  /**
+   * Issue #402 段階2 OOM ガード発動時のみ存在。実マッチ件数 (truncate 前)。
+   * FE で "上位 N 件のみ表示しています (実 M 件中)" バナー表示用 (follow-up PR で消費予定)。
+   */
+  actualMatchedCount?: number;
 }
 
 /** 検索結果ドキュメント */
@@ -81,7 +91,10 @@ const cache = new Map<string, CacheEntry>();
 
 // OOM ガード上限 (Issue #402 段階2)。256MiB Functions で db.getAll() の戻りを安全に
 // 保持できる件数の暫定値。document 1 件 ~ 数 KB × 500 = 数 MB 程度。段階1 計測ログの
-// N 分布から見直す前提の暫定値で、段階3 (posting に fileDate 内包) まで保持する。
+// N 分布から見直す前提の暫定値で、段階3 (posting に fileDate 内包 or getAll chunk 分割)
+// まで保持する。
+// TODO(#402): 段階3 完了時に MAX_GETALL / truncatedBeforeCount / truncated / actualMatchedCount
+// を撤去する。AC10 fixture (test/searchDocumentsIntegration.test.ts) は本定数に依存。
 const MAX_GETALL = 500;
 
 function getCacheKey(query: string, limit: number, offset: number): string {
@@ -342,6 +355,12 @@ export const searchDocuments = onCall<SearchRequest>(
       documents,
       total,
       hasMore: offset + limit < total,
+      // OOM ガード発動時のみ truncated / actualMatchedCount を露出 (Issue #402 段階2)。
+      // silent loss 防止: FE は optional field として未読でも互換、follow-up PR でバナー表示。
+      ...(truncated && {
+        truncated: true as const,
+        actualMatchedCount: truncatedBeforeCount,
+      }),
     };
 
     setCache(cacheKey, result);

--- a/functions/test/searchDocumentsIntegration.test.ts
+++ b/functions/test/searchDocumentsIntegration.test.ts
@@ -659,4 +659,193 @@ describe('searchDocuments handler integration (#401a, Closes #401)', () => {
       expect(perfLogs).to.have.lengthOf(0);
     });
   });
+
+  // ----------------------------------------
+  // AC10: OOM ガード暫定 (Issue #402 段階2)
+  //
+  // filteredDocs.length > MAX_GETALL (=500) のとき、score 降順で上位 MAX_GETALL 件
+  // のみを getAll する。fileDate ソートは MAX_GETALL 件の範囲内に限定 (部分犠牲)。
+  // 256MiB Functions の OOM 防止が目的。本 AC では production 定数 MAX_GETALL=500
+  // に依存しつつ、501 件で境界 +1 を検証する (production 定数の変更は別 PR で扱う)。
+  // ----------------------------------------
+  describe('AC10: OOM ガード暫定 (#402 段階2)', () => {
+    let originalWarn: typeof console.warn;
+    let warnCalls: unknown[][];
+    let originalInfo: typeof console.info;
+    let infoCalls: unknown[][];
+
+    beforeEach(() => {
+      originalWarn = console.warn;
+      warnCalls = [];
+      console.warn = (...args: unknown[]) => {
+        warnCalls.push(args);
+      };
+      originalInfo = console.info;
+      infoCalls = [];
+      console.info = (...args: unknown[]) => {
+        infoCalls.push(args);
+      };
+    });
+
+    afterEach(() => {
+      console.warn = originalWarn;
+      console.info = originalInfo;
+    });
+
+    it('matchedCount > 500 のとき score 上位 500 件のみ取得、warn 発火 + truncated=true', async () => {
+      await seedUser();
+
+      // AC2 と同じ「score-desc を実 fixture で強制検証」設計:
+      // 2 token AND + token 順 (token1 高 df / token2 低 df) で idf > 0 を成立させる。
+      // 単一 token search では totalDocs == df となり idf = log(1) = 0 で score 差が
+      // 消えるため、501 件全件が同 score になり OOM ガードの「上位 N 件取得」が
+      // 検証できない (前回 fail 原因)。
+      //
+      // ac10common: df=10000 (人為値)、501 doc 全部に posting (score=1.0)
+      // ac10rare:   df=2 (人為値)、    501 doc 全部に posting (score=1..501)
+      // → 最初の token (ac10common) で totalDocs=10000、次の token (ac10rare) で
+      //   idf = log(10001/3) ≈ 8.12 が成立 → ac10rare 経由の score=i*8.12 が最終 score
+      const MATCHED = 501;
+      const TRUNCATE_LIMIT = 500;
+      const commonPostings: Record<string, { score: number; fieldsMask: number }> = {};
+      const rarePostings: Record<string, { score: number; fieldsMask: number }> = {};
+      for (let i = 1; i <= MATCHED; i++) {
+        const docId = `doc-ac10-${String(i).padStart(3, '0')}`;
+        commonPostings[docId] = { score: 1.0, fieldsMask: 8 };
+        rarePostings[docId] = { score: i, fieldsMask: 8 };
+      }
+      await seedSearchIndex('ac10common', commonPostings, 10000);
+      await seedSearchIndex('ac10rare', rarePostings, 2);
+
+      // documents を batch write で seed (admin SDK batch 制限 500 op/commit のため 2 batch)。
+      const proc = ts('2026-04-27T12:00:00Z');
+      for (let batchStart = 1; batchStart <= MATCHED; batchStart += 400) {
+        const batch = db.batch();
+        const batchEnd = Math.min(batchStart + 399, MATCHED);
+        for (let i = batchStart; i <= batchEnd; i++) {
+          const docId = `doc-ac10-${String(i).padStart(3, '0')}`;
+          batch.set(db.doc(`documents/${docId}`), {
+            fileName: `oom-${docId}.pdf`,
+            customerName: '',
+            officeName: '',
+            documentType: '',
+            fileDate: null,
+            processedAt: proc,
+            status: 'processed',
+          });
+        }
+        await batch.commit();
+      }
+
+      // Act
+      const result = await callSearch({
+        query: 'ac10common ac10rare',
+        limit: 50,
+        offset: 0,
+      });
+
+      // Assert 1: total は取得した件数 (MAX_GETALL=500)。 全マッチ 501 件中 1 件は犠牲。
+      expect(result.total).to.equal(TRUNCATE_LIMIT);
+      expect(result.hasMore).to.be.true;
+
+      // Assert 2: 除外される 1 件 (score=1, doc-ac10-001) は結果セットに含まれない。
+      // limit=50 で 1 ページ目を取る場合、score 降順なら上位 50 件 (501..452) で 001 は含まれない。
+      const ids = result.documents.map((d) => d.id);
+      expect(ids).to.not.include('doc-ac10-001');
+
+      // Assert 3: 1 ページ目は score 上位 50 件 (501..452) が含まれる。
+      // fileDate=null + processedAt 同一 + score 降順 → ID 末尾 501..452 が並ぶ。
+      const expectedTopIds = Array.from(
+        { length: 50 },
+        (_, k) => `doc-ac10-${String(MATCHED - k).padStart(3, '0')}`
+      );
+      expect(ids).to.deep.equal(expectedTopIds);
+
+      // Assert 4: console.warn が発火している (OOM ガード payload を pattern match で絞り込む)。
+      const guardWarns = warnCalls.filter((args) =>
+        args.some(
+          (a) => typeof a === 'string' && a.includes('exceeds safe getAll limit')
+        )
+      );
+      expect(guardWarns).to.have.lengthOf(1);
+
+      // Assert 5: warn payload は queryLength のみ含み raw query は含まない (PII リスク対策)。
+      // payload は 2 番目の argument (object) として渡される。
+      const guardPayload = guardWarns[0]![1] as {
+        queryLength?: number;
+        matchedCount?: number;
+        limit?: number;
+        query?: string;
+      };
+      expect(guardPayload.queryLength).to.equal('ac10common ac10rare'.length);
+      expect(guardPayload.matchedCount).to.equal(MATCHED);
+      expect(guardPayload.limit).to.equal(TRUNCATE_LIMIT);
+      expect(guardPayload).to.not.have.property('query');
+
+      // Assert 6: perf info ログに truncated=true が反映される (matchedCount は実マッチ数 501)。
+      const perfLogs = infoCalls.filter((args) =>
+        args.some((a) => typeof a === 'string' && a.includes('[searchDocuments] perf'))
+      );
+      expect(perfLogs).to.have.lengthOf(1);
+      const perfPayload = perfLogs[0]![1] as {
+        matchedCount?: number;
+        fetchedCount?: number;
+        truncated?: boolean;
+      };
+      expect(perfPayload.matchedCount).to.equal(MATCHED);
+      expect(perfPayload.fetchedCount).to.equal(TRUNCATE_LIMIT);
+      expect(perfPayload.truncated).to.be.true;
+    }).timeout(60000); // 501 件 seed + getAll で時間がかかる場合のマージン
+
+    it('matchedCount <= 500 のとき OOM ガード warn は発火せず truncated=false', async () => {
+      // 境界の反対側: 100 件 (perf info ログ閾値は超えるが OOM ガードは未発動) を seed。
+      await seedUser();
+      const COUNT = 150;
+      const postings: Record<string, { score: number; fieldsMask: number }> = {};
+      for (let i = 1; i <= COUNT; i++) {
+        postings[`doc-ac10b-${i}`] = { score: i, fieldsMask: 8 };
+      }
+      await seedSearchIndex('ac10bbelowword', postings);
+
+      const proc = ts('2026-04-27T12:00:00Z');
+      const batch = db.batch();
+      for (let i = 1; i <= COUNT; i++) {
+        batch.set(db.doc(`documents/doc-ac10b-${i}`), {
+          fileName: `below-${i}.pdf`,
+          customerName: '',
+          officeName: '',
+          documentType: '',
+          fileDate: null,
+          processedAt: proc,
+          status: 'processed',
+        });
+      }
+      await batch.commit();
+
+      // Act
+      const result = await callSearch({
+        query: 'ac10bbelowword',
+        limit: 50,
+        offset: 0,
+      });
+
+      // Assert: 全件取得 + OOM warn 未発火 + perf info の truncated=false
+      expect(result.total).to.equal(COUNT);
+      const guardWarns = warnCalls.filter((args) =>
+        args.some(
+          (a) => typeof a === 'string' && a.includes('exceeds safe getAll limit')
+        )
+      );
+      expect(guardWarns).to.have.lengthOf(0);
+
+      const perfLogs = infoCalls.filter((args) =>
+        args.some((a) => typeof a === 'string' && a.includes('[searchDocuments] perf'))
+      );
+      // matchedCount=150 > 100 閾値なので perf info ログは出力される
+      expect(perfLogs).to.have.lengthOf(1);
+      const perfPayload = perfLogs[0]![1] as { truncated?: boolean; matchedCount?: number };
+      expect(perfPayload.matchedCount).to.equal(COUNT);
+      expect(perfPayload.truncated).to.be.false;
+    }).timeout(30000);
+  });
 });

--- a/functions/test/searchDocumentsIntegration.test.ts
+++ b/functions/test/searchDocumentsIntegration.test.ts
@@ -748,6 +748,12 @@ describe('searchDocuments handler integration (#401a, Closes #401)', () => {
       expect(result.total).to.equal(TRUNCATE_LIMIT);
       expect(result.hasMore).to.be.true;
 
+      // Assert 1b: silent loss 防止 (silent-failure-hunter CRT-1 対応)。
+      // 切り捨て発動時は SearchResult に truncated=true + actualMatchedCount=実マッチ件数を
+      // 含める。FE で「上位 N 件のみ表示」バナー表示用 (follow-up PR で消費)。
+      expect((result as { truncated?: boolean }).truncated).to.equal(true);
+      expect((result as { actualMatchedCount?: number }).actualMatchedCount).to.equal(MATCHED);
+
       // Assert 2: 除外される 1 件 (score=1, doc-ac10-001) は結果セットに含まれない。
       // limit=50 で 1 ページ目を取る場合、score 降順なら上位 50 件 (501..452) で 001 は含まれない。
       const ids = result.documents.map((d) => d.id);
@@ -781,6 +787,15 @@ describe('searchDocuments handler integration (#401a, Closes #401)', () => {
       expect(guardPayload.matchedCount).to.equal(MATCHED);
       expect(guardPayload.limit).to.equal(TRUNCATE_LIMIT);
       expect(guardPayload).to.not.have.property('query');
+
+      // Assert 5b: PII 防御 negative — raw query 文字列が warn payload のどの key 経由でも
+      // 漏れないことを全文検索で固定 (key 改名で漏れるリスクへの 2 段防御)。pr-test-analyzer
+      // SUGGESTION #6 対応。
+      const guardWarnSerialized = JSON.stringify(guardWarns[0]);
+      expect(
+        guardWarnSerialized,
+        'raw query "ac10common ac10rare" must not appear in warn payload'
+      ).to.not.include('ac10common ac10rare');
 
       // Assert 6: perf info ログに truncated=true が反映される (matchedCount は実マッチ数 501)。
       const perfLogs = infoCalls.filter((args) =>
@@ -829,8 +844,14 @@ describe('searchDocuments handler integration (#401a, Closes #401)', () => {
         offset: 0,
       });
 
-      // Assert: 全件取得 + OOM warn 未発火 + perf info の truncated=false
+      // Assert: 全件取得 + OOM warn 未発火 + perf info の truncated=false + 結果に
+      // truncated/actualMatchedCount フィールドが付与されない (silent-failure-hunter
+      // CRT-1 と対称な non-firing 側 fixate)。
       expect(result.total).to.equal(COUNT);
+      expect((result as { truncated?: boolean })).to.not.have.property('truncated');
+      expect((result as { actualMatchedCount?: number })).to.not.have.property(
+        'actualMatchedCount'
+      );
       const guardWarns = warnCalls.filter((args) =>
         args.some(
           (a) => typeof a === 'string' && a.includes('exceeds safe getAll limit')


### PR DESCRIPTION
## Summary

- `db.getAll()` の戻りを 256MiB Functions の安全圏に抑えるため、マッチ全件が **MAX_GETALL=500** を超えた場合は score 降順で上位 N 件のみ取得する暫定ガードを追加 (Issue #402 段階2、本文提案 #2 に対応)。
- 段階1 (PR #417) の perf observability ログに `truncated` フィールドを追加。`matchedCount` は段階2 ガード発動後の値ではなく**実マッチ件数**を記録し、N 分布の観測継続 = 段階3 (posting に fileDate 内包 or chunk 分割) 移行判断データを維持する。
- `console.warn` payload は段階1 と整合し `queryLength` のみ記録 (raw query は PII リスクのため除外)。
- **silent loss 防止**: SearchResult に `truncated` / `actualMatchedCount` を optional で追加 (silent-failure-hunter CRT-1 対応)。FE は未読でも互換、follow-up PR で SearchBar にバナー追加し semi-silent 化予定。

## 設計補足

| 項目 | 値 | 根拠 |
|------|-----|------|
| `MAX_GETALL` | 500 件 | Issue #402 本文の暫定値、document 1 件 ~ 数 KB × 500 = 数 MB 程度で 256MiB Functions 安全圏 |
| ガード発動時のソート | score 降順切り捨て → MAX_GETALL 件内で fileDate ソート | Issue 本文記載: fileDate ソートを部分犠牲 |
| ログ点 | `console.warn` (ガード発動時) + `console.info` perf (matchedCount 100 超 or elapsedMs 1000ms 超) | 段階1 perf ログと cross-reference 可 |
| `total` の挙動 | 取得した件数 (= MAX_GETALL) を返す | FE 側互換性維持 (現状の hasMore/pagination 設計はそのまま) |
| `truncated` / `actualMatchedCount` | 発動時のみ付与 (optional) | silent loss を semi-silent loss に格上げ。FE bannar 表示は follow-up PR |
| PII 対策 | `query` 文字列はログに含めず、`queryLength` のみ記録 | 段階1 (PR #417) と整合、AC10 で全文 negative 検証 (`JSON.stringify` 全文に raw query が出ないこと) |

## Out of scope

- **段階3 (真の対応)**: posting に fileDate 内包 / getAll chunk 分割。段階1 計測ログの N 分布データを蓄積してから別 Issue で判断する。
- **段階4 (cacheKey から offset 除外)**: Issue #402 提案 #4 として記載済だが、キャッシュ設計の影響範囲が大きいため独立 PR で扱う。
- **FE バナー表示**: SearchBar に `{truncated && <Banner />}` 追加。本 PR で API contract (`truncated` / `actualMatchedCount`) を確定し follow-up PR で UI 実装。
- **`total` に実マッチ件数を返す UX 改修**: FE 互換性破壊のため本 PR では現状維持。`actualMatchedCount` で代替露出済。

## Test plan

- [x] `npm test` (functions, unit + contract) — 1381 passing
- [x] `firebase emulators:exec --only firestore` 経由で Integration テスト全 PASS — 17 passing (AC10 2 件含む)
- [x] `npx tsc --noEmit` — error なし
- [x] `npx eslint src/search/searchDocuments.ts test/searchDocumentsIntegration.test.ts` — warn/error なし
- [ ] dev (main merge 時の CI 自動デプロイ) で perf info ログ + warn ログが Cloud Logging に届くことを次セッションで確認
- [ ] FE バナー follow-up PR merge 後、Functions / FE を kanameone / cocoro へ全環境展開

## レビュー反映 (PR 内で完結)

`/review-pr` (4 エージェント並列、本 PR commit `a27c067` で同梱):

- **silent-failure-hunter CRT-1**: ガード発動が API レスポンスに露出せず silent loss → SearchResult に `truncated` / `actualMatchedCount` を optional 追加。FE バナーは follow-up PR。
- **comment-analyzer IMPORTANT-1**: 段階3 着手時のクリーンアップ責務が暗黙 → MAX_GETALL 定数に `TODO(#402)` で撤去対象 (MAX_GETALL / truncatedBeforeCount / truncated / actualMatchedCount) を明示。AC10 fixture が本定数依存である旨も追記。
- **comment-analyzer SUGGESTION-1**: 段階3 の選択肢が片方のみ → 「posting に fileDate 内包 or getAll chunk 分割」両方をコメントに残す。
- **pr-test-analyzer SUGGESTION #6**: PII 防御の negative アサーションを補強 → `JSON.stringify(guardWarns[0]).not.include('ac10common ac10rare')` 全文検証で、raw query が warn payload のどの key 経由でも漏れないことを 2 段防御。
- **silent-failure-hunter CRT-1 対称検証**: AC10 非発動側 (150 件) で `truncated` / `actualMatchedCount` フィールド不在を明示検証。

## レビューで残置 (follow-up Issue 候補)

- **pr-test-analyzer IMPORTANT-1** (rating 7): fileDate 部分犠牲の明示検証 → FE バナー対応 PR で同梱予定 (CRT-1 follow-up にスコープ統合)
- **pr-test-analyzer IMPORTANT-2** (rating 6): 境界値 500 ちょうど検証 → AC10 補強として follow-up
- **pr-test-analyzer IMPORTANT-3** (rating 6): cache 経路で truncated 結果固着検証 → 段階4 (cacheKey 改修) PR と合流
- **silent-failure-hunter IMP-3**: HttpsError('resource-exhausted') 不採用根拠 → 本 PR description で代替明示済 (silent → semi-silent 化方針)

## AC10 設計メモ

発動側テスト (501 件 seed) は **AC2 と同じ「2 token AND + token 順 (高 df / 低 df)」設計**で idf > 0 を成立させ、score-desc 段が実 fixture で機能していることを検証する。単一 token 検索では `totalDocs == df` で `idf = log(1) = 0` となり全件同 score になるため、OOM ガードの「score 上位 N 件取得」が検証できない (初回実装で fail した教訓)。

非発動側テスト (150 件 seed) は MAX_GETALL=500 未満で `truncated=false` が perf info ログに含まれること + `console.warn` 未発火 + SearchResult に `truncated` / `actualMatchedCount` フィールド不在を確認。

## デプロイ範囲 (マルチクライアント運用、CLAUDE.md catchup マトリクス準拠)

| 工程 | dev | kanameone | cocoro |
|------|-----|-----------|--------|
| 1. dev 側 OOM ガード + truncated flag 実装 (本 PR) | ✅ | - | - |
| 2. dev 側テスト (unit 1381 + integration 17 PASS) | ✅ | - | - |
| 3. dev へ展開 (main merge 後 CI 自動) | CI 自動 | - | - |
| 4. FE バナー follow-up PR (silent loss → semi-silent) | ❌ | - | - |
| 5. Functions / FE 全クライアント反映 (deploy) | CI 自動 | ❌ (FE バナー PR merge 後) | ❌ (FE バナー PR merge 後) |
| 6. 各クライアント動作確認 (検索動作 + 501 件マッチケース観測) | ❌ | ❌ | ❌ |

**「dev のみ展開で完了」ではない**: 本 PR は OOM ガード = 機能変更 + API contract (`truncated` / `actualMatchedCount`) 変更を含み、検索機能は kanameone / cocoro 本番運用中で **実運用データ量も OOM リスク対象に該当する**。silent-failure-hunter も「kanameone/cocoro 展開前に FE バナーを follow-up で同梱推奨」と段階的展開を明示。

ロードマップ:
1. 本 PR #496 を main へ merge → dev 自動デプロイ
2. Follow-up PR (SearchBar バナー追加 + IMPORTANT-1 fileDate 部分犠牲テスト同梱) を起票・実装
3. Follow-up PR merge 後、Functions + Hosting を kanameone / cocoro へ deploy
4. 各クライアントで検索動作確認 + Cloud Logging で `truncated=true` 発生頻度を観測 (段階3 移行判断材料蓄積)

Refs #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)