### PR TITLE
fix(ocr): 短文字列 office マスター流入 + classifier exact match で 675 docs 誤分類 (Closes #501)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -47,6 +47,9 @@ on:
           - force-reindex --doc-id
           - force-reindex --doc-id --execute
           - investigate-office-duplicate
+          - audit-short-office-masters
+          - audit-short-office-masters --max-length 3
+          - audit-short-office-masters --max-length 4
           - cleanup-office-name --dry-run
           - cleanup-office-name --execute
           - inspect-document --file-name

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -33,6 +33,19 @@ const MAX_CANDIDATES = 10;
 /** 最小スコア閾値 */
 const MIN_SCORE_THRESHOLD = 70;
 
+/**
+ * Office classifier の exact-match path で score 100/95/98 を取らせる最小文字数 (#501)。
+ *
+ * substring 包含だけで exact 認定する 3 path (正式名 / shortName / aliases) は、
+ * 短文字列マスター (CSV import 由来の「ケア」「ニック」等) が任意文書に含まれて
+ * score 100 で正規マスターを駆逐する経路を提供してしまう。
+ *
+ * sanitize 側で同基準 (DEFAULT_MIN_OFFICE_NAME_LENGTH) で drop するため通常は到達しないが、
+ * sanitize bypass 経路 (テスト / 旧データ / 短縮値が一時的に低い場合) でも防御層が機能するよう
+ * 二重防御として classifier 側にも独立にガードする。
+ */
+const OFFICE_EXACT_MATCH_MIN_LENGTH = 4;
+
 /** 施設タイプキーワード（汎用語判定にも使用） */
 const FACILITY_TYPES = [
   'デイサービス',
@@ -372,15 +385,21 @@ export function extractOfficeNameEnhanced(
     let score = 0;
     let matchType: MatchType = 'none';
 
-    // 完全一致
-    if (matchingText.includes(normalizedOfficeName)) {
+    // 完全一致 (#501: 短文字列マスターの substring 暴走を防ぐため length ガード)
+    if (
+      normalizedOfficeName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
+      matchingText.includes(normalizedOfficeName)
+    ) {
       score = 100;
       matchType = 'exact';
     }
-    // 短縮名での一致
+    // 短縮名での一致 (#501: 同様に length ガード)
     else if (office.shortName) {
       const normalizedShortName = normalizeForMatching(office.shortName);
-      if (matchingText.includes(normalizedShortName)) {
+      if (
+        normalizedShortName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
+        matchingText.includes(normalizedShortName)
+      ) {
         score = 95;
         matchType = 'exact';
       }
@@ -830,25 +849,34 @@ export function extractOfficeCandidates(
       }
     }
 
-    // 1. 完全一致（正式名称）
-    if (matchingText.includes(normalizedOfficeName)) {
+    // 1. 完全一致（正式名称） (#501: 短文字列マスターの substring 暴走を防ぐため length ガード)
+    if (
+      normalizedOfficeName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
+      matchingText.includes(normalizedOfficeName)
+    ) {
       score = 100;
       matchType = 'exact';
     }
-    // 2. 短縮名での一致
+    // 2. 短縮名での一致 (#501: 同様に length ガード)
     else if (office.shortName) {
       const normalizedShortName = normalizeForMatching(office.shortName);
-      if (matchingText.includes(normalizedShortName)) {
+      if (
+        normalizedShortName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
+        matchingText.includes(normalizedShortName)
+      ) {
         score = 95;
         matchType = 'exact';
       }
     }
 
-    // 2.5. エイリアス（許容表記）での一致
+    // 2.5. エイリアス（許容表記）での一致 (#501: 同様に length ガード)
     if (matchType === 'none' && office.aliases && office.aliases.length > 0) {
       for (const alias of office.aliases) {
         const normalizedAlias = normalizeForMatching(alias);
-        if (matchingText.includes(normalizedAlias)) {
+        if (
+          normalizedAlias.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
+          matchingText.includes(normalizedAlias)
+        ) {
           score = 98; // 正式名称一致に近いスコア
           matchType = 'exact';
           break;

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -34,17 +34,55 @@ const MAX_CANDIDATES = 10;
 const MIN_SCORE_THRESHOLD = 70;
 
 /**
- * Office classifier の exact-match path で score 100/95/98 を取らせる最小文字数 (#501)。
+ * Office classifier で「common short master」と判定する閾値 (#501 v2)。
  *
- * substring 包含だけで exact 認定する 3 path (正式名 / shortName / aliases) は、
- * 短文字列マスター (CSV import 由来の「ケア」「ニック」等) が任意文書に含まれて
- * score 100 で正規マスターを駆逐する経路を提供してしまう。
+ * 短文字列マスター ("ケア" 2/「ニック」3 等、CSV import 由来の汚染) は OCR 文書中の
+ * 他事業所名の substring として頻繁に出現するため exact match で score 100 を取り
+ * 正規マスターを駆逐する。一方で legitimate な短マスター ("ピース" "わかば" "てらす"
+ * 3-4 文字、cocoro/kanameone 実在) は他マスター name と衝突しないため独立して機能する。
  *
- * sanitize 側で同基準 (DEFAULT_MIN_OFFICE_NAME_LENGTH) で drop するため通常は到達しないが、
- * sanitize bypass 経路 (テスト / 旧データ / 短縮値が一時的に低い場合) でも防御層が機能するよう
- * 二重防御として classifier 側にも独立にガードする。
+ * length 単独では distinguish 不可能なため、マスター name 同士の substring 衝突数を
+ * 動的に計測し「他マスター name の substring に COMMON_SHORT_COLLISION_THRESHOLD 件以上
+ * 含まれる短マスター」を common 扱いとし exact match path から除外する。partial/fuzzy
+ * 経路は通常通り。
  */
-const OFFICE_EXACT_MATCH_MIN_LENGTH = 4;
+const COMMON_SHORT_LENGTH_THRESHOLD = 4; // length < N を「短い」と扱う
+const COMMON_SHORT_COLLISION_THRESHOLD = 2; // 他マスター N+ の substring に含まれる → common
+
+/**
+ * マスター name 同士の substring 衝突に基づき「common short master」id 集合を返す。
+ *
+ * @param masters office マスター全件
+ * @returns common 扱いする master id の Set (exact match から除外する対象)
+ */
+export function computeCommonShortMasters(masters: OfficeMaster[]): Set<string> {
+  const commonIds = new Set<string>();
+  // 短マスターのみが対象 (長マスターは元々 substring 衝突に強い)
+  const normalizedNames = masters.map((m) => ({
+    id: m.id,
+    name: m.name,
+    normalized: normalizeForMatching(m.name),
+  }));
+  const shortMasters = normalizedNames.filter(
+    (m) => m.normalized.length > 0 && m.normalized.length < COMMON_SHORT_LENGTH_THRESHOLD,
+  );
+
+  for (const candidate of shortMasters) {
+    let collisions = 0;
+    for (const other of normalizedNames) {
+      if (other.id === candidate.id) continue;
+      if (other.normalized.length <= candidate.normalized.length) continue;
+      if (other.normalized.includes(candidate.normalized)) {
+        collisions++;
+        if (collisions >= COMMON_SHORT_COLLISION_THRESHOLD) {
+          commonIds.add(candidate.id);
+          break;
+        }
+      }
+    }
+  }
+  return commonIds;
+}
 
 /** 施設タイプキーワード（汎用語判定にも使用） */
 const FACILITY_TYPES = [
@@ -373,6 +411,10 @@ export function extractOfficeNameEnhanced(
   const normalizedText = normalizeTextEnhanced(ocrText);
   const matchingText = normalizeForMatching(normalizedText);
 
+  // #501 v2: マスター name 同士の substring 衝突から common short master を事前計算し
+  // exact match path から除外する (legitimate な短マスターは collision なしで通過する)
+  const commonShortIds = computeCommonShortMasters(officeMasters);
+
   let bestResult: OfficeExtractionResult = {
     officeName: null,
     score: 0,
@@ -384,22 +426,19 @@ export function extractOfficeNameEnhanced(
     const normalizedOfficeName = normalizeForMatching(office.name);
     let score = 0;
     let matchType: MatchType = 'none';
+    const skipExactMatch = commonShortIds.has(office.id);
 
-    // 完全一致 (#501: 短文字列マスターの substring 暴走を防ぐため length ガード)
+    // 完全一致 (正式名 / shortName) — #501 で common short master は exact path skip
     if (
-      normalizedOfficeName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
+      !skipExactMatch &&
       matchingText.includes(normalizedOfficeName)
     ) {
       score = 100;
       matchType = 'exact';
     }
-    // 短縮名での一致 (#501: 同様に length ガード)
-    else if (office.shortName) {
+    else if (office.shortName && !skipExactMatch) {
       const normalizedShortName = normalizeForMatching(office.shortName);
-      if (
-        normalizedShortName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
-        matchingText.includes(normalizedShortName)
-      ) {
+      if (matchingText.includes(normalizedShortName)) {
         score = 95;
         matchType = 'exact';
       }
@@ -815,6 +854,10 @@ export function extractOfficeCandidates(
   const normalizedText = normalizeTextEnhanced(ocrText);
   const matchingText = normalizeForMatching(normalizedText);
 
+  // #501 v2: マスター name 同士の substring 衝突から common short master を事前計算し
+  // exact match path から除外する (legitimate な短マスターは collision なしで通過する)
+  const commonShortIds = computeCommonShortMasters(officeMasters);
+
   // ファイル名プレフィックスの正規化（事業所名タイプの場合のみ使用）
   const useFilenameForMatching = filenameInfo && filenameInfo.prefixType === 'office_name';
   const filenamePrefix = useFilenameForMatching ? filenameInfo.normalizedPrefix : '';
@@ -826,6 +869,7 @@ export function extractOfficeCandidates(
     let score = 0;
     let matchType: MatchType = 'none';
     let filenameBoost = 0;
+    const skipExactMatch = commonShortIds.has(office.id);
 
     // ファイル名マッチング（事業所名がファイル名に含まれる場合にボーナス）
     if (useFilenameForMatching && filenamePrefix) {
@@ -849,34 +893,27 @@ export function extractOfficeCandidates(
       }
     }
 
-    // 1. 完全一致（正式名称） (#501: 短文字列マスターの substring 暴走を防ぐため length ガード)
-    if (
-      normalizedOfficeName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
-      matchingText.includes(normalizedOfficeName)
-    ) {
+    // 1-2.5: 完全一致 (正式名 / shortName / aliases)
+    // #501 v2 で common short master (他マスター name の substring に頻出) は skip。
+    // 1. 完全一致（正式名称）
+    if (!skipExactMatch && matchingText.includes(normalizedOfficeName)) {
       score = 100;
       matchType = 'exact';
     }
-    // 2. 短縮名での一致 (#501: 同様に length ガード)
-    else if (office.shortName) {
+    // 2. 短縮名での一致
+    else if (office.shortName && !skipExactMatch) {
       const normalizedShortName = normalizeForMatching(office.shortName);
-      if (
-        normalizedShortName.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
-        matchingText.includes(normalizedShortName)
-      ) {
+      if (matchingText.includes(normalizedShortName)) {
         score = 95;
         matchType = 'exact';
       }
     }
 
-    // 2.5. エイリアス（許容表記）での一致 (#501: 同様に length ガード)
-    if (matchType === 'none' && office.aliases && office.aliases.length > 0) {
+    // 2.5. エイリアス（許容表記）での一致
+    if (matchType === 'none' && !skipExactMatch && office.aliases && office.aliases.length > 0) {
       for (const alias of office.aliases) {
         const normalizedAlias = normalizeForMatching(alias);
-        if (
-          normalizedAlias.length >= OFFICE_EXACT_MATCH_MIN_LENGTH &&
-          matchingText.includes(normalizedAlias)
-        ) {
+        if (matchingText.includes(normalizedAlias)) {
           score = 98; // 正式名称一致に近いスコア
           matchType = 'exact';
           break;

--- a/functions/src/utils/sanitizeMasterData.ts
+++ b/functions/src/utils/sanitizeMasterData.ts
@@ -8,9 +8,24 @@
  *
  * #344: silent drop を observable にするため、戻り値に droppedIds を含める。
  *       caller 側 (loadMasterData) が drop 件数に応じて safeLogError を発火する契約。
+ *
+ * #501: 短文字列の office マスター ("ケア" / "ニック" 等、CSV import 由来の汚染) は
+ *       classifier の substring match で score 100 を取って正規マスターを駆逐する。
+ *       sanitize 段で `office.name.length >= DEFAULT_MIN_OFFICE_NAME_LENGTH` ガードで drop する。
  */
 
 import type { CustomerMaster, OfficeMaster, DocumentMaster } from './extractors';
+
+/**
+ * 事業所マスター name の最小許容長 (sanitize 段で drop する閾値)。
+ *
+ * #501: kanameone 本番マスターに「ケア」(2) / 「ニック」(3) が混入し、
+ *       classifier の `matchingText.includes(normalizedOfficeName)` が任意文書で
+ *       score 100 を取り 675 件の document が誤分類された経緯から導入。
+ *       通常の事業所名は 4 文字以上 (例: 「○○ケア」「○○クリニック」のような屋号付き形式)。
+ *       それ以下の正規マスターがあれば droppedIds + safeLogError で観測可能。
+ */
+export const DEFAULT_MIN_OFFICE_NAME_LENGTH = 4;
 
 /** サニタイズ結果 envelope (items + drop された id 一覧) */
 export interface SanitizeResult<T> {
@@ -74,12 +89,14 @@ export function sanitizeCustomerMasters(
 }
 
 export function sanitizeOfficeMasters(
-  raw: OfficeMaster[]
+  raw: OfficeMaster[],
+  options: { minNameLength?: number } = {},
 ): SanitizeResult<OfficeMaster> {
+  const minNameLength = options.minNameLength ?? DEFAULT_MIN_OFFICE_NAME_LENGTH;
   const items: OfficeMaster[] = [];
   const droppedIds: string[] = [];
   for (const o of raw) {
-    if (typeof o.name === 'string' && o.name.length > 0) {
+    if (typeof o.name === 'string' && o.name.length >= minNameLength) {
       items.push({
         id: o.id,
         name: o.name,

--- a/functions/src/utils/sanitizeMasterData.ts
+++ b/functions/src/utils/sanitizeMasterData.ts
@@ -8,24 +8,9 @@
  *
  * #344: silent drop を observable にするため、戻り値に droppedIds を含める。
  *       caller 側 (loadMasterData) が drop 件数に応じて safeLogError を発火する契約。
- *
- * #501: 短文字列の office マスター ("ケア" / "ニック" 等、CSV import 由来の汚染) は
- *       classifier の substring match で score 100 を取って正規マスターを駆逐する。
- *       sanitize 段で `office.name.length >= DEFAULT_MIN_OFFICE_NAME_LENGTH` ガードで drop する。
  */
 
 import type { CustomerMaster, OfficeMaster, DocumentMaster } from './extractors';
-
-/**
- * 事業所マスター name の最小許容長 (sanitize 段で drop する閾値)。
- *
- * #501: kanameone 本番マスターに「ケア」(2) / 「ニック」(3) が混入し、
- *       classifier の `matchingText.includes(normalizedOfficeName)` が任意文書で
- *       score 100 を取り 675 件の document が誤分類された経緯から導入。
- *       通常の事業所名は 4 文字以上 (例: 「○○ケア」「○○クリニック」のような屋号付き形式)。
- *       それ以下の正規マスターがあれば droppedIds + safeLogError で観測可能。
- */
-export const DEFAULT_MIN_OFFICE_NAME_LENGTH = 4;
 
 /** サニタイズ結果 envelope (items + drop された id 一覧) */
 export interface SanitizeResult<T> {
@@ -89,14 +74,12 @@ export function sanitizeCustomerMasters(
 }
 
 export function sanitizeOfficeMasters(
-  raw: OfficeMaster[],
-  options: { minNameLength?: number } = {},
+  raw: OfficeMaster[]
 ): SanitizeResult<OfficeMaster> {
-  const minNameLength = options.minNameLength ?? DEFAULT_MIN_OFFICE_NAME_LENGTH;
   const items: OfficeMaster[] = [];
   const droppedIds: string[] = [];
   for (const o of raw) {
-    if (typeof o.name === 'string' && o.name.length >= minNameLength) {
+    if (typeof o.name === 'string' && o.name.length > 0) {
       items.push({
         id: o.id,
         name: o.name,

--- a/functions/test/extractors.test.ts
+++ b/functions/test/extractors.test.ts
@@ -581,11 +581,14 @@ TEL: 052-509-2292
   // === 全ひらがな事業所名 ===
 
   it('全ひらがな事業所名: OCRに含まれる場合は完全一致', () => {
+    // #501: 短文字列マスター ("ケア" 2/「ニック」3 文字) の substring 暴走防止のため
+    // exact match path に length >= 4 ガード導入。本テストは「ひらがな office 名がマッチする」
+    // という意図を保つため 4 文字のひらがな名で検証する。
     const testOfficeMasters: OfficeMaster[] = [
-      { id: 'off1', name: 'あさひ', isDuplicate: false },
+      { id: 'off1', name: 'あさひや', isDuplicate: false },
     ];
 
-    const ocrText = 'あさひ 訪問介護サービス提供票';
+    const ocrText = 'あさひや 訪問介護サービス提供票';
     const result = extractOfficeCandidates(ocrText, testOfficeMasters);
 
     expect(result.bestMatch).to.not.be.null;
@@ -622,6 +625,111 @@ TEL: 052-509-2292
     if (midori) {
       expect(midori.score).to.be.lessThan(70);
     }
+  });
+
+  // #501: 短文字列マスター ("ケア" / "ニック" 等、CSV import 由来) は
+  // substring 包含で exact match score 100 を取って正規マスターを駆逐する。
+  // sanitize 段で drop されるが二重防御として classifier 側も length ガードを持つ。
+  describe('#501 短文字列マスター classifier 防御', () => {
+    it('"ケア" (2 文字) は substring 包含されても score 100 にならず正規マスターが勝つ', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'short-care', name: 'ケア', isDuplicate: false },
+        { id: 'normal', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+      ];
+      const ocrText = '発行元: ニチイケアセンター岩倉 担当: 佐藤';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal('normal');
+      // 「ケア」マスターは exact match に到達しないため score 100 にならない
+      const short = result.candidates.find((c) => c.id === 'short-care');
+      if (short) {
+        expect(short.score).to.be.lessThan(100);
+        expect(short.matchType).to.not.equal('exact');
+      }
+    });
+
+    it('"ニック" (3 文字) は substring 包含されても score 100 にならない', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'short-nick', name: 'ニック', isDuplicate: false },
+        { id: 'normal', name: '正翔会クリニック小牧', isDuplicate: false },
+      ];
+      const ocrText = 'クリニック発行: 正翔会クリニック小牧';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal('normal');
+      const short = result.candidates.find((c) => c.id === 'short-nick');
+      if (short) {
+        expect(short.score).to.be.lessThan(100);
+      }
+    });
+
+    it('境界値: name.length === 4 (正規マスター下限) は exact match で score 100 を取れる', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'len-4', name: 'デイケア', isDuplicate: false },
+      ];
+      const ocrText = 'デイケア施設発行';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.score).to.equal(100);
+      expect(result.bestMatch!.matchType).to.equal('exact');
+    });
+
+    it('shortName が短文字列の場合も exact match score 95 を取らない', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'short-sn', name: '株式会社テストケア', shortName: 'ケア', isDuplicate: false },
+      ];
+      // OCR text に 'ケア' は含まれるが正式名・shortName は完全には含まれない
+      const ocrText = 'ケアプラン作成依頼';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      // shortName 「ケア」は length ガードで exact match されない
+      const found = result.candidates.find((c) => c.id === 'short-sn');
+      if (found) {
+        expect(found.score).to.not.equal(95);
+      }
+    });
+
+    it('aliases が短文字列の場合も exact match score 98 を取らない', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'short-alias', name: '株式会社テストオフィス', aliases: ['ケア'], isDuplicate: false },
+      ];
+      const ocrText = 'ケアプラン記録票';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      const found = result.candidates.find((c) => c.id === 'short-alias');
+      if (found) {
+        expect(found.score).to.not.equal(98);
+      }
+    });
+  });
+});
+
+describe('#501 短文字列マスター classifier 防御 (extractOfficeNameEnhanced)', () => {
+  it('"ケア" (2 文字) は substring 包含されても score 100 にならず正規マスターが勝つ', () => {
+    const testMasters: OfficeMaster[] = [
+      { id: 'short-care', name: 'ケア', isDuplicate: false },
+      { id: 'normal', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+    ];
+    const ocrText = '発行元: ニチイケアセンター岩倉';
+    const result = extractOfficeNameEnhanced(ocrText, testMasters);
+
+    expect(result.officeName).to.equal('ニチイケアセンター岩倉');
+    expect(result.score).to.equal(100);
+  });
+
+  it('境界値: name.length === 4 は exact match で score 100 を取れる', () => {
+    const testMasters: OfficeMaster[] = [
+      { id: 'len-4', name: 'デイケア', isDuplicate: false },
+    ];
+    const ocrText = 'デイケア発行';
+    const result = extractOfficeNameEnhanced(ocrText, testMasters);
+
+    expect(result.officeName).to.equal('デイケア');
+    expect(result.score).to.equal(100);
+    expect(result.matchType).to.equal('exact');
   });
 });
 

--- a/functions/test/extractors.test.ts
+++ b/functions/test/extractors.test.ts
@@ -13,6 +13,7 @@ import {
   extractDateEnhanced,
   ensureCustomerEntry,
   extractAllInformation,
+  computeCommonShortMasters,
   DocumentMaster,
   OfficeMaster,
   CustomerMaster,
@@ -581,14 +582,13 @@ TEL: 052-509-2292
   // === 全ひらがな事業所名 ===
 
   it('全ひらがな事業所名: OCRに含まれる場合は完全一致', () => {
-    // #501: 短文字列マスター ("ケア" 2/「ニック」3 文字) の substring 暴走防止のため
-    // exact match path に length >= 4 ガード導入。本テストは「ひらがな office 名がマッチする」
-    // という意図を保つため 4 文字のひらがな名で検証する。
+    // #501 v2: collision-based 抑制方式では length 単独で drop しないため、
+    // 衝突がなければ 3 文字 hiragana name も exact 認定される (legitimate 保護)
     const testOfficeMasters: OfficeMaster[] = [
-      { id: 'off1', name: 'あさひや', isDuplicate: false },
+      { id: 'off1', name: 'あさひ', isDuplicate: false },
     ];
 
-    const ocrText = 'あさひや 訪問介護サービス提供票';
+    const ocrText = 'あさひ 訪問介護サービス提供票';
     const result = extractOfficeCandidates(ocrText, testOfficeMasters);
 
     expect(result.bestMatch).to.not.be.null;
@@ -627,91 +627,132 @@ TEL: 052-509-2292
     }
   });
 
-  // #501: 短文字列マスター ("ケア" / "ニック" 等、CSV import 由来) は
-  // substring 包含で exact match score 100 を取って正規マスターを駆逐する。
-  // sanitize 段で drop されるが二重防御として classifier 側も length ガードを持つ。
-  describe('#501 短文字列マスター classifier 防御', () => {
-    it('"ケア" (2 文字) は substring 包含されても score 100 にならず正規マスターが勝つ', () => {
+  // #501 v2: 短文字列マスター ("ケア" / "ニック" 等) が長マスター name の substring に
+  // 頻出する場合 (collision >= 2) は「common short master」と判定し exact match から除外。
+  // length 単独でなく collision 数で動的判定するため legitimate 短マスター ("ピース" "てらす"
+  // 等、cocoro/kanameone 実在で collision=0-1) はそのまま動作する。
+  describe('#501 v2 common short master 抑制', () => {
+    it('"ケア" マスターは他マスターの substring に頻出 (collision>=2) → bug マスターと判定され exact 認定されない', () => {
       const testMasters: OfficeMaster[] = [
-        { id: 'short-care', name: 'ケア', isDuplicate: false },
-        { id: 'normal', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+        { id: 'bug-care', name: 'ケア', isDuplicate: false },
+        { id: 'long-1', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+        { id: 'long-2', name: 'エスケアステーション開明', isDuplicate: false },
       ];
       const ocrText = '発行元: ニチイケアセンター岩倉 担当: 佐藤';
       const result = extractOfficeCandidates(ocrText, testMasters);
 
       expect(result.bestMatch).to.not.be.null;
-      expect(result.bestMatch!.id).to.equal('normal');
-      // 「ケア」マスターは exact match に到達しないため score 100 にならない
-      const short = result.candidates.find((c) => c.id === 'short-care');
-      if (short) {
-        expect(short.score).to.be.lessThan(100);
-        expect(short.matchType).to.not.equal('exact');
+      expect(result.bestMatch!.id).to.equal('long-1');
+      // bug マスター「ケア」は exact match に到達しない (skip)
+      const bug = result.candidates.find((c) => c.id === 'bug-care');
+      if (bug) {
+        expect(bug.matchType).to.not.equal('exact');
+        expect(bug.score).to.be.lessThan(100);
       }
     });
 
-    it('"ニック" (3 文字) は substring 包含されても score 100 にならない', () => {
+    it('"ニック" マスターはクリニック系の substring に頻出 → 除外', () => {
       const testMasters: OfficeMaster[] = [
-        { id: 'short-nick', name: 'ニック', isDuplicate: false },
-        { id: 'normal', name: '正翔会クリニック小牧', isDuplicate: false },
+        { id: 'bug-nick', name: 'ニック', isDuplicate: false },
+        { id: 'long-1', name: '正翔会クリニック小牧', isDuplicate: false },
+        { id: 'long-2', name: '木の香往診クリニック', isDuplicate: false },
       ];
       const ocrText = 'クリニック発行: 正翔会クリニック小牧';
       const result = extractOfficeCandidates(ocrText, testMasters);
 
       expect(result.bestMatch).to.not.be.null;
-      expect(result.bestMatch!.id).to.equal('normal');
-      const short = result.candidates.find((c) => c.id === 'short-nick');
-      if (short) {
-        expect(short.score).to.be.lessThan(100);
+      expect(result.bestMatch!.id).to.equal('long-1');
+      const bug = result.candidates.find((c) => c.id === 'bug-nick');
+      if (bug) {
+        expect(bug.matchType).to.not.equal('exact');
       }
     });
 
-    it('境界値: name.length === 4 (正規マスター下限) は exact match で score 100 を取れる', () => {
+    it('legitimate な短マスター "ピース" は他マスターと衝突しない → そのまま exact 認定', () => {
+      // kanameone 実在事例: 「ピース」(3 文字、Firestore auto ID、12 件運用) は
+      // 他マスター name と衝突しないため legitimate に動作する
       const testMasters: OfficeMaster[] = [
-        { id: 'len-4', name: 'デイケア', isDuplicate: false },
+        { id: 'legit-piece', name: 'ピース', isDuplicate: false },
+        { id: 'unrelated-1', name: 'デイサービスさくら', isDuplicate: false },
+        { id: 'unrelated-2', name: '訪問看護ステーション桜', isDuplicate: false },
       ];
-      const ocrText = 'デイケア施設発行';
+      const ocrText = '発行元: ピース 利用明細書';
       const result = extractOfficeCandidates(ocrText, testMasters);
 
       expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal('legit-piece');
       expect(result.bestMatch!.score).to.equal(100);
       expect(result.bestMatch!.matchType).to.equal('exact');
     });
 
-    it('shortName が短文字列の場合も exact match score 95 を取らない', () => {
+    it('境界値: 衝突が 1 件のみ → uncommon と判定 (exact 認定可)', () => {
+      // COMMON_SHORT_COLLISION_THRESHOLD=2 のため、1 件衝突では skip しない
       const testMasters: OfficeMaster[] = [
-        { id: 'short-sn', name: '株式会社テストケア', shortName: 'ケア', isDuplicate: false },
+        { id: 'short', name: 'ケア', isDuplicate: false },
+        { id: 'long-1', name: 'デイケアセンター', isDuplicate: false },
       ];
-      // OCR text に 'ケア' は含まれるが正式名・shortName は完全には含まれない
-      const ocrText = 'ケアプラン作成依頼';
+      const ocrText = 'ケア 担当者報告';
       const result = extractOfficeCandidates(ocrText, testMasters);
 
-      // shortName 「ケア」は length ガードで exact match されない
-      const found = result.candidates.find((c) => c.id === 'short-sn');
-      if (found) {
-        expect(found.score).to.not.equal(95);
-      }
+      const short = result.candidates.find((c) => c.id === 'short');
+      // 「ケア」は他マスター 1 件のみに含まれるので exact 認定される
+      expect(short).to.not.be.undefined;
+      expect(short!.score).to.equal(100);
     });
 
-    it('aliases が短文字列の場合も exact match score 98 を取らない', () => {
+    it('長マスター (length>=4) は collision 計算対象外、現状通り exact 認定', () => {
+      // 長マスター同士の衝突は本機構の対象外 (短マスターのみが対象)
       const testMasters: OfficeMaster[] = [
-        { id: 'short-alias', name: '株式会社テストオフィス', aliases: ['ケア'], isDuplicate: false },
+        { id: 'long-1', name: 'デイケアセンター', isDuplicate: false },
+        { id: 'long-2', name: 'デイケアセンター岩倉', isDuplicate: false },
       ];
-      const ocrText = 'ケアプラン記録票';
+      const ocrText = 'デイケアセンター 発行';
       const result = extractOfficeCandidates(ocrText, testMasters);
 
-      const found = result.candidates.find((c) => c.id === 'short-alias');
-      if (found) {
-        expect(found.score).to.not.equal(98);
-      }
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.score).to.equal(100);
+    });
+
+    it('shortName 経路: common short master は exact 認定 skip', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'bug-sn', name: '株式会社テストケア', shortName: 'ケア', isDuplicate: false },
+        { id: 'long-1', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+        { id: 'long-2', name: 'エスケアステーション開明', isDuplicate: false },
+      ];
+      // shortName "ケア" がほかマスター name に頻出 → ただし shortName 自体は対象外で
+      // bug-sn の name 「株式会社テストケア」(長) は collision 対象外
+      // よって短 shortName 経由の skip にはならない仕様 (= 形式名長 ≥4 ならば対象外)
+      const ocrText = '株式会社テストケア 利用明細';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      // 名前 'ケア' を含む文書では正式名一致 'bug-sn' が score 100 で勝つ
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal('bug-sn');
+      expect(result.bestMatch!.score).to.equal(100);
+    });
+
+    it('aliases 経路: common short master でない長 aliases は exact 認定', () => {
+      // 回帰防止: aliases は正規長で正常動作する
+      const testMasters: OfficeMaster[] = [
+        { id: 'al', name: '正翔会クリニック小牧', aliases: ['正翔クリニック'], isDuplicate: false },
+      ];
+      const ocrText = '発行元: 正翔クリニック';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal('al');
+      expect(result.bestMatch!.score).to.equal(98);
+      expect(result.bestMatch!.matchType).to.equal('exact');
     });
   });
 });
 
-describe('#501 短文字列マスター classifier 防御 (extractOfficeNameEnhanced)', () => {
-  it('"ケア" (2 文字) は substring 包含されても score 100 にならず正規マスターが勝つ', () => {
+describe('#501 v2 common short master 抑制 (extractOfficeNameEnhanced)', () => {
+  it('"ケア" マスターは collision 多 → exact 認定 skip、正規マスターが勝つ', () => {
     const testMasters: OfficeMaster[] = [
-      { id: 'short-care', name: 'ケア', isDuplicate: false },
-      { id: 'normal', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+      { id: 'bug-care', name: 'ケア', isDuplicate: false },
+      { id: 'long-1', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+      { id: 'long-2', name: 'エスケアステーション開明', isDuplicate: false },
     ];
     const ocrText = '発行元: ニチイケアセンター岩倉';
     const result = extractOfficeNameEnhanced(ocrText, testMasters);
@@ -720,16 +761,54 @@ describe('#501 短文字列マスター classifier 防御 (extractOfficeNameEnha
     expect(result.score).to.equal(100);
   });
 
-  it('境界値: name.length === 4 は exact match で score 100 を取れる', () => {
+  it('legitimate 短マスター "ピース" は collision なし → exact 認定可', () => {
     const testMasters: OfficeMaster[] = [
-      { id: 'len-4', name: 'デイケア', isDuplicate: false },
+      { id: 'legit', name: 'ピース', isDuplicate: false },
+      { id: 'unrelated', name: 'デイサービスさくら', isDuplicate: false },
     ];
-    const ocrText = 'デイケア発行';
+    const ocrText = '発行元: ピース 報告書';
     const result = extractOfficeNameEnhanced(ocrText, testMasters);
 
-    expect(result.officeName).to.equal('デイケア');
+    expect(result.officeName).to.equal('ピース');
     expect(result.score).to.equal(100);
     expect(result.matchType).to.equal('exact');
+  });
+});
+
+describe('#501 v2 computeCommonShortMasters', () => {
+  it('短マスター + 衝突 >= 2 → common 集合に含まれる', () => {
+    const masters: OfficeMaster[] = [
+      { id: 'short', name: 'ケア', isDuplicate: false },
+      { id: 'long-1', name: 'デイケアセンター', isDuplicate: false },
+      { id: 'long-2', name: 'ニチイケアセンター', isDuplicate: false },
+    ];
+    const result = computeCommonShortMasters(masters);
+    expect(result.has('short')).to.be.true;
+    expect(result.has('long-1')).to.be.false;
+  });
+
+  it('短マスター + 衝突 < 2 → common 集合に含まれない (legitimate 保護)', () => {
+    const masters: OfficeMaster[] = [
+      { id: 'short', name: 'ピース', isDuplicate: false },
+      { id: 'long', name: 'デイサービスさくら', isDuplicate: false },
+    ];
+    const result = computeCommonShortMasters(masters);
+    expect(result.has('short')).to.be.false;
+  });
+
+  it('長マスター (length>=4) は対象外', () => {
+    const masters: OfficeMaster[] = [
+      { id: 'len-4', name: 'デイケア', isDuplicate: false },
+      { id: 'long-1', name: 'デイケアセンター岩倉', isDuplicate: false },
+      { id: 'long-2', name: 'デイケアスマイル', isDuplicate: false },
+    ];
+    const result = computeCommonShortMasters(masters);
+    expect(result.has('len-4')).to.be.false;
+  });
+
+  it('空マスター配列 → 空集合', () => {
+    const result = computeCommonShortMasters([]);
+    expect(result.size).to.equal(0);
   });
 });
 

--- a/functions/test/sanitizeMasterData.test.ts
+++ b/functions/test/sanitizeMasterData.test.ts
@@ -115,6 +115,64 @@ describe('sanitizeMasterData', () => {
       const result = sanitizeOfficeMasters(input);
       expect(result.items[0].shortName).to.equal('さくら');
     });
+
+    // #501: 短文字列マスター (CSV import 由来の「ケア」「ニック」等) は
+    // classifier の substring match で score 100 を取って正規マスターを駆逐するため
+    // sanitize 段で length ガードで drop する。境界値テスト + 観測性 (droppedIds) を担保する。
+    describe('#501 短文字列マスター drop ガード', () => {
+      it('name.length が 4 未満のレコードは drop される ("ケア" = 2 文字)', () => {
+        const input = [{ id: 'short-care', name: 'ケア' }];
+        const result = sanitizeOfficeMasters(input);
+        expect(result.items).to.have.length(0);
+        expect(result.droppedIds).to.deep.equal(['short-care']);
+      });
+
+      it('name.length が 4 未満のレコードは drop される ("ニック" = 3 文字)', () => {
+        const input = [{ id: 'short-nick', name: 'ニック' }];
+        const result = sanitizeOfficeMasters(input);
+        expect(result.items).to.have.length(0);
+        expect(result.droppedIds).to.deep.equal(['short-nick']);
+      });
+
+      it('境界値: name.length === 3 は drop', () => {
+        const input = [{ id: 'three', name: 'あいう' }];
+        const result = sanitizeOfficeMasters(input);
+        expect(result.items).to.have.length(0);
+        expect(result.droppedIds).to.deep.equal(['three']);
+      });
+
+      it('境界値: name.length === 4 は通過', () => {
+        const input = [{ id: 'four', name: 'あいうえ' }];
+        const result = sanitizeOfficeMasters(input);
+        expect(result.items).to.have.length(1);
+        expect(result.items[0].name).to.equal('あいうえ');
+        expect(result.droppedIds).to.deep.equal([]);
+      });
+
+      it('options.minNameLength で閾値を上書きできる (テスト容易性)', () => {
+        const input = [
+          { id: 'len-2', name: 'ケア' },
+          { id: 'len-3', name: 'ニック' },
+          { id: 'len-4', name: 'デイサ' + 'ービス' },
+        ];
+        const result = sanitizeOfficeMasters(input, { minNameLength: 2 });
+        expect(result.items).to.have.length(3);
+        expect(result.droppedIds).to.deep.equal([]);
+      });
+
+      it('短文字列と正規マスターが混在する場合、短文字列のみ drop され正規は通過する', () => {
+        const input = [
+          { id: 'short-care', name: 'ケア' },
+          { id: 'normal-1', name: 'デイサービスさくら' },
+          { id: 'short-nick', name: 'ニック' },
+          { id: 'normal-2', name: '訪問看護ステーション桜' },
+        ];
+        const result = sanitizeOfficeMasters(input);
+        expect(result.items).to.have.length(2);
+        expect(result.items.map((o) => o.id)).to.deep.equal(['normal-1', 'normal-2']);
+        expect(result.droppedIds).to.deep.equal(['short-care', 'short-nick']);
+      });
+    });
   });
 
   describe('sanitizeDocumentMasters', () => {

--- a/functions/test/sanitizeMasterData.test.ts
+++ b/functions/test/sanitizeMasterData.test.ts
@@ -116,63 +116,6 @@ describe('sanitizeMasterData', () => {
       expect(result.items[0].shortName).to.equal('さくら');
     });
 
-    // #501: 短文字列マスター (CSV import 由来の「ケア」「ニック」等) は
-    // classifier の substring match で score 100 を取って正規マスターを駆逐するため
-    // sanitize 段で length ガードで drop する。境界値テスト + 観測性 (droppedIds) を担保する。
-    describe('#501 短文字列マスター drop ガード', () => {
-      it('name.length が 4 未満のレコードは drop される ("ケア" = 2 文字)', () => {
-        const input = [{ id: 'short-care', name: 'ケア' }];
-        const result = sanitizeOfficeMasters(input);
-        expect(result.items).to.have.length(0);
-        expect(result.droppedIds).to.deep.equal(['short-care']);
-      });
-
-      it('name.length が 4 未満のレコードは drop される ("ニック" = 3 文字)', () => {
-        const input = [{ id: 'short-nick', name: 'ニック' }];
-        const result = sanitizeOfficeMasters(input);
-        expect(result.items).to.have.length(0);
-        expect(result.droppedIds).to.deep.equal(['short-nick']);
-      });
-
-      it('境界値: name.length === 3 は drop', () => {
-        const input = [{ id: 'three', name: 'あいう' }];
-        const result = sanitizeOfficeMasters(input);
-        expect(result.items).to.have.length(0);
-        expect(result.droppedIds).to.deep.equal(['three']);
-      });
-
-      it('境界値: name.length === 4 は通過', () => {
-        const input = [{ id: 'four', name: 'あいうえ' }];
-        const result = sanitizeOfficeMasters(input);
-        expect(result.items).to.have.length(1);
-        expect(result.items[0].name).to.equal('あいうえ');
-        expect(result.droppedIds).to.deep.equal([]);
-      });
-
-      it('options.minNameLength で閾値を上書きできる (テスト容易性)', () => {
-        const input = [
-          { id: 'len-2', name: 'ケア' },
-          { id: 'len-3', name: 'ニック' },
-          { id: 'len-4', name: 'デイサ' + 'ービス' },
-        ];
-        const result = sanitizeOfficeMasters(input, { minNameLength: 2 });
-        expect(result.items).to.have.length(3);
-        expect(result.droppedIds).to.deep.equal([]);
-      });
-
-      it('短文字列と正規マスターが混在する場合、短文字列のみ drop され正規は通過する', () => {
-        const input = [
-          { id: 'short-care', name: 'ケア' },
-          { id: 'normal-1', name: 'デイサービスさくら' },
-          { id: 'short-nick', name: 'ニック' },
-          { id: 'normal-2', name: '訪問看護ステーション桜' },
-        ];
-        const result = sanitizeOfficeMasters(input);
-        expect(result.items).to.have.length(2);
-        expect(result.items.map((o) => o.id)).to.deep.equal(['normal-1', 'normal-2']);
-        expect(result.droppedIds).to.deep.equal(['short-care', 'short-nick']);
-      });
-    });
   });
 
   describe('sanitizeDocumentMasters', () => {

--- a/scripts/audit-short-office-masters.js
+++ b/scripts/audit-short-office-masters.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * 短文字列 office マスター監査スクリプト (read-only)
+ *
+ * `masters/offices/items` 全件を取得し、name.length が閾値以下のエントリを列挙する。
+ * Issue #501 の 3 層防御 (sanitize length>=4 ガード) が legitimate な短マスターを
+ * 巻き込まないか確認するために使用。
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=<project-id> node scripts/audit-short-office-masters.js [--max-length N]
+ *
+ * オプション:
+ *   --max-length N  name.length <= N のエントリを出力 (default: 3)
+ */
+
+const admin = require('firebase-admin');
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID 環境変数を設定してください');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+let maxLength = 3;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--max-length' && args[i + 1]) {
+    const n = parseInt(args[i + 1], 10);
+    if (!Number.isInteger(n) || n < 0) {
+      console.error(`--max-length は非負整数を指定してください (got: ${args[i + 1]})`);
+      process.exit(1);
+    }
+    maxLength = n;
+    i++;
+  }
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+async function main() {
+  console.log(`プロジェクト: ${projectId}`);
+  console.log(`抽出条件: name.length <= ${maxLength}\n`);
+
+  const snap = await db.collection('masters/offices/items').get();
+  console.log(`masters/offices/items 全件: ${snap.size}\n`);
+
+  const short = [];
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const name = typeof data.name === 'string' ? data.name : '';
+    if (name.length === 0) {
+      short.push({ id: doc.id, name, length: 0, data });
+      continue;
+    }
+    if (name.length <= maxLength) {
+      short.push({ id: doc.id, name, length: name.length, data });
+    }
+  }
+
+  console.log(`=== name.length <= ${maxLength} のマスター: ${short.length}件 ===\n`);
+  if (short.length === 0) {
+    console.log('該当なし');
+    return;
+  }
+
+  for (const entry of short) {
+    console.log(`id=${entry.id}`);
+    console.log(`  name="${entry.name}" (length=${entry.length})`);
+    console.log(`  shortName="${entry.data.shortName || ''}"`);
+    console.log(`  aliases=${JSON.stringify(entry.data.aliases || [])}`);
+    console.log(`  isDuplicate=${entry.data.isDuplicate ?? false}`);
+    console.log(`  notes="${entry.data.notes || ''}"`);
+
+    // 関連 documents の件数 (officeName 完全一致 / officeId 参照)
+    const [byName, byId] = await Promise.all([
+      db.collection('documents').where('officeName', '==', entry.name).count().get(),
+      db.collection('documents').where('officeId', '==', entry.id).count().get(),
+    ]);
+    console.log(`  関連 documents (officeName=="${entry.name}"): ${byName.data().count}件`);
+    console.log(`  関連 documents (officeId=="${entry.id}"): ${byId.data().count}件`);
+    console.log('');
+  }
+
+  console.log(`\n=== サマリー ===`);
+  console.log(`プロジェクト: ${projectId}`);
+  console.log(`全件: ${snap.size}`);
+  console.log(`length <= ${maxLength}: ${short.length}件`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('エラー:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary (v2 設計)

- kanameone 本番マスターに CSV import 由来の短文字列「ケア」「ニック」が混入し 675 docs を誤分類していた問題
- **v1 (length>=4 ガード) は 3 環境監査で legitimate な短マスターを巻き込むことが判明し却下**
- **v2: マスター name 同士の substring 衝突を動的計測し「common short master」を exact match から除外**

## 3 環境監査結果 (audit-short-office-masters.js)

| 環境 | 全件 | length<=4 件数 | 内訳 |
|------|------|---------------|------|
| **dev** | 10 | 0 | 該当なし ✅ |
| **cocoro** | 114 | 3 件 | てらす:3字:9件 / ゆい:2字:3件 / 港北区:3字:14件 |
| **kanameone** | 450 | 13 件 | ケア(2件):2字:585件 / ニック:3字:90件+ / **legitimate:** ピース:3字 / わかば:3字 / かいと:3字 / ニコット:4字 / はごろも:4字 / まちなか:4字 |

v1 の length>=4 ガードは cocoro 3 件 / kanameone 6+ 件の **legitimate な短マスター** (Firestore auto ID、実運用中の事業所マスター) を巻き込み、本番事案を新規発生させる設計欠陥が判明。

## v2 設計

### 仮説
length では legitimate vs bug を distinguish 不可能。
真の違いは「他マスター name の substring として何件出現するか」:
- 「ケア」: 数十マスター (デイケア / ニチイケア / エスケア / メディケア…) に含まれる → bug
- 「ピース」: 衝突 0-1 件 → legitimate

### 実装 (`extractors.ts`)
- 新関数 `computeCommonShortMasters(masters)`: 短マスター (length<4) について他マスター name の substring として 2 件以上出現する id を抽出
- `extractOfficeCandidates` / `extractOfficeNameEnhanced` 入り口で common short master id 集合を事前計算 (1 回のみ、O(n²) だが n=450 で即時)
- exact match path (正式名 / shortName / aliases) で common short master は skip → partial/fuzzy 経路に fall-through

### 結果
- 「ケア」「ニック」: skip → 正規マスターが score 100 で勝つ ✓
- 「ピース」「てらす」「わかば」等: 衝突なし → そのまま exact 認定可 ✓

## Acceptance Criteria

- [x] AC1: `extractOfficeCandidates` で common short master (衝突≥2) が exact match から除外される
- [x] AC2: `extractOfficeNameEnhanced` も同様に防御
- [x] AC3: legitimate な短マスター (衝突 0-1) は引き続き exact match で score 100/95/98 を取れる
- [x] AC4: sanitize gate は length 制約なし (`length > 0`) に戻し、legitimate 短マスターを保護
- [x] AC5: `computeCommonShortMasters` の単体テスト (境界値 / 長マスター対象外 / 空配列)
- [x] AC6: 既存テスト 1394 件全 pass + frontend build pass
- [ ] AC7: 3 環境展開 (dev → kanameone, cocoro) — merge 後に CI 自動 + 手動 deploy
- [ ] AC8 (層3、別 PR、destructive、番号単位認可必要): kanameone 本番 3 エントリ (id=`6umj52B2r7pYLYWJjPx8`, id=`ケア`, id=`ニック`) 削除 + 影響 675 件 force-reindex
- [ ] AC9 (別 PR、別 Issue で defer): drop kind 識別性向上 (`droppedReasons` map 化)

## Test plan

- [x] functions: `npm test` (1394 pass / 6 pending / 0 fail、新規 collision-based テスト含む)
- [x] frontend: `npm run build` (vite 成功、tsc 経由 type-check pass)
- [x] **3 環境マスター監査**: dev/cocoro/kanameone の `masters/offices/items` を read-only で audit-short-office-masters.js 経由で集計 → length 方式の致命的問題発見 (v1→v2 設計変更の根拠)
- [ ] dev 環境動作確認 (CI 自動 deploy 後): OCR 経由で「ケア」「ニック」マスターが exact 認定されないこと

## v1 → v2 設計変更の経緯

詳細は本ブランチのコミット履歴参照:
- `ac30fdf` v1: length>=4 ガード方式 (sanitize + classifier 2 層)
- `c985e9e` audit script + workflow choice 追加 (#501 PR-A 前提検証)
- (中間) 3 環境監査実行 → v1 が legitimate masters を巻き込む致命的問題発見
- `e2bf7e9` v2: collision-based 抑制方式に再設計

## 関連

- Issue #501 (本 PR で close)
- PR #419 (同パターン過去事例: "ケア21上飯田0")
- 現場報告 (kanameone 2026-05-09〜11 集計、94 行 Excel) より発見

## 監査スクリプト (副産物)

`scripts/audit-short-office-masters.js` + workflow choice 追加。将来同種事案で再利用可能なため残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an audit script for inspecting office master data with configurable filtering parameters
  * Added workflow options for running audit operations with different configurations
  * Enhanced office name matching to improve accuracy by suppressing exact matches for common short office names

* **Tests**
  * Added comprehensive test coverage for office name matching suppression behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->