### PR TITLE
feat(prevention): 短マスター混入予防の多層防御 (Closes #506)

### DIFF
--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -1,0 +1,116 @@
+name: Scheduled Master Audit
+
+# #506: 短マスター混入予防のための定期 audit
+# - 3 環境 (dev/kanameone/cocoro) の masters/offices/items から name.length <= 3 を抽出
+# - 検出時に GitHub issue を自動作成 (運用者が next step を判断する materials)
+# - cron は日次 (06:00 JST = 21:00 UTC、前日分)。Phase 1 で全 write 経路に
+#   予防 validation 入れたため理論上検出ゼロのはず。検出時は新たな抜け道発見の signal。
+
+on:
+  schedule:
+    # 毎日 21:00 UTC = 06:00 JST
+    - cron: '0 21 * * *'
+  workflow_dispatch:
+    inputs:
+      max_length:
+        description: 'Detect masters with name.length <= N (default: 3)'
+        required: false
+        default: '3'
+        type: string
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # 1 環境失敗でも他環境続行
+      matrix:
+        environment:
+          - dev
+          - kanameone
+          - cocoro
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies (firebase-admin)
+        working-directory: ./functions
+        run: npm ci
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: |-
+            ${{ matrix.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
+                matrix.environment == 'dev' && secrets.GCP_SA_KEY_DEV ||
+                secrets.GCP_SA_KEY }}
+
+      - name: Resolve project ID
+        id: resolve
+        env:
+          ENVIRONMENT: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          PROJECT_ID=$(node scripts/helpers/firebaserc-helper.js get-project "$ENVIRONMENT")
+          echo "project_id=$PROJECT_ID" >> "$GITHUB_OUTPUT"
+          echo "Resolved project_id: $ENVIRONMENT → $PROJECT_ID"
+
+      - name: Run audit (--fail-on-detected)
+        id: audit
+        env:
+          PROJECT_ID: ${{ steps.resolve.outputs.project_id }}
+          # workflow_dispatch input は数値のみ許可 → bash で数値検証
+          MAX_LENGTH_INPUT: ${{ github.event.inputs.max_length }}
+        run: |
+          set -euo pipefail
+          # input validation (デフォルト 3、整数のみ許可、injection 防止)
+          MAX_LENGTH="${MAX_LENGTH_INPUT:-3}"
+          if ! [[ "$MAX_LENGTH" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: max_length must be non-negative integer (got: \"$MAX_LENGTH\")" >&2
+            exit 1
+          fi
+          NODE_PATH=./functions/node_modules \
+            FIREBASE_PROJECT_ID="$PROJECT_ID" \
+            node scripts/audit-short-office-masters.js \
+              --max-length "$MAX_LENGTH" \
+              --fail-on-detected
+
+  notify-on-detection:
+    needs: audit
+    runs-on: ubuntu-latest
+    if: always() && needs.audit.result == 'failure'
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create issue for detected short masters
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TODAY=$(date -u +%Y-%m-%d)
+          gh issue create \
+            --title "[scheduled-audit] 短 office マスター検出 (${TODAY})" \
+            --label "bug,P2" \
+            --body "$(cat <<EOF
+## Scheduled audit が短マスターを検出
+
+[Workflow run](${RUN_URL}) で 3 環境 (dev/kanameone/cocoro) のいずれかで length<=3 の office マスターが検出されました。
+
+## 確認手順
+1. workflow run ログで該当 master id / name / 環境を確認
+2. legitimate な短マスター (新規追加分) なら本 issue を close
+3. CSV import 由来の汚染なら scripts/delete-office-master + scripts/reset-documents-by-office で cleanup
+
+## 関連
+- Issue #506 (予防策実装の親 Issue)
+- Phase 1 で全 write 経路に validation 入れたため理論上検出ゼロのはず。本検出は新たな抜け道発見の signal。
+EOF
+)"

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -73,11 +73,14 @@ jobs:
             echo "ERROR: max_length must be non-negative integer (got: \"$MAX_LENGTH\")" >&2
             exit 1
           fi
+          # #507 review Critical #2: --fail-on-collision を使うことで legitimate な
+          # 短マスター ("ピース"・"わかば" 等) では false-positive Issue を抑制。
+          # collision 検出 (PR #502 v2 と同じ判定) のみで通知発火する。
           NODE_PATH=./functions/node_modules \
             FIREBASE_PROJECT_ID="$PROJECT_ID" \
             node scripts/audit-short-office-masters.js \
               --max-length "$MAX_LENGTH" \
-              --fail-on-detected
+              --fail-on-collision
 
   notify-on-detection:
     needs: audit

--- a/frontend/src/hooks/useMasters.ts
+++ b/frontend/src/hooks/useMasters.ts
@@ -22,12 +22,27 @@ import type {
   OfficeMaster,
   CareManagerMaster,
 } from '@shared/types'
+import { validateOfficeMasterImport } from '@shared/officeMasterValidation'
 
 // 重複エラークラス
 export class DuplicateError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'DuplicateError'
+  }
+}
+
+/**
+ * 短マスター混入 reject エラー (#506)。
+ *
+ * CSV import 由来の汚染パターン (「ケア」「ニック」等、length<4 で他マスター name の
+ * substring に頻出するもの) を登録しようとした際に発火する。誤分類を未然に防ぐため
+ * 操作者へのフィードバックとして利用。
+ */
+export class ShortMasterRejectedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShortMasterRejectedError'
   }
 }
 
