### PR TITLE
feat(ocr): Vertex AI 429 RESOURCE_EXHAUSTED resilience 強化 (ADR-0017)

### DIFF
--- a/docs/adr/0017-vertex-429-resilience.md
+++ b/docs/adr/0017-vertex-429-resilience.md
@@ -1,0 +1,124 @@
+# ADR-0017: Vertex AI 429 RESOURCE_EXHAUSTED Resilience 強化
+
+## Status
+
+Proposed (2026-06-12、本 PR で実装、Phase B/C deploy 完了で Accepted)。
+
+## Context
+
+### 発端 (2026-06-11 kanameone 健全性レポート)
+
+2026-06-11 11:04-11:43 (39 分間)、kanameone (docsplit-kanameone) 本番環境で Vertex AI Gemini API が `429 Too Many Requests` (`RESOURCE_EXHAUSTED`) を継続発生。**21 件のドキュメントが MAX_RETRY_COUNT=5 を超過 (3 min × 5 = 15 min) して `status:error` に確定**し、健全性レポートに残留した。
+
+### 既存設計の限界 (Issue #194 / #196 / #360 の積み残し)
+
+| 既存パターン | 限界 |
+|------------|------|
+| `MAX_RETRY_COUNT = 5` (transient 共通) | 429 系の長期 quota 枯渇に対し最大 15 分 (3 min × 5) しか粘れない |
+| `retryAfter = 3 min` (429 系固定) | exponential backoff なし → quota 復旧前に再衝突 |
+| jitter なし | 複数 doc 同時 429 → 同時刻 retry → thundering herd で再衝突 |
+| `error` 状態の自動回復なし | `rescueStuckProcessingDocs` は `processing` 状態のみ。`error` は手動 `fix-stuck-documents.js --include-errors` まで放置 |
+
+### 達成可能な保証ライン
+
+**主防御**: 同種事象 (39 分 quota 枯渇) で `error` 状態に落ちる doc をゼロにする。
+**補助 (backstop)**: 万一 `error` に落ちても 1 時間後に自動 rescue。
+**不可侵な保証**: 「Vertex AI が落ちても処理遅延ゼロ」は **約束しない** (外部 API 依存)。
+
+### Codex セカンドオピニオン (採用)
+
+設計妥当性確認を `mcp__codex__codex` (thread `019eb9bd-441a-7872-9500-3cd90a0e6e20`) で実施。要点採用:
+
+- 429 系は通常 transient retry と分離 (`MAX_RETRY_COUNT_429` 専用カウンタ)
+- exponential delay + **jitter ±20%** (thundering herd 対策)
+- error rescue は backstop に格下げ (error semantics「処理不能・要介入」を維持)
+- 初回 delay を 3 分から 1 分に短縮 (軽微 rate spike からは早期復帰)
+
+## Decision
+
+### 主防御: 429 系専用 retry policy (handleProcessingError 改修)
+
+- `MAX_RETRY_COUNT_429 = 8` を新設 (既存 `MAX_RETRY_COUNT = 5` は非 429 transient 用に維持)
+- `RETRY_DELAYS_429_MS = [1, 3, 6, 12, 24, 48, 60, 60] 分` の exponential 配列
+- `RETRY_JITTER_FACTOR = 0.2` で ±20% jitter (`calculateRetryDelay429Ms(retryCount, rng)`)
+- 429 連発の cumulative horizon: 約 3.5 時間 (累計 214 分)
+
+実装: `is429Error(error)` で分岐し、429 系のみ `MAX_RETRY_COUNT_429` + `calculateRetryDelay429Ms()` を適用。非 429 transient は既存挙動 (`MAX_RETRY_COUNT=5` + 1 min retryAfter) を **完全維持**。
+
+### 補助 (backstop): error 状態自動 rescue
+
+- `rescueErroredDocuments`: status=error AND lastErrorMessage に 429 系キーワード AND updatedAt < (now - 1h) AND errorRescueCount < 3 を満たす doc を pending に戻す
+- `rescueErroredDocumentsIfDue`: `meta/ocrRescueState.lastErrorRescueAt` で 1 時間 interval ガード (既存 1 min cadence processOCR scheduler に統合、別 Cloud Scheduler 追加なし)
+- 永続ループ防止: `errorRescueCount >= MAX_ERROR_RESCUE_COUNT (= 3)` で対象外
+- rescue 動作: `status=pending, retryCount=0, retryAfter=now+10min, errorRescueCount++, lastRescuedAt`
+
+### 派生フィールド追加プロトコル (CLAUDE.md #178 教訓)
+
+新規フィールド `errorRescueCount` / `lastRescuedAt`:
+
+- ✅ `getReprocessClearFields()` に追加: 手動 reprocess で「自動 rescue 諦め (MAX 到達)」を user 操作で解除可能化
+- ✅ `fix-stuck-documents.js` に `deleteField()` 追加: 手動 reset 時もクリア
+- 既存パターン踏襲: `shared/types.ts` / `firestoreToDocument()` への追加は **不要** (既存 `retryCount`/`retryAfter`/`lastErrorMessage` も同様に未追加 = FE 表示しない内部フィールド扱い)
+
+## Consequences
+
+### Positive
+
+- 39 分 quota 枯渇事象を主防御で吸収 (cumulative 3.5h horizon)
+- 万一 error 確定しても 1h で自動 rescue → 健全性レポート長期残留なし
+- 非 429 transient (timeout 等) は既存挙動完全維持 → 既存テスト・運用パターン無影響
+- DRY 改善: `QUOTA_ERROR_MESSAGE_KEYWORDS` 単一定数で `is429Error` / `isQuotaErrorMessage` の drift 不可
+- `handleProcessingError` の error 確定時に `retryAfter: deleteField()` を追加 (一貫性向上、`rescueStuckProcessingDocs` の fatal 分岐と同パターン)
+
+### Negative
+
+- 429 連発時の max horizon が 15 min → 3.5h に伸長 → ユーザー体感の処理遅延が長期化 (ただし error 確定は避けられる)
+- `meta/ocrRescueState` doc が新規 (1 doc only)、`maxInstances=1` 前提で non-transactional interval guard
+- 永続的に 429 が続く場合: rescue × 3 で諦め (最悪 ~13.5h)、その後は手動 `fix-stuck-documents.js --include-errors` 介入が必要
+
+### Risks
+
+| リスク | 対応 |
+|--------|------|
+| `maxInstances` 変更時に rescue scan の race condition | コメントで明記、変更時は transaction 化 |
+| Vertex AI quota が 3.5 時間以上枯渇 | rescue で再 pending、最終的に処理完走を待つ。完全保証は外部要因のため不可能 |
+| rescue 直後の retryCount=0 リセットで指数バックオフ履歴消失 | rescue 時 retryAfter=now+10min を併用、即時再衝突を回避 |
+| `errorRescueCount` 未定義 doc | `|| 0` で 0 扱い、migration 不要 |
+
+## Verification
+
+### Acceptance Criteria (evaluator agent で検証済 PASS)
+
+- AC1: 429 系 transient は `MAX_RETRY_COUNT_429=8` まで pending 継続
+- AC2: 429 retry delay は `RETRY_DELAYS_429_MS × jitter ±20%`
+- AC3: 非 429 transient は既存挙動維持 (MAX_RETRY_COUNT=5 / 1 min retryAfter)
+- AC4: 1h+ 経過の 429 系 error は自動 rescue で pending 復帰
+- AC5: `errorRescueCount >= 3` は rescue 対象外
+- AC6: rescue scan は 1h interval (meta/ocrRescueState)
+- AC7-AC9: deploy / 21 件復旧後の実行時評価
+
+### テスト
+
+- `functions/test/ocrProcessor.test.ts`: 86 cases (pure logic, 429 delay 計算 + jitter / maxRetries 分岐 / isQuotaErrorMessage 検証)
+- `functions/test/rescueErroredIntegration.test.ts`: 17 cases (Firestore emulator、429 連発 / rescue / interval guard / race condition)
+- 全 unit + integration test PASS、TypeScript build PASS、ESLint errors 0
+
+### Multi-Client Matrix (Phase B/C/D)
+
+| 工程 | dev | kanameone | cocoro |
+|------|-----|-----------|--------|
+| 1. bugfix + 予防策実装 | ✅ | - | - |
+| 2. dev テスト全 PASS | ✅ | - | - |
+| 3. functions deploy | (Phase B) | (Phase C) | (Phase C) |
+| 4. functions logs 確認 | (Phase B) | (Phase C) | (Phase C) |
+| 5. 21 件 reprocess + 完走 | - | (Phase D) | - |
+| 6. 健全性レポート error=0 | (Phase B) | (Phase D 後) | (Phase C 後) |
+
+## References
+
+- Issue #194 (PR #195): 429 / RESOURCE_EXHAUSTED 検出 + retryAfter 導入
+- Issue #196 (PR #359): rescue MAX_RETRY_COUNT 到達で error 確定 + STUCK_RESCUE_RETRY_AFTER_MS
+- Issue #178: 派生フィールド追加時の 4 ポイント (#178 教訓)
+- Issue #360 (PR #361): rescueStuckProcessingDocs に runTransaction 整合 + safeLogError
+- Codex MCP thread `019eb9bd-441a-7872-9500-3cd90a0e6e20`: 設計セカンドオピニオン
+- Evaluator agent (前提知識なし第三者評価): AC1-AC6 PASS、Phase B 進行可

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -306,6 +306,11 @@ export function getReprocessClearFields() {
     // 古い値を残さずクリアする。#178 教訓 (派生フィールド drift 防止) の延長。
     retryCount: df,
     retryAfter: df,
+    // 429 系 error 自動 rescue 状態 (2026-06-12 vertex 429 resilience):
+    // 手動 reprocess 時もクリアして「自動 rescue 諦め (MAX_ERROR_RESCUE_COUNT 到達)」を
+    // user 操作で解除可能にする。残存すると次回 429 で即「対象外」判定されてしまう。
+    errorRescueCount: df,
+    lastRescuedAt: df,
   }
 }
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "type-check:test": "tsc --noEmit -p tsconfig.test.json",
     "test": "npm run type-check:test && mocha --require ts-node/register --timeout 10000 'test/**/*.test.ts' --ignore 'test/firestore.rules.test.ts' --ignore 'test/*Integration.test.ts'",
     "test:rules": "mocha --require ts-node/register --timeout 10000 'test/firestore.rules.test.ts'",
