### PR TITLE
feat(ops): Issue #492 Phase 2 — 別親グループ (20260509) の重複 cleanup 対応

### DIFF
--- a/functions/test/ambiguousCleanup.test.ts
+++ b/functions/test/ambiguousCleanup.test.ts
@@ -149,6 +149,48 @@ describe('ambiguousCleanup: validatePlanStructure', () => {
     expect(errors.some((e) => e.includes('loser-1b のエントリがない'))).to.equal(true);
   });
 
+  it('expectedParents 指定時に expectedFileUrls が無ければ reject', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-a',
+      'loser-1a': 'parent-b',
+      'loser-1b': 'parent-c',
+    };
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('expectedFileUrls が必須'))).to.equal(true);
+  });
+
+  it('expectedFileUrls を同一親グループ (parentDocumentId) に付けたら reject', () => {
+    const plan = makePlan();
+    plan.groups[0].expectedFileUrls = {
+      'winner-1': 'gs://b/x.pdf',
+      'loser-1a': 'gs://b/y.pdf',
+      'loser-1b': 'gs://b/z.pdf',
+    };
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('指定時のみ使用可'))).to.equal(true);
+  });
+
+  it('expectedFileUrls に loser のエントリが欠けていたら reject', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-a',
+      'loser-1a': 'parent-b',
+      'loser-1b': 'parent-c',
+    };
+    plan.groups[0].expectedFileUrls = {
+      'winner-1': 'gs://b/x.pdf',
+      'loser-1a': 'gs://b/y.pdf',
+      // loser-1b が欠落
+    };
+    const errors = validatePlanStructure(plan);
+    expect(
+      errors.some((e) => e.includes('expectedFileUrls に loser-1b のエントリがない'))
+    ).to.equal(true);
+  });
+
   it('expectedParents に group 外の docId が混入していたら reject', () => {
     const plan = makePlan();
     delete plan.groups[0].parentDocumentId;
@@ -164,11 +206,14 @@ describe('ambiguousCleanup: validatePlanStructure', () => {
 });
 
 describe('ambiguousCleanup: evaluatePreconditions', () => {
-  it('全条件充足なら loser 全件が deletions に載る', () => {
+  it('全条件充足なら loser 全件が deletions に載る (共有 object は不可侵フラグ)', () => {
     const { violations, deletions } = evaluatePreconditions(makePlan(), healthyDocs());
     expect(violations).to.deep.equal([]);
     expect(deletions.map((d) => d.docId)).to.deep.equal(['loser-1a', 'loser-1b']);
     expect(deletions[0].winnerDocId).to.equal('winner-1');
+    // 同一親 (共有 object) グループの loser は object 削除対象にならない
+    expect(deletions.every((d) => d.ownsStorageObject === false)).to.equal(true);
+    expect(deletions[0].fileUrl).to.equal(FILE_URL);
   });
 
   it('loser が verified=true なら reject (ユーザー確認済み doc の削除禁止)', () => {
@@ -298,7 +343,8 @@ describe('ambiguousCleanup: evaluatePreconditions', () => {
     expect(deletions).to.deep.equal([]);
   });
 
-  it('expectedParents (別親グループ): doc ごとの期待親で検証が通過する', () => {
+  // 別親グループ用の plan/docs (本番 Phase 2 と同構造: 各 doc が専用 object)
+  function makeMultiParentPlan(): CleanupPlan {
     const plan = makePlan();
     delete plan.groups[0].parentDocumentId;
     plan.groups[0].expectedParents = {
@@ -306,14 +352,95 @@ describe('ambiguousCleanup: evaluatePreconditions', () => {
       'loser-1a': 'parent-b',
       'loser-1b': 'parent-c',
     };
+    plan.groups[0].expectedFileUrls = {
+      'winner-1': 'gs://bucket/processed/winner-1/x.pdf',
+      'loser-1a': 'gs://bucket/processed/loser-1a/x.pdf',
+      'loser-1b': 'gs://bucket/processed/loser-1b/x.pdf',
+    };
+    return plan;
+  }
+  function makeMultiParentDocs(): Map<string, DocState> {
+    return makeDocs({
+      'winner-1': makeDoc({
+        verified: true,
+        parentDocumentId: 'parent-a',
+        fileUrl: 'gs://bucket/processed/winner-1/x.pdf',
+      }),
+      'loser-1a': makeDoc({
+        parentDocumentId: 'parent-b',
+        fileUrl: 'gs://bucket/processed/loser-1a/x.pdf',
+      }),
+      'loser-1b': makeDoc({
+        parentDocumentId: 'parent-c',
+        fileUrl: 'gs://bucket/processed/loser-1b/x.pdf',
+      }),
+    });
+  }
+
+  it('expectedParents (別親グループ): 期待親 + fileUrl pin 一致で通過し、専有 object フラグが立つ', () => {
+    const { violations, deletions } = evaluatePreconditions(
+      makeMultiParentPlan(),
+      makeMultiParentDocs()
+    );
+    expect(violations).to.deep.equal([]);
+    expect(deletions.map((d) => d.docId)).to.deep.equal(['loser-1a', 'loser-1b']);
+    expect(deletions.every((d) => d.ownsStorageObject === true)).to.equal(true);
+    expect(deletions[0].fileUrl).to.equal('gs://bucket/processed/loser-1a/x.pdf');
+  });
+
+  it('expectedParents (別親グループ): loser の fileUrl が pin と異なれば reject', () => {
+    const docs = makeMultiParentDocs();
+    docs.set(
+      'loser-1a',
+      makeDoc({ parentDocumentId: 'parent-b', fileUrl: 'gs://bucket/processed/DRIFTED.pdf' })
+    );
+    const { violations, deletions } = evaluatePreconditions(makeMultiParentPlan(), docs);
+    expect(violations.some((v) => v.includes('loser-1a') && v.includes('pin と不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('expectedParents (別親グループ): winner の fileUrl が pin と異なれば reject', () => {
+    const docs = makeMultiParentDocs();
+    docs.set(
+      'winner-1',
+      makeDoc({
+        verified: true,
+        parentDocumentId: 'parent-a',
+        fileUrl: 'gs://bucket/processed/DRIFTED.pdf',
+      })
+    );
+    const { violations, deletions } = evaluatePreconditions(makeMultiParentPlan(), docs);
+    expect(violations.some((v) => v.includes('winner') && v.includes('pin と不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('expectedParents で loser が winner と object を共有する場合は専有フラグが立たない', () => {
+    const plan = makeMultiParentPlan();
+    plan.groups[0].expectedFileUrls = {
+      'winner-1': 'gs://bucket/processed/shared.pdf',
+      'loser-1a': 'gs://bucket/processed/shared.pdf',
+      'loser-1b': 'gs://bucket/processed/loser-1b/x.pdf',
+    };
     const docs = makeDocs({
-      'winner-1': makeDoc({ verified: true, parentDocumentId: 'parent-a' }),
-      'loser-1a': makeDoc({ parentDocumentId: 'parent-b' }),
-      'loser-1b': makeDoc({ parentDocumentId: 'parent-c' }),
+      'winner-1': makeDoc({
+        verified: true,
+        parentDocumentId: 'parent-a',
+        fileUrl: 'gs://bucket/processed/shared.pdf',
+      }),
+      'loser-1a': makeDoc({
+        parentDocumentId: 'parent-b',
+        fileUrl: 'gs://bucket/processed/shared.pdf',
+      }),
+      'loser-1b': makeDoc({
+        parentDocumentId: 'parent-c',
+        fileUrl: 'gs://bucket/processed/loser-1b/x.pdf',
+      }),
     });
     const { violations, deletions } = evaluatePreconditions(plan, docs);
     expect(violations).to.deep.equal([]);
-    expect(deletions.map((d) => d.docId)).to.deep.equal(['loser-1a', 'loser-1b']);
+    const byId = new Map(deletions.map((d) => [d.docId, d]));
+    expect(byId.get('loser-1a')?.ownsStorageObject).to.equal(false); // winner と共有 = 不可侵
+    expect(byId.get('loser-1b')?.ownsStorageObject).to.equal(true);
   });
 
   it('expectedParents (別親グループ): loser の実親が期待と異なれば reject', () => {

--- a/functions/test/ambiguousCleanup.test.ts
+++ b/functions/test/ambiguousCleanup.test.ts
@@ -118,6 +118,49 @@ describe('ambiguousCleanup: validatePlanStructure', () => {
     const errors = validatePlanStructure(makePlan({ groups: [], expectedLoserCount: 0 }));
     expect(errors.some((e) => e.includes('groups が空'))).to.equal(true);
   });
+
+  it('parentDocumentId / expectedParents の両方欠落を reject', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('いずれかが必要'))).to.equal(true);
+  });
+
+  it('parentDocumentId と expectedParents の同時指定を reject (排他)', () => {
+    const plan = makePlan();
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-1',
+      'loser-1a': 'parent-1',
+      'loser-1b': 'parent-1',
+    };
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('排他'))).to.equal(true);
+  });
+
+  it('expectedParents に loser のエントリが欠けていたら reject', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-a',
+      'loser-1a': 'parent-b',
+      // loser-1b が欠落
+    };
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('loser-1b のエントリがない'))).to.equal(true);
+  });
+
+  it('expectedParents に group 外の docId が混入していたら reject', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-a',
+      'loser-1a': 'parent-b',
+      'loser-1b': 'parent-b',
+      'stranger-doc': 'parent-c',
+    };
+    const errors = validatePlanStructure(plan);
+    expect(errors.some((e) => e.includes('group 外の docId'))).to.equal(true);
+  });
 });
 
 describe('ambiguousCleanup: evaluatePreconditions', () => {
@@ -255,6 +298,44 @@ describe('ambiguousCleanup: evaluatePreconditions', () => {
     expect(deletions).to.deep.equal([]);
   });
 
+  it('expectedParents (別親グループ): doc ごとの期待親で検証が通過する', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-a',
+      'loser-1a': 'parent-b',
+      'loser-1b': 'parent-c',
+    };
+    const docs = makeDocs({
+      'winner-1': makeDoc({ verified: true, parentDocumentId: 'parent-a' }),
+      'loser-1a': makeDoc({ parentDocumentId: 'parent-b' }),
+      'loser-1b': makeDoc({ parentDocumentId: 'parent-c' }),
+    });
+    const { violations, deletions } = evaluatePreconditions(plan, docs);
+    expect(violations).to.deep.equal([]);
+    expect(deletions.map((d) => d.docId)).to.deep.equal(['loser-1a', 'loser-1b']);
+  });
+
+  it('expectedParents (別親グループ): loser の実親が期待と異なれば reject', () => {
+    const plan = makePlan();
+    delete plan.groups[0].parentDocumentId;
+    plan.groups[0].expectedParents = {
+      'winner-1': 'parent-a',
+      'loser-1a': 'parent-b',
+      'loser-1b': 'parent-c',
+    };
+    const docs = makeDocs({
+      'winner-1': makeDoc({ verified: true, parentDocumentId: 'parent-a' }),
+      'loser-1a': makeDoc({ parentDocumentId: 'parent-WRONG' }),
+      'loser-1b': makeDoc({ parentDocumentId: 'parent-c' }),
+    });
+    const { violations, deletions } = evaluatePreconditions(plan, docs);
+    expect(
+      violations.some((v) => v.includes('loser-1a') && v.includes('parentDocumentId 不一致'))
+    ).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
   it('複数グループ: 1 グループの違反が健全な他グループの削除も止める (all-or-nothing)', () => {
     const plan = makePlan({
       groups: [
@@ -301,12 +382,17 @@ describe('ambiguousCleanup: checked-in plan JSON の実物検証', () => {
     return JSON.parse(fs.readFileSync(path.join(plansDir, name), 'utf-8')) as CleanupPlan;
   }
 
-  it('kanameone plan: 構造検証を通過し、想定値 (8 groups / 16 losers / projectId) と一致', () => {
+  it('kanameone plan (Phase 2): 構造検証を通過し、想定値 (2 groups / 2 losers / projectId) と一致', () => {
     const plan = loadPlanFile('cleanup-ambiguous-492-kanameone.json');
     expect(validatePlanStructure(plan)).to.deep.equal([]);
     expect(plan.projectId).to.equal('docsplit-kanameone');
-    expect(plan.groups).to.have.length(8);
-    expect(plan.expectedLoserCount).to.equal(16);
+    expect(plan.groups).to.have.length(2);
+    expect(plan.expectedLoserCount).to.equal(2);
+    // ユーザー確認済み doc (U4Lf5ZPNA4IyH73SXE2P) が誤って loser に入っていないこと
+    const allLosers = plan.groups.flatMap((g) => g.loserDocIds);
+    expect(allLosers).to.not.include('U4Lf5ZPNA4IyH73SXE2P');
+    expect(allLosers).to.not.include('Lso7jEXzWxBjU4Cj6zqR');
+    expect(allLosers).to.not.include('0ZuExPFZjngfSpddy2HR');
   });
 
   it('dev fixture plan: 構造検証を通過し、想定値 (2 groups / 4 losers / projectId) と一致', () => {

--- a/functions/test/ambiguousCleanup.test.ts
+++ b/functions/test/ambiguousCleanup.test.ts
@@ -259,7 +259,17 @@ describe('ambiguousCleanup: evaluatePreconditions', () => {
     const docs = healthyDocs();
     docs.set('winner-1', makeDoc({ verified: true, fileUrl: undefined }));
     const { violations, deletions } = evaluatePreconditions(makePlan(), docs);
-    expect(violations.some((v) => v.includes('winner') && v.includes('fileUrl'))).to.equal(true);
+    // チェック固有のメッセージで assert (pin 系メッセージも 'fileUrl' を含むため)
+    expect(violations.some((v) => v.includes('winner') && v.includes('fileUrl が空'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('evaluatePreconditions 単独でも件数不一致を violation にする (二重の件数ゲート)', () => {
+    // validatePlanStructure を経由しない直接呼び出しでも「件数厳密アサーション」が
+    // 独立に機能することを pin する
+    const plan = makePlan({ expectedLoserCount: 3 });
+    const { violations, deletions } = evaluatePreconditions(plan, healthyDocs());
+    expect(violations.some((v) => v.includes('件数不一致'))).to.equal(true);
     expect(deletions).to.deep.equal([]);
   });
 
@@ -414,6 +424,60 @@ describe('ambiguousCleanup: evaluatePreconditions', () => {
     expect(deletions).to.deep.equal([]);
   });
 
+  it('expectedFileUrls のエントリ欠落 plan を直接渡しても reject (defense-in-depth)', () => {
+    // validate を経由しない呼び出しで「pin なし = 同一性証明なし」の doc が
+    // 素通りしないことを pin する (比較緩和 refactor への防波堤)
+    const plan = makeMultiParentPlan();
+    delete plan.groups[0].expectedFileUrls!['loser-1a'];
+    const { violations, deletions } = evaluatePreconditions(plan, makeMultiParentDocs());
+    expect(violations.some((v) => v.includes('loser-1a') && v.includes('pin と不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('expectedFileUrls の winner エントリ欠落 plan を直接渡しても reject (defense-in-depth)', () => {
+    const plan = makeMultiParentPlan();
+    delete plan.groups[0].expectedFileUrls!['winner-1'];
+    const { violations, deletions } = evaluatePreconditions(plan, makeMultiParentDocs());
+    expect(violations.some((v) => v.includes('winner') && v.includes('pin と不一致'))).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('expectedParents のエントリ欠落 plan を直接渡しても reject (期待親未解決は素通りさせない)', () => {
+    const plan = makeMultiParentPlan();
+    delete plan.groups[0].expectedParents!['loser-1b'];
+    const { violations, deletions } = evaluatePreconditions(plan, makeMultiParentDocs());
+    expect(
+      violations.some((v) => v.includes('loser-1b') && v.includes('期待親が plan から解決できない'))
+    ).to.equal(true);
+    expect(deletions).to.deep.equal([]);
+  });
+
+  it('同一グループ内の 2 loser が同じ専有 object を pin した場合、両方に専有フラグが立つ', () => {
+    // deletions に重複 path が現れるのは合法な出力で、CLI 側は 404 冪等 +
+    // 「guard は doc 削除後に実行」の順序前提で両立する (順序を入れ替える
+    // refactor をすると兄弟共有 object が保守的 skip に変わる)
+    const plan = makeMultiParentPlan();
+    const dupUrl = 'gs://bucket/processed/dup/x.pdf';
+    plan.groups[0].expectedFileUrls = {
+      'winner-1': 'gs://bucket/processed/winner-1/x.pdf',
+      'loser-1a': dupUrl,
+      'loser-1b': dupUrl,
+    };
+    const docs = makeDocs({
+      'winner-1': makeDoc({
+        verified: true,
+        parentDocumentId: 'parent-a',
+        fileUrl: 'gs://bucket/processed/winner-1/x.pdf',
+      }),
+      'loser-1a': makeDoc({ parentDocumentId: 'parent-b', fileUrl: dupUrl }),
+      'loser-1b': makeDoc({ parentDocumentId: 'parent-c', fileUrl: dupUrl }),
+    });
+    const { violations, deletions } = evaluatePreconditions(plan, docs);
+    expect(violations).to.deep.equal([]);
+    expect(deletions.every((d) => d.ownsStorageObject === true)).to.equal(true);
+    expect(deletions.map((d) => d.fileUrl)).to.deep.equal([dupUrl, dupUrl]);
+  });
+
   it('expectedParents で loser が winner と object を共有する場合は専有フラグが立たない', () => {
     const plan = makeMultiParentPlan();
     plan.groups[0].expectedFileUrls = {
@@ -520,6 +584,22 @@ describe('ambiguousCleanup: checked-in plan JSON の実物検証', () => {
     expect(allLosers).to.not.include('U4Lf5ZPNA4IyH73SXE2P');
     expect(allLosers).to.not.include('Lso7jEXzWxBjU4Cj6zqR');
     expect(allLosers).to.not.include('0ZuExPFZjngfSpddy2HR');
+  });
+
+  it('kanameone plan: pin URL が plan 全体で一意 + 各 loser は winner と別 object を専有', () => {
+    // コピペミスで loser の pin が他 doc (特に winner) の URL を指すと、
+    // 専有判定と object 削除の前提が崩れる。plan 編集時の regression gate
+    const plan = loadPlanFile('cleanup-ambiguous-492-kanameone.json');
+    const allUrls: string[] = [];
+    for (const g of plan.groups) {
+      expect(g.expectedFileUrls, `${g.fileName}: expectedFileUrls 必須`).to.not.equal(undefined);
+      const urls = g.expectedFileUrls!;
+      for (const loserId of g.loserDocIds) {
+        expect(urls[loserId]).to.not.equal(urls[g.winnerDocId]);
+      }
+      allUrls.push(...Object.values(urls));
+    }
+    expect(new Set(allUrls).size).to.equal(allUrls.length);
   });
 
   it('dev fixture plan: 構造検証を通過し、想定値 (2 groups / 4 losers / projectId) と一致', () => {

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -12,8 +12,12 @@
  *     ユーザーが触った doc (verified / editedAt / rotatedAt) は削除禁止
  *   - 削除前に winner+loser 全フィールド JSON バックアップを必ず出力
  *   - 件数厳密アサーション (plan.expectedLoserCount と 1 件でもずれたら abort)
- *   - Storage 実体は一切触らない (winner が同一ファイルを参照継続)。
- *     cleanup 本経路は Storage の read (existence check) のみで delete API を呼ばない
+ *   - Storage 実体の扱い (グループ形式で分岐):
+ *     - 同一親 (共有 object): 一切触らない (winner が同一ファイルを参照継続)
+ *     - 別親 (loser が object を専有): doc 削除後に storageGuard で
+ *       「他 doc が同 fileUrl を参照していない」ことを確認できた場合のみ
+ *       専有 object を削除 (孤児 object を残すと audit-storage-mismatch の
+ *       誤検知源になるため)。共有が検出されたら skip して object を残す
  *   - --execute は STORAGE_BUCKET 必須 (事後検証を欠いた削除を構造的に排除)
  *   - 事後検証: loser 不在 / winner 現存 / winner の実 fileUrl が指す Storage 実体現存
  *   - 未知フラグは exit 2 (typo が黙って dry-run に化けるのを防ぐ)
@@ -44,6 +48,7 @@ import {
   validatePlanStructure,
   evaluatePreconditions,
 } from './lib/ambiguousCleanup';
+import { isPathSafeToDeleteAfterExcluding } from './lib/storageGuard';
 
 const projectId = process.env.FIREBASE_PROJECT_ID;
 const storageBucket = process.env.STORAGE_BUCKET;
@@ -146,6 +151,12 @@ function gsUrl(fileName: string): string {
   return `gs://${storageBucket}/processed/${fileName}`;
 }
 
+/** gs:// URL を {bucket, objectPath} に分解。不正形式は null */
+function parseGsUrl(url: string): { bucket: string; objectPath: string } | null {
+  const m = url.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  return m ? { bucket: m[1], objectPath: m[2] } : null;
+}
+
 /** dev 専用ガード */
 function assertDevOnly(op: string): void {
   if (!projectId!.includes('dev')) {
@@ -189,17 +200,35 @@ async function seedFixture(plan: CleanupPlan): Promise<void> {
   }
 
   for (const [gi, g] of plan.groups.entries()) {
-    // 共有 Storage 実体 (1 グループ 1 ファイル)
-    const pdf = await PDFDocument.create();
-    pdf.addPage([200, 200]);
-    const bytes = await pdf.save();
-    await bucket.file(`processed/${g.fileName}`).save(Buffer.from(bytes), {
-      contentType: 'application/pdf',
-    });
+    const makePdf = async (): Promise<Buffer> => {
+      const pdf = await PDFDocument.create();
+      pdf.addPage([200, 200]);
+      return Buffer.from(await pdf.save());
+    };
 
-    const fileUrl = gsUrl(g.fileName);
+    // Storage 実体: 同一親グループは共有 1 ファイル、別親 (expectedFileUrls)
+    // グループは doc ごとに専有ファイルを作成 (本番 Phase 2 と同じ構造を再現)
+    if (g.expectedFileUrls) {
+      for (const url of new Set(Object.values(g.expectedFileUrls))) {
+        const parsed = parseGsUrl(url);
+        if (!parsed || parsed.bucket !== storageBucket) {
+          console.error(`FATAL: fixture plan の expectedFileUrls が不正: ${url}`);
+          process.exit(2);
+        }
+        await bucket.file(parsed.objectPath).save(await makePdf(), {
+          contentType: 'application/pdf',
+        });
+      }
+    } else {
+      await bucket.file(`processed/${g.fileName}`).save(await makePdf(), {
+        contentType: 'application/pdf',
+      });
+    }
+
+    const sharedFileUrl = gsUrl(g.fileName);
     const docIds = [g.winnerDocId, ...g.loserDocIds];
     for (const [di, docId] of docIds.entries()) {
+      const fileUrl = g.expectedFileUrls ? g.expectedFileUrls[docId] : sharedFileUrl;
       const isWinner = di === 0;
       const data: Record<string, unknown> = {
         fileName: g.fileName,
@@ -243,18 +272,27 @@ async function removeFixture(plan: CleanupPlan): Promise<void> {
       await snap.ref.delete();
     }
   }
-  for (const g of plan.groups) {
-    // 404 のみ冪等扱い。permission/transient エラーは握り潰さず fail させる
-    // (Codex review P2: silent cleanup failure 防止)
-    await bucket
-      .file(`processed/${g.fileName}`)
+  // 404 のみ冪等扱い。permission/transient エラーは握り潰さず fail させる
+  // (Codex review P2: silent cleanup failure 防止)
+  const deleteObject = (objectPath: string) =>
+    bucket
+      .file(objectPath)
       .delete()
       .catch((err: { code?: number }) => {
         if (err.code === 404) return undefined;
         throw err;
       });
+  for (const g of plan.groups) {
+    if (g.expectedFileUrls) {
+      for (const url of new Set(Object.values(g.expectedFileUrls))) {
+        const parsed = parseGsUrl(url);
+        if (parsed && parsed.bucket === storageBucket) await deleteObject(parsed.objectPath);
+      }
+    } else {
+      await deleteObject(`processed/${g.fileName}`);
+    }
   }
-  console.log(`✅ fixture 削除完了 (docs ${ids.size} 件 + Storage ${plan.groups.length} 件)`);
+  console.log(`✅ fixture 削除完了 (docs ${ids.size} 件 + Storage 実体)`);
 }
 
 interface FetchedStates {
@@ -337,7 +375,10 @@ async function main(): Promise<void> {
 
   console.log(`✅ preconditions 全通過。削除対象 ${deletions.length} 件:`);
   for (const d of deletions) {
-    console.log(`  - ${d.docId} (${d.fileName}, winner=${d.winnerDocId})`);
+    const storageNote = d.ownsStorageObject
+      ? ' [専有 object も削除対象 (storageGuard 確認後)]'
+      : ' [object は winner と共有 = 不可侵]';
+    console.log(`  - ${d.docId} (${d.fileName}, winner=${d.winnerDocId})${storageNote}`);
   }
 
   if (!execute) {
@@ -381,9 +422,50 @@ async function main(): Promise<void> {
   }
   console.log(`🗑️ 削除完了: ${deletions.length} 件 (atomic batch + lastUpdateTime precondition)`);
 
+  const bucket = admin.storage().bucket();
+  const postErrors: string[] = [];
+
+  // 4.5 専有 Storage object の削除 (別親グループの loser のみ)。
+  // doc 削除後に storageGuard で「他 doc が同 fileUrl を参照していない」ことを
+  // 確認できた場合のみ削除。共有が検出されたら skip して object を残す (安全側)。
+  const ownedDeletions = deletions.filter((d) => d.ownsStorageObject);
+  const deletedObjectPaths: string[] = [];
+  for (const d of ownedDeletions) {
+    const parsed = parseGsUrl(d.fileUrl);
+    if (!parsed) {
+      postErrors.push(`loser ${d.docId} の fileUrl が gs:// 形式でない: ${d.fileUrl}`);
+      continue;
+    }
+    if (parsed.bucket !== storageBucket) {
+      postErrors.push(
+        `loser ${d.docId} の fileUrl bucket (${parsed.bucket}) が STORAGE_BUCKET と不一致のため object 削除をスキップ`
+      );
+      continue;
+    }
+    const guard = await isPathSafeToDeleteAfterExcluding(db, d.fileUrl, [d.docId]);
+    if (!guard.safe) {
+      console.warn(
+        `⚠️ ${parsed.objectPath} は他 doc (${guard.residualDocIds.join(',')}) が参照中のため削除スキップ (object 残置)`
+      );
+      continue;
+    }
+    try {
+      await bucket.file(parsed.objectPath).delete();
+      deletedObjectPaths.push(parsed.objectPath);
+    } catch (err) {
+      if ((err as { code?: number }).code === 404) {
+        deletedObjectPaths.push(parsed.objectPath); // 既に不在 = 冪等扱い
+      } else {
+        postErrors.push(`専有 object 削除失敗: ${parsed.objectPath}: ${String(err)}`);
+      }
+    }
+  }
+  if (ownedDeletions.length > 0) {
+    console.log(`🗑️ 専有 Storage object 削除: ${deletedObjectPaths.length}/${ownedDeletions.length} 件`);
+  }
+
   // 5. 事後検証
   const { states: after } = await fetchDocStates(plan);
-  const postErrors: string[] = [];
   for (const g of plan.groups) {
     if (!after.get(g.winnerDocId)?.exists) {
       postErrors.push(`winner ${g.winnerDocId} が消えている (${g.fileName})`);
@@ -398,7 +480,6 @@ async function main(): Promise<void> {
   // (`processed/${fileName}` の再構築は split 由来 doc の docId namespace 形式
   //  `processed/{docId}/{fileName}` と乖離しうる — code review Important 反映)。
   // fileUrl は preconditions で非空を検証済み。STORAGE_BUCKET は --execute で必須。
-  const bucket = admin.storage().bucket();
   for (const g of plan.groups) {
     const winnerFileUrl = docs.get(g.winnerDocId)?.data?.fileUrl as string;
     const m = winnerFileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/);
@@ -416,6 +497,13 @@ async function main(): Promise<void> {
     const [exists] = await bucket.file(objectPath).exists();
     if (!exists) {
       postErrors.push(`Storage 実体 ${objectPath} が不在 (winner ${g.winnerDocId} が閲覧不能)`);
+    }
+  }
+  // 削除した専有 object が実際に不在になったことを確認
+  for (const objectPath of deletedObjectPaths) {
+    const [exists] = await bucket.file(objectPath).exists();
+    if (exists) {
+      postErrors.push(`専有 object ${objectPath} が削除後も残存`);
     }
   }
 

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -252,7 +252,7 @@ async function seedFixture(plan: CleanupPlan): Promise<void> {
     }
   }
   console.log(
-    `✅ fixture 投入完了: parent 1 + docs ${plan.groups.reduce((n, g) => n + 1 + g.loserDocIds.length, 0)} 件` +
+    `✅ fixture 投入完了: parent ${allParentIds(plan).size} + docs ${plan.groups.reduce((n, g) => n + 1 + g.loserDocIds.length, 0)} 件` +
       (seedViolation ? ' (violation: グループ1 loser-a に editedAt 付与)' : '')
   );
 }
@@ -286,7 +286,12 @@ async function removeFixture(plan: CleanupPlan): Promise<void> {
     if (g.expectedFileUrls) {
       for (const url of new Set(Object.values(g.expectedFileUrls))) {
         const parsed = parseGsUrl(url);
-        if (parsed && parsed.bucket === storageBucket) await deleteObject(parsed.objectPath);
+        if (!parsed || parsed.bucket !== storageBucket) {
+          // 無言 skip すると fixture object が残置されて観測不能になる (F5)
+          console.warn(`⚠️ fixture object 削除スキップ (URL 不正 or bucket 不一致): ${url}`);
+          continue;
+        }
+        await deleteObject(parsed.objectPath);
       }
     } else {
       await deleteObject(`processed/${g.fileName}`);
@@ -381,6 +386,30 @@ async function main(): Promise<void> {
     console.log(`  - ${d.docId} (${d.fileName}, winner=${d.winnerDocId})${storageNote}`);
   }
 
+  // 3.5 pre-flight: 専有 object の pin URL 形式/bucket を「削除前に」検証する。
+  // step 4 (doc 削除) は不可逆なので、plan の pin 記載ミス / STORAGE_BUCKET 誤設定は
+  // ここで abort する (silent-failure review F3: 事後検出だと doc だけ消えて
+  // object が孤児化する再実行不能状態になってから発覚する)。
+  const ownedDeletions = deletions.filter((d) => d.ownsStorageObject);
+  {
+    const preflightErrors: string[] = [];
+    for (const d of ownedDeletions) {
+      const parsed = parseGsUrl(d.fileUrl);
+      if (!parsed) {
+        preflightErrors.push(`loser ${d.docId} の fileUrl が gs:// 形式でない: ${d.fileUrl}`);
+      } else if (storageBucket && parsed.bucket !== storageBucket) {
+        preflightErrors.push(
+          `loser ${d.docId} の fileUrl bucket (${parsed.bucket}) が STORAGE_BUCKET (${storageBucket}) と不一致`
+        );
+      }
+    }
+    if (preflightErrors.length > 0) {
+      console.error(`❌ 専有 object pre-flight 違反 ${preflightErrors.length} 件。削除は一切行いません:`);
+      for (const e of preflightErrors) console.error(`  - ${e}`);
+      process.exit(1);
+    }
+  }
+
   if (!execute) {
     console.log('dry-run 終了 (削除するには --execute を指定)');
     return;
@@ -424,96 +453,138 @@ async function main(): Promise<void> {
 
   const bucket = admin.storage().bucket();
   const postErrors: string[] = [];
-
-  // 4.5 専有 Storage object の削除 (別親グループの loser のみ)。
-  // doc 削除後に storageGuard で「他 doc が同 fileUrl を参照していない」ことを
-  // 確認できた場合のみ削除。共有が検出されたら skip して object を残す (安全側)。
-  const ownedDeletions = deletions.filter((d) => d.ownsStorageObject);
   const deletedObjectPaths: string[] = [];
-  for (const d of ownedDeletions) {
-    const parsed = parseGsUrl(d.fileUrl);
-    if (!parsed) {
-      postErrors.push(`loser ${d.docId} の fileUrl が gs:// 形式でない: ${d.fileUrl}`);
-      continue;
-    }
-    if (parsed.bucket !== storageBucket) {
-      postErrors.push(
-        `loser ${d.docId} の fileUrl bucket (${parsed.bucket}) が STORAGE_BUCKET と不一致のため object 削除をスキップ`
-      );
-      continue;
-    }
-    const guard = await isPathSafeToDeleteAfterExcluding(db, d.fileUrl, [d.docId]);
-    if (!guard.safe) {
-      console.warn(
-        `⚠️ ${parsed.objectPath} は他 doc (${guard.residualDocIds.join(',')}) が参照中のため削除スキップ (object 残置)`
-      );
-      continue;
-    }
-    try {
-      await bucket.file(parsed.objectPath).delete();
-      deletedObjectPaths.push(parsed.objectPath);
-    } catch (err) {
-      if ((err as { code?: number }).code === 404) {
-        deletedObjectPaths.push(parsed.objectPath); // 既に不在 = 冪等扱い
-      } else {
-        postErrors.push(`専有 object 削除失敗: ${parsed.objectPath}: ${String(err)}`);
-      }
-    }
-  }
-  if (ownedDeletions.length > 0) {
-    console.log(`🗑️ 専有 Storage object 削除: ${deletedObjectPaths.length}/${ownedDeletions.length} 件`);
-  }
+  const skippedObjects: string[] = [];
 
-  // 5. 事後検証
-  const { states: after } = await fetchDocStates(plan);
-  for (const g of plan.groups) {
-    if (!after.get(g.winnerDocId)?.exists) {
-      postErrors.push(`winner ${g.winnerDocId} が消えている (${g.fileName})`);
+  // doc 削除後の全収集情報を必ず出力する (silent-failure review F1:
+  // 途中 throw で postErrors が報告前に消えると、不可逆ゾーンで何が起きたか
+  // 分からなくなる)。object 削除失敗時は復旧手順も出す (F2: doc は削除済みの
+  // ため再実行は precondition abort になり、本スクリプトでは回収できない)。
+  const flushPostDeletionReport = (): void => {
+    if (deletedObjectPaths.length > 0) {
+      console.log(`🗑️ 削除済み専有 object: ${deletedObjectPaths.join(', ')}`);
     }
-    for (const id of g.loserDocIds) {
-      if (after.get(id)?.exists) {
-        postErrors.push(`loser ${id} が残存 (${g.fileName})`);
+    if (skippedObjects.length > 0) {
+      console.warn(`⚠️ 削除スキップした専有 object ${skippedObjects.length} 件 (要確認): ${skippedObjects.join(', ')}`);
+    }
+    if (postErrors.length > 0) {
+      console.error(`❌ 事後エラー ${postErrors.length} 件:`);
+      for (const e of postErrors) console.error(`  - ${e}`);
+      if (postErrors.some((e) => e.includes('専有 object'))) {
+        console.error(
+          '📌 復旧手順: doc は削除済みのため本スクリプトの再実行では回収できません。' +
+            '残存 object は手動削除してください (例: gsutil rm gs://<bucket>/<path>)。' +
+            '放置すると audit-storage-mismatch で孤児として誤検知されます。'
+        );
       }
     }
-  }
-  // Storage 実体の現存確認は winner の実 fileUrl から object path を導出する
-  // (`processed/${fileName}` の再構築は split 由来 doc の docId namespace 形式
-  //  `processed/{docId}/{fileName}` と乖離しうる — code review Important 反映)。
-  // fileUrl は preconditions で非空を検証済み。STORAGE_BUCKET は --execute で必須。
-  for (const g of plan.groups) {
-    const winnerFileUrl = docs.get(g.winnerDocId)?.data?.fileUrl as string;
-    const m = winnerFileUrl.match(/^gs:\/\/([^/]+)\/(.+)$/);
-    if (!m) {
-      postErrors.push(`winner ${g.winnerDocId} の fileUrl が gs:// 形式でない: ${winnerFileUrl}`);
-      continue;
+  };
+
+  try {
+    // 4.5 専有 Storage object の削除 (別親グループの loser のみ)。
+    // doc 削除後に storageGuard で「他 doc が同 fileUrl を参照していない」ことを
+    // 確認できた場合のみ削除。共有が検出されたら skip して object を残す (安全側)。
+    // NOTE: guard は「doc batch 削除の後」に実行される前提。exclude が [d.docId]
+    // 単独で足りるのは兄弟 loser が既に削除済みだから — 順序を入れ替える refactor
+    // をすると兄弟共有 object が保守的に skip されるようになる (安全側だが挙動変化)。
+    for (const d of ownedDeletions) {
+      const parsed = parseGsUrl(d.fileUrl);
+      if (!parsed) {
+        // pre-flight 済みのため到達不能。防御的に記録のみ
+        postErrors.push(`専有 object 削除不能 (fileUrl 不正): ${d.fileUrl}`);
+        continue;
+      }
+      try {
+        const guard = await isPathSafeToDeleteAfterExcluding(db, d.fileUrl, [d.docId]);
+        if (!guard.safe) {
+          console.warn(
+            `⚠️ ${parsed.objectPath} は他 doc (${guard.residualDocIds.join(',')}) が参照中のため削除スキップ (object 残置)`
+          );
+          skippedObjects.push(parsed.objectPath);
+          continue;
+        }
+        try {
+          await bucket.file(parsed.objectPath).delete();
+          deletedObjectPaths.push(parsed.objectPath);
+        } catch (err) {
+          if ((err as { code?: number }).code === 404) {
+            console.log(`  (既に不在: ${parsed.objectPath})`);
+            deletedObjectPaths.push(parsed.objectPath); // 冪等扱い
+          } else {
+            postErrors.push(`専有 object 削除失敗: ${parsed.objectPath}: ${String(err)}`);
+          }
+        }
+      } catch (err) {
+        // guard の Firestore query 失敗等。次の object の処理は継続する
+        postErrors.push(`専有 object 処理失敗 (storageGuard): ${parsed.objectPath}: ${String(err)}`);
+      }
     }
-    const [, urlBucket, objectPath] = m;
-    if (urlBucket !== storageBucket) {
-      postErrors.push(
-        `winner ${g.winnerDocId} の fileUrl bucket (${urlBucket}) が STORAGE_BUCKET (${storageBucket}) と不一致`
+    if (ownedDeletions.length > 0) {
+      console.log(
+        `🗑️ 専有 Storage object 削除: ${deletedObjectPaths.length}/${ownedDeletions.length} 件` +
+          (skippedObjects.length > 0 ? ` (スキップ ${skippedObjects.length} 件)` : '')
       );
-      continue;
     }
-    const [exists] = await bucket.file(objectPath).exists();
-    if (!exists) {
-      postErrors.push(`Storage 実体 ${objectPath} が不在 (winner ${g.winnerDocId} が閲覧不能)`);
+
+    // 5. 事後検証
+    const { states: after } = await fetchDocStates(plan);
+    for (const g of plan.groups) {
+      if (!after.get(g.winnerDocId)?.exists) {
+        postErrors.push(`winner ${g.winnerDocId} が消えている (${g.fileName})`);
+      }
+      for (const id of g.loserDocIds) {
+        if (after.get(id)?.exists) {
+          postErrors.push(`loser ${id} が残存 (${g.fileName})`);
+        }
+      }
     }
-  }
-  // 削除した専有 object が実際に不在になったことを確認
-  for (const objectPath of deletedObjectPaths) {
-    const [exists] = await bucket.file(objectPath).exists();
-    if (exists) {
-      postErrors.push(`専有 object ${objectPath} が削除後も残存`);
+    // Storage 実体の現存確認は winner の実 fileUrl から object path を導出する
+    // (`processed/${fileName}` の再構築は split 由来 doc の docId namespace 形式
+    //  `processed/{docId}/{fileName}` と乖離しうる — code review Important 反映)。
+    // fileUrl は preconditions で非空を検証済み。STORAGE_BUCKET は --execute で必須。
+    for (const g of plan.groups) {
+      const winnerFileUrl = docs.get(g.winnerDocId)?.data?.fileUrl as string;
+      const parsed = parseGsUrl(winnerFileUrl);
+      if (!parsed) {
+        postErrors.push(`winner ${g.winnerDocId} の fileUrl が gs:// 形式でない: ${winnerFileUrl}`);
+        continue;
+      }
+      if (parsed.bucket !== storageBucket) {
+        postErrors.push(
+          `winner ${g.winnerDocId} の fileUrl bucket (${parsed.bucket}) が STORAGE_BUCKET (${storageBucket}) と不一致`
+        );
+        continue;
+      }
+      const [exists] = await bucket.file(parsed.objectPath).exists();
+      if (!exists) {
+        postErrors.push(`Storage 実体 ${parsed.objectPath} が不在 (winner ${g.winnerDocId} が閲覧不能)`);
+      }
     }
+    // 削除した専有 object が実際に不在になったことを確認
+    for (const objectPath of deletedObjectPaths) {
+      const [exists] = await bucket.file(objectPath).exists();
+      if (exists) {
+        postErrors.push(`専有 object ${objectPath} が削除後も残存`);
+      }
+    }
+  } catch (err) {
+    // 不可逆ゾーンでの予期しない throw でも、収集済みの状態を必ず出力してから落とす
+    flushPostDeletionReport();
+    throw err;
   }
 
   if (postErrors.length > 0) {
-    console.error('❌ 事後検証エラー:');
-    for (const e of postErrors) console.error(`  - ${e}`);
+    flushPostDeletionReport();
     process.exit(1);
   }
   console.log(
-    `✅ 事後検証 OK: winner ${plan.groups.length} 件現存 / loser ${plan.expectedLoserCount} 件削除済 / Storage 実体現存`
+    `✅ 事後検証 OK: winner ${plan.groups.length} 件現存 / loser ${plan.expectedLoserCount} 件削除済 / Storage 実体現存` +
+      (ownedDeletions.length > 0
+        ? ` / 専有 object 削除 ${deletedObjectPaths.length} 件` +
+          (skippedObjects.length > 0
+            ? ` (スキップ ${skippedObjects.length} 件: ${skippedObjects.join(', ')} — plan 前提と実態の乖離のため要確認)`
+            : '')
+        : '')
   );
 }
 

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -158,19 +158,35 @@ function assertDevOnly(op: string): void {
   }
 }
 
+/** group 内の docId → 期待親 を解決 (uniform / per-doc 両対応) */
+function parentOf(g: CleanupPlan['groups'][number], docId: string): string {
+  return (g.expectedParents ? g.expectedParents[docId] : g.parentDocumentId) ?? '';
+}
+
+/** plan 内の全親 docId (重複排除) */
+function allParentIds(plan: CleanupPlan): Set<string> {
+  const ids = new Set<string>();
+  for (const g of plan.groups) {
+    if (g.parentDocumentId) ids.add(g.parentDocumentId);
+    if (g.expectedParents) for (const p of Object.values(g.expectedParents)) ids.add(p);
+  }
+  return ids;
+}
+
 async function seedFixture(plan: CleanupPlan): Promise<void> {
   assertDevOnly('--seed-dev-fixture');
   const bucket = admin.storage().bucket();
 
-  // 親 doc
-  const parentId = plan.groups[0].parentDocumentId;
-  await db.collection('documents').doc(parentId).set({
-    fileName: 'fixture492-parent.pdf',
-    status: 'processed',
-    createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    fixture: 'issue-492-cleanup',
-  });
+  // 親 docs (uniform / per-doc 両形式の親をすべて作成)
+  for (const parentId of allParentIds(plan)) {
+    await db.collection('documents').doc(parentId).set({
+      fileName: `${parentId}.pdf`,
+      status: 'processed',
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      fixture: 'issue-492-cleanup',
+    });
+  }
 
   for (const [gi, g] of plan.groups.entries()) {
     // 共有 Storage 実体 (1 グループ 1 ファイル)
@@ -188,7 +204,7 @@ async function seedFixture(plan: CleanupPlan): Promise<void> {
       const data: Record<string, unknown> = {
         fileName: g.fileName,
         fileUrl,
-        parentDocumentId: g.parentDocumentId,
+        parentDocumentId: parentOf(g, docId),
         status: 'processed',
         customerName: '未判定',
         documentType: '未判定',
@@ -215,7 +231,7 @@ async function seedFixture(plan: CleanupPlan): Promise<void> {
 async function removeFixture(plan: CleanupPlan): Promise<void> {
   assertDevOnly('--cleanup-fixture');
   const bucket = admin.storage().bucket();
-  const ids = new Set<string>([plan.groups[0].parentDocumentId]);
+  const ids = allParentIds(plan);
   for (const g of plan.groups) {
     ids.add(g.winnerDocId);
     for (const id of g.loserDocIds) ids.add(id);

--- a/scripts/lib/ambiguousCleanup.ts
+++ b/scripts/lib/ambiguousCleanup.ts
@@ -33,6 +33,13 @@ export interface CleanupGroup {
    */
   expectedParents?: Record<string, string>;
   /**
+   * doc ごとの期待 fileUrl (expectedParents 指定時は必須)。
+   * 別親グループは #432 復旧で各 doc が専用 Storage path に移行済みのことがあり
+   * 「fileUrl 共有」による同一性証明が使えないため、plan 作成時に実測した
+   * fileUrl を pin して「検証した doc と同一の doc を消す」ことを保証する。
+   */
+  expectedFileUrls?: Record<string, string>;
+  /**
    * 残す doc。plan 作成時の選定ポリシーは「クライアント編集/確認済み doc 優先、
    * なければ docId 辞書順先頭」(本モジュールはこのポリシー自体を検証しない)
    */
@@ -61,6 +68,14 @@ export interface PlannedDeletion {
   docId: string;
   fileName: string;
   winnerDocId: string;
+  /** loser の現 fileUrl (preconditions 通過時点の検証済み値) */
+  fileUrl: string;
+  /**
+   * true = loser が winner と別の Storage object を専有しており、doc 削除後に
+   * 孤児化する (CLI は storageGuard 確認の上でこの object も削除してよい)。
+   * false = winner と共有 (object は不可侵)。
+   */
+  ownsStorageObject: boolean;
 }
 
 export interface PreconditionResult {
@@ -101,17 +116,32 @@ export function validatePlanStructure(plan: CleanupPlan): string[] {
       errors.push(`${g.fileName}: parentDocumentId と expectedParents は排他 (両方指定不可)`);
     }
     if (g.expectedParents) {
-      for (const id of [g.winnerDocId, ...(g.loserDocIds ?? [])]) {
-        if (id && !g.expectedParents[id]) {
-          errors.push(`${g.fileName}: expectedParents に ${id} のエントリがない`);
-        }
+      // expectedParents 使用時は fileUrl 共有による同一性証明が使えないため
+      // expectedFileUrls の pin が必須
+      if (!g.expectedFileUrls) {
+        errors.push(`${g.fileName}: expectedParents 指定時は expectedFileUrls が必須`);
       }
       const members = new Set([g.winnerDocId, ...(g.loserDocIds ?? [])]);
-      for (const key of Object.keys(g.expectedParents)) {
-        if (!members.has(key)) {
-          errors.push(`${g.fileName}: expectedParents に group 外の docId ${key} が含まれる`);
+      for (const [label, map] of [
+        ['expectedParents', g.expectedParents],
+        ['expectedFileUrls', g.expectedFileUrls],
+      ] as const) {
+        if (!map) continue;
+        for (const id of members) {
+          if (id && !map[id]) {
+            errors.push(`${g.fileName}: ${label} に ${id} のエントリがない`);
+          }
+        }
+        for (const key of Object.keys(map)) {
+          if (!members.has(key)) {
+            errors.push(`${g.fileName}: ${label} に group 外の docId ${key} が含まれる`);
+          }
         }
       }
+    } else if (g.expectedFileUrls) {
+      errors.push(
+        `${g.fileName}: expectedFileUrls は expectedParents 指定時のみ使用可 (同一親グループは fileUrl 共有で同一性を証明する)`
+      );
     }
     if (!g.winnerDocId) errors.push(`${g.fileName}: winnerDocId 未設定`);
     if (!Array.isArray(g.loserDocIds) || g.loserDocIds.length === 0) {
@@ -151,7 +181,11 @@ function str(data: Record<string, unknown>, key: string): string | undefined {
  *   - loser.parentDocumentId === 期待親 (group.parentDocumentId、または
  *     group.expectedParents[docId] — 別親グループ用)
  *   - loser.status === 'processed'
- *   - loser.fileUrl が非空かつ winner.fileUrl と同一 (Storage path 共有の証明)
+ *   - fileUrl 同一性証明 (グループ形式で分岐):
+ *     - 同一親 (parentDocumentId): loser.fileUrl が非空かつ winner.fileUrl と同一
+ *       (Storage path 共有の証明)
+ *     - 別親 (expectedParents): loser/winner とも fileUrl が plan の
+ *       expectedFileUrls の pin と完全一致 (検証した doc と同一であることの証明)
  *   - loser.verified !== true (確認済み doc は削除禁止)
  *   - loser.editedAt が存在しない (クライアント編集済み doc は削除禁止)
  *   - loser.rotatedAt が存在しない (回転操作済み doc は削除禁止)
@@ -204,6 +238,11 @@ export function evaluatePreconditions(
     if (!winnerFileUrl) {
       violations.push(`${g.fileName}: winner ${g.winnerDocId} の fileUrl が空`);
     }
+    if (g.expectedFileUrls && winnerFileUrl !== g.expectedFileUrls[g.winnerDocId]) {
+      violations.push(
+        `${g.fileName}: winner ${g.winnerDocId} の fileUrl が plan の pin と不一致 (actual=${winnerFileUrl})`
+      );
+    }
 
     for (const loserId of g.loserDocIds) {
       const loser = docs.get(loserId);
@@ -228,10 +267,20 @@ export function evaluatePreconditions(
         );
       }
       const loserFileUrl = str(d, 'fileUrl');
-      if (!loserFileUrl || loserFileUrl !== winnerFileUrl) {
-        violations.push(
-          `${g.fileName}: loser ${loserId} の fileUrl が winner と不一致 (Storage path 共有が証明できない)`
-        );
+      if (g.expectedFileUrls) {
+        // 別親グループ: plan 作成時に実測した fileUrl との完全一致で同一性を証明
+        if (!loserFileUrl || loserFileUrl !== g.expectedFileUrls[loserId]) {
+          violations.push(
+            `${g.fileName}: loser ${loserId} の fileUrl が plan の pin と不一致 (actual=${loserFileUrl})`
+          );
+        }
+      } else {
+        // 同一親グループ: winner との fileUrl 共有で同一性を証明
+        if (!loserFileUrl || loserFileUrl !== winnerFileUrl) {
+          violations.push(
+            `${g.fileName}: loser ${loserId} の fileUrl が winner と不一致 (Storage path 共有が証明できない)`
+          );
+        }
       }
       if (d.verified === true) {
         violations.push(
@@ -248,7 +297,16 @@ export function evaluatePreconditions(
           `${g.fileName}: loser ${loserId} に rotatedAt あり (回転操作済み doc は削除禁止)`
         );
       }
-      deletions.push({ docId: loserId, fileName: g.fileName, winnerDocId: g.winnerDocId });
+      deletions.push({
+        docId: loserId,
+        fileName: g.fileName,
+        winnerDocId: g.winnerDocId,
+        fileUrl: loserFileUrl ?? '',
+        // 別親グループで winner と異なる object を持つ loser のみ「専有」。
+        // 同一親 (共有) グループは常に false = object 不可侵
+        ownsStorageObject:
+          !!g.expectedFileUrls && !!loserFileUrl && loserFileUrl !== winnerFileUrl,
+      });
     }
   }
 

--- a/scripts/lib/ambiguousCleanup.ts
+++ b/scripts/lib/ambiguousCleanup.ts
@@ -138,6 +138,15 @@ export function validatePlanStructure(plan: CleanupPlan): string[] {
           }
         }
       }
+      // pin URL は gs:// 形式のみ許可 (doc 削除後の object 操作で初めて形式不正が
+      // 発覚するのを防ぐ — 静的に検証できる情報は plan 段階で弾く)
+      if (g.expectedFileUrls) {
+        for (const [id, url] of Object.entries(g.expectedFileUrls)) {
+          if (!/^gs:\/\/[^/]+\/.+$/.test(url)) {
+            errors.push(`${g.fileName}: expectedFileUrls[${id}] が gs:// 形式でない: ${url}`);
+          }
+        }
+      }
     } else if (g.expectedFileUrls) {
       errors.push(
         `${g.fileName}: expectedFileUrls は expectedParents 指定時のみ使用可 (同一親グループは fileUrl 共有で同一性を証明する)`
@@ -220,8 +229,21 @@ export function evaluatePreconditions(
       violations.push(`${g.fileName}: winner ${g.winnerDocId} が存在しない`);
       continue;
     }
-    const expectedParentOf = (docId: string): string | undefined =>
-      g.expectedParents ? g.expectedParents[docId] : g.parentDocumentId;
+    // 期待親が解決できない doc は「一致」で素通りさせず violation にする
+    // (validatePlanStructure を経由しない直接呼び出しへの defense-in-depth。
+    //  undefined === undefined で親チェックが無効化されるのを防ぐ)
+    const checkParent = (docId: string, role: 'winner' | 'loser', data: Record<string, unknown>): void => {
+      const expected = g.expectedParents ? g.expectedParents[docId] : g.parentDocumentId;
+      if (!expected) {
+        violations.push(`${g.fileName}: ${role} ${docId} の期待親が plan から解決できない (plan 不備)`);
+        return;
+      }
+      if (str(data, 'parentDocumentId') !== expected) {
+        violations.push(
+          `${g.fileName}: ${role} ${docId} の parentDocumentId 不一致 (actual=${str(data, 'parentDocumentId')})`
+        );
+      }
+    };
 
     const winnerData = winner.data;
     if (str(winnerData, 'fileName') !== g.fileName) {
@@ -229,11 +251,7 @@ export function evaluatePreconditions(
         `${g.fileName}: winner ${g.winnerDocId} の fileName 不一致 (actual=${str(winnerData, 'fileName')})`
       );
     }
-    if (str(winnerData, 'parentDocumentId') !== expectedParentOf(g.winnerDocId)) {
-      violations.push(
-        `${g.fileName}: winner ${g.winnerDocId} の parentDocumentId 不一致 (actual=${str(winnerData, 'parentDocumentId')})`
-      );
-    }
+    checkParent(g.winnerDocId, 'winner', winnerData);
     const winnerFileUrl = str(winnerData, 'fileUrl');
     if (!winnerFileUrl) {
       violations.push(`${g.fileName}: winner ${g.winnerDocId} の fileUrl が空`);
@@ -256,11 +274,7 @@ export function evaluatePreconditions(
           `${g.fileName}: loser ${loserId} の fileName 不一致 (actual=${str(d, 'fileName')})`
         );
       }
-      if (str(d, 'parentDocumentId') !== expectedParentOf(loserId)) {
-        violations.push(
-          `${g.fileName}: loser ${loserId} の parentDocumentId 不一致 (actual=${str(d, 'parentDocumentId')})`
-        );
-      }
+      checkParent(loserId, 'loser', d);
       if (str(d, 'status') !== 'processed') {
         violations.push(
           `${g.fileName}: loser ${loserId} の status が processed でない (actual=${str(d, 'status')})`

--- a/scripts/lib/ambiguousCleanup.ts
+++ b/scripts/lib/ambiguousCleanup.ts
@@ -21,8 +21,17 @@ export type AmbiguousCleanupSchemaVersion = typeof AMBIGUOUS_CLEANUP_SCHEMA_VERS
 export interface CleanupGroup {
   /** 共有されている fileName (例: 20260413_未判定_未判定_p1-4.pdf) */
   fileName: string;
-  /** グループ全 docs が持つべき親 doc ID */
-  parentDocumentId: string;
+  /**
+   * グループ全 docs が持つべき親 doc ID (同一親グループ用)。
+   * expectedParents と排他 — どちらか一方のみ指定する。
+   */
+  parentDocumentId?: string;
+  /**
+   * doc ごとの期待親 doc ID (別親グループ用。Gmail 重複受信由来など、
+   * 同一内容が別親から split されたケース)。winner + 全 loser を network せず
+   * 検証できるよう、グループ内の全 docId をキーに持つこと。
+   */
+  expectedParents?: Record<string, string>;
   /**
    * 残す doc。plan 作成時の選定ポリシーは「クライアント編集/確認済み doc 優先、
    * なければ docId 辞書順先頭」(本モジュールはこのポリシー自体を検証しない)
@@ -84,7 +93,26 @@ export function validatePlanStructure(plan: CleanupPlan): string[] {
   let loserTotal = 0;
   for (const g of plan.groups) {
     if (!g.fileName) errors.push(`fileName 未設定の group あり`);
-    if (!g.parentDocumentId) errors.push(`${g.fileName}: parentDocumentId 未設定`);
+    // 親の期待値は uniform (parentDocumentId) XOR per-doc (expectedParents)
+    if (!g.parentDocumentId && !g.expectedParents) {
+      errors.push(`${g.fileName}: parentDocumentId / expectedParents のいずれかが必要`);
+    }
+    if (g.parentDocumentId && g.expectedParents) {
+      errors.push(`${g.fileName}: parentDocumentId と expectedParents は排他 (両方指定不可)`);
+    }
+    if (g.expectedParents) {
+      for (const id of [g.winnerDocId, ...(g.loserDocIds ?? [])]) {
+        if (id && !g.expectedParents[id]) {
+          errors.push(`${g.fileName}: expectedParents に ${id} のエントリがない`);
+        }
+      }
+      const members = new Set([g.winnerDocId, ...(g.loserDocIds ?? [])]);
+      for (const key of Object.keys(g.expectedParents)) {
+        if (!members.has(key)) {
+          errors.push(`${g.fileName}: expectedParents に group 外の docId ${key} が含まれる`);
+        }
+      }
+    }
     if (!g.winnerDocId) errors.push(`${g.fileName}: winnerDocId 未設定`);
     if (!Array.isArray(g.loserDocIds) || g.loserDocIds.length === 0) {
       errors.push(`${g.fileName}: loserDocIds が空`);
@@ -120,7 +148,8 @@ function str(data: Record<string, unknown>, key: string): string | undefined {
  * loser 削除可能条件 (全て AND):
  *   - loser doc が存在する
  *   - loser.fileName === plan.fileName
- *   - loser.parentDocumentId === plan.parentDocumentId
+ *   - loser.parentDocumentId === 期待親 (group.parentDocumentId、または
+ *     group.expectedParents[docId] — 別親グループ用)
  *   - loser.status === 'processed'
  *   - loser.fileUrl が非空かつ winner.fileUrl と同一 (Storage path 共有の証明)
  *   - loser.verified !== true (確認済み doc は削除禁止)
@@ -157,13 +186,16 @@ export function evaluatePreconditions(
       violations.push(`${g.fileName}: winner ${g.winnerDocId} が存在しない`);
       continue;
     }
+    const expectedParentOf = (docId: string): string | undefined =>
+      g.expectedParents ? g.expectedParents[docId] : g.parentDocumentId;
+
     const winnerData = winner.data;
     if (str(winnerData, 'fileName') !== g.fileName) {
       violations.push(
         `${g.fileName}: winner ${g.winnerDocId} の fileName 不一致 (actual=${str(winnerData, 'fileName')})`
       );
     }
-    if (str(winnerData, 'parentDocumentId') !== g.parentDocumentId) {
+    if (str(winnerData, 'parentDocumentId') !== expectedParentOf(g.winnerDocId)) {
       violations.push(
         `${g.fileName}: winner ${g.winnerDocId} の parentDocumentId 不一致 (actual=${str(winnerData, 'parentDocumentId')})`
       );
@@ -185,7 +217,7 @@ export function evaluatePreconditions(
           `${g.fileName}: loser ${loserId} の fileName 不一致 (actual=${str(d, 'fileName')})`
         );
       }
-      if (str(d, 'parentDocumentId') !== g.parentDocumentId) {
+      if (str(d, 'parentDocumentId') !== expectedParentOf(loserId)) {
         violations.push(
           `${g.fileName}: loser ${loserId} の parentDocumentId 不一致 (actual=${str(d, 'parentDocumentId')})`
         );

--- a/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
+++ b/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
@@ -17,6 +17,11 @@
         "fixture492-g2-loser-a": "fixture492-parent-y",
         "fixture492-g2-loser-b": "fixture492-parent-y"
       },
+      "expectedFileUrls": {
+        "fixture492-g2-winner": "gs://doc-split-dev.firebasestorage.app/processed/fixture492-g2-winner/20990101_未判定_未判定_p3-4.fixture492.pdf",
+        "fixture492-g2-loser-a": "gs://doc-split-dev.firebasestorage.app/processed/fixture492-g2-loser-a/20990101_未判定_未判定_p3-4.fixture492.pdf",
+        "fixture492-g2-loser-b": "gs://doc-split-dev.firebasestorage.app/processed/fixture492-g2-loser-b/20990101_未判定_未判定_p3-4.fixture492.pdf"
+      },
       "winnerDocId": "fixture492-g2-winner",
       "loserDocIds": ["fixture492-g2-loser-a", "fixture492-g2-loser-b"]
     }

--- a/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
+++ b/scripts/plans/cleanup-ambiguous-492-dev-fixture.json
@@ -2,7 +2,7 @@
   "schemaVersion": "ambiguous-cleanup-v1",
   "issue": 492,
   "projectId": "doc-split-dev",
-  "description": "Issue #492 dev リハーサル用 fixture plan。cleanup-ambiguous-collision-docs.ts --seed-dev-fixture がこの plan と一致する合成 docs + 共有 Storage 実体を投入する。グループ 1 は winner が verified=true (本番 p1-4/p23-24 相当)、グループ 2 は全 doc 未操作 (本番の辞書順選定グループに相当。fixture ID 自体は辞書順を再現していない)。",
+  "description": "Issue #492 dev リハーサル用 fixture plan。cleanup-ambiguous-collision-docs.ts --seed-dev-fixture がこの plan と一致する合成 docs + 共有 Storage 実体を投入する。グループ 1 は同一親 (parentDocumentId 形式、winner が verified=true — 本番 Phase 1 相当)、グループ 2 は別親 (expectedParents 形式、全 doc 未操作 — 本番 Phase 2 の Gmail 重複受信ケース相当)。",
   "groups": [
     {
       "fileName": "20990101_未判定_未判定_p1-2.fixture492.pdf",
@@ -12,7 +12,11 @@
     },
     {
       "fileName": "20990101_未判定_未判定_p3-4.fixture492.pdf",
-      "parentDocumentId": "fixture492-parent",
+      "expectedParents": {
+        "fixture492-g2-winner": "fixture492-parent-x",
+        "fixture492-g2-loser-a": "fixture492-parent-y",
+        "fixture492-g2-loser-b": "fixture492-parent-y"
+      },
       "winnerDocId": "fixture492-g2-winner",
       "loserDocIds": ["fixture492-g2-loser-a", "fixture492-g2-loser-b"]
     }

--- a/scripts/plans/cleanup-ambiguous-492-kanameone.json
+++ b/scripts/plans/cleanup-ambiguous-492-kanameone.json
@@ -2,56 +2,26 @@
   "schemaVersion": "ambiguous-cleanup-v1",
   "issue": 492,
   "projectId": "docsplit-kanameone",
-  "description": "Issue #492 Phase 1: 20260413 の同一親 (qwCIJLBkTNDvjVFbQNgm)・同一ページ範囲・fingerprint 一致の真の重複 8 グループ。winner はクライアント操作済み doc (verified=true / editedAt あり) 優先、なければ docId 辞書順先頭。20260509 の 2 グループ (別親、Gmail 重複受信由来) は Phase 2 で本 plan 対象外。根拠: session83 classify artifact + 2026-07-02 本番 batchGet 実測。",
+  "description": "Issue #492 Phase 2: 20260509 の別親 2 グループ (Gmail 重複受信由来とみられる同一内容 docs)。expectedParents で doc ごとの親を検証する。削除対象はユーザー未操作の重複のみ — p3 の U4Lf5ZPNA4IyH73SXE2P はユーザー確認済みのため意図的に plan 対象外 (確認済み 2 docs が残る)。Phase 1 (20260413 の 8 グループ / 16 losers) は 2026-07-02 GHA run 28622728191 で削除完了済みのため本 plan から除外 (backup: cleanup-ambiguous-backup-kanameone-28622728191)。根拠: session83 classify artifact + 2026-07-02 本番 batchGet 実測。",
   "groups": [
     {
-      "fileName": "20260413_未判定_未判定_p1-4.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "MMBWDxbNtHEBdVuWZoV7",
-      "loserDocIds": ["MYQHsGN4T4g8dyIE7pMF", "QaHRDFH2CCeBRQc2IYDY"]
+      "fileName": "20260509_未判定_未判定_p1-2.pdf",
+      "expectedParents": {
+        "Lso7jEXzWxBjU4Cj6zqR": "Xe6jCKoTk4yflHqefDtb",
+        "gifjllJ57Sx58TktzHCf": "EkZ6bwIM3ji17UugWeEr"
+      },
+      "winnerDocId": "Lso7jEXzWxBjU4Cj6zqR",
+      "loserDocIds": ["gifjllJ57Sx58TktzHCf"]
     },
     {
-      "fileName": "20260413_未判定_未判定_p13-14.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "CEyZ0HwvGWNSW5gBofmv",
-      "loserDocIds": ["nNr0eCWKCJ0TdOYqajS5", "tAsra5fGb7COwI6SHHKK"]
-    },
-    {
-      "fileName": "20260413_未判定_未判定_p15-16.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "0FUs833maylUXBquK6LI",
-      "loserDocIds": ["KqhURvjQqM08MGSfz7vX", "kVhhqwe2HeMSoxgwiaZI"]
-    },
-    {
-      "fileName": "20260413_未判定_未判定_p17-18.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "BZJ9hppNiqIc22nKG24k",
-      "loserDocIds": ["S2Z5Pazn04K1XHzdrv8d", "nZeaA7KLm4pOrADkdSTg"]
-    },
-    {
-      "fileName": "20260413_未判定_未判定_p19-20.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "eJjtsWIP9qKl8iFQ83ly",
-      "loserDocIds": ["r2YHGzCEwAiJgyYdbHzH", "tdWonj8jW9dE6ykseAaO"]
-    },
-    {
-      "fileName": "20260413_未判定_未判定_p21-22.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "0n1iJ8YjTgKLnWUWfEAL",
-      "loserDocIds": ["Fk3gws1plaX2pzOJ16R0", "NVQopGScKJATXNy90Gtu"]
-    },
-    {
-      "fileName": "20260413_未判定_未判定_p23-24.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "XJz5w5ekAFu9eE5DXWGr",
-      "loserDocIds": ["GMqzUhEQWDXtHi9SCSxg", "ePqahIlfVMIKbwoLfeV6"]
-    },
-    {
-      "fileName": "20260413_未判定_未判定_p25-26.pdf",
-      "parentDocumentId": "qwCIJLBkTNDvjVFbQNgm",
-      "winnerDocId": "Oz9x4D0xfUcxU0GPCABf",
-      "loserDocIds": ["k7xtgOLdqVwxKQIp3CXG", "ts2bm0LuuxFqg5Qnyuc7"]
+      "fileName": "20260509_未判定_未判定_p3.pdf",
+      "expectedParents": {
+        "0ZuExPFZjngfSpddy2HR": "lqoU41gSf9Yj1gM1qgZK",
+        "M7i4Nx6khiYEo2KTGJHg": "EkZ6bwIM3ji17UugWeEr"
+      },
+      "winnerDocId": "0ZuExPFZjngfSpddy2HR",
+      "loserDocIds": ["M7i4Nx6khiYEo2KTGJHg"]
     }
   ],
-  "expectedLoserCount": 16
+  "expectedLoserCount": 2
 }

--- a/scripts/plans/cleanup-ambiguous-492-kanameone.json
+++ b/scripts/plans/cleanup-ambiguous-492-kanameone.json
@@ -2,13 +2,17 @@
   "schemaVersion": "ambiguous-cleanup-v1",
   "issue": 492,
   "projectId": "docsplit-kanameone",
-  "description": "Issue #492 Phase 2: 20260509 の別親 2 グループ (Gmail 重複受信由来とみられる同一内容 docs)。expectedParents で doc ごとの親を検証する。削除対象はユーザー未操作の重複のみ — p3 の U4Lf5ZPNA4IyH73SXE2P はユーザー確認済みのため意図的に plan 対象外 (確認済み 2 docs が残る)。Phase 1 (20260413 の 8 グループ / 16 losers) は 2026-07-02 GHA run 28622728191 で削除完了済みのため本 plan から除外 (backup: cleanup-ambiguous-backup-kanameone-28622728191)。根拠: session83 classify artifact + 2026-07-02 本番 batchGet 実測。",
+  "description": "Issue #492 Phase 2: 20260509 の別親 2 グループ (Gmail 重複受信由来とみられる同一内容 docs)。expectedParents で doc ごとの親を、expectedFileUrls で doc ごとの実測 fileUrl を検証する (#432 復旧で各 doc が専用 Storage path に移行済みのため fileUrl 共有による同一性証明は使えない — Codex review 指摘反映)。loser の専有 object は storageGuard 確認後に削除。削除対象はユーザー未操作の重複のみ — p3 の U4Lf5ZPNA4IyH73SXE2P はユーザー確認済みのため意図的に plan 対象外 (確認済み 2 docs が残る)。Phase 1 (20260413 の 8 グループ / 16 losers) は 2026-07-02 GHA run 28622728191 で削除完了済みのため本 plan から除外 (backup: cleanup-ambiguous-backup-kanameone-28622728191)。根拠: session83 classify artifact + 2026-07-02/03 本番 batchGet 実測。",
   "groups": [
     {
       "fileName": "20260509_未判定_未判定_p1-2.pdf",
       "expectedParents": {
         "Lso7jEXzWxBjU4Cj6zqR": "Xe6jCKoTk4yflHqefDtb",
         "gifjllJ57Sx58TktzHCf": "EkZ6bwIM3ji17UugWeEr"
+      },
+      "expectedFileUrls": {
+        "Lso7jEXzWxBjU4Cj6zqR": "gs://docsplit-kanameone.firebasestorage.app/processed/Lso7jEXzWxBjU4Cj6zqR/20260509_未判定_未判定_p1-2.pdf",
+        "gifjllJ57Sx58TktzHCf": "gs://docsplit-kanameone.firebasestorage.app/processed/gifjllJ57Sx58TktzHCf/20260509_未判定_未判定_p1-2.pdf"
       },
       "winnerDocId": "Lso7jEXzWxBjU4Cj6zqR",
       "loserDocIds": ["gifjllJ57Sx58TktzHCf"]
@@ -18,6 +22,10 @@
       "expectedParents": {
         "0ZuExPFZjngfSpddy2HR": "lqoU41gSf9Yj1gM1qgZK",
         "M7i4Nx6khiYEo2KTGJHg": "EkZ6bwIM3ji17UugWeEr"
+      },
+      "expectedFileUrls": {
+        "0ZuExPFZjngfSpddy2HR": "gs://docsplit-kanameone.firebasestorage.app/processed/20260509_未判定_未判定_p3_r1778340000575.pdf",
+        "M7i4Nx6khiYEo2KTGJHg": "gs://docsplit-kanameone.firebasestorage.app/processed/M7i4Nx6khiYEo2KTGJHg/20260509_未判定_未判定_p3.pdf"
       },
       "winnerDocId": "0ZuExPFZjngfSpddy2HR",
       "loserDocIds": ["M7i4Nx6khiYEo2KTGJHg"]


### PR DESCRIPTION
## 概要

Issue #492 Phase 2。20260509 の別親 2 グループ（Gmail 重複受信由来とみられる同一内容 docs、計 5 docs）のうち、**ユーザー未操作の重複 2 docs** を削除対象化する。Phase 1（20260413 の 16 docs）は PR #520 + GHA run 28622728191 で完了済み。

decision-maker 判断（2026-07-03）: 「明らかに重複であり改修前システムの弊害のため、クライアント確認なしでこちらで修復する」

## Phase 1 との構造差分

Codex review（xhigh）が「5/9 docs は fileUrl 共有前提が成立しない」と指摘 → **本番実測で確認**: #432 復旧により各 doc が専用 Storage path（docId namespace / rotation copy）に移行済みだった。旧ロジックのままなら dry-run で全件 abort（fail-closed は機能）。以下で対応:

- **expectedParents**: doc ごとの期待親を検証（別親グループ用。parentDocumentId と排他）
- **expectedFileUrls**: plan 作成時に実測した fileUrl を pin し、winner/loser とも完全一致を precondition 化（「検証した doc と同一の doc を消す」保証）
- **専有 Storage object の guarded 削除**: doc 削除後、既存 storageGuard で「他 doc が同 fileUrl を参照していない」ことを確認できた場合のみ loser の専有 object を削除（孤児 object を残すと audit-storage-mismatch の誤検知源になるため）。**共有 object は従来通り不可侵**（winner と共有が検出されたら skip して残置）
- kanameone plan を Phase 2 内容に置換（Phase 1 の 16 losers は削除済みのため、残すと「loser 不在」violation で abort する）

## 安全装置（Phase 1 から維持 + 追加）

- 維持: dry-run デフォルト / all-or-nothing preconditions / ユーザー操作済み doc（verified/editedAt/rotatedAt）削除禁止 / atomic batch + lastUpdateTime precondition / バックアップ必須 / 件数厳密一致 / --execute は STORAGE_BUCKET 必須 / 未知フラグ reject
- 追加: fileUrl pin 完全一致 / storageGuard による専有 object 削除の共有チェック / 削除後の専有 object 不在検証
- **p3 の `U4Lf5ZPNA4IyH73SXE2P` はユーザー確認済みのため意図的に対象外**（plan JSON テストで loser 混入を regression gate 化）。p3 は確認済み 2 docs が残る（安全装置を緩めて 1 本化はしない）

## Test plan（全て実行済み）

- [x] 単体テスト 37/37 PASS（expectedParents/expectedFileUrls の valid/欠落/排他/混入/pin 不一致、専有フラグ判定、plan JSON 実物検証）
- [x] scripts 型チェック PASS / YAML lint PASS
- [x] dev リハーサル（GHA、本 PR ref）: per-doc object fixture → dry-run → execute で **専有 object 2/2 を storageGuard 確認後に削除、共有 object 不可侵、事後検証 OK** → fixture 片付け
- [x] Codex review（xhigh）: P1 指摘 → 本番実測で事実確認の上、本 PR で全面反映（修正部分の再レビューは user 判断でスキップ、テスト + リハーサルで代替）

## 本番実行手順（merge 後、番号認可制）

1. GHA: kanameone / `--dry-run` → 削除対象 2 件（gifjllJ57Sx…, M7i4Nx6khiYE…）+ 専有 object フラグの列挙を確認
2. user 認可後: `--execute` → 事後検証 + バックアップ artifact 確認
3. 完了後 Issue #492 close（Net -1）

Refs #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded cleanup support for cases where related items may share or not share the same stored file.
  * Added support for validating per-item parent and file-link expectations in cleanup plans.

* **Bug Fixes**
  * Improved cleanup checks to reject incomplete or inconsistent plan details.
  * Made deletion handling safer by avoiding removal of shared stored files when they may still be in use.
  * Updated regression coverage and fixture data to reflect the current cleanup scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->