### PR TITLE
fix(workflow): scheduled-audit.yml YAML block scalar indent 修正

### DIFF
--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -99,21 +99,28 @@ jobs:
         run: |
           set -euo pipefail
           TODAY=$(date -u +%Y-%m-%d)
+          # YAML literal block scalar の indent (10 spaces) を heredoc 内も維持する必要がある。
+          # block scalar 終了と誤判定されて workflow 全体の parse が壊れ、
+          # workflow_dispatch / schedule trigger が認識されなくなるため。
+          # heredoc 出力後に行頭 10 spaces を sed で除去して issue body 化する。
+          BODY=$(cat <<EOF
+          ## Scheduled audit が短マスターを検出
+
+          [Workflow run](${RUN_URL}) で 3 環境 (dev/kanameone/cocoro) のいずれかで length<=3 の office マスターが検出されました。
+
+          ## 確認手順
+          1. workflow run ログで該当 master id / name / 環境を確認
+          2. legitimate な短マスター (新規追加分) なら本 issue を close
+          3. CSV import 由来の汚染なら scripts/delete-office-master + scripts/reset-documents-by-office で cleanup
+
+          ## 関連
+          - Issue #506 (予防策実装の親 Issue)
+          - Phase 1 で全 write 経路に validation 入れたため理論上検出ゼロのはず。本検出は新たな抜け道発見の signal。
+          EOF
+          )
+          # shellcheck disable=SC2001  # 行頭限定除去のため sed が簡潔
+          BODY=$(echo "$BODY" | sed 's/^          //')
           gh issue create \
             --title "[scheduled-audit] 短 office マスター検出 (${TODAY})" \
             --label "bug,P2" \
-            --body "$(cat <<EOF
-## Scheduled audit が短マスターを検出
-
-[Workflow run](${RUN_URL}) で 3 環境 (dev/kanameone/cocoro) のいずれかで length<=3 の office マスターが検出されました。
-
-## 確認手順
-1. workflow run ログで該当 master id / name / 環境を確認
-2. legitimate な短マスター (新規追加分) なら本 issue を close
-3. CSV import 由来の汚染なら scripts/delete-office-master + scripts/reset-documents-by-office で cleanup
-
-## 関連
-- Issue #506 (予防策実装の親 Issue)
-- Phase 1 で全 write 経路に validation 入れたため理論上検出ゼロのはず。本検出は新たな抜け道発見の signal。
-EOF
-)"
+            --body "$BODY"


### PR DESCRIPTION
## Summary
- `notify-on-detection` job の `run: |` literal block scalar 内 heredoc が block scalar の indent (10 spaces) を満たさず column 1 から開始していたため、YAML parser が block scalar を line 106 で終了と誤判定し、`on:` セクション全体が壊れていた
- 結果として `workflow_dispatch` trigger が認識されず手動起動不能、`schedule` cron (06:00 JST) も同根で起動失敗していた可能性大
- heredoc 内全行を block scalar indent に揃え、出力後に sed で行頭 10 spaces を除去して issue body 化する形式に変更

## 影響範囲
- **本番サービス影響なし** (OCR/classifier/FE 無関係)
- **データ破壊リスクなし** (read-only audit + GitHub issue 作成のみ)
- **予防本体動作中** — PR #507 の主要 deliverable (write 経路 validation = `shared/officeMasterValidation.ts` + `import-masters.js` + `useMasters.ts` + `seedMasters.ts`) は別レイヤーで稼働中
- **検知の手動代替あり** — `Run Operations Script` workflow 経由で `audit-short-office-masters` 手動実行可能 (session86 で 3 環境すべて collision 0 確認済)
- 自動化分の遅延 (日次 06:00 JST cron 通知) が現状失敗、修正後復帰

## Test plan
- [x] `actionlint .github/workflows/scheduled-audit.yml` → exit=0 (修正前: line 108:0 error)
- [x] Python yaml で `on`/`jobs`/`steps` 全構造正常認識
- [ ] merge 後 `gh workflow run scheduled-audit.yml -f max_length=3` で 3 環境 matrix 起動 → collision 0 / exit 0 期待
- [ ] notify-on-detection job 動作確認は audit が `--fail-on-collision` で fail する状況の発生を待つ (現状 collision 0 なので発火しない設計)

## 関連
- PR #507 (Issue #506) で導入した scheduled-audit の YAML syntax bug (4 並列 + Codex + Evaluator review で見逃した抜け穴)
- Follow-up としてグローバル設定での actionlint hook 機構化を別工程で検討予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal GitHub Actions workflow process for generating audit notifications. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasushi-honda/doc-split/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->