### PR TITLE
feat(search): SearchBar OOM ガード発動時バナー追加 + fileDate 部分犠牲テスト補強 (Closes #497)

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -27,6 +27,8 @@ export function SearchBar({ onResultClick }: SearchBarProps) {
     results,
     total,
     hasMore,
+    truncated,
+    actualMatchedCount,
     isLoading,
     isError,
     loadMore,
@@ -131,6 +133,20 @@ export function SearchBar({ onResultClick }: SearchBarProps) {
             {/* 結果リスト */}
             {!isLoading && results.length > 0 && (
               <>
+                {/*
+                 * OOM ガード発動時のみ表示するバナー (Issue #402 段階2 / Issue #497)。
+                 * silent loss を semi-silent に格上げ: ユーザーが「上位 N 件のみ」事実に
+                 * 気付ける状態を作る。BE 側 (functions/src/search/searchDocuments.ts) で
+                 * MAX_GETALL=500 超過時のみ truncated=true + actualMatchedCount を付与。
+                 */}
+                {truncated && actualMatchedCount > 0 && (
+                  <div
+                    role="status"
+                    className="mb-2 rounded border border-yellow-300 bg-yellow-50 px-2 py-1.5 text-xs text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200"
+                  >
+                    該当が多すぎるため上位 {total} 件のみ表示しています（{actualMatchedCount} 件中）。検索語句を追加すると絞り込めます。
+                  </div>
+                )}
                 <div className="mb-2 px-2 text-xs text-muted-foreground">
                   {total}件の結果
                 </div>

--- a/frontend/src/components/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/__tests__/SearchBar.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * SearchBar コンポーネントテスト (Issue #497)
+ *
+ * OOM ガード発動時バナーの表示/非表示を検証する。silent-failure-hunter CRT-1 対応
+ * (Issue #402 段階2、PR #496) で BE 側に `truncated` / `actualMatchedCount` flag を
+ * 追加した後、FE 側でユーザーが切り捨て事実に気付ける semi-silent 状態を実現する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SearchBar } from '../SearchBar'
+
+// useDebouncedSearch をモックして戻り値を直接制御
+vi.mock('@/hooks/useSearch', async () => {
+  return {
+    useDebouncedSearch: vi.fn(),
+  }
+})
+
+import { useDebouncedSearch } from '@/hooks/useSearch'
+
+type MockedHookReturn = ReturnType<typeof useDebouncedSearch>
+
+function setupMockedSearch(overrides: Partial<MockedHookReturn>): void {
+  const base: MockedHookReturn = {
+    query: 'test',
+    setQuery: vi.fn(),
+    results: [
+      {
+        id: 'doc-1',
+        fileName: 'sample.pdf',
+        customerName: 'テスト顧客',
+        officeName: 'テスト事業所',
+        documentType: '請求書',
+        fileDate: '2026-05-17',
+        score: 1.0,
+      },
+    ],
+    total: 20,
+    hasMore: false,
+    truncated: false,
+    actualMatchedCount: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    search: vi.fn(),
+    loadMore: vi.fn(),
+    reset: vi.fn(),
+  }
+  ;(useDebouncedSearch as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    ...base,
+    ...overrides,
+  })
+}
+
+describe('SearchBar — OOM ガード発動時バナー (Issue #497)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('truncated=true + actualMatchedCount>0 でバナーが表示される (silent loss → semi-silent)', () => {
+    setupMockedSearch({
+      total: 500,
+      truncated: true,
+      actualMatchedCount: 501,
+    })
+
+    render(<SearchBar />)
+
+    // dropdown は query.length >= 2 + focus で開く設計だが、テストでは初期 isOpen=false
+    // のため、まず query を入力扱いにする必要がある。ここでは isOpen を制御できないので、
+    // 直接 useDebouncedSearch の query を 2 文字以上 + onFocus シミュレーションは不要で、
+    // テスト対象は「results.length > 0 のとき truncated=true ならバナーが現れる」。
+    // 実際の DOM は dropdown 内 (isOpen=true) でしか描画されないため、テストでは
+    // SearchBar 内部の isOpen を強制的に true にする手段が必要。
+    //
+    // 簡易策: input に value='test' (query.length>=2) を入れた状態で focus を発火させて
+    // dropdown を開く。
+    const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
+    fireEvent.focus(input)
+
+    // バナー role="status" を直接検索 (dropdown open 後に DOM に存在)
+    const banner = screen.queryByRole('status')
+    if (banner) {
+      expect(banner.textContent).toContain('該当が多すぎるため上位 500 件のみ表示しています')
+      expect(banner.textContent).toContain('501 件中')
+      expect(banner.textContent).toContain('検索語句を追加すると絞り込めます')
+    } else {
+      // dropdown が open していない場合は isOpen 制御が必要。本テストは描画ロジック確認
+      // のため、focus 後に dropdown が開いていない場合は SearchBar の isOpen state を
+      // 検証できない。代わりに「results が描画される DOM 構造を Card 配下に持つ」前提で
+      // 不開状態をスキップせず明示的に fail させる。
+      throw new Error(
+        'dropdown が open していないためバナー検証不可。SearchBar の onFocus 条件を確認してください。',
+      )
+    }
+  })
+
+  it('truncated=false ではバナーが表示されない (非発動側)', () => {
+    setupMockedSearch({
+      total: 20,
+      truncated: false,
+      actualMatchedCount: 0,
+    })
+
+    render(<SearchBar />)
+    const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
+    fireEvent.focus(input)
+
+    // バナーは存在してはならない
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('truncated=true でも actualMatchedCount=0 ならバナーが表示されない (防御的 short-circuit)', () => {
+    // 異常系: BE 側 contract 違反で truncated=true なのに actualMatchedCount が欠落する
+    // ケース。SearchBar 側は && actualMatchedCount > 0 でガードしているため非表示が正解。
+    setupMockedSearch({
+      total: 500,
+      truncated: true,
+      actualMatchedCount: 0,
+    })
+
+    render(<SearchBar />)
+    const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
+    fireEvent.focus(input)
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/frontend/src/components/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/__tests__/SearchBar.test.tsx
@@ -4,18 +4,19 @@
  * OOM ガード発動時バナーの表示/非表示を検証する。silent-failure-hunter CRT-1 対応
  * (Issue #402 段階2、PR #496) で BE 側に `truncated` / `actualMatchedCount` flag を
  * 追加した後、FE 側でユーザーが切り捨て事実に気付ける semi-silent 状態を実現する。
+ *
+ * E2E (Playwright) では別 issue で実機確認予定 (dark mode 視覚検証、aria-live 通知の
+ * 実際の screen reader 挙動)。本ファイルは描画ロジック契約 (props 駆動の表示判定 +
+ * accessibility role 属性 + 防御短絡) の単体検証に範囲を限定する。
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SearchBar } from '../SearchBar'
 
-// useDebouncedSearch をモックして戻り値を直接制御
-vi.mock('@/hooks/useSearch', async () => {
-  return {
-    useDebouncedSearch: vi.fn(),
-  }
-})
+vi.mock('@/hooks/useSearch', async () => ({
+  useDebouncedSearch: vi.fn(),
+}))
 
 import { useDebouncedSearch } from '@/hooks/useSearch'
 
@@ -53,77 +54,88 @@ function setupMockedSearch(overrides: Partial<MockedHookReturn>): void {
   })
 }
 
+/**
+ * dropdown を open させて render する shorthand。mock の query='test' により
+ * `query.length >= 2 && setIsOpen(true)` で focus 1 回で確実に dropdown が描画される。
+ */
+function renderAndOpen(): void {
+  render(<SearchBar />)
+  const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
+  fireEvent.focus(input)
+}
+
 describe('SearchBar — OOM ガード発動時バナー (Issue #497)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('truncated=true + actualMatchedCount>0 でバナーが表示される (silent loss → semi-silent)', () => {
+  it('truncated=true + actualMatchedCount>0 でバナー描画 + role=status + 文言固定', () => {
+    setupMockedSearch({ total: 500, truncated: true, actualMatchedCount: 501 })
+    renderAndOpen()
+
+    // CRIT-1 対応: getByRole は要素未発見で自動 fail (前回 fail 時の if-else fallback 廃止)。
+    const banner = screen.getByRole('status')
+
+    // CRIT-2 対応: aria-live region 相当の role="status" 属性を直接 fixate。
+    // class だけ残して role が消えるリファクタは silent regression のため明示固定する。
+    expect(banner.getAttribute('role')).toBe('status')
+
+    // 文言は silent loss 改善の核心 UX (= ユーザーが「実 M 件中の上位 N 件」事実に
+    // 気付けて検索語句絞り込みに誘導される) のため 3 要素を独立検証する。
+    const text = banner.textContent ?? ''
+    expect(text).toContain('該当が多すぎるため上位 500 件のみ表示しています')
+    expect(text).toContain('501 件中')
+    expect(text).toContain('検索語句を追加すると絞り込めます')
+  })
+
+  it('truncated=false ではバナー非表示', () => {
+    setupMockedSearch({ total: 20, truncated: false, actualMatchedCount: 0 })
+    renderAndOpen()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('truncated=true でも actualMatchedCount=0 ならバナー非表示 (防御短絡: 数値不正値)', () => {
+    setupMockedSearch({ total: 500, truncated: true, actualMatchedCount: 0 })
+    renderAndOpen()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('truncated=true でも actualMatchedCount=undefined ならバナー非表示 (防御短絡: 型契約)', () => {
+    // BE contract 違反シミュレーション: spread 漏れで `truncated: true` のみ送られ
+    // `actualMatchedCount` が欠落するケース。FE 側 `?? 0` フォールバック後に
+    // `&& actualMatchedCount > 0` で短絡されるため非表示が正解 (IMP-3 対応)。
     setupMockedSearch({
+      total: 500,
+      truncated: true,
+      actualMatchedCount: undefined as unknown as number,
+    })
+    renderAndOpen()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('isLoading=true のときは truncated=true でもバナー非表示 (描画ネスト位置の固定)', () => {
+    // バナーは `{!isLoading && results.length > 0 && (<>...</>)}` 配下にネスト。
+    // ローディング中にバナーが残るリファクタを silent regression として検出 (IMP-4 対応)。
+    setupMockedSearch({
+      isLoading: true,
       total: 500,
       truncated: true,
       actualMatchedCount: 501,
     })
-
-    render(<SearchBar />)
-
-    // dropdown は query.length >= 2 + focus で開く設計だが、テストでは初期 isOpen=false
-    // のため、まず query を入力扱いにする必要がある。ここでは isOpen を制御できないので、
-    // 直接 useDebouncedSearch の query を 2 文字以上 + onFocus シミュレーションは不要で、
-    // テスト対象は「results.length > 0 のとき truncated=true ならバナーが現れる」。
-    // 実際の DOM は dropdown 内 (isOpen=true) でしか描画されないため、テストでは
-    // SearchBar 内部の isOpen を強制的に true にする手段が必要。
-    //
-    // 簡易策: input に value='test' (query.length>=2) を入れた状態で focus を発火させて
-    // dropdown を開く。
-    const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
-    fireEvent.focus(input)
-
-    // バナー role="status" を直接検索 (dropdown open 後に DOM に存在)
-    const banner = screen.queryByRole('status')
-    if (banner) {
-      expect(banner.textContent).toContain('該当が多すぎるため上位 500 件のみ表示しています')
-      expect(banner.textContent).toContain('501 件中')
-      expect(banner.textContent).toContain('検索語句を追加すると絞り込めます')
-    } else {
-      // dropdown が open していない場合は isOpen 制御が必要。本テストは描画ロジック確認
-      // のため、focus 後に dropdown が開いていない場合は SearchBar の isOpen state を
-      // 検証できない。代わりに「results が描画される DOM 構造を Card 配下に持つ」前提で
-      // 不開状態をスキップせず明示的に fail させる。
-      throw new Error(
-        'dropdown が open していないためバナー検証不可。SearchBar の onFocus 条件を確認してください。',
-      )
-    }
-  })
-
-  it('truncated=false ではバナーが表示されない (非発動側)', () => {
-    setupMockedSearch({
-      total: 20,
-      truncated: false,
-      actualMatchedCount: 0,
-    })
-
-    render(<SearchBar />)
-    const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
-    fireEvent.focus(input)
-
-    // バナーは存在してはならない
+    renderAndOpen()
     expect(screen.queryByRole('status')).toBeNull()
   })
 
-  it('truncated=true でも actualMatchedCount=0 ならバナーが表示されない (防御的 short-circuit)', () => {
-    // 異常系: BE 側 contract 違反で truncated=true なのに actualMatchedCount が欠落する
-    // ケース。SearchBar 側は && actualMatchedCount > 0 でガードしているため非表示が正解。
+  it('results.length===0 のときは truncated=true でもバナー非表示 (BE contract 違反防御)', () => {
+    // 論理的にあり得ないが BE 側 contract 違反 (truncated=true なのに documents=[]) で
+    // 起こり得る。`results.length > 0` ガード破壊を回帰検出 (IMP-4 対応)。
     setupMockedSearch({
-      total: 500,
+      results: [],
+      total: 0,
       truncated: true,
-      actualMatchedCount: 0,
+      actualMatchedCount: 501,
     })
-
-    render(<SearchBar />)
-    const input = screen.getByPlaceholderText('顧客名、事業所名、書類種別で検索...')
-    fireEvent.focus(input)
-
+    renderAndOpen()
     expect(screen.queryByRole('status')).toBeNull()
   })
 })

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -54,9 +54,17 @@ interface UseSearchResult {
   results: SearchResultDocument[];
   total: number;
   hasMore: boolean;
-  /** Issue #402 段階2 OOM ガード発動時のみ true (SearchBar バナー表示用)。 */
+  /**
+   * Issue #402 段階2 OOM ガード発動時のみ true。SearchBar の表示判定は
+   * `truncated && actualMatchedCount > 0` の AND 条件 (BE contract 違反時の防御短絡)。
+   * BE が field を返さない場合は `?? false` でフォールバック。
+   */
   truncated: boolean;
-  /** Issue #402 段階2 OOM ガード発動時のみ実マッチ件数。未発動時は 0 (SearchBar 未表示)。 */
+  /**
+   * Issue #402 段階2 OOM ガード発動時のみ BE から付与される (optional)。truncate 前の
+   * 実マッチ件数。FE では未発動時 / フィールド欠落時に 0 にフォールバック (`?? 0`)。
+   * 0 のときは BE contract 違反として SearchBar のバナーは非表示 (上の AND 短絡)。
+   */
   actualMatchedCount: number;
   isLoading: boolean;
   isError: boolean;

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -27,6 +27,17 @@ export interface SearchResult {
   documents: SearchResultDocument[];
   total: number;
   hasMore: boolean;
+  /**
+   * Issue #402 段階2 OOM ガード発動時のみ true。BE 側 (functions/src/search/searchDocuments.ts)
+   * の SearchResult 型と同期する optional field。true のとき total = MAX_GETALL (= 取得件数)
+   * で、実マッチ件数は actualMatchedCount を参照。
+   */
+  truncated?: boolean;
+  /**
+   * Issue #402 段階2 OOM ガード発動時のみ存在。truncate 前の実マッチ件数。
+   * SearchBar で「上位 N 件のみ表示しています (実 M 件中)」バナー表示用 (Issue #497)。
+   */
+  actualMatchedCount?: number;
 }
 
 /** 検索リクエスト */
@@ -43,6 +54,10 @@ interface UseSearchResult {
   results: SearchResultDocument[];
   total: number;
   hasMore: boolean;
+  /** Issue #402 段階2 OOM ガード発動時のみ true (SearchBar バナー表示用)。 */
+  truncated: boolean;
+  /** Issue #402 段階2 OOM ガード発動時のみ実マッチ件数。未発動時は 0 (SearchBar 未表示)。 */
+  actualMatchedCount: number;
   isLoading: boolean;
   isError: boolean;
   error: Error | null;
@@ -128,6 +143,8 @@ export function useSearch(): UseSearchResult {
     results,
     total: data?.total || 0,
     hasMore: data?.hasMore || false,
+    truncated: data?.truncated ?? false,
+    actualMatchedCount: data?.actualMatchedCount ?? 0,
     isLoading,
     isError,
     error: error as Error | null,

--- a/functions/test/searchDocumentsIntegration.test.ts
+++ b/functions/test/searchDocumentsIntegration.test.ts
@@ -868,5 +868,87 @@ describe('searchDocuments handler integration (#401a, Closes #401)', () => {
       expect(perfPayload.matchedCount).to.equal(COUNT);
       expect(perfPayload.truncated).to.be.false;
     }).timeout(30000);
+
+    // ----------------------------------------
+    // AC10-c: fileDate 部分犠牲 — score 下位は fileDate 最新でも犠牲対象 (Issue #497、
+    //         PR #496 レビュー pr-test-analyzer IMPORTANT-1 対応)
+    //
+    // OOM ガードは score 降順切り捨てで上位 MAX_GETALL 件のみ getAll する設計。fileDate
+    // ソート (compareSearchResults の tier-1) は MAX_GETALL 件の範囲内に限定 (= 全体
+    // ソートの「部分犠牲」)。本テストは「score 最下位 (= 犠牲対象) に最新 fileDate を
+    // 仕込んでも結果に含まれない」ことを 1 アサーションで固定し、将来「ガード前に
+    // fileDate sort してから getAll」へ書き換わるリファクタを回帰検出可能にする。
+    // ----------------------------------------
+    it('fileDate 部分犠牲 — score 下位は fileDate 最新でも犠牲対象 (IMPORTANT-1)', async () => {
+      await seedUser();
+
+      // AC10 発動側と同じ「2 token AND + 高 df / 低 df」設計で idf > 0 を成立させる。
+      // 501 件のうち doc-ac10c-001 (score=1、最下位) のみ将来 fileDate を持たせ、残りは
+      // null。ガード発動で doc-ac10c-001 が犠牲になることを「fileDate 最新でも除外」で
+      // 明示検証する。
+      const MATCHED = 501;
+      const TRUNCATE_LIMIT = 500;
+      const commonPostings: Record<string, { score: number; fieldsMask: number }> = {};
+      const rarePostings: Record<string, { score: number; fieldsMask: number }> = {};
+      for (let i = 1; i <= MATCHED; i++) {
+        const docId = `doc-ac10c-${String(i).padStart(3, '0')}`;
+        commonPostings[docId] = { score: 1.0, fieldsMask: 8 };
+        rarePostings[docId] = { score: i, fieldsMask: 8 };
+      }
+      await seedSearchIndex('ac10ccommon', commonPostings, 10000);
+      await seedSearchIndex('ac10crare', rarePostings, 2);
+
+      const proc = ts('2026-04-27T12:00:00Z');
+      // 上位 500 件 (doc-ac10c-002..doc-ac10c-501): fileDate=null
+      // 最下位 1 件 (doc-ac10c-001): fileDate=2099-01-01 (将来日付、ソート tier-1 では最先頭)
+      const futureFileDate = ts('2099-01-01T00:00:00Z');
+      for (let batchStart = 1; batchStart <= MATCHED; batchStart += 400) {
+        const batch = db.batch();
+        const batchEnd = Math.min(batchStart + 399, MATCHED);
+        for (let i = batchStart; i <= batchEnd; i++) {
+          const docId = `doc-ac10c-${String(i).padStart(3, '0')}`;
+          batch.set(db.doc(`documents/${docId}`), {
+            fileName: `oom-fd-${docId}.pdf`,
+            customerName: '',
+            officeName: '',
+            documentType: '',
+            fileDate: i === 1 ? futureFileDate : null, // score=1 (最下位) のみ最新 fileDate
+            processedAt: proc,
+            status: 'processed',
+          });
+        }
+        await batch.commit();
+      }
+
+      // Act
+      const result = await callSearch({
+        query: 'ac10ccommon ac10crare',
+        limit: 50,
+        offset: 0,
+      });
+
+      // Assert: doc-ac10c-001 は fileDate 最新だが score 最下位のため犠牲対象。
+      // ガード発動なしの設計 (= fileDate sort 先行で getAll する実装) では doc-ac10c-001
+      // が tier-1 fileDate desc で結果先頭に来るはずだが、本実装 (score 降順切り捨て)
+      // では犠牲対象になり結果セットに含まれない。
+      expect(result.total).to.equal(TRUNCATE_LIMIT);
+      expect((result as { truncated?: boolean }).truncated).to.equal(true);
+      expect((result as { actualMatchedCount?: number }).actualMatchedCount).to.equal(MATCHED);
+
+      const ids = result.documents.map((d) => d.id);
+      expect(
+        ids,
+        'fileDate 最新でも score 最下位 (doc-ac10c-001) は犠牲対象として除外される',
+      ).to.not.include('doc-ac10c-001');
+
+      // 上位 500 件は score 降順切り捨て後の集合 (doc-ac10c-002..501)、fileDate=null。
+      // limit=50 + offset=0 で 1 ページ目は score 降順上位 50 件 = doc-ac10c-501..452。
+      // fileDate=null なので tier-1 NULLS LAST 内では tier-2 score desc が支配。
+      const expectedTopIds = Array.from(
+        { length: 50 },
+        (_, k) => `doc-ac10c-${String(MATCHED - k).padStart(3, '0')}`,
+      );
+      expect(ids).to.deep.equal(expectedTopIds);
+    }).timeout(60000);
   });
 });


### PR DESCRIPTION
## Summary

PR #496 (Issue #402 段階2 OOM ガード暫定) で BE 側 SearchResult に追加した optional フィールド `truncated` / `actualMatchedCount` を FE 側で消費し、silent-failure-hunter CRT-1 で指摘された silent loss を **semi-silent loss に格上げ**する。kanameone / cocoro の本番展開 prerequisite。

## 変更内容

| ファイル | 変更 |
|---|---|
| `frontend/src/hooks/useSearch.ts` | `SearchResult` / `UseSearchResult` 型に `truncated` / `actualMatchedCount` を追加、フック return で BE レスポンスから取り回す |
| `frontend/src/components/SearchBar.tsx` | 結果リスト先頭に `role="status"` のバナー追加。`truncated && actualMatchedCount > 0` のときのみ表示 (防御的 short-circuit)。dark mode 対応 (`bg-yellow-50` / `dark:bg-yellow-950`) |
| `frontend/src/components/__tests__/SearchBar.test.tsx` (新規) | バナー表示 / 非表示 / 防御的 short-circuit の 3 ケース |
| `functions/test/searchDocumentsIntegration.test.ts` | AC10-c 追加: pr-test-analyzer IMPORTANT-1 対応で「score 最下位 (doc-ac10c-001) に将来 fileDate を仕込んでも犠牲対象」を 1 アサーションで固定 |

## バナー設計

```tsx
{truncated && actualMatchedCount > 0 && (
  <div
    role=\"status\"
    className=\"mb-2 rounded border border-yellow-300 bg-yellow-50 px-2 py-1.5 text-xs text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200\"
  >
    該当が多すぎるため上位 {total} 件のみ表示しています（{actualMatchedCount} 件中）。検索語句を追加すると絞り込めます。
  </div>
)}
```

- 警告色 (黄系) で「結果は部分」と視覚的に伝える
- `role=\"status\"` で screen reader 通知 (ARIA accessibility)
- 「検索語句を追加すると絞り込めます」とユーザー行動を誘導
- `actualMatchedCount > 0` 防御で BE contract 違反時の誤表示を防止

## AC10-c の意義 (pr-test-analyzer IMPORTANT-1)

PR #496 の元 AC10 では 501 件全件 fileDate=null + 同 processedAt で seed していたため tier-1 (fileDate desc NULLS LAST) が trivial に成立。将来 「ガード前に fileDate sort してから getAll」 リファクタが入った場合に AC10 は通るが production の挙動 (score 上位 N 件のうち fileDate 降順) が壊れる懸念があった。

AC10-c は score 最下位 (doc-ac10c-001) に **将来 fileDate (2099-01-01)** を仕込み、ガード発動時に「fileDate 最新でも犠牲」を 1 アサーションで固定する:

```ts
expect(ids).to.not.include('doc-ac10c-001');
```

ガード前に fileDate sort する実装に変わると AC10-c が FAIL する。

## Test plan

- [x] `npm test` (frontend, vitest) — 14 files / 244 tests + 新規 SearchBar 3 tests = 全 PASS
- [x] `npm run typecheck` (frontend) — error なし
- [x] `npm run lint` (frontend) — warn/error なし
- [x] `npm test` (functions, unit + contract) — 1381 passing (変更なし、念のため再実行可)
- [x] `firebase emulators:exec --only firestore` 経由 Integration — 18 passing (AC10-c 追加で 17→18)
- [ ] main merge 後の dev 自動デプロイで実画面のバナー描画を Playwright で確認 (501 件 mock セッション)
- [ ] kanameone / cocoro 展開後に検索動作確認 + Cloud Logging で `truncated=true` 発生時の挙動相関

## デプロイ範囲 (マルチクライアント運用)

| 工程 | dev | kanameone | cocoro |
|------|-----|-----------|--------|
| 1. SearchBar バナー実装 (本 PR) | ✅ | - | - |
| 2. FE テスト + BE Integration テスト | ✅ | - | - |
| 3. dev へ展開 (main merge 後 CI 自動) | CI 自動 | - | - |
| 4. dev で Playwright スクショ確認 | ❌ (merge 後) | - | - |
| 5. Functions + Hosting を kanameone / cocoro へ deploy | ✅ (CI 自動) | ❌ (本 PR merge + dev 確認後) | ❌ (本 PR merge + dev 確認後) |
| 6. 各クライアント検索動作確認 | ❌ | ❌ | ❌ |

PR #496 と本 PR がセットで Issue #402 段階2 (OOM ガード + silent loss 防止) の完成形。kanameone / cocoro 展開はこの 2 PR merge 完了 + dev 確認完了後にユーザー判断で実施。

Closes #497
Refs #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now display a warning banner when results are limited by system capacity constraints, indicating how many results are shown versus total matches found, and encouraging query refinement.

* **Tests**
  * Added comprehensive unit and integration tests validating the search result limitation warning and capacity constraint handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->