### PR TITLE
fix(audit): audit-short-office-masters.js 0 件 case で TypeError 修正 (Closes #510)

### DIFF
--- a/scripts/audit-short-office-masters.js
+++ b/scripts/audit-short-office-masters.js
@@ -76,7 +76,9 @@ async function main() {
   console.log(`=== name.length <= ${maxLength} のマスター: ${short.length}件 ===\n`);
   if (short.length === 0) {
     console.log('該当なし');
-    return;
+    // Issue #510: main().then(({ detectedCount, collisionCount }) => {}) で destructure するため、
+    // 0 件 case でも shape を維持して return する必要がある。
+    return { detectedCount: 0, collisionCount: 0 };
   }
 
   for (const entry of short) {


### PR DESCRIPTION
## Summary
- `scripts/audit-short-office-masters.js:77-79` で `short.length === 0` のとき `return;` で undefined を返していた
- 後段の `main().then(({ detectedCount, collisionCount }) => {})` で destructure → TypeError
- `return { detectedCount: 0, collisionCount: 0 };` で shape 維持

## Root cause
PR #507 で `--fail-on-collision` flag を追加した際に「該当なし」path の return shape が崩れた。0 件の dev 環境では発火するが、cocoro/kanameone は短マスター 1+ で path に入らず発覚せず。

## 実害
- scheduled-audit (PR #509 で復活) が **dev 環境で常時 failure**
- notify-on-detection job が毎日 false-positive Issue を自動作成する状態
- 「検出ゼロ目標 = clean status」が「false-positive で常時 1+ Issue」に崩壊し signal-to-noise 比悪化

## Test plan
- [x] syntax check: `node -c scripts/audit-short-office-masters.js` pass
- [x] git diff stat: 1 file changed, +3/-1 (return shape + 説明 comment)
- [ ] merge 後 `gh workflow run scheduled-audit.yml -f max_length=3` で 3 環境 matrix 全 success 期待
- [ ] notify-on-detection job が起動しないこと (collision 0 / detected 0 / exit 0)

## 関連
- Issue #510 (本 PR で auto close)
- PR #509 (workflow YAML indent bug を別途修正)
- PR #507 (Issue #506) の review 抜け穴
- 4 並列 + Codex + Evaluator review が見逃した 2 つの bug の教訓 → グローバル設定で actionlint hook + script unit test gap 検出の機構化を別工程で議論予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)