-    "test:integration": "mocha --require ts-node/register --timeout 10000 test/ocrRetryIntegration.test.ts test/rescueStuckProcessingIntegration.test.ts test/gmailAttachmentIntegration.test.ts test/splitPdfIntegration.test.ts test/searchDocumentsIntegration.test.ts"
+    "test:integration": "mocha --require ts-node/register --timeout 15000 test/ocrRetryIntegration.test.ts test/rescueStuckProcessingIntegration.test.ts test/rescueErroredIntegration.test.ts test/gmailAttachmentIntegration.test.ts test/splitPdfIntegration.test.ts test/searchDocumentsIntegration.test.ts"
   },
   "engines": {
     "node": "20"

--- a/functions/src/ocr/constants.ts
+++ b/functions/src/ocr/constants.ts
@@ -36,3 +36,74 @@ export const STUCK_RESCUE_PENDING_MESSAGE = 'Processing timed out, retrying' as 
  * 変更すると外部監視が壊れる。test で `.include()` lock-in してドリフトを検知する。
  */
 export const STUCK_RESCUE_FATAL_MESSAGE_PREFIX = 'Processing timed out, max retries exceeded' as const;
+
+/**
+ * 429/RESOURCE_EXHAUSTED 専用リトライ上限。
+ *
+ * 既存 MAX_RETRY_COUNT (5) は他 transient (network/timeout 等) に使用継続。
+ * 429 系のみ別カウンタで Vertex AI quota 長期枯渇 (数十分〜数時間) を吸収する。
+ * 2026-06-11 kanameone で 39 分間 quota 枯渇 → 21 件 error 確定の事象を予防。
+ */
+export const MAX_RETRY_COUNT_429 = 8;
+
+/**
+ * 429 系 retry delay 配列 (ms)。index = retry attempt - 1。
+ *
+ * 合計 horizon 約 3.5 時間 (39 分 quota 枯渇に対し十分なマージン)。
+ * 初回 1 min は軽微 rate spike からの早期復帰用。
+ */
+export const RETRY_DELAYS_429_MS = [
+  1 * 60 * 1000, //   1 min
+  3 * 60 * 1000, //   3 min
+  6 * 60 * 1000, //   6 min
+  12 * 60 * 1000, //  12 min
+  24 * 60 * 1000, //  24 min
+  48 * 60 * 1000, //  48 min
+  60 * 60 * 1000, //  60 min
+  60 * 60 * 1000, //  60 min
+] as const;
+
+/**
+ * 429 系 retry delay の jitter factor (±20%)。
+ *
+ * 複数 doc が同時に 429 を踏んだ際の thundering herd (一斉再 retry で再衝突) を防止。
+ */
+export const RETRY_JITTER_FACTOR = 0.2;
+
+/**
+ * error 状態を rescue 対象とする最低経過時間 (ms)。
+ *
+ * 1 時間未満の error は handleProcessingError 直後の可能性があり、
+ * 429 retry policy で粘っている最中と誤認しないよう猶予を持たせる。
+ */
+export const ERROR_RESCUE_THRESHOLD_MS = 60 * 60 * 1000;
+
+/**
+ * error rescue 試行回数上限 (永続ループ防止)。
+ *
+ * 3 回 rescue しても回復しない doc は構造的問題ありとみなし手動介入。
+ * 既存フィールド名衝突回避のため `errorRescueCount` を新規導入 (未定義は 0 扱い)。
+ */
+export const MAX_ERROR_RESCUE_COUNT = 3;
+
+/**
+ * error rescue scan の最小実行間隔 (ms)。
+ *
+ * 既存 processOCR (1 min cadence) 内で 1 時間に 1 回だけ scan 実行。
+ * `meta/ocrRescueState` doc の lastErrorRescueAt で制御。
+ */
+export const ERROR_RESCUE_SCAN_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * error rescue 後の retryAfter 待機時間 (ms)。
+ *
+ * rescue 直後の再 429 を回避するため pending 戻し時に retryAfter=now+10min を設定。
+ */
+export const ERROR_RESCUE_RETRY_AFTER_MS = 10 * 60 * 1000;
+
+/**
+ * error rescue 状態管理 doc path (Firestore)。
+ *
+ * lastErrorRescueAt timestamp を保持。1 時間 interval 制御に使用。
+ */
+export const RESCUE_STATE_DOC_PATH = 'meta/ocrRescueState' as const;

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -7,7 +7,13 @@
 import * as admin from 'firebase-admin';
 import { VertexAI } from '@google-cloud/vertexai';
 import { PDFDocument } from 'pdf-lib';
-import { withRetry, RETRY_CONFIGS, isTransientError, is429Error } from '../utils/retry';
+import {
+  withRetry,
+  RETRY_CONFIGS,
+  isTransientError,
+  is429Error,
+  calculateRetryDelay429Ms,
+} from '../utils/retry';
 import { safeLogError } from '../utils/errorLogger';
 import { getRateLimiter } from '../utils/rateLimiter';
 import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
@@ -400,13 +406,17 @@ export async function processDocument(
 // MAX_RETRY_COUNT は side-effect-free な constants.ts から re-export (#196)。
 // ここを直接 const として定義すると test 側 import で admin.firestore() top-level 実行が走る。
 export { MAX_RETRY_COUNT } from './constants';
-import { MAX_RETRY_COUNT } from './constants';
+import { MAX_RETRY_COUNT, MAX_RETRY_COUNT_429 } from './constants';
 
 /**
  * エラー時の処理
  *
- * transientエラー（429等）の場合はstatus:pendingに戻して自動リトライ。
- * リトライ上限（MAX_RETRY_COUNT）超過時のみstatus:errorに設定。
+ * transient エラー (429 等) の場合は status:pending に戻して自動リトライ。
+ * - 429/RESOURCE_EXHAUSTED 系: MAX_RETRY_COUNT_429 (8) + exponential delay + jitter
+ *   (Vertex AI quota 数十分〜数時間の枯渇を吸収、kanameone 2026-06-11 事象予防)
+ * - その他 transient (network/timeout 等): MAX_RETRY_COUNT (5) + 1 分 delay (既存挙動維持)
+ *
+ * リトライ上限超過 or 非 transient エラーは status:error 確定。
  */
 export async function handleProcessingError(
   docId: string,
@@ -416,6 +426,8 @@ export async function handleProcessingError(
   console.error(`Error processing document ${docId}:`, error.message);
 
   const transient = isTransientError(error);
+  const isQuotaError = is429Error(error);
+  const maxRetries = isQuotaError ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
 
   // ステータス更新を最優先（トランザクションでretryCountをアトミックに管理）
   try {
@@ -425,12 +437,15 @@ export async function handleProcessingError(
       const currentRetryCount = (doc.data()?.retryCount as number) || 0;
       const newRetryCount = currentRetryCount + 1;
 
-      if (transient && newRetryCount < MAX_RETRY_COUNT) {
+      if (transient && newRetryCount < maxRetries) {
         // transientエラーかつ上限未満 → pendingに戻して自動リトライ
-        // 429/RESOURCE_EXHAUSTEDは3分、その他transientは1分待機
-        const isQuotaError = is429Error(error);
-        const retryAfterMs = isQuotaError ? 3 * 60 * 1000 : 1 * 60 * 1000;
-        console.log(`Transient error for ${docId}, retrying (${newRetryCount}/${MAX_RETRY_COUNT}), retryAfter: ${retryAfterMs / 1000}s (quota: ${isQuotaError})`);
+        const retryAfterMs = isQuotaError
+          ? calculateRetryDelay429Ms(newRetryCount)
+          : 1 * 60 * 1000;
+        console.log(
+          `Transient error for ${docId}, retrying (${newRetryCount}/${maxRetries}), ` +
+            `retryAfter: ${Math.round(retryAfterMs / 1000)}s (quota: ${isQuotaError})`
+        );
         tx.update(docRef, {
           status: 'pending',
           retryCount: newRetryCount,
@@ -440,10 +455,16 @@ export async function handleProcessingError(
         });
       } else {
         // 非transientエラーまたはリトライ上限超過 → error確定
-        console.error(`Fatal/max-retry error for ${docId} (retryCount: ${newRetryCount}, transient: ${transient})`);
+        console.error(
+          `Fatal/max-retry error for ${docId} (retryCount: ${newRetryCount}/${maxRetries}, ` +
+            `transient: ${transient}, quota: ${isQuotaError})`
+        );
+        // retryAfter は直前 retry で書き込まれた値が残存しうる → delete で一貫性確保
+        // (rescueStuckProcessingDocs の fatal 分岐 #196 と同じパターン)
         tx.update(docRef, {
           status: 'error',
           retryCount: newRetryCount,
+          retryAfter: admin.firestore.FieldValue.delete(),
           lastErrorMessage: error.message.slice(0, 500),
           updatedAt: admin.firestore.FieldValue.serverTimestamp(),
         });

--- a/functions/src/ocr/processOCR.ts
+++ b/functions/src/ocr/processOCR.ts
@@ -14,6 +14,7 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
 import { trackGeminiUsage } from '../utils/rateLimiter';
+import { isQuotaErrorMessage } from '../utils/retry';
 import { logError, safeLogError } from '../utils/errorLogger';
 import {
   tryStartProcessing,
@@ -28,6 +29,11 @@ import {
   STUCK_PROCESSING_THRESHOLD_MS,
   STUCK_RESCUE_PENDING_MESSAGE,
   STUCK_RESCUE_FATAL_MESSAGE_PREFIX,
+  ERROR_RESCUE_THRESHOLD_MS,
+  ERROR_RESCUE_RETRY_AFTER_MS,
+  ERROR_RESCUE_SCAN_INTERVAL_MS,
+  MAX_ERROR_RESCUE_COUNT,
+  RESCUE_STATE_DOC_PATH,
 } from './constants';
 
 const db = admin.firestore();
@@ -73,6 +79,10 @@ export const processOCR = onSchedule(
     try {
       // processing状態で長時間スタックしたドキュメントを救済
       await rescueStuckProcessingDocs();
+
+      // 429 系 error 状態 doc を 1 時間ごとに rescue (backstop)
+      // 主防御は handleProcessingError 内の 429 専用 retry policy。本 rescue は保険。
+      await rescueErroredDocumentsIfDue();
 
       // pending状態のドキュメントを取得
       const pendingDocs = await db
@@ -246,4 +256,132 @@ export async function rescueStuckProcessingDocs(): Promise<void> {
       });
     }
   }
+}
+
+/**
+ * processOCR scheduler の冒頭で呼び出す interval ガード。
+ *
+ * `meta/ocrRescueState` doc の lastErrorRescueAt を参照し、
+ * `ERROR_RESCUE_SCAN_INTERVAL_MS` (1 時間) 経過時のみ scan 実行 + timestamp 更新。
+ * 1 min cadence の processOCR で毎回 scan を走らせる過剰実行を防止。
+ *
+ * doc 不在 (初回起動) の場合は即時 scan、その後 timestamp 書き込み。
+ *
+ * NOTE: `processOCR` の `maxInstances: 1` を前提に non-transactional な read-then-write
+ * で実装している。`maxInstances` を 2+ に変更する場合は state read/write を transaction
+ * 化して並列 instance の同時 scan を防ぐこと (現状の実装では同時 scan が稀に発生しうる)。
+ */
+export async function rescueErroredDocumentsIfDue(): Promise<void> {
+  const stateRef = db.doc(RESCUE_STATE_DOC_PATH);
+  const stateSnap = await stateRef.get();
+  const lastAt = (stateSnap.data()?.lastErrorRescueAt as admin.firestore.Timestamp | undefined)
+    ?.toMillis?.();
+  const now = Date.now();
+
+  if (lastAt && now - lastAt < ERROR_RESCUE_SCAN_INTERVAL_MS) {
+    return; // interval 未到達 → skip
+  }
+
+  try {
+    await rescueErroredDocuments();
+  } finally {
+    // scan 失敗時も次回再試行を 1 時間後にずらす (storm 回避)。
+    // 失敗を完全に隠さないよう内側で catch しない。
+    await stateRef.set(
+      { lastErrorRescueAt: admin.firestore.Timestamp.fromMillis(now) },
+      { merge: true }
+    );
+  }
+}
+
+/**
+ * 429 系 error 状態の doc を pending に戻す (backstop)。
+ *
+ * 主防御 (handleProcessingError 内の 429 専用 retry policy) を逃れて error 確定した doc を救済。
+ * - 条件: status='error' AND updatedAt < (now - 1h) AND lastErrorMessage に 429 系キーワード AND errorRescueCount < 3
+ * - 動作: status='pending', retryCount=0 リセット, retryAfter=now+10min, errorRescueCount++
+ * - 永続ループ防止: errorRescueCount >= MAX_ERROR_RESCUE_COUNT で対象外 (手動介入)
+ *
+ * integration test から直接呼び出すため export している。
+ */
+export async function rescueErroredDocuments(): Promise<void> {
+  const cutoff = admin.firestore.Timestamp.fromMillis(Date.now() - ERROR_RESCUE_THRESHOLD_MS);
+
+  const erroredDocs = await db
+    .collection('documents')
+    .where('status', '==', 'error')
+    .where('updatedAt', '<', cutoff)
+    .limit(BATCH_SIZE * 2) // 1 時間ごとなので多めに拾う
+    .get();
+
+  if (erroredDocs.empty) return;
+
+  console.log(`Found ${erroredDocs.size} errored documents to evaluate for rescue`);
+
+  let rescuedCount = 0;
+  let skippedNon429 = 0;
+  let skippedMaxRescue = 0;
+
+  for (const docSnapshot of erroredDocs.docs) {
+    const docId = docSnapshot.id;
+    const data = docSnapshot.data();
+
+    if (!isQuotaErrorMessage(data.lastErrorMessage as string | null | undefined)) {
+      skippedNon429++;
+      continue;
+    }
+
+    const rescueCount = (data.errorRescueCount as number) || 0;
+    if (rescueCount >= MAX_ERROR_RESCUE_COUNT) {
+      skippedMaxRescue++;
+      continue;
+    }
+
+    const docRef = db.doc(`documents/${docId}`);
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const rescued = await db.runTransaction(async (tx) => {
+        const fresh = await tx.get(docRef);
+        const freshData = fresh.data();
+        // 並列で他 worker が status を変えた場合は no-op (race condition 対策)
+        if (freshData?.status !== 'error') return false;
+        const currentRescueCount = (freshData?.errorRescueCount as number) || 0;
+        if (currentRescueCount >= MAX_ERROR_RESCUE_COUNT) return false;
+
+        tx.update(docRef, {
+          status: 'pending',
+          retryCount: 0,
+          retryAfter: admin.firestore.Timestamp.fromMillis(
+            Date.now() + ERROR_RESCUE_RETRY_AFTER_MS
+          ),
+          errorRescueCount: currentRescueCount + 1,
+          lastRescuedAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+        return true;
+      });
+
+      if (rescued) {
+        rescuedCount++;
+        console.log(
+          `Rescued errored ${docId} (rescueCount: ${rescueCount + 1}/${MAX_ERROR_RESCUE_COUNT}, ` +
+            `retryAfter: ${ERROR_RESCUE_RETRY_AFTER_MS / 60000}min)`
+        );
+      }
+    } catch (err) {
+      console.error(`Failed to rescue errored document ${docId}:`, err);
+      // eslint-disable-next-line no-await-in-loop
+      await safeLogError({
+        error: err instanceof Error ? err : new Error(String(err)),
+        source: 'ocr',
+        functionName: FUNCTION_NAME,
+        documentId: docId,
+      });
+    }
+  }
+
+  console.log(
+    `Error rescue summary: rescued=${rescuedCount}, skipped_non429=${skippedNon429}, ` +
+      `skipped_max_rescue=${skippedMaxRescue}`
+  );
 }

--- a/functions/src/utils/retry.ts
+++ b/functions/src/utils/retry.ts
@@ -4,6 +4,8 @@
  * error-handling-policy.md に基づく Exponential Backoff 実装
  */
 
+import { RETRY_DELAYS_429_MS, RETRY_JITTER_FACTOR } from '../ocr/constants';
+
 /** リトライ設定 */
 export interface RetryConfig {
   maxRetries: number;
@@ -88,6 +90,21 @@ export function isTransientError(error: unknown): boolean {
 }
 
 /**
+ * 429/RESOURCE_EXHAUSTED 系の message キーワード集合。
+ *
+ * `is429Error` (Error 引数) と `isQuotaErrorMessage` (string 引数) で共通利用。
+ * 片方の追加時に他方が drift しないよう単一定義 (DRY)。
+ * すべて lowercase で記述すること (両関数とも入力を toLowerCase してから match)。
+ */
+const QUOTA_ERROR_MESSAGE_KEYWORDS: readonly string[] = [
+  '429',
+  'too many requests',
+  'resource exhausted',
+  'resource_exhausted',
+  'quota exceeded',
+];
+
+/**
  * 429/RESOURCE_EXHAUSTEDエラー（配額超過）かどうか判定
  *
  * retryAfter待機時間の決定に使用（429系は長めに待機）
@@ -105,18 +122,45 @@ export function is429Error(error: unknown): boolean {
   // gRPCコード RESOURCE_EXHAUSTED
   if (errorWithCode.code === 'RESOURCE_EXHAUSTED') return true;
 
-  // メッセージベース検出
-  if (
-    message.includes('429') ||
-    message.includes('too many requests') ||
-    message.includes('resource exhausted') ||
-    message.includes('resource_exhausted') ||
-    message.includes('quota exceeded')
-  ) {
-    return true;
-  }
+  // メッセージベース検出 (QUOTA_ERROR_MESSAGE_KEYWORDS を共有)
+  return QUOTA_ERROR_MESSAGE_KEYWORDS.some((kw) => message.includes(kw));
+}
 
-  return false;
+/**
+ * lastErrorMessage 文字列に 429/RESOURCE_EXHAUSTED 系のキーワードが含まれるか判定。
+ *
+ * `is429Error` は Error オブジェクト引数 (status/code/message の多経路チェック) だが、
+ * 本関数は Firestore に保存された `lastErrorMessage` (string) を判定する用途。
+ * rescueErroredDocuments で「処理時の 429 が原因の error 状態 doc のみ rescue」判定に使用。
+ *
+ * `is429Error` の message ベース判定と同じ QUOTA_ERROR_MESSAGE_KEYWORDS を共有。
+ */
+export function isQuotaErrorMessage(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  const lower = msg.toLowerCase();
+  return QUOTA_ERROR_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+/**
+ * 429/RESOURCE_EXHAUSTED 専用 retry delay 計算 (jitter 込み)。
+ *
+ * retryCount に応じて RETRY_DELAYS_429_MS から base 値を選び、
+ * ±RETRY_JITTER_FACTOR の範囲で jitter を加える (thundering herd 対策)。
+ *
+ * @param retryCount 1-indexed の retry attempt 数
+ * @param rng [0,1) を返す乱数生成器 (テスト時に inject 可)
+ * @returns retry 待機時間 (ms)
+ */
+export function calculateRetryDelay429Ms(
+  retryCount: number,
+  rng: () => number = Math.random
+): number {
+  const safeAttempt = Math.max(1, retryCount);
+  const idx = Math.min(safeAttempt - 1, RETRY_DELAYS_429_MS.length - 1);
+  const baseMs = RETRY_DELAYS_429_MS[idx];
+  // jitter: rng() ∈ [0,1) → (rng()*2 - 1) ∈ [-1,1) → factor 倍で ±RETRY_JITTER_FACTOR
+  const jitterMultiplier = 1 + (rng() * 2 - 1) * RETRY_JITTER_FACTOR;
+  return Math.round(baseMs * jitterMultiplier);
 }
 
 /**

--- a/functions/test/ocrProcessor.test.ts
+++ b/functions/test/ocrProcessor.test.ts
@@ -5,9 +5,20 @@
  */
 
 import { expect } from 'chai';
-import { isTransientError, is429Error } from '../src/utils/retry';
+import {
+  isTransientError,
+  is429Error,
+  isQuotaErrorMessage,
+  calculateRetryDelay429Ms,
+} from '../src/utils/retry';
 // #196: 実装値を side-effect-free な constants.ts から import して drift 防止
-import { MAX_RETRY_COUNT, STUCK_RESCUE_RETRY_AFTER_MS } from '../src/ocr/constants';
+import {
+  MAX_RETRY_COUNT,
+  MAX_RETRY_COUNT_429,
+  RETRY_DELAYS_429_MS,
+  RETRY_JITTER_FACTOR,
+  STUCK_RESCUE_RETRY_AFTER_MS,
+} from '../src/ocr/constants';
 
 describe('ocrProcessor', () => {
   describe('tryStartProcessing ロジック検証', () => {
@@ -510,6 +521,167 @@ describe('ocrProcessor', () => {
         const shouldSkip = retryAfter > Date.now();
         expect(shouldSkip).to.be.false;
       });
+    });
+  });
+
+  // 429 専用 retry policy (Vertex AI 429 Resilience 2026-06-12)
+  // 既存 MAX_RETRY_COUNT (5) は他 transient 用に維持。429 系のみ MAX_RETRY_COUNT_429 (8) + exponential delay。
+  describe('calculateRetryDelay429Ms (429 専用 delay 計算)', () => {
+    it('retry 1 の base delay は 1 分 (60_000 ms)', () => {
+      const delay = calculateRetryDelay429Ms(1, () => 0.5);
+      expect(delay).to.equal(60_000);
+    });
+
+    it('retry 2 の base delay は 3 分 (180_000 ms)', () => {
+      const delay = calculateRetryDelay429Ms(2, () => 0.5);
+      expect(delay).to.equal(180_000);
+    });
+
+    it('retry 6 の base delay は 48 分 (2_880_000 ms)', () => {
+      const delay = calculateRetryDelay429Ms(6, () => 0.5);
+      expect(delay).to.equal(2_880_000);
+    });
+
+    it('retry 8 (最大) の base delay は 60 分 (3_600_000 ms)', () => {
+      const delay = calculateRetryDelay429Ms(8, () => 0.5);
+      expect(delay).to.equal(3_600_000);
+    });
+
+    it('retry 9+ は配列末尾値で clamp (3_600_000 ms)', () => {
+      const delay = calculateRetryDelay429Ms(99, () => 0.5);
+      expect(delay).to.equal(3_600_000);
+    });
+
+    it('retry 0 / 負数は retry 1 と同等 (safe guard)', () => {
+      expect(calculateRetryDelay429Ms(0, () => 0.5)).to.equal(60_000);
+      expect(calculateRetryDelay429Ms(-3, () => 0.5)).to.equal(60_000);
+    });
+
+    it('jitter 下端 (rng=0) は base * 0.8 (factor 0.2)', () => {
+      const delay = calculateRetryDelay429Ms(1, () => 0);
+      // base 60_000 * (1 + (0*2-1)*0.2) = 60_000 * 0.8 = 48_000
+      expect(delay).to.equal(48_000);
+    });
+
+    it('jitter 上端付近 (rng≈1) は base * 1.2 弱 (factor 0.2)', () => {
+      // rng() は [0,1) なので 1 は到達不可。0.999... 近似
+      const delay = calculateRetryDelay429Ms(1, () => 0.9999999);
+      // base 60_000 * (1 + (0.9999*2-1)*0.2) ≈ 60_000 * 1.2 ≈ 72_000
+      expect(delay).to.be.closeTo(72_000, 50);
+    });
+
+    it('jitter range が全 retry attempt で base ±20% に収まる', () => {
+      for (let attempt = 1; attempt <= RETRY_DELAYS_429_MS.length; attempt++) {
+        const base = RETRY_DELAYS_429_MS[attempt - 1];
+        const lower = calculateRetryDelay429Ms(attempt, () => 0);
+        const upper = calculateRetryDelay429Ms(attempt, () => 0.9999999);
+        expect(lower).to.be.at.least(Math.floor(base * (1 - RETRY_JITTER_FACTOR)));
+        expect(upper).to.be.at.most(Math.ceil(base * (1 + RETRY_JITTER_FACTOR)));
+      }
+    });
+  });
+
+  describe('429 vs 非 429 transient の maxRetries 分岐 (handleProcessingError)', () => {
+    /**
+     * 実装ロジック:
+     *   const newRetryCount = (currentRetryCount || 0) + 1;
+     *   const maxRetries = is429Error(error) ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
+     *   if (transient && newRetryCount < maxRetries) pending else error
+     *
+     * 本 describe は newRetryCount を直接代入する pure logic 検証。
+     * (currentRetryCount → newRetryCount の +1 増分は integration test 側でカバー)
+     */
+
+    it('429 系 + newRetryCount=5 → pending (< MAX_RETRY_COUNT_429=8)', () => {
+      const isQuotaError = true;
+      const maxRetries = isQuotaError ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
+      const newRetryCount = 5;
+      expect(newRetryCount < maxRetries).to.be.true;
+    });
+
+    it('429 系 + newRetryCount=7 → pending (< MAX_RETRY_COUNT_429=8、最後の retry)', () => {
+      const isQuotaError = true;
+      const maxRetries = isQuotaError ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
+      const newRetryCount = 7;
+      expect(newRetryCount < maxRetries).to.be.true;
+    });
+
+    it('429 系 + newRetryCount=8 → error 確定 (== MAX_RETRY_COUNT_429 到達)', () => {
+      const isQuotaError = true;
+      const maxRetries = isQuotaError ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
+      const newRetryCount = 8;
+      expect(newRetryCount < maxRetries).to.be.false;
+    });
+
+    it('非 429 transient + newRetryCount=4 → pending (< MAX_RETRY_COUNT=5、既存挙動)', () => {
+      const isQuotaError = false;
+      const maxRetries = isQuotaError ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
+      const newRetryCount = 4;
+      expect(newRetryCount < maxRetries).to.be.true;
+    });
+
+    it('非 429 transient + newRetryCount=5 → error 確定 (== MAX_RETRY_COUNT 到達、既存挙動維持)', () => {
+      const isQuotaError = false;
+      const maxRetries = isQuotaError ? MAX_RETRY_COUNT_429 : MAX_RETRY_COUNT;
+      const newRetryCount = 5;
+      expect(newRetryCount < maxRetries).to.be.false;
+    });
+
+    it('39 分 quota 枯渇 (kanameone 2026-06-11 事象) は MAX_RETRY_COUNT_429 で吸収可能', () => {
+      // retry 1: 1 min, retry 2: 3 min, retry 3: 6 min → 累計 10 分で 3 回 retry 完了
+      // retry 4: 12 min → 累計 22 分で 4 回 retry 完了
+      // retry 5: 24 min → 累計 46 分で 5 回 retry 完了
+      // 39 分時点では retry 5 進行中 → error 確定せず pending 継続
+      const cumulativeMinutes = [1, 4, 10, 22, 46, 94, 154, 214];
+      // retry 5 完了時点で 46 分 > 39 分 ∴ 39 分間の quota 枯渇は retry 1-5 のいずれかで吸収
+      expect(cumulativeMinutes[4]).to.be.greaterThan(39);
+      // 旧 MAX_RETRY_COUNT=5 + 3 min 固定だと累計 15 分 < 39 分 → error 確定するパターン
+      expect(MAX_RETRY_COUNT * 3).to.be.lessThan(39);
+    });
+  });
+
+  describe('isQuotaErrorMessage (lastErrorMessage string 判定)', () => {
+    it('null/undefined/空文字は false', () => {
+      expect(isQuotaErrorMessage(null)).to.be.false;
+      expect(isQuotaErrorMessage(undefined)).to.be.false;
+      expect(isQuotaErrorMessage('')).to.be.false;
+    });
+
+    it('"429" を含む文字列は true', () => {
+      expect(isQuotaErrorMessage('VertexAI.ClientError: got status: 429 Too Many Requests')).to.be
+        .true;
+    });
+
+    it('"RESOURCE_EXHAUSTED" (大文字混在) は true', () => {
+      expect(isQuotaErrorMessage('status: RESOURCE_EXHAUSTED')).to.be.true;
+    });
+
+    it('"resource exhausted" (スペース版) は true', () => {
+      expect(isQuotaErrorMessage('Resource Exhausted: quota limit reached')).to.be.true;
+    });
+
+    it('"quota exceeded" は true', () => {
+      expect(isQuotaErrorMessage('Quota exceeded for this project')).to.be.true;
+    });
+
+    it('"too many requests" は true', () => {
+      expect(isQuotaErrorMessage('Too Many Requests - please retry later')).to.be.true;
+    });
+
+    it('非 429 系 transient (timeout 等) は false', () => {
+      expect(isQuotaErrorMessage('Request timeout')).to.be.false;
+      expect(isQuotaErrorMessage('Connection reset')).to.be.false;
+    });
+
+    it('一般的なエラー (permission denied 等) は false', () => {
+      expect(isQuotaErrorMessage('Permission denied')).to.be.false;
+      expect(isQuotaErrorMessage('Invalid argument')).to.be.false;
+    });
+
+    it('kanameone 2026-06-11 実エラー message は true', () => {
+      const actual =
+        '[VertexAI.ClientError]: got status: 429 Too Many Requests. {"error":{"code":429,"message":"Resource exhausted. Please try again later. ...","status":"RESOURCE_EXHAUSTED"}}';
+      expect(isQuotaErrorMessage(actual)).to.be.true;
     });
   });
 });

--- a/functions/test/rescueErroredIntegration.test.ts
+++ b/functions/test/rescueErroredIntegration.test.ts
@@ -1,0 +1,390 @@
+/**
+ * rescueErroredDocuments + handleProcessingError (429 専用 retry policy) 統合テスト
+ *
+ * Vertex AI 429 Resilience (2026-06-12) で導入した以下を Firestore emulator 経由で検証する:
+ * - 429 系 transient error は MAX_RETRY_COUNT_429 (8) まで pending retry
+ * - 非 429 transient は既存 MAX_RETRY_COUNT (5) で error 確定 (既存挙動維持)
+ * - rescueErroredDocuments: 1h+ 経過した 429 系 error doc を pending 復帰
+ * - errorRescueCount >= 3 で rescue 対象外 (永続ループ防止)
+ * - rescueErroredDocumentsIfDue: 1h interval ガード (meta/ocrRescueState 経由)
+ *
+ * 実行:
+ *   firebase emulators:exec --only firestore --project rescue-stuck-integration-test \
+ *     'npx mocha --require ts-node/register --timeout 10000 test/rescueErroredIntegration.test.ts'
+ *
+ * 本ファイルは rescueStuckProcessingIntegration.test.ts と同じ default app + emulator init helper を使う。
+ */
+
+// 必ず最初に import: default admin app + emulator host を先行初期化。
+import './helpers/initFirestoreEmulator';
+
+import { expect } from 'chai';
+import * as admin from 'firebase-admin';
+import { handleProcessingError } from '../src/ocr/ocrProcessor';
+import {
+  rescueErroredDocuments,
+  rescueErroredDocumentsIfDue,
+} from '../src/ocr/processOCR';
+import {
+  MAX_RETRY_COUNT,
+  RETRY_DELAYS_429_MS,
+  RETRY_JITTER_FACTOR,
+  ERROR_RESCUE_THRESHOLD_MS,
+  ERROR_RESCUE_RETRY_AFTER_MS,
+  ERROR_RESCUE_SCAN_INTERVAL_MS,
+  MAX_ERROR_RESCUE_COUNT,
+  RESCUE_STATE_DOC_PATH,
+} from '../src/ocr/constants';
+import { cleanupCollections } from './helpers/cleanupEmulator';
+
+const db = admin.firestore();
+const COLLECTIONS_TO_CLEAN: readonly string[] = ['documents', 'errors', 'meta'];
+
+/** Vertex AI 429 を模した Error (handleProcessingError の is429Error 判定が true になる) */
+function make429Error(): Error {
+  const err = new Error(
+    '[VertexAI.ClientError]: got status: 429 Too Many Requests. ' +
+      '{"error":{"code":429,"message":"Resource exhausted. Please try again later.",' +
+      '"status":"RESOURCE_EXHAUSTED"}}'
+  );
+  return err;
+}
+
+/** 非 429 transient (timeout 等) を模した Error */
+function makeTimeoutError(): Error {
+  return new Error('Request timeout - exception posting request to model');
+}
+
+/** rescue 対象になる error doc を fixture として作成 */
+async function createErrorDoc(params: {
+  id: string;
+  lastErrorMessage: string;
+  updatedAtMs?: number;
+  errorRescueCount?: number;
+  retryCount?: number;
+}): Promise<void> {
+  const data: Record<string, unknown> = {
+    status: 'error',
+    fileName: `${params.id}.pdf`,
+    lastErrorMessage: params.lastErrorMessage,
+    retryCount: params.retryCount ?? MAX_RETRY_COUNT,
+    updatedAt: admin.firestore.Timestamp.fromMillis(
+      params.updatedAtMs ?? Date.now() - ERROR_RESCUE_THRESHOLD_MS - 60_000
+    ),
+  };
+  if (params.errorRescueCount !== undefined) {
+    data.errorRescueCount = params.errorRescueCount;
+  }
+  await db.doc(`documents/${params.id}`).set(data);
+}
+
+describe('429 専用 retry policy + rescueErroredDocuments 統合テスト', () => {
+  beforeEach(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  after(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  describe('handleProcessingError: 429 系 transient (MAX_RETRY_COUNT_429=8)', () => {
+    it('429 + retryCount=0 → pending, retryCount=1 (1 min ± 20% retryAfter)', async () => {
+      const docId = 'handle-429-first-retry';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        retryCount: 0,
+        fileName: `${docId}.pdf`,
+      });
+
+      const before = Date.now();
+      await handleProcessingError(docId, make429Error(), 'test-fn');
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('pending');
+      expect(data.retryCount).to.equal(1);
+      const retryAfterMs = data.retryAfter.toMillis() - before;
+      const baseMs = RETRY_DELAYS_429_MS[0]; // 1 min
+      const lower = baseMs * (1 - RETRY_JITTER_FACTOR);
+      const upper = baseMs * (1 + RETRY_JITTER_FACTOR);
+      expect(retryAfterMs).to.be.at.least(Math.floor(lower) - 100);
+      expect(retryAfterMs).to.be.at.most(Math.ceil(upper) + 5_000);
+    });
+
+    it('429 + retryCount=6 → pending (newRetryCount=7, MAX_RETRY_COUNT_429=8 未満、最後の retry)', async () => {
+      // 実装: newRetryCount = (currentRetryCount || 0) + 1; if (newRetryCount < maxRetries) pending
+      const docId = 'handle-429-just-before-max';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        retryCount: 6,
+        fileName: `${docId}.pdf`,
+      });
+
+      await handleProcessingError(docId, make429Error(), 'test-fn');
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('pending');
+      expect(data.retryCount).to.equal(7);
+    });
+
+    it('429 + retryCount=7 → error 確定 (newRetryCount=8, MAX_RETRY_COUNT_429 到達)', async () => {
+      const docId = 'handle-429-max-reached';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        retryCount: 7,
+        fileName: `${docId}.pdf`,
+      });
+
+      await handleProcessingError(docId, make429Error(), 'test-fn');
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('error');
+      expect(data.retryCount).to.equal(8);
+      expect(data.lastErrorMessage).to.include('429');
+    });
+
+    it('429 が旧 MAX_RETRY_COUNT=5 を超えても粘る (currentRetryCount=4 → newRetryCount=5, MAX_RETRY_COUNT_429=8 未満)', async () => {
+      // 旧挙動 (MAX_RETRY_COUNT=5 単独) なら currentRetryCount=4 で newRetryCount=5 → 5<5=false → error 確定。
+      // 新挙動は 429 系のみ MAX_RETRY_COUNT_429=8 適用 → 5<8=true → pending 継続。
+      const docId = 'handle-429-beyond-old-max';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        retryCount: 4,
+        fileName: `${docId}.pdf`,
+      });
+
+      await handleProcessingError(docId, make429Error(), 'test-fn');
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('pending');
+      expect(data.retryCount).to.equal(5);
+    });
+  });
+
+  describe('handleProcessingError: 非 429 transient (MAX_RETRY_COUNT=5、既存挙動維持)', () => {
+    it('非 429 transient + retryCount=3 → pending, retryAfter=1min (newRetryCount=4 < MAX_RETRY_COUNT=5)', async () => {
+      const docId = 'handle-non429-pending';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        retryCount: 3,
+        fileName: `${docId}.pdf`,
+      });
+
+      const before = Date.now();
+      await handleProcessingError(docId, makeTimeoutError(), 'test-fn');
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('pending');
+      expect(data.retryCount).to.equal(4);
+      // retryAfter ≈ 1 min (60_000ms 固定、jitter なし)
+      const retryAfterMs = data.retryAfter.toMillis() - before;
+      expect(retryAfterMs).to.be.at.least(60_000 - 100);
+      expect(retryAfterMs).to.be.at.most(60_000 + 5_000);
+    });
+
+    it('非 429 transient + retryCount=4 → error 確定 (newRetryCount=5, MAX_RETRY_COUNT 到達、既存挙動)', async () => {
+      const docId = 'handle-non429-max';
+      await db.doc(`documents/${docId}`).set({
+        status: 'processing',
+        retryCount: 4,
+        fileName: `${docId}.pdf`,
+      });
+
+      await handleProcessingError(docId, makeTimeoutError(), 'test-fn');
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('error');
+      expect(data.retryCount).to.equal(5);
+    });
+  });
+
+  describe('rescueErroredDocuments: 429 系 error doc 救済 (backstop)', () => {
+    it('1h+ 経過 + 429 系 error doc は pending 復帰、errorRescueCount=1', async () => {
+      const docId = 'rescue-429-target';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage:
+          '[VertexAI.ClientError]: got status: 429 Too Many Requests. RESOURCE_EXHAUSTED',
+      });
+
+      const before = Date.now();
+      await rescueErroredDocuments();
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('pending');
+      expect(data.retryCount).to.equal(0); // リセット
+      expect(data.errorRescueCount).to.equal(1);
+      expect(data.lastRescuedAt).to.exist;
+      // retryAfter は now + 10 min
+      const retryAfterMs = data.retryAfter.toMillis() - before;
+      expect(retryAfterMs).to.be.at.least(ERROR_RESCUE_RETRY_AFTER_MS - 100);
+      expect(retryAfterMs).to.be.at.most(ERROR_RESCUE_RETRY_AFTER_MS + 5_000);
+    });
+
+    it('1h 未満経過の error doc は対象外 (誤発火防止)', async () => {
+      const docId = 'rescue-too-recent';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'RESOURCE_EXHAUSTED',
+        updatedAtMs: Date.now() - 30 * 60 * 1000, // 30 分前
+      });
+
+      await rescueErroredDocuments();
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      expect(snap.data()!.status).to.equal('error'); // unchanged
+    });
+
+    it('非 429 系 error doc (lastErrorMessage に 429 系キーワードなし) は対象外', async () => {
+      const docId = 'rescue-non-429';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'Invalid argument: malformed PDF',
+      });
+
+      await rescueErroredDocuments();
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      expect(snap.data()!.status).to.equal('error'); // unchanged
+    });
+
+    it('errorRescueCount >= MAX_ERROR_RESCUE_COUNT (3) の doc は対象外 (永続ループ防止)', async () => {
+      const docId = 'rescue-max-reached';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'RESOURCE_EXHAUSTED quota exhausted',
+        errorRescueCount: MAX_ERROR_RESCUE_COUNT,
+      });
+
+      await rescueErroredDocuments();
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('error');
+      expect(data.errorRescueCount).to.equal(MAX_ERROR_RESCUE_COUNT); // unchanged
+    });
+
+    it('errorRescueCount = MAX_ERROR_RESCUE_COUNT - 1 は最後の rescue で MAX 到達', async () => {
+      const docId = 'rescue-last-chance';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'Too Many Requests 429',
+        errorRescueCount: MAX_ERROR_RESCUE_COUNT - 1,
+      });
+
+      await rescueErroredDocuments();
+
+      const snap = await db.doc(`documents/${docId}`).get();
+      const data = snap.data()!;
+      expect(data.status).to.equal('pending');
+      expect(data.errorRescueCount).to.equal(MAX_ERROR_RESCUE_COUNT);
+    });
+
+    it('対象 0 件 (error doc 全くなし) は安全に no-op', async () => {
+      await rescueErroredDocuments();
+      // no throw, no side effect
+    });
+
+    it('対象 doc が並列で他処理によって status 変更 → no-op (race condition safety)', async () => {
+      const docId = 'rescue-race-condition';
+      // 1 時間前で error 状態に作る
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'RESOURCE_EXHAUSTED',
+      });
+      // 並列を simulate: scan が走る直前に status を pending に変える
+      await db.doc(`documents/${docId}`).update({ status: 'pending' });
+
+      await rescueErroredDocuments();
+
+      // 変更後 status を尊重 (rescue は status=error の transaction 内 check で空振り)
+      const snap = await db.doc(`documents/${docId}`).get();
+      expect(snap.data()!.status).to.equal('pending');
+      // rescue が動いていれば errorRescueCount=1 になるはずだが、status check で no-op
+      expect(snap.data()!.errorRescueCount).to.be.undefined;
+    });
+  });
+
+  describe('rescueErroredDocumentsIfDue: 1 時間 interval ガード', () => {
+    it('lastErrorRescueAt 不在 (初回) → 即時 scan + state doc 作成', async () => {
+      const docId = 'if-due-first-scan';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'RESOURCE_EXHAUSTED',
+      });
+
+      await rescueErroredDocumentsIfDue();
+
+      // scan 実行確認: doc が pending に変わる
+      const docSnap = await db.doc(`documents/${docId}`).get();
+      expect(docSnap.data()!.status).to.equal('pending');
+
+      // state doc が作成される
+      const stateSnap = await db.doc(RESCUE_STATE_DOC_PATH).get();
+      expect(stateSnap.exists).to.be.true;
+      expect(stateSnap.data()!.lastErrorRescueAt).to.exist;
+    });
+
+    it('lastErrorRescueAt < ERROR_RESCUE_SCAN_INTERVAL_MS (1h) → scan skip', async () => {
+      // 直前に scan 完了したと仮定
+      await db.doc(RESCUE_STATE_DOC_PATH).set({
+        lastErrorRescueAt: admin.firestore.Timestamp.fromMillis(
+          Date.now() - 30 * 60 * 1000 // 30 分前
+        ),
+      });
+      const docId = 'if-due-too-recent-scan';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'RESOURCE_EXHAUSTED',
+      });
+
+      await rescueErroredDocumentsIfDue();
+
+      // scan skip により doc は error のまま
+      const docSnap = await db.doc(`documents/${docId}`).get();
+      expect(docSnap.data()!.status).to.equal('error');
+    });
+
+    it('lastErrorRescueAt >= ERROR_RESCUE_SCAN_INTERVAL_MS (1h) → scan 実行 + timestamp 更新', async () => {
+      const oldTimestamp = Date.now() - 2 * ERROR_RESCUE_SCAN_INTERVAL_MS;
+      await db.doc(RESCUE_STATE_DOC_PATH).set({
+        lastErrorRescueAt: admin.firestore.Timestamp.fromMillis(oldTimestamp),
+      });
+      const docId = 'if-due-scan-runs';
+      await createErrorDoc({
+        id: docId,
+        lastErrorMessage: 'RESOURCE_EXHAUSTED',
+      });
+
+      const beforeScan = Date.now();
+      await rescueErroredDocumentsIfDue();
+
+      // scan 実行 → doc が pending に
+      const docSnap = await db.doc(`documents/${docId}`).get();
+      expect(docSnap.data()!.status).to.equal('pending');
+
+      // state timestamp 更新
+      const stateSnap = await db.doc(RESCUE_STATE_DOC_PATH).get();
+      const newTimestamp = (stateSnap.data()!.lastErrorRescueAt as admin.firestore.Timestamp).toMillis();
+      expect(newTimestamp).to.be.at.least(beforeScan);
+    });
+  });
+
+  describe('AC9 (kanameone 2026-06-11 事象の予防)', () => {
+    it('39 分間 quota 枯渇 → MAX_RETRY_COUNT_429=8 + exponential delay で吸収可能', () => {
+      // base delay 累計: 1+3+6+12+24+48+60+60 = 214 分 ≈ 3.5h
+      const cumulativeMs = RETRY_DELAYS_429_MS.reduce((acc, d) => acc + d, 0);
+      const cumulativeMinutes = cumulativeMs / 60_000;
+      expect(cumulativeMinutes).to.equal(214);
+      // 39 分時点で retry 5 (累計 46 分) 進行中 → error 確定せず
+      const cumulativeAtRetry5 = RETRY_DELAYS_429_MS.slice(0, 5).reduce((a, d) => a + d, 0) / 60_000;
+      expect(cumulativeAtRetry5).to.be.greaterThan(39);
+    });
+  });
+});