@@ -530,6 +545,21 @@ async function addOffice(params: AddOfficeParams | string): Promise<string> {
   const force = typeof params === 'string' ? false : params.force
 
   const normalizedName = normalizeName(name)
+
+  // #506: 短マスター混入予防 collision-based validation
+  // 既存マスター全件と比較し、length<4 かつ他マスター name の substring に頻出する
+  // 短マスター ("ケア"・"ニック" 等の汚染パターン) は登録を拒否。
+  const existingSnapshot = await getDocs(collection(db, COLLECTION_PATHS.offices))
+  const existing = existingSnapshot.docs.map(d => ({ id: d.id, name: (d.data().name as string) || '' }))
+  const verdict = validateOfficeMasterImport({ id: '__new__', name: normalizedName }, existing)
+  if (verdict.kind === 'reject-short-common') {
+    throw new ShortMasterRejectedError(
+      `「${normalizedName}」は他事業所名の一部として頻出する短い名前のため登録できません (誤分類の原因になります)。`,
+    )
+  }
+  if (verdict.kind === 'warning-short-uncommon') {
+    console.warn(`[short master warning] "${normalizedName}" は短い名前です。誤入力でないか確認してください。`)
+  }
 
   // 重複チェック（force=trueの場合はスキップ）
   if (!force) {
@@ -1164,20 +1194,48 @@ async function bulkImportOfficesWithActions(
   // 既存データを取得
   const snapshot = await getDocs(collection(db, COLLECTION_PATHS.offices))
   const existingByName = new Map<string, string>()
+  const existingForCollision: Array<{ id: string; name: string }> = []
   snapshot.docs.forEach(d => {
-    existingByName.set(d.data().name, d.id)
+    const docName = (d.data().name as string) || ''
+    existingByName.set(docName, d.id)
+    existingForCollision.push({ id: d.id, name: docName })
   })
+
+  // #506: 短マスター混入予防 — 新規登録予定 row も合算して collision-based 判定
+  // (新規 row 同士の衝突も検知できる)。reject 行は skip カウントに含める。
+  const newCandidates = items.map((item, idx) => ({
+    id: `__new_${idx}__`,
+    name: normalizeName(item.data.name),
+  }))
+  const combined = existingForCollision.concat(newCandidates)
+  const rejectedShortIndices = new Set<number>()
+  for (let i = 0; i < newCandidates.length; i++) {
+    const verdict = validateOfficeMasterImport(newCandidates[i]!, combined)
+    if (verdict.kind === 'reject-short-common') {
+      rejectedShortIndices.add(i)
+    } else if (verdict.kind === 'warning-short-uncommon') {
+      console.warn(`[short master warning] "${newCandidates[i]!.name}" は短い名前です。誤入力でないか確認してください。`)
+    }
+  }
 
   let added = 0
   let overwritten = 0
   let skipped = 0
   const skippedNames: string[] = []
 
-  for (const item of items) {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!
     const normalizedName = normalizeName(item.data.name)
     if (!normalizedName) {
       skipped++
       skippedNames.push('(空)')
+      continue
+    }
+
+    // #506: 短マスター reject 行は skip としてカウント、skippedNames に明示
+    if (rejectedShortIndices.has(i)) {
+      skipped++
+      skippedNames.push(`${normalizedName} (短マスター reject)`)
       continue
     }
 

--- a/frontend/src/pages/MastersPage.tsx
+++ b/frontend/src/pages/MastersPage.tsx
@@ -63,6 +63,7 @@ import {
   useDeleteCareManager,
   useBulkImportCareManagersWithActions,
   DuplicateError,
+  ShortMasterRejectedError,
   type ImportAction,
   type BulkImportResultDetailed,
 } from '@/hooks/useMasters'
@@ -1007,8 +1008,14 @@ function OfficesMaster() {
         resetForm()
         setIsAddOpen(false)
       }
-    } catch {
-      setFormError('追加に失敗しました')
+    } catch (error) {
+      // #506 #507: ShortMasterRejectedError は collision 検出時の reject メッセージを
+      // 持つため、操作者が理由を理解できるよう message をそのまま表示する
+      if (error instanceof ShortMasterRejectedError) {
+        setFormError(error.message)
+      } else {
+        setFormError('追加に失敗しました')
+      }
     } finally {
       setCheckingDuplicate(false)
     }
@@ -1027,8 +1034,13 @@ function OfficesMaster() {
       resetForm()
       setIsAddOpen(false)
       setDuplicateConfirmOpen(false)
-    } catch {
-      setFormError('追加に失敗しました')
+    } catch (error) {
+      // #506 #507: 同上 (force=true でも collision-based reject は阻止される設計)
+      if (error instanceof ShortMasterRejectedError) {
+        setFormError(error.message)
+      } else {
+        setFormError('追加に失敗しました')
+      }
     }
   }
 

--- a/functions/src/admin/seedMasters.ts
+++ b/functions/src/admin/seedMasters.ts
@@ -11,7 +11,7 @@
  */
 
 import { onRequest } from 'firebase-functions/v2/https'
-import { getFirestore, FieldValue } from 'firebase-admin/firestore'
+import { getFirestore, FieldValue, type Firestore } from 'firebase-admin/firestore'
 import { initializeApp, getApps } from 'firebase-admin/app'
 
 if (getApps().length === 0) {
@@ -19,6 +19,56 @@ if (getApps().length === 0) {
 }
 
 const db = getFirestore()
+
+/**
+ * シードマスター name の最小許容長 (Issue #506)。
+ *
+ * 短マスター ("ケア" 2/「ニック」3 等) はそれ自体が CSV import 由来の汚染パターンで
+ * あり、seed には絶対に混入させない。length<MIN を含む場合 deploy / 呼び出し時に
+ * 即座に panic させて開発者に通知する。
+ */
+const MIN_SEED_MASTER_NAME_LENGTH = 4
+
+/**
+ * 既存マスターを name で lookup し、あれば merge update、なければ auto ID で create
+ * する upsert pattern (Issue #506)。
+ *
+ * 旧実装の `db.collection(...).doc(name)` + `{ merge: true }` は id=name で固定する
+ * 副作用で「ケア」「ニック」のような日本語 ID 汚染を生み出す経路だった。本関数は
+ * id を auto-generate しつつ name 単位の冪等性を担保する。
+ */
+async function upsertMastersByName(
+  firestore: Firestore,
+  collection: string,
+  items: Array<Record<string, unknown> & { name: string }>,
+): Promise<number> {
+  let count = 0
+  for (const item of items) {
+    if (typeof item.name !== 'string' || item.name.length === 0) {
+      throw new Error(`Seed master name is empty or non-string: ${JSON.stringify(item)}`)
+    }
+    if (item.name.length < MIN_SEED_MASTER_NAME_LENGTH) {
+      throw new Error(
+        `Seed master name too short: "${item.name}" (length=${item.name.length} < ${MIN_SEED_MASTER_NAME_LENGTH}). 短マスターは CSV import 由来の汚染パターンであり seed では拒否します。`,
+      )
+    }
+    const existing = await firestore.collection(collection).where('name', '==', item.name).limit(1).get()
+    if (!existing.empty) {
+      await existing.docs[0]!.ref.set(
+        { ...item, updatedAt: FieldValue.serverTimestamp() },
+        { merge: true },
+      )
+    } else {
+      await firestore.collection(collection).add({
+        ...item,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      })
+    }
+    count++
+  }
+  return count
+}
 
 // 書類種別マスターデータ
 const DOCUMENT_MASTERS = [
@@ -72,22 +122,12 @@ export const seedDocumentMasters = onRequest(
   { region: 'asia-northeast1', memory: '256MiB' },
   async (req, res) => {
     try {
-      const batch = db.batch()
+      // #506: doc(name) → name lookup + auto ID upsert に統一 (汚染経路潰し)
+      const count = await upsertMastersByName(db, 'masters/documents/items', DOCUMENT_MASTERS)
 
-      for (const doc of DOCUMENT_MASTERS) {
-        const ref = db.collection('masters/documents/items').doc(doc.name)
-        batch.set(ref, {
-          ...doc,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-        }, { merge: true })
-      }
-
-      await batch.commit()
-
-      const message = `書類種別マスター ${DOCUMENT_MASTERS.length}件 シード完了`
+      const message = `書類種別マスター ${count}件 シード完了`
       console.log(message)
-      res.json({ success: true, message, count: DOCUMENT_MASTERS.length })
+      res.json({ success: true, message, count })
     } catch (error) {
       console.error('シードエラー:', error)
       res.status(500).json({ success: false, error: String(error) })
@@ -104,57 +144,13 @@ export const seedAllMasters = onRequest(
     try {
       const results: Record<string, number> = {}
 
-      // 書類種別
-      const docBatch = db.batch()
-      for (const doc of DOCUMENT_MASTERS) {
-        const ref = db.collection('masters/documents/items').doc(doc.name)
-        docBatch.set(ref, {
-          ...doc,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-        }, { merge: true })
-      }
-      await docBatch.commit()
-      results.documents = DOCUMENT_MASTERS.length
-
-      // 顧客
-      const custBatch = db.batch()
-      for (const cust of CUSTOMER_MASTERS) {
-        const ref = db.collection('masters/customers/items').doc(cust.name)
-        custBatch.set(ref, {
-          ...cust,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-        }, { merge: true })
-      }
-      await custBatch.commit()
-      results.customers = CUSTOMER_MASTERS.length
-
-      // 事業所
-      const officeBatch = db.batch()
-      for (const office of OFFICE_MASTERS) {
-        const ref = db.collection('masters/offices/items').doc(office.name)
-        officeBatch.set(ref, {
-          ...office,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-        }, { merge: true })
-      }
-      await officeBatch.commit()
-      results.offices = OFFICE_MASTERS.length
-
-      // ケアマネジャー
-      const cmBatch = db.batch()
-      for (const cm of CAREMANAGER_MASTERS) {
-        const ref = db.collection('masters/caremanagers/items').doc(cm.name)
-        cmBatch.set(ref, {
-          ...cm,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-        }, { merge: true })
-      }
-      await cmBatch.commit()
-      results.caremanagers = CAREMANAGER_MASTERS.length
+      // #506: 全 master を name lookup + auto ID upsert pattern に統一
+      // (旧実装の doc(name) は id=name 固定で「ケア」「ニック」等の日本語 ID 汚染を
+      // 生む経路だった。新実装は冪等性を name 一意性で担保しつつ auto ID 化)
+      results.documents = await upsertMastersByName(db, 'masters/documents/items', DOCUMENT_MASTERS)
+      results.customers = await upsertMastersByName(db, 'masters/customers/items', CUSTOMER_MASTERS)
+      results.offices = await upsertMastersByName(db, 'masters/offices/items', OFFICE_MASTERS)
+      results.caremanagers = await upsertMastersByName(db, 'masters/caremanagers/items', CAREMANAGER_MASTERS)
 
       console.log('全マスターデータシード完了:', results)
       res.json({ success: true, results })

--- a/functions/src/admin/seedMasters.ts
+++ b/functions/src/admin/seedMasters.ts
@@ -13,6 +13,10 @@
 import { onRequest } from 'firebase-functions/v2/https'
 import { getFirestore, FieldValue, type Firestore } from 'firebase-admin/firestore'
 import { initializeApp, getApps } from 'firebase-admin/app'
+import {
+  normalizeForMatching,
+  COMMON_SHORT_LENGTH_THRESHOLD,
+} from '../../../shared/officeMasterValidation'
 
 if (getApps().length === 0) {
   initializeApp()
@@ -24,10 +28,11 @@ const db = getFirestore()
  * シードマスター name の最小許容長 (Issue #506)。
  *
  * 短マスター ("ケア" 2/「ニック」3 等) はそれ自体が CSV import 由来の汚染パターンで
- * あり、seed には絶対に混入させない。length<MIN を含む場合 deploy / 呼び出し時に
- * 即座に panic させて開発者に通知する。
+ * あり、seed には絶対に混入させない。`shared/officeMasterValidation.ts` の
+ * `COMMON_SHORT_LENGTH_THRESHOLD` を共有 (Evaluator 指摘 HIGH #4: 定数 drift 防止)。
+ * 判定は **normalize 後の length** で行う (raw length と shared 側挙動の不一致を回避)。
  */
-const MIN_SEED_MASTER_NAME_LENGTH = 4
+const MIN_SEED_MASTER_NAME_LENGTH = COMMON_SHORT_LENGTH_THRESHOLD
 
 /**
  * 既存マスターを name で lookup し、あれば merge update、なければ auto ID で create
@@ -47,9 +52,11 @@ async function upsertMastersByName(
     if (typeof item.name !== 'string' || item.name.length === 0) {
       throw new Error(`Seed master name is empty or non-string: ${JSON.stringify(item)}`)
     }
-    if (item.name.length < MIN_SEED_MASTER_NAME_LENGTH) {
+    // #506 #507 Evaluator HIGH #4: normalize 後 length で判定 (shared と同一仕様)
+    const normalizedLength = normalizeForMatching(item.name).length
+    if (normalizedLength < MIN_SEED_MASTER_NAME_LENGTH) {
       throw new Error(
-        `Seed master name too short: "${item.name}" (length=${item.name.length} < ${MIN_SEED_MASTER_NAME_LENGTH}). 短マスターは CSV import 由来の汚染パターンであり seed では拒否します。`,
+        `Seed master name too short: "${item.name}" (normalized length=${normalizedLength} < ${MIN_SEED_MASTER_NAME_LENGTH}). 短マスターは CSV import 由来の汚染パターンであり seed では拒否します。`,
       )
     }
     const existing = await firestore.collection(collection).where('name', '==', item.name).limit(1).get()

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -27,62 +27,25 @@ import { similarityScore, SIMILARITY_THRESHOLDS } from './similarity';
 // Re-export for use in other modules
 export { normalizeForMatching } from './textNormalizer';
 
+// #506: collision-based common short master 判定は shared/ に集約 (BE/FE/import-masters
+// 全 write 経路で同等ロジックを共有して drift 防止)。再 export は既存 import 経路の
+// 後方互換維持のため (functions/test/extractors.test.ts 等の import 先を変えずに済む)。
+import {
+  computeCommonShortMasters,
+  COMMON_SHORT_LENGTH_THRESHOLD,
+  COMMON_SHORT_COLLISION_THRESHOLD,
+} from '../../../shared/officeMasterValidation';
+export {
+  computeCommonShortMasters,
+  COMMON_SHORT_LENGTH_THRESHOLD,
+  COMMON_SHORT_COLLISION_THRESHOLD,
+};
+
 /** 候補の最大数 */
 const MAX_CANDIDATES = 10;
 
 /** 最小スコア閾値 */
 const MIN_SCORE_THRESHOLD = 70;
-
-/**
- * Office classifier で「common short master」と判定する閾値 (#501 v2)。
- *
- * 短文字列マスター ("ケア" 2/「ニック」3 等、CSV import 由来の汚染) は OCR 文書中の
- * 他事業所名の substring として頻繁に出現するため exact match で score 100 を取り
- * 正規マスターを駆逐する。一方で legitimate な短マスター ("ピース" "わかば" "てらす"
- * 3-4 文字、cocoro/kanameone 実在) は他マスター name と衝突しないため独立して機能する。
- *
- * length 単独では distinguish 不可能なため、マスター name 同士の substring 衝突数を
- * 動的に計測し「他マスター name の substring に COMMON_SHORT_COLLISION_THRESHOLD 件以上
- * 含まれる短マスター」を common 扱いとし exact match path から除外する。partial/fuzzy
- * 経路は通常通り。
- */
-const COMMON_SHORT_LENGTH_THRESHOLD = 4; // length < N を「短い」と扱う
-const COMMON_SHORT_COLLISION_THRESHOLD = 2; // 他マスター N+ の substring に含まれる → common
-
-/**
- * マスター name 同士の substring 衝突に基づき「common short master」id 集合を返す。
- *
- * @param masters office マスター全件
- * @returns common 扱いする master id の Set (exact match から除外する対象)
- */
-export function computeCommonShortMasters(masters: OfficeMaster[]): Set<string> {
-  const commonIds = new Set<string>();
-  // 短マスターのみが対象 (長マスターは元々 substring 衝突に強い)
-  const normalizedNames = masters.map((m) => ({
-    id: m.id,
-    name: m.name,
-    normalized: normalizeForMatching(m.name),
-  }));
-  const shortMasters = normalizedNames.filter(
-    (m) => m.normalized.length > 0 && m.normalized.length < COMMON_SHORT_LENGTH_THRESHOLD,
-  );
-
-  for (const candidate of shortMasters) {
-    let collisions = 0;
-    for (const other of normalizedNames) {
-      if (other.id === candidate.id) continue;
-      if (other.normalized.length <= candidate.normalized.length) continue;
-      if (other.normalized.includes(candidate.normalized)) {
-        collisions++;
-        if (collisions >= COMMON_SHORT_COLLISION_THRESHOLD) {
-          commonIds.add(candidate.id);
-          break;
-        }
-      }
-    }
-  }
-  return commonIds;
-}
 
 /** 施設タイプキーワード（汎用語判定にも使用） */
 const FACILITY_TYPES = [

--- a/functions/test/extractors.test.ts
+++ b/functions/test/extractors.test.ts
@@ -812,6 +812,49 @@ describe('#501 v2 computeCommonShortMasters', () => {
   });
 });
 
+// #506: 本番で発見された bug pattern を fixture から流して回帰テスト
+// (classifier collision-based 抑制 + shared validation の意図しない rollback を CI で検出)
+import { BUG_OFFICE_MASTER_PATTERNS, LEGITIMATE_SHORT_OFFICE_MASTERS } from './fixtures/bug-masters';
+
+describe('#506 本番 bug pattern 回帰テスト (extractOfficeCandidates)', () => {
+  for (const pattern of BUG_OFFICE_MASTER_PATTERNS) {
+    it(`${pattern.label}: collision 多 → exact 認定 skip、正規マスターが勝つ`, () => {
+      const masters: OfficeMaster[] = [pattern.master, ...pattern.collidingLongMasters];
+      // 任意の長マスター name を含む OCR で検証
+      const ocrText = `発行元: ${pattern.collidingLongMasters[0]!.name} 担当者報告書`;
+      const result = extractOfficeCandidates(ocrText, masters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal(pattern.collidingLongMasters[0]!.id);
+      // bug master は exact 認定されない
+      const bugMatch = result.candidates.find((c) => c.id === pattern.master.id);
+      if (bugMatch) {
+        expect(bugMatch.matchType).to.not.equal('exact');
+        expect(bugMatch.score).to.be.lessThan(100);
+      }
+    });
+  }
+});
+
+describe('#506 legitimate 短マスター保護 (extractOfficeCandidates)', () => {
+  for (const legit of LEGITIMATE_SHORT_OFFICE_MASTERS) {
+    it(`"${legit.name}" (length=${legit.name.length}): collision なし → exact 認定 score 100 を取れる`, () => {
+      const masters: OfficeMaster[] = [
+        legit,
+        { id: 'unrelated-1', name: 'デイサービスさくら', isDuplicate: false },
+        { id: 'unrelated-2', name: '訪問看護ステーション桜', isDuplicate: false },
+      ];
+      const ocrText = `発行元: ${legit.name} 利用明細書`;
+      const result = extractOfficeCandidates(ocrText, masters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal(legit.id);
+      expect(result.bestMatch!.score).to.equal(100);
+      expect(result.bestMatch!.matchType).to.equal('exact');
+    });
+  }
+});
+
 describe('aggregateOfficeCandidates', () => {
   it('複数ページの事業所候補を集約', () => {
     const pageResults: Array<{ pageNumber: number; result: OfficeExtractionResultWithCandidates }> = [

--- a/functions/test/fixtures/bug-masters.ts
+++ b/functions/test/fixtures/bug-masters.ts
@@ -1,0 +1,85 @@
+/**
+ * Bug master pattern fixture (Issue #506)
+ *
+ * kanameone / cocoro 本番で発見された短マスター汚染パターンの集約。BE classifier
+ * (PR #502 v2 collision-based 抑制) + shared validation (Issue #506) の意図しない
+ * rollback を回帰テストで検出するための knowledge accumulation。
+ *
+ * 新規 bug pattern を発見したらここに追加すること。fixture は extractors.test.ts /
+ * sharedValidation.test.ts 等の複数テストから参照される。
+ */
+
+import type { OfficeMaster } from '../../src/utils/extractors';
+
+/**
+ * 既知の汚染 office マスター pattern。
+ *
+ * 各エントリは「過去の本番事案」から抽出された短文字列マスター。
+ * length と collision の組み合わせで classifier / validation が drift していないか
+ * 検証するために利用する。
+ */
+export const BUG_OFFICE_MASTER_PATTERNS: Array<{
+  /** 識別ラベル (テスト名に使う) */
+  label: string;
+  /** 検出環境 */
+  source: 'kanameone' | 'cocoro';
+  /** 汚染 master データ */
+  master: OfficeMaster;
+  /** 他マスター name の substring に頻出する想定の長マスター集 (回帰テストで衝突起こす) */
+  collidingLongMasters: OfficeMaster[];
+}> = [
+  {
+    label: 'ケア (kanameone, 2 文字, 765 件 officeId 影響)',
+    source: 'kanameone',
+    master: { id: 'bug-care', name: 'ケア', isDuplicate: false },
+    collidingLongMasters: [
+      { id: 'long-nichii', name: 'ニチイケアセンター岩倉', isDuplicate: false },
+      { id: 'long-eskea', name: 'エスケアステーション開明', isDuplicate: false },
+      { id: 'long-pana', name: 'パナソニックエイジフリーケアセンター名古屋上小田井', isDuplicate: false },
+    ],
+  },
+  {
+    label: 'ニック (kanameone, 3 文字, 124 件 officeId 影響)',
+    source: 'kanameone',
+    master: { id: 'bug-nick', name: 'ニック', isDuplicate: false },
+    collidingLongMasters: [
+      { id: 'long-seisho', name: '正翔会クリニック小牧', isDuplicate: false },
+      { id: 'long-kinoka', name: '木の香往診クリニック', isDuplicate: false },
+      { id: 'long-inoue', name: '井上内科クリニック', isDuplicate: false },
+    ],
+  },
+  {
+    label: 'ゆい (cocoro, 2 文字)',
+    source: 'cocoro',
+    master: { id: 'bug-yui', name: 'ゆい', isDuplicate: false },
+    collidingLongMasters: [
+      // ゆい は collision が低い汚染パターン (id が日本語で混入痕跡)。
+      // 衝突生成のための実例代替を 2 件追加。
+      { id: 'long-yuihaya', name: 'ゆいまーる事業所', isDuplicate: false },
+      { id: 'long-yuibo', name: 'ゆいの里デイサービス', isDuplicate: false },
+    ],
+  },
+  {
+    label: '港北区 (cocoro, 3 文字, 地域名)',
+    source: 'cocoro',
+    master: { id: 'bug-kohoku', name: '港北区', isDuplicate: false },
+    collidingLongMasters: [
+      { id: 'long-kohoku-a', name: '港北区社会福祉協議会本部', isDuplicate: false },
+      { id: 'long-kohoku-b', name: '港北区高田支援事業所', isDuplicate: false },
+    ],
+  },
+];
+
+/**
+ * Legitimate な短マスター pattern (collision なし、PR #502 v1 巻き込み事案の対象)。
+ *
+ * これらが共通短マスター抑制で誤検出されないことを境界値テストで保証する。
+ * 本番の Firestore auto ID 由来 (kanameone「ピース」「わかば」「ニコット」 / cocoro「てらす」)
+ * に近い文字種で構成。
+ */
+export const LEGITIMATE_SHORT_OFFICE_MASTERS: OfficeMaster[] = [
+  { id: 'legit-piece', name: 'ピース', isDuplicate: false },
+  { id: 'legit-wakaba', name: 'わかば', isDuplicate: false },
+  { id: 'legit-terasu', name: 'てらす', isDuplicate: false },
+  { id: 'legit-nicotto', name: 'ニコット', isDuplicate: false }, // 4 文字、length 境界
+];

--- a/functions/test/sharedValidation.test.ts
+++ b/functions/test/sharedValidation.test.ts
@@ -1,0 +1,144 @@
+/**
+ * shared/officeMasterValidation のテスト (Issue #506)
+ *
+ * - validateOfficeMasterImport の 3 verdict (ok / warning-short-uncommon / reject-short-common)
+ * - shared 版 normalizeForMatching と BE 版 (textNormalizer.ts) の同等性
+ *   → drift 発生時に CI 失敗で検出 (single source of truth 保証)
+ */
+
+import { expect } from 'chai';
+import {
+  validateOfficeMasterImport,
+  computeCommonShortMasters,
+  normalizeForMatching as sharedNormalize,
+  COMMON_SHORT_LENGTH_THRESHOLD,
+  COMMON_SHORT_COLLISION_THRESHOLD,
+} from '../../shared/officeMasterValidation';
+import { normalizeForMatching as beNormalize } from '../src/utils/textNormalizer';
+import {
+  BUG_OFFICE_MASTER_PATTERNS,
+  LEGITIMATE_SHORT_OFFICE_MASTERS,
+} from './fixtures/bug-masters';
+
+describe('#506 shared/officeMasterValidation', () => {
+  describe('validateOfficeMasterImport', () => {
+    it('長マスター (length>=4) は ok', () => {
+      const result = validateOfficeMasterImport(
+        { id: 'new', name: 'デイサービスさくら' },
+        [],
+      );
+      expect(result.kind).to.equal('ok');
+    });
+
+    it('短マスター (length<4) + collision >= 2 → reject-short-common', () => {
+      const existing = [
+        { id: 'a', name: 'デイケアセンター' },
+        { id: 'b', name: 'ニチイケアセンター岩倉' },
+      ];
+      const result = validateOfficeMasterImport({ id: 'new', name: 'ケア' }, existing);
+      expect(result.kind).to.equal('reject-short-common');
+    });
+
+    it('短マスター + collision < 2 → warning-short-uncommon (legitimate 短マスター)', () => {
+      const existing = [
+        { id: 'a', name: 'デイサービスさくら' },
+        { id: 'b', name: '訪問看護ステーション桜' },
+      ];
+      const result = validateOfficeMasterImport({ id: 'new', name: 'ピース' }, existing);
+      expect(result.kind).to.equal('warning-short-uncommon');
+    });
+
+    it('空文字 → reject-short-common (明確 reject)', () => {
+      const result = validateOfficeMasterImport({ id: 'new', name: '' }, []);
+      expect(result.kind).to.equal('reject-short-common');
+    });
+
+    it('境界値: 正規化後 length=3 + collision=2 → reject', () => {
+      const existing = [
+        { id: 'a', name: '正翔会クリニック小牧' },
+        { id: 'b', name: '木の香往診クリニック' },
+      ];
+      const result = validateOfficeMasterImport({ id: 'new', name: 'ニック' }, existing);
+      expect(result.kind).to.equal('reject-short-common');
+    });
+
+    it('境界値: 正規化後 length=4 は collision に関わらず ok', () => {
+      const existing = [
+        { id: 'a', name: 'ニコットの里デイサービス' },
+        { id: 'b', name: 'ニコット訪問看護' },
+      ];
+      const result = validateOfficeMasterImport({ id: 'new', name: 'ニコット' }, existing);
+      expect(result.kind).to.equal('ok');
+    });
+  });
+
+  describe('shared と BE 版 normalizeForMatching の同等性 (drift 検出)', () => {
+    const SAMPLE_INPUTS = [
+      '',
+      'ケア',
+      'デイサービスさくら',
+      'パナソニックエイジフリーケアセンター',
+      'Ａｂｃ１２３',
+      '株式会社／テスト・ケア（株）',
+      '訪問-看護－ステーションーひまわり',
+      '半角 と　全角空白 と　U+3000',
+      '株式会社　ABC・テスト123',
+      'カタカナ ひらがな 漢字',
+    ];
+
+    for (const input of SAMPLE_INPUTS) {
+      it(`同等: "${input}" → 同一結果`, () => {
+        expect(sharedNormalize(input)).to.equal(beNormalize(input));
+      });
+    }
+  });
+
+  describe('閾値定数の整合性', () => {
+    it('COMMON_SHORT_LENGTH_THRESHOLD = 4', () => {
+      expect(COMMON_SHORT_LENGTH_THRESHOLD).to.equal(4);
+    });
+    it('COMMON_SHORT_COLLISION_THRESHOLD = 2', () => {
+      expect(COMMON_SHORT_COLLISION_THRESHOLD).to.equal(2);
+    });
+  });
+
+  describe('本番 bug pattern fixture との連携', () => {
+    for (const pattern of BUG_OFFICE_MASTER_PATTERNS) {
+      it(`${pattern.label}: validateOfficeMasterImport が reject-short-common を返す`, () => {
+        const result = validateOfficeMasterImport(
+          { id: pattern.master.id, name: pattern.master.name },
+          pattern.collidingLongMasters.map((m) => ({ id: m.id, name: m.name })),
+        );
+        expect(result.kind).to.equal('reject-short-common');
+      });
+    }
+
+    for (const legit of LEGITIMATE_SHORT_OFFICE_MASTERS) {
+      it(`legitimate "${legit.name}": collision なしで warning または ok`, () => {
+        const result = validateOfficeMasterImport(
+          { id: legit.id, name: legit.name },
+          [
+            { id: 'unrelated-1', name: 'デイサービスさくら' },
+            { id: 'unrelated-2', name: '訪問看護ステーション桜' },
+          ],
+        );
+        expect(result.kind).to.be.oneOf(['warning-short-uncommon', 'ok']);
+      });
+    }
+  });
+
+  describe('computeCommonShortMasters integration', () => {
+    it('shared 版が PR #502 v2 と同じ挙動を返す (固定 fixture)', () => {
+      const masters = [
+        { id: 'bug-care', name: 'ケア' },
+        { id: 'long-1', name: 'デイケアセンター' },
+        { id: 'long-2', name: 'ニチイケアセンター' },
+        { id: 'legit', name: 'ピース' },
+      ];
+      const common = computeCommonShortMasters(masters);
+      expect(common.has('bug-care')).to.be.true;
+      expect(common.has('legit')).to.be.false;
+      expect(common.has('long-1')).to.be.false;
+    });
+  });
+});

--- a/scripts/audit-short-office-masters.js
+++ b/scripts/audit-short-office-masters.js
@@ -10,7 +10,11 @@
  *   FIREBASE_PROJECT_ID=<project-id> node scripts/audit-short-office-masters.js [--max-length N]
  *
  * オプション:
- *   --max-length N  name.length <= N のエントリを出力 (default: 3)
+ *   --max-length N         name.length <= N のエントリを出力 (default: 3)
+ *   --fail-on-detected     length<=N のエントリが 1件でも見つかれば exit 1 (legitimate 含む)
+ *   --fail-on-collision    PR #507 review Critical #2 対応: legitimate 短マスター (collision なし)
+ *                          を除外し、common short master (PR #502 v2 と同じ collision 判定)
+ *                          のみで exit 1 する。scheduled audit から呼ぶ場合の推奨 flag。
  */
 
 const admin = require('firebase-admin');
@@ -24,6 +28,7 @@ if (!projectId) {
 const args = process.argv.slice(2);
 let maxLength = 3;
 let failOnDetected = false;
+let failOnCollision = false;
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--max-length' && args[i + 1]) {
     const n = parseInt(args[i + 1], 10);
@@ -34,10 +39,16 @@ for (let i = 0; i < args.length; i++) {
     maxLength = n;
     i++;
   } else if (args[i] === '--fail-on-detected') {
-    // #506: scheduled audit から workflow が exit code で検知できるよう non-zero exit を選択可能化
+    // length<=N で 1 件でも検出 → exit 1 (legitimate 短マスター含む)
     failOnDetected = true;
+  } else if (args[i] === '--fail-on-collision') {
+    // #507 review Critical #2: legitimate (collision なし) を除外し、common short master のみで exit 1
+    failOnCollision = true;
   }
 }
+
+// shared collision 判定 (PR #502 v2 と同等)。Bridge 経由で ts-node から TS を require
+const { computeCommonShortMasters } = require('./lib/officeMasterValidationBridge');
 
 admin.initializeApp({ projectId });
 const db = admin.firestore();
@@ -86,19 +97,39 @@ async function main() {
     console.log('');
   }
 
+  // #507 review Critical #2: collision 判定で legitimate と汚染を区別
+  const allMasters = snap.docs.map((doc) => ({
+    id: doc.id,
+    name: typeof doc.data().name === 'string' ? doc.data().name : '',
+  }));
+  const commonShortIds = computeCommonShortMasters(allMasters);
+  const collisionDetected = short.filter((s) => commonShortIds.has(s.id));
+
   console.log(`\n=== サマリー ===`);
   console.log(`プロジェクト: ${projectId}`);
   console.log(`全件: ${snap.size}`);
   console.log(`length <= ${maxLength}: ${short.length}件`);
-  return short.length;
+  console.log(`うち common short master (collision 検出): ${collisionDetected.length}件`);
+  if (collisionDetected.length > 0) {
+    console.log('common short master id:');
+    for (const c of collisionDetected) {
+      console.log(`  - ${c.id} (name="${c.name}")`);
+    }
+  }
+  return { detectedCount: short.length, collisionCount: collisionDetected.length };
 }
 
 main()
-  .then((detectedCount) => {
-    // #506: --fail-on-detected が指定された場合、検出件数>0 で non-zero exit
-    // (scheduled workflow から exit code 経由で Slack 通知 / Issue 自動作成を分岐可能に)
+  .then(({ detectedCount, collisionCount }) => {
+    // #507 review: --fail-on-collision (新規) を優先評価 → legitimate 短マスターでは
+    // exit 0、bug pattern (collision 検出) でのみ exit 1。scheduled audit からは
+    // 本 flag を使うことで false-positive Issue を抑制する。
+    if (failOnCollision && collisionCount > 0) {
+      console.error(`\n[FAIL] --fail-on-collision: common short master ${collisionCount}件が検出されたため exit 1`);
+      process.exit(1);
+    }
     if (failOnDetected && detectedCount > 0) {
-      console.error(`\n[FAIL] --fail-on-detected: ${detectedCount}件の短マスターが検出されたため exit 1`);
+      console.error(`\n[FAIL] --fail-on-detected: ${detectedCount}件の短マスターが検出されたため exit 1 (legitimate 含む)`);
       process.exit(1);
     }
     process.exit(0);

--- a/scripts/audit-short-office-masters.js
+++ b/scripts/audit-short-office-masters.js
@@ -23,6 +23,7 @@ if (!projectId) {
 
 const args = process.argv.slice(2);
 let maxLength = 3;
+let failOnDetected = false;
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--max-length' && args[i + 1]) {
     const n = parseInt(args[i + 1], 10);
@@ -32,6 +33,9 @@ for (let i = 0; i < args.length; i++) {
     }
     maxLength = n;
     i++;
+  } else if (args[i] === '--fail-on-detected') {
+    // #506: scheduled audit から workflow が exit code で検知できるよう non-zero exit を選択可能化
+    failOnDetected = true;
   }
 }
 
@@ -86,10 +90,19 @@ async function main() {
   console.log(`プロジェクト: ${projectId}`);
   console.log(`全件: ${snap.size}`);
   console.log(`length <= ${maxLength}: ${short.length}件`);
+  return short.length;
 }
 
 main()
-  .then(() => process.exit(0))
+  .then((detectedCount) => {
+    // #506: --fail-on-detected が指定された場合、検出件数>0 で non-zero exit
+    // (scheduled workflow から exit code 経由で Slack 通知 / Issue 自動作成を分岐可能に)
+    if (failOnDetected && detectedCount > 0) {
+      console.error(`\n[FAIL] --fail-on-detected: ${detectedCount}件の短マスターが検出されたため exit 1`);
+      process.exit(1);
+    }
+    process.exit(0);
+  })
   .catch((err) => {
     console.error('エラー:', err);
     process.exit(1);

--- a/scripts/import-masters.js
+++ b/scripts/import-masters.js
@@ -322,10 +322,13 @@ async function importOffices(filePath, dryRun) {
       console.error(`     行${r.idx}: name="${r.name}" — 他マスター name の substring に頻出するため、誤分類の原因になります`);
     }
     console.error(`     計 ${rejected.length} 件の reject 行があります。CSV を修正してから再実行してください。`);
-    if (!dryRun) {
-      console.error('     (abort: --execute を中止しました。--dry-run で問題なく完了することを先に確認してください)');
-      process.exit(1);
+    // #507 review: dry-run でも reject 1+ なら exit 1 (CI gate が dry-run pass で誤判定する経路を塞ぐ)
+    if (dryRun) {
+      console.error(`     [DRY-RUN] reject=${rejected.length}, warned=${warned.length}. exit 1 で abort します。`);
+    } else {
+      console.error('     (abort: --execute を中止しました)');
     }
+    process.exit(1);
   }
   if (warned.length > 0) {
     console.warn('  ⚠ 短マスター warning (衝突は検出されないが正規名として疑わしい):');

--- a/scripts/import-masters.js
+++ b/scripts/import-masters.js
@@ -292,13 +292,59 @@ async function importOffices(filePath, dryRun) {
     console.log(`  同名事業所を検出: ${duplicateNames.join(', ')}`);
   }
 
+  // #506: 短マスター混入予防 — collision-based 動的判定
+  // 既存マスター + 新規 CSV row を合算して各 row の verdict を計算する
+  // (新規 row 同士の衝突も検知できる)。
+  const { validateOfficeMasterImport } = require('./lib/officeMasterValidationBridge');
+  const existingSnap = await db.collection('masters/offices/items').get();
+  const existing = existingSnap.docs.map((d) => ({ id: d.id, name: d.data().name || '' }));
+  // 新規 row 集合 (仮 id 付与で内部識別のみに利用、Firestore 書き込み時は別 auto ID を生成)
+  const newCandidates = rows.map((row, idx) => ({
+    id: `__new_${idx}__`,
+    name: row['name'] || row['事業所名'] || '',
+  }));
+  const combined = existing.concat(newCandidates);
+  const rejected = []; // { row, name, idx }
+  const warned = []; // { row, name, idx }
+  for (let i = 0; i < newCandidates.length; i++) {
+    const candidate = newCandidates[i];
+    const verdict = validateOfficeMasterImport(candidate, combined);
+    if (verdict.kind === 'reject-short-common') {
+      rejected.push({ idx: i + 2, name: candidate.name }); // CSV 行番号 (header=1 とした 2 起点)
+    } else if (verdict.kind === 'warning-short-uncommon') {
+      warned.push({ idx: i + 2, name: candidate.name });
+    }
+  }
+
+  if (rejected.length > 0) {
+    console.error('  ❌ 短マスター衝突 reject (CSV import 由来の汚染パターン、登録不可):');
+    for (const r of rejected) {
+      console.error(`     行${r.idx}: name="${r.name}" — 他マスター name の substring に頻出するため、誤分類の原因になります`);
+    }
+    console.error(`     計 ${rejected.length} 件の reject 行があります。CSV を修正してから再実行してください。`);
+    if (!dryRun) {
+      console.error('     (abort: --execute を中止しました。--dry-run で問題なく完了することを先に確認してください)');
+      process.exit(1);
+    }
+  }
+  if (warned.length > 0) {
+    console.warn('  ⚠ 短マスター warning (衝突は検出されないが正規名として疑わしい):');
+    for (const w of warned) {
+      console.warn(`     行${w.idx}: name="${w.name}" — 短い正規事業所名なら問題なし、誤入力の場合は CSV を修正してください`);
+    }
+  }
+
   console.log(`  ✓ ${rows.length}件の事業所を解析しました`);
   if (dryRun) return;
 
+  // reject があれば既に process.exit(1) 済。warning は通過させて続行 (operator 判断)。
   const batch = db.batch();
   let count = 0;
 
-  for (const row of rows) {
+  for (let i = 0; i < rows.length; i++) {
+    // reject 行は skip
+    if (rejected.some((r) => r.idx === i + 2)) continue;
+    const row = rows[i];
     // 期待するカラム: name, shortName (optional)
     const name = row['name'] || row['事業所名'] || '';
     const docRef = db.collection('masters/offices/items').doc();

--- a/scripts/lib/officeMasterValidationBridge.js
+++ b/scripts/lib/officeMasterValidationBridge.js
@@ -1,0 +1,13 @@
+/**
+ * shared/officeMasterValidation.ts を CommonJS から使うための bridge (Issue #506)
+ *
+ * scripts/ 配下の CommonJS スクリプト (import-masters.js 等) が shared TS の
+ * validateOfficeMasterImport / computeCommonShortMasters を drift なく利用するための
+ * ts-node 経由 require ラッパー。
+ *
+ * scripts/tsconfig.json は include に ../shared/**\/*.ts を含み、scripts/package.json は
+ * devDeps に ts-node を持つため、本 bridge ロード時に ts-node/register を実行することで
+ * 親プロセスが node のままでも TS source を解決できる。
+ */
+require('ts-node/register');
+module.exports = require('../../shared/officeMasterValidation');

--- a/shared/officeMasterValidation.ts
+++ b/shared/officeMasterValidation.ts
@@ -1,0 +1,128 @@
+/**
+ * 事業所マスター混入予防のための共通バリデーション (Issue #506)
+ *
+ * BE/FE/import-masters.js 全 write 経路で同等の collision-based 判定を実行できるよう
+ * shared に集約。BE extractors.ts の computeCommonShortMasters はここから re-export
+ * (drift 防止)。
+ *
+ * NOTE: normalizeForMatching は BE textNormalizer.ts と同等仕様。同等性は
+ * `functions/test/sharedNormalize.test.ts` で assertion テストする (drift 検出)。
+ */
+
+/** 全角→半角変換 (BE convertFullWidthToHalfWidth と同等仕様) */
+function convertFullWidthToHalfWidth(str: string): string {
+  if (!str) return '';
+  return str
+    .replace(/[０-９]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0))
+    .replace(/[Ａ-Ｚａ-ｚ]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0))
+    .replace(/／/g, '/')
+    .replace(/．/g, '.')
+    .replace(/－/g, '-')
+    .replace(/（/g, '(')
+    .replace(/）/g, ')');
+}
+
+/** マッチング用テキスト正規化 (BE normalizeForMatching と同等仕様) */
+export function normalizeForMatching(text: string): string {
+  if (!text) return '';
+  let normalized = convertFullWidthToHalfWidth(text);
+  normalized = normalized
+    .replace(/[\s　]+/g, '')
+    .replace(/[・．.。、，,]/g, '')
+    .replace(/[-－ー]/g, '')
+    .toLowerCase();
+  return normalized;
+}
+
+/** 短マスターと判定する name 長 (正規化後)。length < N → 短マスター扱い */
+export const COMMON_SHORT_LENGTH_THRESHOLD = 4;
+
+/** 短マスターが「common」と判定される collision 数。他マスター N+ の substring に含まれる → common */
+export const COMMON_SHORT_COLLISION_THRESHOLD = 2;
+
+/** computeCommonShortMasters / validateOfficeMasterImport の入力型 */
+export interface OfficeMasterLike {
+  id: string;
+  name: string;
+}
+
+/**
+ * マスター name 同士の substring 衝突から「common short master」id 集合を返す。
+ *
+ * 短マスター (normalize 後 length < COMMON_SHORT_LENGTH_THRESHOLD) について、他マスター
+ * name の substring として COMMON_SHORT_COLLISION_THRESHOLD 件以上出現するものを common
+ * 扱いとする。CSV import 由来の汚染マスター (「ケア」「ニック」等) を動的に判定可能。
+ *
+ * @param masters 全 office マスター (現状 Firestore データ)
+ * @returns common 扱いする master id の Set
+ */
+export function computeCommonShortMasters(masters: OfficeMasterLike[]): Set<string> {
+  const commonIds = new Set<string>();
+  const normalizedNames = masters.map((m) => ({
+    id: m.id,
+    name: m.name,
+    normalized: normalizeForMatching(m.name),
+  }));
+  const shortMasters = normalizedNames.filter(
+    (m) => m.normalized.length > 0 && m.normalized.length < COMMON_SHORT_LENGTH_THRESHOLD,
+  );
+
+  for (const candidate of shortMasters) {
+    let collisions = 0;
+    for (const other of normalizedNames) {
+      if (other.id === candidate.id) continue;
+      if (other.normalized.length <= candidate.normalized.length) continue;
+      if (other.normalized.includes(candidate.normalized)) {
+        collisions++;
+        if (collisions >= COMMON_SHORT_COLLISION_THRESHOLD) {
+          commonIds.add(candidate.id);
+          break;
+        }
+      }
+    }
+  }
+  return commonIds;
+}
+
+/** validateOfficeMasterImport の出力種別 */
+export type ImportValidationVerdict =
+  | { kind: 'ok' } // 通常マスター、登録可
+  | { kind: 'warning-short-uncommon' } // 短マスターだが衝突なし、登録可だが操作者に警告
+  | { kind: 'reject-short-common' }; // 短マスター + 衝突あり、登録拒否
+
+/**
+ * 1 件の新規 office マスターを既存マスター集合と照合して登録可否を判定する。
+ *
+ * 用途: import-masters.js / seedMasters.ts / useMasters.ts の write 経路で
+ * 同等のロジックを使う single source of truth.
+ *
+ * @param newMaster 新規追加候補 (id は仮、または auto ID 化前)
+ * @param existing 既存マスター全件
+ * @returns 判定結果 (ok / warning-short-uncommon / reject-short-common)
+ */
+export function validateOfficeMasterImport(
+  newMaster: OfficeMasterLike,
+  existing: OfficeMasterLike[],
+): ImportValidationVerdict {
+  const normalized = normalizeForMatching(newMaster.name);
+  if (normalized.length === 0) {
+    return { kind: 'reject-short-common' }; // 空文字は明確に reject
+  }
+  if (normalized.length >= COMMON_SHORT_LENGTH_THRESHOLD) {
+    return { kind: 'ok' };
+  }
+  // length < THRESHOLD: 既存マスターとの collision を計測
+  let collisions = 0;
+  for (const other of existing) {
+    if (other.id === newMaster.id) continue;
+    const otherNormalized = normalizeForMatching(other.name);
+    if (otherNormalized.length <= normalized.length) continue;
+    if (otherNormalized.includes(normalized)) {
+      collisions++;
+      if (collisions >= COMMON_SHORT_COLLISION_THRESHOLD) {
+        return { kind: 'reject-short-common' };
+      }
+    }
+  }
+  return { kind: 'warning-short-uncommon' };
+}


### PR DESCRIPTION
## Summary

PR #502 / #505 cleanup tail に続く **再発防止の多層防御** を整備:
- **shared に validation 集約** (drift 防止、BE/FE/scripts で同一ロジック)
- **全 write 経路にガード追加** (import-masters.js / seedMasters.ts / useMasters.ts)
- **bug pattern fixture + 回帰テスト** (本番 4 件「ケア」「ニック」「ゆい」「港北区」)
- **日次 scheduled audit + 検出時 GitHub issue 自動作成**

## 設計判断の経緯

Codex review で 6 件の指摘 (Critical 2 + Important 3 + Suggestion 1) を反映済:

| 指摘 | 反映 |
|------|------|
| **Critical (Focus 1)**: length<4 一律 reject は PR #502 v1 再演リスク | collision-based 動的判定 (≥2 件衝突で reject、衝突なし短名は warning) |
| **Critical (Focus 3)**: FE useMasters.ts に混入経路あり | FE 単体追加 + CSV bulk 双方に validation 追加 |
| **Important (Focus 2)**: seedMasters auto ID 化で merge 消失 | upsertMastersByName helper (name lookup + auto ID create) |
| **Important**: audit script は exit 0 のまま | `--fail-on-detected` flag 追加 |
| **Important**: setup-tenant.sh / seed-e2e-data.js も master write | (office 以外なので本 PR scope 外、Issue #506 body に明記済) |
| **Suggestion (Focus 4)**: cron 周期 | 週次→**日次** (FE/admin 直書きが残る間は厳重監視) |

## 変更ファイル (10 files、+540/-145、Evaluator 必須規模)

### 新規 (5 ファイル)
- `shared/officeMasterValidation.ts` — single source of truth
- `scripts/lib/officeMasterValidationBridge.js` — ts-node 経由 require ラッパー
- `functions/test/fixtures/bug-masters.ts` — 本番 4 pattern + legitimate 4 件
- `functions/test/sharedValidation.test.ts` — shared vs BE drift 検出 + validation 単体
- `.github/workflows/scheduled-audit.yml` — 日次 audit + issue 自動作成

### 更新 (5 ファイル)
- `functions/src/utils/extractors.ts` — computeCommonShortMasters を shared から re-export
- `functions/src/admin/seedMasters.ts` — upsertMastersByName pattern に統一
- `frontend/src/hooks/useMasters.ts` — addOffice + bulk 両方に validation
- `scripts/import-masters.js` — collision-based reject/warning
- `scripts/audit-short-office-masters.js` — --fail-on-detected
- `functions/test/extractors.test.ts` — bug fixture 経由回帰 8 件

## Acceptance Criteria

- [x] AC1: import-masters.js で length<4 検出 + reject/warning
- [x] AC2: seedMasters.ts は auto ID + name lookup
- [x] AC3: scheduled-audit.yml で日次 3 環境 audit
- [x] AC4: 検出時に GitHub issue 自動作成
- [x] AC5: bug-masters.ts fixture 新規 + 4 件 bug pattern
- [x] AC6: classifier テストで bug fixture 経由回帰 pass
- [x] AC7: functions/frontend build pass、1429 件テスト pass (1394 既存 + 35 新規)
- [ ] AC8 (別工程): dev 環境 end-to-end 動作確認 (merge 後 CI 自動 deploy で実施)

## Test plan

- [x] `cd functions && npm test`: 1429 passing / 6 pending / 0 fail
- [x] `npm run build`: frontend (vite) + functions (tsc) 成功
- [x] shared vs BE normalize 同等性 10 入力 (drift 検出テスト) pass
- [ ] dev で `node scripts/import-masters.js --dry-run --offices test.csv` (length<4 含む) → reject 確認
- [ ] dev で `gh workflow run scheduled-audit.yml` dispatch → 通知発火確認
- [ ] FE フォームから length<4 office 登録試行 → ShortMasterRejectedError 表示確認

## 関連

- Issue #506 (本 PR で close、impl-plan v2 = Codex review 反映)
- PR #502 (#501、classifier 側修正、v1 length ガード失敗 → v2 collision-based)
- PR #505 (#504、cleanup tail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily scheduled audit that detects problematic short office masters and auto-creates an issue when detections occur.
  * Prevents short-name collisions during single office adds and bulk imports; rejected rows are skipped and callers see clear error messages.

* **Bug Fixes**
  * Idempotent upserts for seeded masters to avoid duplicate/create-update inconsistencies.

* **Tests**
  * New unit and integration tests covering short-name validation and collision scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->