### PR TITLE
feat(ops): Issue #492 Ambiguous collision docs cleanup スクリプト (方針A データ駆動版)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -663,7 +663,10 @@ jobs:
         with:
           name: cleanup-ambiguous-backup-${{ github.event.inputs.environment }}-${{ github.run_id }}
           path: scripts/cleanup-ambiguous-backup.json
-          if-no-files-found: ignore
+          # fixture 系 run では backup が出ないため error にはしないが、
+          # --execute run で backup 不在なら気付けるよう warn (ignore は復旧材料の
+          # 消失を無音化するため不可 — silent-failure review 反映)
+          if-no-files-found: warn
           retention-days: 90
 
       - name: Upload audit-session61-parent-provenance report artifact

--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -76,6 +76,11 @@ on:
           - pdf-feature-survey --source gcs --prefix processed/ --limit 200
           - pdf-feature-survey --source gcs --prefix processed/ --expect-filter /CCITTFaxDecode --expect-subtype /Image
           - pdf-feature-survey --source local --paths fixtures/ --expect-filter /CCITTFaxDecode,/JBIG2Decode,/JPXDecode,/DCTDecode --expect-subtype /Image --expect-encrypted
+          - cleanup-ambiguous-collision-docs --dry-run
+          - cleanup-ambiguous-collision-docs --execute
+          - cleanup-ambiguous-collision-docs --seed-dev-fixture
+          - cleanup-ambiguous-collision-docs --seed-dev-fixture --seed-violation
+          - cleanup-ambiguous-collision-docs --cleanup-fixture
           - verify-pdf-determinism --synthetic
           - verify-pdf-determinism --paths fixtures/simple.pdf,fixtures/with-ccittfaxdecode.pdf,fixtures/with-jbig2decode.pdf,fixtures/with-jpxdecode.pdf,fixtures/with-dctdecode.pdf,fixtures/encrypted.pdf
       doc_id:
@@ -557,6 +562,17 @@ jobs:
               FIREBASE_PROJECT_ID="$PROJECT_ID" \
               STORAGE_BUCKET="$STORAGE_BUCKET" \
               npx ts-node "${SCRIPT_NAME}.ts" $SCRIPT_ARGS $EXTRA_ARGS
+          elif [ "$SCRIPT_NAME" = "cleanup-ambiguous-collision-docs" ]; then
+            # Issue #492: Ambiguous collision docs cleanup。scripts/lib/* (TypeScript)
+            # 依存のため ts-node 経由。plan は projectId から scripts/plans/ 配下を
+            # 自動選択 (plan.projectId と FIREBASE_PROJECT_ID の二重照合あり)。
+            # バックアップ JSON は log secret masking 回避のため artifact 経由で取得。
+            cd scripts
+            NODE_PATH=../functions/node_modules \
+              FIREBASE_PROJECT_ID="$PROJECT_ID" \
+              STORAGE_BUCKET="$STORAGE_BUCKET" \
+              npx ts-node "${SCRIPT_NAME}.ts" $SCRIPT_ARGS \
+                --backup-out "${GITHUB_WORKSPACE}/scripts/cleanup-ambiguous-backup.json"
           elif [ "$SCRIPT_NAME" = "inspect-document" ]; then
             # SCRIPT_ARGS は workflow_dispatch で選んだ "--file-name" / "--doc-id" / "... --include-related"
             # FILE_NAME / DOC_ID は env 経由で受け取り、配列に積んで execv 渡しでシェル展開を経由しない