--- a/scripts/fix-stuck-documents.js
+++ b/scripts/fix-stuck-documents.js
@@ -39,9 +39,14 @@ async function resetDoc(docRef, data) {
     status: 'pending',
     retryCount: 0,
     lastErrorMessage: null,
+    // 2026-06-12 vertex 429 resilience: 自動 rescue 状態もクリア。
+    // 残存すると errorRescueCount 由来で次回自動 rescue 対象外になり手動意図と矛盾する。
+    errorRescueCount: admin.firestore.FieldValue.delete(),
+    lastRescuedAt: admin.firestore.FieldValue.delete(),
+    retryAfter: admin.firestore.FieldValue.delete(),
     updatedAt: admin.firestore.FieldValue.serverTimestamp(),
   });
-  console.log(`    → pendingに変更（retryCount: 0）`);
+  console.log(`    → pendingに変更（retryCount: 0, rescue state cleared）`);
 }
 
 async function runSingle() {


### PR DESCRIPTION
## Summary

2026-06-11 11:04-11:43 (39 分間) に kanameone 本番で Vertex AI Gemini 429 RESOURCE_EXHAUSTED が継続発生し、21 件のドキュメントが旧 retry policy (15 min horizon) 超過で `status:error` に確定した事象を予防する構造改修。

詳細は [ADR-0017](docs/adr/0017-vertex-429-resilience.md) を参照。

- **主防御**: 429 系専用 retry policy (`MAX_RETRY_COUNT_429=8` + exponential delay `[1,3,6,12,24,48,60,60]` 分 + jitter ±20%) で cumulative horizon 約 3.5 時間
- **補助 (backstop)**: `error` 状態の 429 系 doc を 1 時間ごとに自動 rescue。`errorRescueCount >= 3` で永続ループ防止
- 非 429 transient (timeout 等) は既存挙動 (`MAX_RETRY_COUNT=5` / 1 min retryAfter) を **完全維持**
- 派生フィールド追加プロトコル (#178 教訓) 準拠

## 評価ゲート

- Codex MCP セカンドオピニオン取得済 (thread `019eb9bd-...`)
- Pure tests 1453 PASS / Integration tests 17 PASS / build / lint errors 0
- safe-refactor: QUOTA_ERROR_MESSAGE_KEYWORDS 単一定数化
- code-review medium: 7 angles → 派生フィールドプロトコル違反 4 件検出 → 全修正
- Evaluator agent (前提知識なし): AC1-AC6 PASS、Phase B 進行可

## Test plan

- [x] Pure tests / integration tests / build / lint 全 PASS
- [ ] Phase B: dev deploy + functions logs 確認
- [ ] Phase C: kanameone / cocoro deploy
- [ ] Phase D: kanameone 21 件 reprocess (運用スクリプト GitHub Actions 経由)
- [ ] Phase E: handoff + マルチクライアントマトリクス記録

## 関連

- ADR-0017
- 既存対策の延長: Issue #194 / #196 / #360
- #178 教訓 (派生フィールド追加プロトコル)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced resilience handling for quota/rate-limit errors with dedicated retry and recovery policies.
  * Implemented automatic recovery mechanism for documents in error state due to quota issues, with reprocessing after 1 hour.

* **Documentation**
  * Added Architecture Decision Record documenting quota error resilience strategy and recovery workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->