@@ -637,6 +653,18 @@ jobs:
           path: scripts/verify-pdf-determinism-output.json
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Upload cleanup-ambiguous backup artifact
+        # Issue #492: 削除前バックアップ (winner 含む全対象 doc スナップショット)。
+        # destructive 操作の復旧材料のため retention を長めに取る。
+        # dry-run でも出力されるためレビュー材料としても使える。
+        if: ${{ startsWith(github.event.inputs.script, 'cleanup-ambiguous-collision-docs') && always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cleanup-ambiguous-backup-${{ github.event.inputs.environment }}-${{ github.run_id }}
+          path: scripts/cleanup-ambiguous-backup.json
+          if-no-files-found: ignore
+          retention-days: 90
 
       - name: Upload audit-session61-parent-provenance report artifact
         # Issue #432 PR-C2-execution post-audit: log secret masking 回避のため

--- a/functions/test/ambiguousCleanup.test.ts
+++ b/functions/test/ambiguousCleanup.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Issue #492: ambiguousCleanup (重複 docs cleanup の純ロジック) の単体テスト
+ *
+ * 検証対象は all-or-nothing precondition 評価。destructive 操作の gate なので
+ * 「reject すべきものを確実に reject する」側のケースを網羅する:
+ *   - plan 構造エラー (docId 重複 / winner が loser に混入 / 件数不一致)
+ *   - loser が verified=true / editedAt あり / rotatedAt あり (ユーザー操作済み)
+ *   - fileUrl 不一致 (Storage path 共有が証明できない)
+ *   - winner / loser 不在、fileName / parentDocumentId / status 不一致
+ *   - 違反 1 件でも deletions が空になること (all-or-nothing)
+ */
+
+import { expect } from 'chai';
+import {
+  AMBIGUOUS_CLEANUP_SCHEMA_VERSION,
+  CleanupPlan,
+  DocState,
+  validatePlanStructure,
+  evaluatePreconditions,
+} from '../../scripts/lib/ambiguousCleanup';
+
+const FILE_URL = 'gs://bucket/processed/20260413_未判定_未判定_p1-4.pdf';
+
+function makePlan(overrides: Partial<CleanupPlan> = {}): CleanupPlan {
+  return {
+    schemaVersion: AMBIGUOUS_CLEANUP_SCHEMA_VERSION,
+    issue: 492,
+    projectId: 'test-project',
+    groups: [
+      {
+        fileName: '20260413_未判定_未判定_p1-4.pdf',
+        parentDocumentId: 'parent-1',
+        winnerDocId: 'winner-1',
+        loserDocIds: ['loser-1a', 'loser-1b'],
+      },
+    ],
+    expectedLoserCount: 2,
+    ...overrides,
+  };
+}
+
+function makeDoc(overrides: Record<string, unknown> = {}): DocState {
+  return {
+    exists: true,
+    data: {
+      fileName: '20260413_未判定_未判定_p1-4.pdf',
+      parentDocumentId: 'parent-1',
+      status: 'processed',
+      fileUrl: FILE_URL,
+      verified: false,
+      ...overrides,
+    },
+  };
+}
+
+function makeDocs(entries: Record<string, DocState>): Map<string, DocState> {
+  return new Map(Object.entries(entries));
+}
+
+function healthyDocs(): Map<string, DocState> {
+  return makeDocs({
+    'winner-1': makeDoc({ verified: true }),
+    'loser-1a': makeDoc(),
+    'loser-1b': makeDoc(),
+  });
+}
+
+describe('ambiguousCleanup: validatePlanStructure', () => {
+  it('妥当な plan はエラーなし', () => {
+    expect(validatePlanStructure(makePlan())).to.deep.equal([]);
+  });
+
+  it('schemaVersion 不一致を reject', () => {
+    const errors = validatePlanStructure(makePlan({ schemaVersion: 'v0' }));
+    expect(errors.some((e) => e.includes('schemaVersion'))).to.equal(true);
+  });
+
+  it('winner が loserDocIds に混入していたら reject', () => {
+    const plan = makePlan();
+    plan.groups[0].loserDocIds = ['winner-1', 'loser-1b'];
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('winner'))).to.equal(true);
+  });
+
+  it('グループ跨ぎの docId 重複を reject', () => {
+    const plan = makePlan();
+    plan.groups.push({
+      fileName: 'other.pdf',
+      parentDocumentId: 'parent-1',
+      winnerDocId: 'winner-2',
+      loserDocIds: ['loser-1a'], // group1 と重複
+    });
+    plan.expectedLoserCount = 3;
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('重複'))).to.equal(true);
+  });
+
+  it('expectedLoserCount 不一致を reject (境界: ±1)', () => {
+    expect(
+      validatePlanStructure(makePlan({ expectedLoserCount: 1 })).some((e) =>
+        e.includes('loser 合計不一致')
+      )
+    ).to.equal(true);
+    expect(
+      validatePlanStructure(makePlan({ expectedLoserCount: 3 })).some((e) =>
+        e.includes('loser 合計不一致')
+      )
+    ).to.equal(true);
+  });
+
+  it('groups 空を reject', () => {
+    const errors = validatePlanStructure(makePlan({ groups: [], expectedLoserCount: 0 }));
+    expect(errors.some((e) => e.includes('groups が空'))).to.equal(true);
+  });
+});
+
+describe('ambiguousCleanup: evaluatePreconditions', () => {
+  it('全条件充足なら loser 全件が deletions に載る', () => {
+    const { violations, deletions } = evaluatePreconditions(makePlan(), healthyDocs());
+    expect(violations).to.deep.equal([]);
+    expect(deletions.map((d) => d.docId)).to.deep.equal(['loser-1a', 'loser-1b']);
+    expect(deletions[0].winnerDocId).to.equal('winner-1');
+  });
+
+  it('loser が verified=true なら reject (ユーザー確認済み doc の削除禁止)', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', makeDoc({ verified: true }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('verified=true'))).to.equal(true);
+    expect(deletions).to.deep.equal([]); // all-or-nothing
+  });
+
+  it('loser に editedAt があれば reject (ユーザー編集済み doc の削除禁止)', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1b', makeDoc({ editedAt: { _seconds: 1, _nanoseconds: 0 } }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('editedAt'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('loser の editedAt=null は「未編集」扱いで通過', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', makeDoc({ editedAt: null }));
+    const { violations } = evaluatePreconditions(makePlan(), docs);
+    expect(violations).to.deep.equal([]);
+  });
+
+  it('loser に rotatedAt があれば reject', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', makeDoc({ rotatedAt: { _seconds: 1, _nanoseconds: 0 } }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('rotatedAt'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('loser の fileUrl が winner と異なれば reject (path 共有が証明できない)', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', makeDoc({ fileUrl: 'gs://bucket/processed/other.pdf' }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('fileUrl'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('winner の fileUrl が空なら reject', () => {
+    const docs = healthyDocs();
+    docs.set('winner-1', makeDoc({ verified: true, fileUrl: undefined }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('winner') && v.includes('fileUrl'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('winner 不在なら reject', () => {
+    const docs = healthyDocs();
+    docs.set('winner-1', { exists: false });
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('winner') && v.includes('存在しない'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('loser 不在なら reject (既に消えている場合も再実行は abort)', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', { exists: false });
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('loser-1a') && v.includes('存在しない'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('loser の fileName 不一致なら reject', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', makeDoc({ fileName: 'unexpected.pdf' }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('fileName 不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('loser の parentDocumentId 不一致なら reject', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1b', makeDoc({ parentDocumentId: 'other-parent' }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('parentDocumentId 不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('loser の status が processed 以外なら reject', () => {
+    const docs = healthyDocs();
+    docs.set('loser-1a', makeDoc({ status: 'processing' }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('status'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('winner は verified=false でも通過する (winner に操作履歴は要求しない)', () => {
+    const docs = makeDocs({
+      'winner-1': makeDoc(), // verified: false
+      'loser-1a': makeDoc(),
+      'loser-1b': makeDoc(),
+    });
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations).to.deep.equal([]);
+    expect(deletions).to.have.length(2);
+  });
+});

--- a/functions/test/ambiguousCleanup.test.ts
+++ b/functions/test/ambiguousCleanup.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   AMBIGUOUS_CLEANUP_SCHEMA_VERSION,
   CleanupPlan,
@@ -71,7 +73,9 @@ describe('ambiguousCleanup: validatePlanStructure', () => {
   });
 
   it('schemaVersion 不一致を reject', () => {
-    const errors = validatePlanStructure(makePlan({ schemaVersion: 'v0' }));
+    const errors = validatePlanStructure(
+      makePlan({ schemaVersion: 'v0' as CleanupPlan['schemaVersion'] })
+    );
     expect(errors.some((e) => e.includes('schemaVersion'))).to.equal(true);
   });
 
@@ -79,7 +83,9 @@ describe('ambiguousCleanup: validatePlanStructure', () => {
     const plan = makePlan();
     plan.groups[0].loserDocIds = ['winner-1', 'loser-1b'];
     const errors = validatePlanStructure(plan);
-    expect(errors.some((e) => e.includes('winner'))).to.equal(true);
+    // 専用チェックのメッセージ固有文字列で assert (「docId 重複」との overlap で
+    // 専用チェック削除を検知できなくなるのを防ぐ — pr-test-analyzer 反映)
+    expect(errors.some((e) => e.includes('loserDocIds に含まれる'))).to.equal(true);
   });
 
   it('グループ跨ぎの docId 重複を reject', () => {
@@ -218,5 +224,96 @@ describe('ambiguousCleanup: evaluatePreconditions', () => {
     const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
     expect(violations).to.deep.equal([]);
     expect(deletions).to.have.length(2);
+  });
+
+  it('winner の fileName 不一致なら reject (stale plan の防波堤)', () => {
+    const docs = healthyDocs();
+    docs.set('winner-1', makeDoc({ verified: true, fileName: 'reassigned.pdf' }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(violations.some((v) => v.includes('winner') && v.includes('fileName 不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('winner の parentDocumentId 不一致なら reject', () => {
+    const docs = healthyDocs();
+    docs.set('winner-1', makeDoc({ verified: true, parentDocumentId: 'other-parent' }));
+    const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
+    expect(
+      violations.some((v) => v.includes('winner') && v.includes('parentDocumentId 不一致'))
+    ).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('winner が loserDocIds に混入した plan は evaluatePreconditions 単独でも reject (defense-in-depth)', () => {
+    // validatePlanStructure を経由しない呼び出し経路への防御。混入時は loser の
+    // fileUrl 照合が「winner 自身との比較」になり全 precondition を素通りするため、
+    // ここで止めないと winner 本体が削除対象に載る
+    const plan = makePlan();
+    plan.groups[0].loserDocIds = ['winner-1', 'loser-1b'];
+    const { violations, deletions } = evaluatePreconditions(plan, healthyDocs());
+    expect(violations.some((v) => v.includes('loserDocIds に含まれる'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('複数グループ: 1 グループの違反が健全な他グループの削除も止める (all-or-nothing)', () => {
+    const plan = makePlan({
+      groups: [
+        {
+          fileName: '20260413_未判定_未判定_p1-4.pdf',
+          parentDocumentId: 'parent-1',
+          winnerDocId: 'winner-1',
+          loserDocIds: ['loser-1a', 'loser-1b'],
+        },
+        {
+          fileName: '20260413_未判定_未判定_p13-14.pdf',
+          parentDocumentId: 'parent-1',
+          winnerDocId: 'winner-2',
+          loserDocIds: ['loser-2a'],
+        },
+      ],
+      expectedLoserCount: 3,
+    });
+    const fileUrl2 = 'gs://bucket/processed/20260413_未判定_未判定_p13-14.pdf';
+    const docs = makeDocs({
+      'winner-1': makeDoc({ verified: true }),
+      'loser-1a': makeDoc(),
+      'loser-1b': makeDoc(),
+      'winner-2': makeDoc({ fileName: '20260413_未判定_未判定_p13-14.pdf', fileUrl: fileUrl2 }),
+      // グループ 2 の loser がユーザー確認済み → グループ 1 も削除してはいけない
+      'loser-2a': makeDoc({
+        fileName: '20260413_未判定_未判定_p13-14.pdf',
+        fileUrl: fileUrl2,
+        verified: true,
+      }),
+    });
+    const { violations, deletions } = evaluatePreconditions(plan, docs);
+    expect(violations.some((v) => v.includes('loser-2a'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+});
+
+describe('ambiguousCleanup: checked-in plan JSON の実物検証', () => {
+  // 本番削除を駆動するデータそのものを regression gate にかける
+  // (Phase 2 での plan 編集時の docId コピペ重複・件数更新漏れを検知する)
+  const plansDir = path.join(__dirname, '..', '..', 'scripts', 'plans');
+
+  function loadPlanFile(name: string): CleanupPlan {
+    return JSON.parse(fs.readFileSync(path.join(plansDir, name), 'utf-8')) as CleanupPlan;
+  }
+
+  it('kanameone plan: 構造検証を通過し、想定値 (8 groups / 16 losers / projectId) と一致', () => {
+    const plan = loadPlanFile('cleanup-ambiguous-492-kanameone.json');
+    expect(validatePlanStructure(plan)).to.deep.equal([]);
+    expect(plan.projectId).to.equal('docsplit-kanameone');
+    expect(plan.groups).to.have.length(8);
+    expect(plan.expectedLoserCount).to.equal(16);
+  });
+
+  it('dev fixture plan: 構造検証を通過し、想定値 (2 groups / 4 losers / projectId) と一致', () => {
+    const plan = loadPlanFile('cleanup-ambiguous-492-dev-fixture.json');
+    expect(validatePlanStructure(plan)).to.deep.equal([]);
+    expect(plan.projectId).to.equal('doc-split-dev');
+    expect(plan.groups).to.have.length(2);
+    expect(plan.expectedLoserCount).to.equal(4);
   });
 });

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -5,7 +5,7 @@
  * 同名・同 Storage path を共有する重複 Firestore docs (Issue #432 復旧で
  * manual-review 除外された Ambiguous 群) を winner 1 件残しで削除する。
  *
- * 安全装置:
+ * 安全装置 (cleanup 本経路 = dry-run / --execute):
  *   - dry-run デフォルト。--execute 明示時のみ削除
  *   - plan JSON (scripts/plans/) に winner/loser を固定。projectId 二重照合
  *   - preconditions all-or-nothing (scripts/lib/ambiguousCleanup.ts 参照)。
@@ -13,16 +13,22 @@
  *   - 削除前に winner+loser 全フィールド JSON バックアップを必ず出力
  *   - 件数厳密アサーション (plan.expectedLoserCount と 1 件でもずれたら abort)
  *   - Storage 実体は一切触らない (winner が同一ファイルを参照継続)。
- *     本スクリプトは Storage の read (existence check) のみで delete API を呼ばない
- *   - 事後検証: loser 不在 / winner 現存 / 共有 Storage path 現存
+ *     cleanup 本経路は Storage の read (existence check) のみで delete API を呼ばない
+ *   - --execute は STORAGE_BUCKET 必須 (事後検証を欠いた削除を構造的に排除)
+ *   - 事後検証: loser 不在 / winner 現存 / winner の実 fileUrl が指す Storage 実体現存
+ *   - 未知フラグは exit 2 (typo が黙って dry-run に化けるのを防ぐ)
+ *
+ * ※ 例外経路: --seed-dev-fixture / --cleanup-fixture は dev 専用 (assertDevOnly
+ *    ガード) で、fixture の Storage 実体の作成・削除を行う。
  *
  * 使用方法:
  *   FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
  *     npx ts-node scripts/cleanup-ambiguous-collision-docs.ts \
- *       [--plan <path>] [--execute] [--backup-out <path>]
+ *       [--plan <path>] [--dry-run] [--execute] [--backup-out <path>]
  *       [--seed-dev-fixture [--seed-violation]] [--cleanup-fixture]
  *
  *   --plan 省略時は FIREBASE_PROJECT_ID から plans/ 配下を自動選択
+ *   --dry-run: 明示フラグ (デフォルト挙動と同じ。workflow choice の可読性用)
  *   --seed-dev-fixture: dev 専用。fixture plan と一致する合成 docs を投入
  *   --seed-violation: fixture の loser 1 件に editedAt を付与 (reject 経路の実証用)
  *   --cleanup-fixture: dev 専用。fixture docs + Storage 実体を削除
@@ -52,11 +58,42 @@ function getOpt(name: string): string | null {
   return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
 }
 
+// 未知フラグ reject: typo (--exeucte 等) が黙って dry-run に化けるのを防ぐ
+const KNOWN_FLAGS = new Set([
+  '--execute',
+  '--dry-run',
+  '--seed-dev-fixture',
+  '--seed-violation',
+  '--cleanup-fixture',
+]);
+const VALUE_OPTS = new Set(['--plan', '--backup-out']);
+{
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (VALUE_OPTS.has(a)) {
+      i++; // 値をスキップ
+      continue;
+    }
+    if (a.startsWith('--') && !KNOWN_FLAGS.has(a)) {
+      console.error(`FATAL: 未知のフラグ: ${a} (有効: ${[...KNOWN_FLAGS, ...VALUE_OPTS].join(' ')})`);
+      process.exit(2);
+    }
+  }
+}
+
 const execute = process.argv.includes('--execute');
 const seedDevFixture = process.argv.includes('--seed-dev-fixture');
 const seedViolation = process.argv.includes('--seed-violation');
 const cleanupFixture = process.argv.includes('--cleanup-fixture');
 const planPathOpt = getOpt('--plan');
+
+// --execute は事後検証 (Storage 実体現存チェック) まで含めて 1 セット。
+// STORAGE_BUCKET なしの削除実行を構造的に排除する (silent-failure review 反映)
+if (execute && !storageBucket) {
+  console.error('FATAL: --execute には STORAGE_BUCKET が必須です (事後検証に使用)');
+  process.exit(2);
+}
 const backupOut =
   getOpt('--backup-out') ||
   path.join(process.cwd(), `cleanup-ambiguous-backup-${projectId}.json`);
@@ -82,7 +119,14 @@ admin.initializeApp(
 const db = admin.firestore();
 
 function loadPlan(planPath: string): CleanupPlan {
-  const plan = JSON.parse(fs.readFileSync(planPath, 'utf-8')) as CleanupPlan;
+  let plan: CleanupPlan;
+  try {
+    plan = JSON.parse(fs.readFileSync(planPath, 'utf-8')) as CleanupPlan;
+  } catch (err) {
+    // SyntaxError にはファイルパスが含まれないため文脈を付けて rethrow
+    console.error(`FATAL: plan の読込/parse に失敗: ${planPath}`);
+    throw err;
+  }
   const structErrors = validatePlanStructure(plan);
   if (structErrors.length > 0) {
     console.error('FATAL: plan 構造エラー:');
@@ -237,12 +281,20 @@ function writeBackup(plan: CleanupPlan, docs: Map<string, DocState>): void {
 
 async function main(): Promise<void> {
   const planPath = resolvePlanPath();
-  const plan = loadPlan(planPath);
-
   console.log('=== Issue #492 Ambiguous collision docs cleanup ===');
   console.log(`project: ${projectId}`);
-  console.log(`plan: ${planPath} (groups=${plan.groups.length}, expectedLoserCount=${plan.expectedLoserCount})`);
-  console.log(`mode: ${execute ? '⚠️ EXECUTE (削除実行)' : 'dry-run (書き込みなし)'}`);
+  console.log(`plan: ${planPath}`);
+  const plan = loadPlan(planPath);
+  console.log(`  groups=${plan.groups.length}, expectedLoserCount=${plan.expectedLoserCount}`);
+  // mode 表示は実際の動作と一致させる (fixture 系は --execute なしで書き込む dev 専用経路)
+  const mode = cleanupFixture
+    ? '⚠️ fixture-cleanup (dev: fixture docs + Storage 実体を削除)'
+    : seedDevFixture
+      ? 'fixture-seed (dev: fixture docs + Storage 実体を作成)'
+      : execute
+        ? '⚠️ EXECUTE (削除実行)'
+        : 'dry-run (Firestore/Storage 書き込みなし。バックアップ JSON のみローカル出力)';
+  console.log(`mode: ${mode}`);
 
   if (cleanupFixture) {
     await removeFixture(plan);
@@ -300,9 +352,13 @@ async function main(): Promise<void> {
   try {
     await batch.commit();
   } catch (err) {
+    // gRPC FAILED_PRECONDITION (code 9) = lastUpdateTime 不一致 = 検証後に doc が更新された
+    const isPreconditionFailure = (err as { code?: number }).code === 9;
     console.error(
       '❌ batch 削除が失敗しました (atomic のため部分削除はありません)。' +
-        '検証後に doc が更新された可能性があります。再実行前に dry-run で状態を確認してください。'
+        (isPreconditionFailure
+          ? '検証後に doc が更新されています (lastUpdateTime precondition 不一致)。再実行前に dry-run で状態を確認してください。'
+          : '一時的エラー/権限エラーの可能性があります。原因解消後に dry-run から再実行してください。')
     );
     console.error(err);
     process.exit(1);
@@ -322,16 +378,29 @@ async function main(): Promise<void> {
       }
     }
   }
-  if (storageBucket) {
-    const bucket = admin.storage().bucket();
-    for (const g of plan.groups) {
-      const [exists] = await bucket.file(`processed/${g.fileName}`).exists();
-      if (!exists) {
-        postErrors.push(`Storage 実体 processed/${g.fileName} が不在 (winner が閲覧不能)`);
-      }
+  // Storage 実体の現存確認は winner の実 fileUrl から object path を導出する
+  // (`processed/${fileName}` の再構築は split 由来 doc の docId namespace 形式
+  //  `processed/{docId}/{fileName}` と乖離しうる — code review Important 反映)。
+  // fileUrl は preconditions で非空を検証済み。STORAGE_BUCKET は --execute で必須。
+  const bucket = admin.storage().bucket();
+  for (const g of plan.groups) {
+    const winnerFileUrl = docs.get(g.winnerDocId)?.data?.fileUrl as string;
+    const m = winnerFileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/);
+    if (!m) {
+      postErrors.push(`winner ${g.winnerDocId} の fileUrl が gs:// 形式でない: ${winnerFileUrl}`);
+      continue;
     }
-  } else {
-    console.warn('⚠️ STORAGE_BUCKET 未設定のため Storage 実体の事後検証をスキップ');
+    const [, urlBucket, objectPath] = m;
+    if (urlBucket !== storageBucket) {
+      postErrors.push(
+        `winner ${g.winnerDocId} の fileUrl bucket (${urlBucket}) が STORAGE_BUCKET (${storageBucket}) と不一致`
+      );
+      continue;
+    }
+    const [exists] = await bucket.file(objectPath).exists();
+    if (!exists) {
+      postErrors.push(`Storage 実体 ${objectPath} が不在 (winner ${g.winnerDocId} が閲覧不能)`);
+    }
   }
 
   if (postErrors.length > 0) {

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -184,26 +184,41 @@ async function removeFixture(plan: CleanupPlan): Promise<void> {
     }
   }
   for (const g of plan.groups) {
+    // 404 のみ冪等扱い。permission/transient エラーは握り潰さず fail させる
+    // (Codex review P2: silent cleanup failure 防止)
     await bucket
       .file(`processed/${g.fileName}`)
       .delete()
-      .catch(() => undefined); // 404 は冪等扱い
+      .catch((err: { code?: number }) => {
+        if (err.code === 404) return undefined;
+        throw err;
+      });
   }
   console.log(`✅ fixture 削除完了 (docs ${ids.size} 件 + Storage ${plan.groups.length} 件)`);
 }
 
-async function fetchDocStates(plan: CleanupPlan): Promise<Map<string, DocState>> {
+interface FetchedStates {
+  states: Map<string, DocState>;
+  /** 検証時点の snapshot updateTime。削除時の lastUpdateTime precondition に使う */
+  updateTimes: Map<string, FirebaseFirestore.Timestamp>;
+}
+
+async function fetchDocStates(plan: CleanupPlan): Promise<FetchedStates> {
   const ids: string[] = [];
   for (const g of plan.groups) {
     ids.push(g.winnerDocId, ...g.loserDocIds);
   }
   const refs = ids.map((id) => db.collection('documents').doc(id));
   const snaps = await db.getAll(...refs);
-  const map = new Map<string, DocState>();
+  const states = new Map<string, DocState>();
+  const updateTimes = new Map<string, FirebaseFirestore.Timestamp>();
   snaps.forEach((snap, i) => {
-    map.set(ids[i], { exists: snap.exists, data: snap.data() as Record<string, unknown> });
+    states.set(ids[i], { exists: snap.exists, data: snap.data() as Record<string, unknown> });
+    if (snap.exists && snap.updateTime) {
+      updateTimes.set(ids[i], snap.updateTime);
+    }
   });
-  return map;
+  return { states, updateTimes };
 }
 
 function writeBackup(plan: CleanupPlan, docs: Map<string, DocState>): void {
@@ -239,7 +254,7 @@ async function main(): Promise<void> {
   }
 
   // 1. 現状取得
-  const docs = await fetchDocStates(plan);
+  const { states: docs, updateTimes } = await fetchDocStates(plan);
 
   // 2. バックアップ (dry-run でも出力し、レビュー材料にする)
   writeBackup(plan, docs);
@@ -263,21 +278,39 @@ async function main(): Promise<void> {
   }
 
   // 4. 削除実行 (Firestore doc のみ。Storage は不可侵)
-  let deleted = 0;
-  for (const d of deletions) {
-    await db.collection('documents').doc(d.docId).delete();
-    deleted++;
-  }
-  if (deleted !== plan.expectedLoserCount) {
+  // Codex review P1 反映:
+  //   - 単一 atomic batch commit (全成功 or 全失敗。部分削除状態を作らない)
+  //   - lastUpdateTime precondition (検証後に doc が更新されていたら batch ごと fail
+  //     = 検証〜削除間の TOCTOU でユーザー操作済み doc を消さない)
+  if (deletions.length !== plan.expectedLoserCount) {
     console.error(
-      `❌ 削除件数不一致: expected=${plan.expectedLoserCount} actual=${deleted}。事後検証で確認してください。`
+      `❌ 削除対象件数不一致: expected=${plan.expectedLoserCount} actual=${deletions.length}`
     );
     process.exit(1);
   }
-  console.log(`🗑️ 削除完了: ${deleted} 件`);
+  const batch = db.batch();
+  for (const d of deletions) {
+    const lastUpdateTime = updateTimes.get(d.docId);
+    if (!lastUpdateTime) {
+      console.error(`❌ ${d.docId} の updateTime が取得できず precondition を構成できません`);
+      process.exit(1);
+    }
+    batch.delete(db.collection('documents').doc(d.docId), { lastUpdateTime });
+  }
+  try {
+    await batch.commit();
+  } catch (err) {
+    console.error(
+      '❌ batch 削除が失敗しました (atomic のため部分削除はありません)。' +
+        '検証後に doc が更新された可能性があります。再実行前に dry-run で状態を確認してください。'
+    );
+    console.error(err);
+    process.exit(1);
+  }
+  console.log(`🗑️ 削除完了: ${deletions.length} 件 (atomic batch + lastUpdateTime precondition)`);
 
   // 5. 事後検証
-  const after = await fetchDocStates(plan);
+  const { states: after } = await fetchDocStates(plan);
   const postErrors: string[] = [];
   for (const g of plan.groups) {
     if (!after.get(g.winnerDocId)?.exists) {

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -1,0 +1,317 @@
+#!/usr/bin/env ts-node
+/**
+ * Issue #492: Ambiguous collision docs cleanup (方針 A データ駆動版)
+ *
+ * 同名・同 Storage path を共有する重複 Firestore docs (Issue #432 復旧で
+ * manual-review 除外された Ambiguous 群) を winner 1 件残しで削除する。
+ *
+ * 安全装置:
+ *   - dry-run デフォルト。--execute 明示時のみ削除
+ *   - plan JSON (scripts/plans/) に winner/loser を固定。projectId 二重照合
+ *   - preconditions all-or-nothing (scripts/lib/ambiguousCleanup.ts 参照)。
+ *     ユーザーが触った doc (verified / editedAt / rotatedAt) は削除禁止
+ *   - 削除前に winner+loser 全フィールド JSON バックアップを必ず出力
+ *   - 件数厳密アサーション (plan.expectedLoserCount と 1 件でもずれたら abort)
+ *   - Storage 実体は一切触らない (winner が同一ファイルを参照継続)。
+ *     本スクリプトは Storage の read (existence check) のみで delete API を呼ばない
+ *   - 事後検証: loser 不在 / winner 現存 / 共有 Storage path 現存
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=<project-id> STORAGE_BUCKET=<bucket> \
+ *     npx ts-node scripts/cleanup-ambiguous-collision-docs.ts \
+ *       [--plan <path>] [--execute] [--backup-out <path>]
+ *       [--seed-dev-fixture [--seed-violation]] [--cleanup-fixture]
+ *
+ *   --plan 省略時は FIREBASE_PROJECT_ID から plans/ 配下を自動選択
+ *   --seed-dev-fixture: dev 専用。fixture plan と一致する合成 docs を投入
+ *   --seed-violation: fixture の loser 1 件に editedAt を付与 (reject 経路の実証用)
+ *   --cleanup-fixture: dev 専用。fixture docs + Storage 実体を削除
+ */
+
+import * as admin from 'firebase-admin';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PDFDocument } from 'pdf-lib';
+import {
+  CleanupPlan,
+  DocState,
+  validatePlanStructure,
+  evaluatePreconditions,
+} from './lib/ambiguousCleanup';
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const storageBucket = process.env.STORAGE_BUCKET;
+
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+
+function getOpt(name: string): string | null {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+
+const execute = process.argv.includes('--execute');
+const seedDevFixture = process.argv.includes('--seed-dev-fixture');
+const seedViolation = process.argv.includes('--seed-violation');
+const cleanupFixture = process.argv.includes('--cleanup-fixture');
+const planPathOpt = getOpt('--plan');
+const backupOut =
+  getOpt('--backup-out') ||
+  path.join(process.cwd(), `cleanup-ambiguous-backup-${projectId}.json`);
+
+// plan 自動選択: projectId → plans/ 配下。未知 projectId は明示 --plan 必須
+function resolvePlanPath(): string {
+  if (planPathOpt) return planPathOpt;
+  if (projectId === 'docsplit-kanameone') {
+    return path.join(__dirname, 'plans', 'cleanup-ambiguous-492-kanameone.json');
+  }
+  if (projectId!.includes('dev')) {
+    return path.join(__dirname, 'plans', 'cleanup-ambiguous-492-dev-fixture.json');
+  }
+  console.error(
+    `FATAL: projectId=${projectId} 用の既定 plan がありません。--plan で明示してください。`
+  );
+  process.exit(2);
+}
+
+admin.initializeApp(
+  storageBucket ? { projectId, storageBucket } : { projectId }
+);
+const db = admin.firestore();
+
+function loadPlan(planPath: string): CleanupPlan {
+  const plan = JSON.parse(fs.readFileSync(planPath, 'utf-8')) as CleanupPlan;
+  const structErrors = validatePlanStructure(plan);
+  if (structErrors.length > 0) {
+    console.error('FATAL: plan 構造エラー:');
+    for (const e of structErrors) console.error(`  - ${e}`);
+    process.exit(2);
+  }
+  if (plan.projectId !== projectId) {
+    console.error(
+      `FATAL: plan.projectId=${plan.projectId} と FIREBASE_PROJECT_ID=${projectId} が不一致`
+    );
+    process.exit(2);
+  }
+  return plan;
+}
+
+function gsUrl(fileName: string): string {
+  return `gs://${storageBucket}/processed/${fileName}`;
+}
+
+/** dev 専用ガード */
+function assertDevOnly(op: string): void {
+  if (!projectId!.includes('dev')) {
+    console.error(`FATAL: ${op} は dev 環境専用です (projectId=${projectId})`);
+    process.exit(2);
+  }
+  if (!storageBucket) {
+    console.error(`FATAL: ${op} には STORAGE_BUCKET が必要です`);
+    process.exit(2);
+  }
+}
+
+async function seedFixture(plan: CleanupPlan): Promise<void> {
+  assertDevOnly('--seed-dev-fixture');
+  const bucket = admin.storage().bucket();
+
+  // 親 doc
+  const parentId = plan.groups[0].parentDocumentId;
+  await db.collection('documents').doc(parentId).set({
+    fileName: 'fixture492-parent.pdf',
+    status: 'processed',
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    fixture: 'issue-492-cleanup',
+  });
+
+  for (const [gi, g] of plan.groups.entries()) {
+    // 共有 Storage 実体 (1 グループ 1 ファイル)
+    const pdf = await PDFDocument.create();
+    pdf.addPage([200, 200]);
+    const bytes = await pdf.save();
+    await bucket.file(`processed/${g.fileName}`).save(Buffer.from(bytes), {
+      contentType: 'application/pdf',
+    });
+
+    const fileUrl = gsUrl(g.fileName);
+    const docIds = [g.winnerDocId, ...g.loserDocIds];
+    for (const [di, docId] of docIds.entries()) {
+      const isWinner = di === 0;
+      const data: Record<string, unknown> = {
+        fileName: g.fileName,
+        fileUrl,
+        parentDocumentId: g.parentDocumentId,
+        status: 'processed',
+        customerName: '未判定',
+        documentType: '未判定',
+        // グループ 1 の winner のみ verified=true (本番 p1-4 / p23-24 相当)
+        verified: isWinner && gi === 0,
+        customerConfirmed: isWinner && gi === 0,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        fixture: 'issue-492-cleanup',
+      };
+      // reject 経路実証: 最初のグループの loser-a に editedAt を付与
+      if (seedViolation && gi === 0 && docId === g.loserDocIds[0]) {
+        data.editedAt = admin.firestore.FieldValue.serverTimestamp();
+      }
+      await db.collection('documents').doc(docId).set(data);
+    }
+  }
+  console.log(
+    `✅ fixture 投入完了: parent 1 + docs ${plan.groups.reduce((n, g) => n + 1 + g.loserDocIds.length, 0)} 件` +
+      (seedViolation ? ' (violation: グループ1 loser-a に editedAt 付与)' : '')
+  );
+}
+
+async function removeFixture(plan: CleanupPlan): Promise<void> {
+  assertDevOnly('--cleanup-fixture');
+  const bucket = admin.storage().bucket();
+  const ids = new Set<string>([plan.groups[0].parentDocumentId]);
+  for (const g of plan.groups) {
+    ids.add(g.winnerDocId);
+    for (const id of g.loserDocIds) ids.add(id);
+  }
+  for (const id of ids) {
+    // fixture マーカー付き doc のみ削除 (実データ巻き込み防止)
+    const snap = await db.collection('documents').doc(id).get();
+    if (snap.exists && snap.data()?.fixture === 'issue-492-cleanup') {
+      await snap.ref.delete();
+    }
+  }
+  for (const g of plan.groups) {
+    await bucket
+      .file(`processed/${g.fileName}`)
+      .delete()
+      .catch(() => undefined); // 404 は冪等扱い
+  }
+  console.log(`✅ fixture 削除完了 (docs ${ids.size} 件 + Storage ${plan.groups.length} 件)`);
+}
+
+async function fetchDocStates(plan: CleanupPlan): Promise<Map<string, DocState>> {
+  const ids: string[] = [];
+  for (const g of plan.groups) {
+    ids.push(g.winnerDocId, ...g.loserDocIds);
+  }
+  const refs = ids.map((id) => db.collection('documents').doc(id));
+  const snaps = await db.getAll(...refs);
+  const map = new Map<string, DocState>();
+  snaps.forEach((snap, i) => {
+    map.set(ids[i], { exists: snap.exists, data: snap.data() as Record<string, unknown> });
+  });
+  return map;
+}
+
+function writeBackup(plan: CleanupPlan, docs: Map<string, DocState>): void {
+  const backup = {
+    createdAt: new Date().toISOString(),
+    projectId,
+    planIssue: plan.issue,
+    note: 'Issue #492 cleanup 前の全対象 doc スナップショット (winner 含む)。Timestamp は {_seconds,_nanoseconds} 形式。',
+    docs: Object.fromEntries(
+      [...docs.entries()].map(([id, s]) => [id, s.exists ? s.data : null])
+    ),
+  };
+  fs.writeFileSync(backupOut, JSON.stringify(backup, null, 2));
+  console.log(`📦 バックアップ出力: ${backupOut} (${docs.size} docs)`);
+}
+
+async function main(): Promise<void> {
+  const planPath = resolvePlanPath();
+  const plan = loadPlan(planPath);
+
+  console.log('=== Issue #492 Ambiguous collision docs cleanup ===');
+  console.log(`project: ${projectId}`);
+  console.log(`plan: ${planPath} (groups=${plan.groups.length}, expectedLoserCount=${plan.expectedLoserCount})`);
+  console.log(`mode: ${execute ? '⚠️ EXECUTE (削除実行)' : 'dry-run (書き込みなし)'}`);
+
+  if (cleanupFixture) {
+    await removeFixture(plan);
+    return;
+  }
+  if (seedDevFixture) {
+    await seedFixture(plan);
+    return;
+  }
+
+  // 1. 現状取得
+  const docs = await fetchDocStates(plan);
+
+  // 2. バックアップ (dry-run でも出力し、レビュー材料にする)
+  writeBackup(plan, docs);
+
+  // 3. preconditions (all-or-nothing)
+  const { violations, deletions } = evaluatePreconditions(plan, docs);
+  if (violations.length > 0) {
+    console.error(`❌ precondition 違反 ${violations.length} 件。削除は一切行いません:`);
+    for (const v of violations) console.error(`  - ${v}`);
+    process.exit(1);
+  }
+
+  console.log(`✅ preconditions 全通過。削除対象 ${deletions.length} 件:`);
+  for (const d of deletions) {
+    console.log(`  - ${d.docId} (${d.fileName}, winner=${d.winnerDocId})`);
+  }
+
+  if (!execute) {
+    console.log('dry-run 終了 (削除するには --execute を指定)');
+    return;
+  }
+
+  // 4. 削除実行 (Firestore doc のみ。Storage は不可侵)
+  let deleted = 0;
+  for (const d of deletions) {
+    await db.collection('documents').doc(d.docId).delete();
+    deleted++;
+  }
+  if (deleted !== plan.expectedLoserCount) {
+    console.error(
+      `❌ 削除件数不一致: expected=${plan.expectedLoserCount} actual=${deleted}。事後検証で確認してください。`
+    );
+    process.exit(1);
+  }
+  console.log(`🗑️ 削除完了: ${deleted} 件`);
+
+  // 5. 事後検証
+  const after = await fetchDocStates(plan);
+  const postErrors: string[] = [];
+  for (const g of plan.groups) {
+    if (!after.get(g.winnerDocId)?.exists) {
+      postErrors.push(`winner ${g.winnerDocId} が消えている (${g.fileName})`);
+    }
+    for (const id of g.loserDocIds) {
+      if (after.get(id)?.exists) {
+        postErrors.push(`loser ${id} が残存 (${g.fileName})`);
+      }
+    }
+  }
+  if (storageBucket) {
+    const bucket = admin.storage().bucket();
+    for (const g of plan.groups) {
+      const [exists] = await bucket.file(`processed/${g.fileName}`).exists();
+      if (!exists) {
+        postErrors.push(`Storage 実体 processed/${g.fileName} が不在 (winner が閲覧不能)`);
+      }
+    }
+  } else {
+    console.warn('⚠️ STORAGE_BUCKET 未設定のため Storage 実体の事後検証をスキップ');
+  }
+
+  if (postErrors.length > 0) {
+    console.error('❌ 事後検証エラー:');
+    for (const e of postErrors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  console.log(
+    `✅ 事後検証 OK: winner ${plan.groups.length} 件現存 / loser ${plan.expectedLoserCount} 件削除済 / Storage 実体現存`
+  );
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/lib/ambiguousCleanup.ts
+++ b/scripts/lib/ambiguousCleanup.ts
@@ -1,0 +1,217 @@
+/**
+ * Issue #492: Ambiguous collision docs cleanup の純ロジック
+ *
+ * 同名・同 Storage path を共有する重複 Firestore docs (Issue #432 復旧で
+ * manual-review 除外された Ambiguous 群) を「winner 1 件残し・loser 削除」で
+ * 整理するための plan 検証 + preconditions 評価。
+ *
+ * 設計方針:
+ *   - all-or-nothing: precondition 違反が 1 件でもあれば削除対象ゼロ
+ *   - 削除は Firestore doc のみ。Storage 実体は winner が参照継続するため不可侵
+ *     (このモジュールは削除自体を行わない。CLI 側も Storage delete API を呼ばない)
+ *   - loser は「ユーザーが一度も触っていない doc」のみ許可
+ *     (verified=true / editedAt あり / rotatedAt あり はすべて reject)
+ */
+
+export const AMBIGUOUS_CLEANUP_SCHEMA_VERSION = 'ambiguous-cleanup-v1';
+
+export interface CleanupGroup {
+  /** 共有されている fileName (例: 20260413_未判定_未判定_p1-4.pdf) */
+  fileName: string;
+  /** グループ全 docs が持つべき親 doc ID */
+  parentDocumentId: string;
+  /** 残す doc (クライアント編集/確認済み doc 優先、なければ docId 辞書順先頭) */
+  winnerDocId: string;
+  /** 削除する docs */
+  loserDocIds: string[];
+}
+
+export interface CleanupPlan {
+  schemaVersion: string;
+  issue: number;
+  projectId: string;
+  description?: string;
+  groups: CleanupGroup[];
+  /** 全グループ loser 合計の期待値。実対象数と 1 件でもずれたら abort */
+  expectedLoserCount: number;
+}
+
+/** Firestore doc snapshot の抽象 (テスト容易性のため admin SDK 非依存) */
+export interface DocState {
+  exists: boolean;
+  data?: Record<string, unknown>;
+}
+
+export interface PlannedDeletion {
+  docId: string;
+  fileName: string;
+  winnerDocId: string;
+}
+
+export interface PreconditionResult {
+  violations: string[];
+  /** violations が空のときのみ非空 (all-or-nothing) */
+  deletions: PlannedDeletion[];
+}
+
+/**
+ * plan 構造の静的検証 (Firestore 参照前)。
+ * エラー配列が空 = 妥当。
+ */
+export function validatePlanStructure(plan: CleanupPlan): string[] {
+  const errors: string[] = [];
+
+  if (plan.schemaVersion !== AMBIGUOUS_CLEANUP_SCHEMA_VERSION) {
+    errors.push(
+      `schemaVersion 不一致: expected=${AMBIGUOUS_CLEANUP_SCHEMA_VERSION} actual=${plan.schemaVersion}`
+    );
+  }
+  if (!plan.projectId) {
+    errors.push('projectId が未設定');
+  }
+  if (!Array.isArray(plan.groups) || plan.groups.length === 0) {
+    errors.push('groups が空');
+    return errors;
+  }
+
+  const seen = new Set<string>();
+  let loserTotal = 0;
+  for (const g of plan.groups) {
+    if (!g.fileName) errors.push(`fileName 未設定の group あり`);
+    if (!g.parentDocumentId) errors.push(`${g.fileName}: parentDocumentId 未設定`);
+    if (!g.winnerDocId) errors.push(`${g.fileName}: winnerDocId 未設定`);
+    if (!Array.isArray(g.loserDocIds) || g.loserDocIds.length === 0) {
+      errors.push(`${g.fileName}: loserDocIds が空`);
+      continue;
+    }
+    if (g.loserDocIds.includes(g.winnerDocId)) {
+      errors.push(`${g.fileName}: winner ${g.winnerDocId} が loserDocIds に含まれる`);
+    }
+    for (const id of [g.winnerDocId, ...g.loserDocIds]) {
+      if (seen.has(id)) errors.push(`docId 重複: ${id}`);
+      seen.add(id);
+    }
+    loserTotal += g.loserDocIds.length;
+  }
+
+  if (loserTotal !== plan.expectedLoserCount) {
+    errors.push(
+      `loser 合計不一致: plan.expectedLoserCount=${plan.expectedLoserCount} actual=${loserTotal}`
+    );
+  }
+
+  return errors;
+}
+
+function str(data: Record<string, unknown>, key: string): string | undefined {
+  const v = data[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * ライブ Firestore 状態に対する preconditions 評価。
+ *
+ * loser 削除可能条件 (全て AND):
+ *   - loser doc が存在する
+ *   - loser.fileName === plan.fileName
+ *   - loser.parentDocumentId === plan.parentDocumentId
+ *   - loser.status === 'processed'
+ *   - loser.fileUrl が非空かつ winner.fileUrl と同一 (Storage path 共有の証明)
+ *   - loser.verified !== true (確認済み doc は削除禁止)
+ *   - loser.editedAt が存在しない (クライアント編集済み doc は削除禁止)
+ *   - loser.rotatedAt が存在しない (回転操作済み doc は削除禁止)
+ * winner 条件:
+ *   - winner doc が存在する
+ *   - winner.fileName === plan.fileName
+ *   - winner.parentDocumentId === plan.parentDocumentId
+ *
+ * 違反が 1 件でもあれば deletions は空 (all-or-nothing)。
+ */
+export function evaluatePreconditions(
+  plan: CleanupPlan,
+  docs: Map<string, DocState>
+): PreconditionResult {
+  const violations: string[] = [];
+  const deletions: PlannedDeletion[] = [];
+
+  for (const g of plan.groups) {
+    const winner = docs.get(g.winnerDocId);
+    if (!winner || !winner.exists || !winner.data) {
+      violations.push(`${g.fileName}: winner ${g.winnerDocId} が存在しない`);
+      continue;
+    }
+    const winnerData = winner.data;
+    if (str(winnerData, 'fileName') !== g.fileName) {
+      violations.push(
+        `${g.fileName}: winner ${g.winnerDocId} の fileName 不一致 (actual=${str(winnerData, 'fileName')})`
+      );
+    }
+    if (str(winnerData, 'parentDocumentId') !== g.parentDocumentId) {
+      violations.push(
+        `${g.fileName}: winner ${g.winnerDocId} の parentDocumentId 不一致 (actual=${str(winnerData, 'parentDocumentId')})`
+      );
+    }
+    const winnerFileUrl = str(winnerData, 'fileUrl');
+    if (!winnerFileUrl) {
+      violations.push(`${g.fileName}: winner ${g.winnerDocId} の fileUrl が空`);
+    }
+
+    for (const loserId of g.loserDocIds) {
+      const loser = docs.get(loserId);
+      if (!loser || !loser.exists || !loser.data) {
+        violations.push(`${g.fileName}: loser ${loserId} が存在しない`);
+        continue;
+      }
+      const d = loser.data;
+      if (str(d, 'fileName') !== g.fileName) {
+        violations.push(
+          `${g.fileName}: loser ${loserId} の fileName 不一致 (actual=${str(d, 'fileName')})`
+        );
+      }
+      if (str(d, 'parentDocumentId') !== g.parentDocumentId) {
+        violations.push(
+          `${g.fileName}: loser ${loserId} の parentDocumentId 不一致 (actual=${str(d, 'parentDocumentId')})`
+        );
+      }
+      if (str(d, 'status') !== 'processed') {
+        violations.push(
+          `${g.fileName}: loser ${loserId} の status が processed でない (actual=${str(d, 'status')})`
+        );
+      }
+      const loserFileUrl = str(d, 'fileUrl');
+      if (!loserFileUrl || loserFileUrl !== winnerFileUrl) {
+        violations.push(
+          `${g.fileName}: loser ${loserId} の fileUrl が winner と不一致 (Storage path 共有が証明できない)`
+        );
+      }
+      if (d.verified === true) {
+        violations.push(
+          `${g.fileName}: loser ${loserId} は verified=true (ユーザー確認済み doc は削除禁止)`
+        );
+      }
+      if (d.editedAt !== undefined && d.editedAt !== null) {
+        violations.push(
+          `${g.fileName}: loser ${loserId} に editedAt あり (ユーザー編集済み doc は削除禁止)`
+        );
+      }
+      if (d.rotatedAt !== undefined && d.rotatedAt !== null) {
+        violations.push(
+          `${g.fileName}: loser ${loserId} に rotatedAt あり (回転操作済み doc は削除禁止)`
+        );
+      }
+      deletions.push({ docId: loserId, fileName: g.fileName, winnerDocId: g.winnerDocId });
+    }
+  }
+
+  if (deletions.length !== plan.expectedLoserCount) {
+    violations.push(
+      `削除対象件数不一致: expectedLoserCount=${plan.expectedLoserCount} actual=${deletions.length}`
+    );
+  }
+
+  // all-or-nothing: 違反 1 件でも deletions を返さない
+  if (violations.length > 0) {
+    return { violations, deletions: [] };
+  }
+  return { violations: [], deletions };
+}

--- a/scripts/lib/ambiguousCleanup.ts
+++ b/scripts/lib/ambiguousCleanup.ts
@@ -8,26 +8,32 @@
  * 設計方針:
  *   - all-or-nothing: precondition 違反が 1 件でもあれば削除対象ゼロ
  *   - 削除は Firestore doc のみ。Storage 実体は winner が参照継続するため不可侵
- *     (このモジュールは削除自体を行わない。CLI 側も Storage delete API を呼ばない)
+ *     (このモジュールは削除自体を行わない。CLI 側も cleanup 本経路 (dry-run / --execute)
+ *      では Storage delete API を呼ばない。dev 専用 --seed-dev-fixture / --cleanup-fixture
+ *      のみ例外で fixture 実体の作成・削除を行う)
  *   - loser は「ユーザーが一度も触っていない doc」のみ許可
  *     (verified=true / editedAt あり / rotatedAt あり はすべて reject)
  */
 
-export const AMBIGUOUS_CLEANUP_SCHEMA_VERSION = 'ambiguous-cleanup-v1';
+export const AMBIGUOUS_CLEANUP_SCHEMA_VERSION = 'ambiguous-cleanup-v1' as const;
+export type AmbiguousCleanupSchemaVersion = typeof AMBIGUOUS_CLEANUP_SCHEMA_VERSION;
 
 export interface CleanupGroup {
   /** 共有されている fileName (例: 20260413_未判定_未判定_p1-4.pdf) */
   fileName: string;
   /** グループ全 docs が持つべき親 doc ID */
   parentDocumentId: string;
-  /** 残す doc (クライアント編集/確認済み doc 優先、なければ docId 辞書順先頭) */
+  /**
+   * 残す doc。plan 作成時の選定ポリシーは「クライアント編集/確認済み doc 優先、
+   * なければ docId 辞書順先頭」(本モジュールはこのポリシー自体を検証しない)
+   */
   winnerDocId: string;
   /** 削除する docs */
   loserDocIds: string[];
 }
 
 export interface CleanupPlan {
-  schemaVersion: string;
+  schemaVersion: AmbiguousCleanupSchemaVersion;
   issue: number;
   projectId: string;
   description?: string;
@@ -124,6 +130,11 @@ function str(data: Record<string, unknown>, key: string): string | undefined {
  *   - winner doc が存在する
  *   - winner.fileName === plan.fileName
  *   - winner.parentDocumentId === plan.parentDocumentId
+ *   - winner.fileUrl が非空
+ *
+ * validatePlanStructure 通過済み plan を前提とするが、winner が loserDocIds に
+ * 混入した plan は本関数単独でも reject する (defense-in-depth。混入時は loser の
+ * fileUrl 照合が「winner 自身との比較」になり全 precondition を素通りするため)。
  *
  * 違反が 1 件でもあれば deletions は空 (all-or-nothing)。
  */
@@ -135,6 +146,12 @@ export function evaluatePreconditions(
   const deletions: PlannedDeletion[] = [];
 
   for (const g of plan.groups) {
+    if (g.loserDocIds.includes(g.winnerDocId)) {
+      violations.push(
+        `${g.fileName}: winner ${g.winnerDocId} が loserDocIds に含まれる (defense-in-depth)`
+      );
+      continue;
+    }
     const winner = docs.get(g.winnerDocId);
     if (!winner || !winner.exists || !winner.data) {
       violations.push(`${g.fileName}: winner ${g.winnerDocId} が存在しない`);

--- a/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
+++ b/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
@@ -2,7 +2,7 @@
   "schemaVersion": "ambiguous-cleanup-v1",
   "issue": 492,
   "projectId": "doc-split-dev",
-  "description": "Issue #492 dev リハーサル用 fixture plan。cleanup-ambiguous-collision-docs.ts --seed-dev-fixture がこの plan と一致する合成 docs + 共有 Storage 実体を投入する。グループ 1 は winner が verified=true (本番 p1-4/p23-24 相当)、グループ 2 は全 doc 未操作 (辞書順 winner 相当)。",
+  "description": "Issue #492 dev リハーサル用 fixture plan。cleanup-ambiguous-collision-docs.ts --seed-dev-fixture がこの plan と一致する合成 docs + 共有 Storage 実体を投入する。グループ 1 は winner が verified=true (本番 p1-4/p23-24 相当)、グループ 2 は全 doc 未操作 (本番の辞書順選定グループに相当。fixture ID 自体は辞書順を再現していない)。",
   "groups": [
     {
       "fileName": "20990101_未判定_未判定_p1-2.fixture492.pdf",

--- a/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
+++ b/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "ambiguous-cleanup-v1",
+  "issue": 492,
+  "projectId": "doc-split-dev",
+  "description": "Issue #492 dev リハーサル用 fixture plan。cleanup-ambiguous-collision-docs.ts --seed-dev-fixture がこの plan と一致する合成 docs + 共有 Storage 実体を投入する。グループ 1 は winner が verified=true (本番 p1-4/p23-24 相当)、グループ 2 は全 doc 未操作 (辞書順 winner 相当)。",
+  "groups": [
+    {
+      "fileName": "20990101_未判定_未判定_p1-2.fixture492.pdf",
+      "parentDocumentId": "fixture492-parent",
+      "winnerDocId": "fixture492-g1-winner",
+      "loserDocIds": ["fixture492-g1-loser-a", "fixture492-g1-loser-b"]
+    },
+    {
+      "fileName": "20990101_未判定_未判定_p3-4.fixture492.pdf",
+      "parentDocumentId": "fixture492-parent",
+      "winnerDocId": "fixture492-g2-winner",
+      "loserDocIds": ["fixture492-g2-loser-a", "fixture492-g2-loser-b"]
+    }
+  ],
+  "expectedLoserCount": 4
+}

--- a/scripts/plans/cleanup-ambiguous-492-kanameone.json
+++ b/scripts/plans/cleanup-ambiguous-492-kanameone.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "ambiguous-cleanup-v1",
+  "issue": 492,
+  "projectId": "docsplit-kanameone",
+  "description": "Issue #492 Phase 1: 20260413 の同一親 (qwCIJLBkTNDvjVFbQNgm)・同一ページ範囲・fingerprint 一致の真の重複 8 グループ。winner はクライアント操作済み doc (verified=true / editedAt あり) 優先、なければ docId 辞書順先頭。20260509 の 2 グループ (別親、Gmail 重複受信由来) は Phase 2 で本 plan 対象外。根拠: session83 classify artifact + 2026-07-02 本番 batchGet 実測。",
+  "groups": [
+    {
+      "fileName": "20260413_未判定_未判定_p1-4.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "MMBWDxbNtHEBdVuWZoV7",
+      "loserDocIds": ["MYQHsGN4T4g8dyIE7pMF", "QaHRDFH2CCeBRQc2IYDY"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p13-14.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "CEyZ0HwvGWNSW5gBofmv",
+      "loserDocIds": ["nNr0eCWKCJ0TdOYqajS5", "tAsra5fGb7COwI6SHHKK"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p15-16.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "0FUs833maylUXBquK6LI",
+      "loserDocIds": ["KqhURvjQqM08MGSfz7vX", "kVhhqwe2HeMSoxgwiaZI"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p17-18.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "BZJ9hppNiqIc22nKG24k",
+      "loserDocIds": ["S2Z5Pazn04K1XHzdrv8d", "nZeaA7KLm4pOrADkdSTg"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p19-20.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "eJjtsWIP9qKl8iFQ83ly",
+      "loserDocIds": ["r2YHGzCEwAiJgyYdbHzH", "tdWonj8jW9dE6ykseAaO"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p21-22.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "0n1iJ8YjTgKLnWUWfEAL",
+      "loserDocIds": ["Fk3gws1plaX2pzOJ16R0", "NVQopGScKJATXNy90Gtu"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p23-24.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "XJz5w5ekAFu9eE5DXWGr",
+      "loserDocIds": ["GMqzUhEQWDXtHi9SCSxg", "ePqahIlfVMIKbwoLfeV6"]
+    },
+    {
+      "fileName": "20260413_未判定_未判定_p25-26.pdf",
+      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
+      "winnerDocId": "Oz9x4D0xfUcxU0GPCABf",
+      "loserDocIds": ["k7xtgOLdqVwxKQIp3CXG", "ts2bm0LuuxFqg5Qnyuc7"]
+    }
+  ],
+  "expectedLoserCount": 16
+}


### PR DESCRIPTION
## 概要

kanameone 運用問い合わせ「書類を編集・確認済みにしても選択待ち/候補表示が残る、チェックマークがつかない」の根本原因である **Ambiguous 重複 docs**（Issue #432 復旧で manual-review 除外された、同名・同 Storage path 共有の重複 Firestore docs）を整理する ops スクリプトを追加する。

調査で判明した事実（2026-07-02 本番実測、PII 除外 field mask）:
- クライアントの操作は正しく反映済み（`20260413_未判定_未判定_p1-4.pdf` の 1 doc を 5/26 に編集・確認済み化）。見た目同一の重複 docs が残るため「直らない」ように見えていた
- 4/13 の 8 グループ 24 docs は全て同一親 `qwCIJLBkTNDvjVFbQNgm`・同一ページ範囲・visual fingerprint 一致 = **どれを残しても情報が失われない真の重複**

## 変更内容

- `scripts/lib/ambiguousCleanup.ts`: plan 検証 + preconditions の純ロジック（all-or-nothing）
- `scripts/plans/cleanup-ambiguous-492-kanameone.json`: Phase 1 対象（8 グループ、winner 8 / loser 16）。winner はクライアント操作済み doc 優先
- `scripts/cleanup-ambiguous-collision-docs.ts`: CLI
- `scripts/plans/cleanup-ambiguous-492-dev-fixture.json` + fixture seed/cleanup: dev リハーサル用
- `run-ops-script.yml`: choice 登録 + バックアップ artifact 保存（90 日）
- `functions/test/ambiguousCleanup.test.ts`: 19 cases

## 安全装置

- dry-run デフォルト、`--execute` 明示時のみ削除
- **Firestore doc のみ削除。Storage 実体は不可侵**（winner が同一ファイルを参照継続。Storage delete API を一切呼ばない）
- preconditions all-or-nothing: `verified=true` / `editedAt` / `rotatedAt` のあるユーザー操作済み doc は削除禁止、fileUrl の winner 一致（path 共有証明）、fileName/parent/status 照合、件数厳密一致
- **単一 atomic batch + `lastUpdateTime` precondition**（Codex review P1×2 反映: 部分削除の構造的排除 + 検証〜削除間 TOCTOU 防止）
- 削除前バックアップ必須出力（GHA artifact、retention 90 日）
- plan.projectId と FIREBASE_PROJECT_ID の二重照合、fixture 系は dev 専用ガード

## Test plan（全て実行済み）

- [x] 単体テスト 19/19 PASS（reject 経路網羅: verified/editedAt/rotatedAt/fileUrl 不一致/不在/件数不一致）
- [x] functions 全スイート 1472 passing / 0 fail
- [x] scripts 型チェック PASS（新規ファイル単体。既存 pr-d4-backfill のエラーは main 由来で本 PR 対象外）
- [x] YAML lint PASS
- [x] dev リハーサル（GHA 経由、計 10 runs 全成功）:
  - violation fixture（loser に editedAt）→ dry-run が削除ゼロで abort（reject 経路実証）
  - クリーン fixture → dry-run（対象 4 件列挙 + バックアップ出力）→ execute（4 件削除 / winner 2 現存 / Storage 現存の事後検証 OK）
  - Codex 反映後の batch + precondition 版でも execute 経路を再検証
  - バックアップ artifact 保存確認
- [x] Codex review（effort=xhigh）: P1×2 + P2×1 を全件反映済み

## 本番実行手順（merge 後、番号認可制）

1. GHA run-ops-script: environment=kanameone / `cleanup-ambiguous-collision-docs --dry-run` → 出力レビュー
2. user 認可後: `--execute` → 事後検証出力 + バックアップ artifact 確認
3. Phase 2（20260509 の 2 グループ、別親）は kaname 確認後に plan 追加で別 PR

Refs #492（close は本番実行 + Phase 2 完了後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cleanup workflow option for removing duplicate collision documents, including dry-run, execution, fixture seeding, and cleanup variants.
  * Introduced a safer cleanup process with validation, backup export, and post-run verification.
  * Added predefined cleanup plans for supported environments.

* **Tests**
  * Added unit coverage for plan validation and cleanup precondition checks, including failure and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->