### PR TITLE
feat(reprocess): 再処理導線を全タブに拡張 + 確認ダイアログの消去範囲明示 (#524)

### DIFF
--- a/frontend/e2e/group-retry.spec.ts
+++ b/frontend/e2e/group-retry.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * グループビュー再試行ボタン E2Eテスト (#524)
+ *
+ * 検証内容:
+ *   - 顧客別タブ: error 書類の行に「再試行」ボタンが表示され、確認ダイアログ経由で再処理できる
+ *   - 担当CM別タブ: 顧客サブグループ配下の error 行にも「再試行」が表示される
+ *
+ * 前提データ: scripts/seed-e2e-data.js の seedGroupRetryTestData
+ * (顧客「組合花子」/ 担当CM「五十嵐恵」配下に error 2 件 + processed 1 件。
+ *  functions emulator の updateDocumentGroups トリガーが documentGroups を生成する)
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginWithTestUser, clickTab } from './helpers';
+
+test.describe('グループビュー再試行 (#524) @emulator', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginWithTestUser(page);
+  });
+
+  test('顧客別タブの error 行から再処理を実行できる', async ({ page }) => {
+    await clickTab(page, '顧客別');
+
+    // 顧客グループを展開
+    const groupHeader = page.locator('button', { hasText: '組合花子' }).first();
+    await expect(groupHeader).toBeVisible({ timeout: 10000 });
+    await groupHeader.click();
+
+    // error 行に「再試行」ボタンが表示される
+    const retryButton = page.locator('button:has-text("再試行")').first();
+    await expect(retryButton).toBeVisible({ timeout: 10000 });
+    await retryButton.click();
+
+    // 確認ダイアログ（対象ファイル名 + リセット内容の説明）
+    await expect(page.locator('text=再処理を実行しますか？')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('text=エラー状態の書類のOCR処理を再実行します')).toBeVisible();
+
+    // 実行 → 成功トースト
+    await page.locator('button:has-text("再処理を実行")').click();
+    await expect(page.locator('text=再処理をリクエストしました')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('担当CM別タブの顧客サブグループ配下 error 行に再試行ボタンが表示されキャンセルできる', async ({ page }) => {
+    await clickTab(page, '担当CM別');
+
+    // 担当CMグループを展開
+    const cmHeader = page.locator('button', { hasText: '五十嵐恵' }).first();
+    await expect(cmHeader).toBeVisible({ timeout: 10000 });
+    await cmHeader.click();
+
+    // 顧客サブグループを展開
+    const customerHeader = page.locator('button', { hasText: '組合花子' }).first();
+    await expect(customerHeader).toBeVisible({ timeout: 10000 });
+    await customerHeader.click();
+
+    // error 行の「再試行」→ ダイアログ表示 → キャンセルで閉じる
+    const retryButton = page.locator('button:has-text("再試行")').first();
+    await expect(retryButton).toBeVisible({ timeout: 10000 });
+    await retryButton.click();
+
+    await expect(page.locator('text=再処理を実行しますか？')).toBeVisible({ timeout: 3000 });
+    await page.locator('button:has-text("キャンセル")').click();
+    await expect(page.locator('text=再処理を実行しますか？')).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/frontend/e2e/reprocess-button.spec.ts
+++ b/frontend/e2e/reprocess-button.spec.ts
@@ -88,6 +88,28 @@ test.describe('再処理ボタン @emulator', () => {
     await expect(modal).toBeVisible();
   });
 
+  test('processed 書類の詳細モーダルに「AIで再解析」ボタンが表示される（#524）', async ({ page }) => {
+    // デフォルトフィルター（完了）の先頭行 = processed 書類
+    await expect(page.locator('tbody tr').first()).toBeVisible({ timeout: 10000 });
+    await page.locator('tbody tr').first().click();
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // 「AIで再解析」ボタンが表示される
+    const reanalyzeButton = modal.locator('button:has-text("AIで再解析")');
+    await expect(reanalyzeButton).toBeVisible();
+    await reanalyzeButton.click();
+
+    // 確認ダイアログに消去項目が明示される
+    await expect(page.locator('text=AIで再解析しますか？')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('text=顧客名・事業所・書類種別・書類日付・担当ケアマネ')).toBeVisible();
+
+    // キャンセルで閉じ、詳細モーダルは開いたまま
+    await page.locator('button:has-text("キャンセル")').click();
+    await expect(page.locator('text=AIで再解析しますか？')).not.toBeVisible({ timeout: 3000 });
+    await expect(modal).toBeVisible();
+  });
+
   test('再処理を実行ボタンが押せてトーストが表示される（#119修正確認）', async ({ page }) => {
     const modal = await openErrorDocument(page);
 

--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -6,11 +6,11 @@
 import { useState, useEffect, useRef } from 'react'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import { Timestamp, doc as firestoreDoc, updateDoc } from 'firebase/firestore'
+import { Timestamp } from 'firebase/firestore'
 import { ref, getDownloadURL } from 'firebase/storage'
 import { Download, ExternalLink, Loader2, FileText, User, UserCheck, Building, Calendar, Tag, AlertCircle, Info, Scissors, Pencil, Save, X, BookMarked, History, ChevronUp, ChevronDown, Sparkles, RefreshCw, CheckCircle, XCircle, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
-import { db, storage } from '@/lib/firebase'
+import { storage } from '@/lib/firebase'
 import { callFunction } from '@/lib/callFunction'
 import { useAuthStore } from '@/stores/authStore'
 import { useQueryClient } from '@tanstack/react-query'
@@ -30,7 +30,7 @@ import { PdfViewer } from '@/components/PdfViewer'
 import { PdfSplitModal } from '@/components/PdfSplitModal'
 import { MasterSelectField } from '@/components/MasterSelectField'
 import { ExtractionInfoPopover } from '@/components/ExtractionInfoPopover'
-import { useDocument, getReprocessClearFields, updateDocumentInListCache } from '@/hooks/useDocuments'
+import { useDocument, useReprocessDocument } from '@/hooks/useDocuments'
 import { useDocumentEdit } from '@/hooks/useDocumentEdit'
 import { useCustomers, useOffices, useDocumentTypes, useCareManagers } from '@/hooks/useMasters'
 import { useMasterAlias } from '@/hooks/useMasterAlias'
@@ -366,7 +366,8 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
   const [showDownloadDialog, setShowDownloadDialog] = useState(false)
   // 再処理確認ダイアログ
   const [showReprocessDialog, setShowReprocessDialog] = useState(false)
-  const [isReprocessing, setIsReprocessing] = useState(false)
+  const { reprocess, reprocessingId } = useReprocessDocument()
+  const isReprocessing = reprocessingId !== null && reprocessingId === documentId
   // 削除確認ダイアログ
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -643,38 +644,11 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
     setIsSplitModalOpen(false)
   }
 
-  // 再処理ハンドラ
+  // 再処理ハンドラ (#524: useReprocessDocument に共通化。processed 書類の再解析にも対応)
   const handleReprocess = async () => {
-    if (!documentId || isReprocessing) return
-    setIsReprocessing(true)
-    try {
-      const clearFields = getReprocessClearFields()
-      const docRef = firestoreDoc(db, 'documents', documentId)
-      await updateDoc(docRef, {
-        status: 'pending',
-        ...clearFields,
-      })
-      // 楽観的更新（即時UI反映）
-      updateDocumentInListCache(queryClient, documentId, {
-        status: 'pending',
-        ocrResult: '',
-        customerName: '',
-        officeName: '',
-        documentType: '',
-        customerConfirmed: false,
-        officeConfirmed: false,
-        verified: false,
-      })
-      queryClient.invalidateQueries({ queryKey: ['document', documentId] })
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      setShowReprocessDialog(false)
-      toast.success('再処理をリクエストしました。処理完了まで画面が自動更新されます。', { duration: 5000 })
-    } catch (err) {
-      console.error('Failed to reprocess:', err)
-      toast.error('再処理リクエストに失敗しました')
-    } finally {
-      setIsReprocessing(false)
-    }
+    if (!documentId) return
+    const ok = await reprocess(documentId)
+    if (ok) setShowReprocessDialog(false)
   }
 
   // 個別削除
@@ -841,7 +815,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                   </Badge>
                 </div>
                 <div className="flex items-center gap-1 sm:gap-2">
-                  {document.status === 'error' && (
+                  {(document.status === 'error' || document.status === 'processed') && (
                     <Button
                       variant="outline"
                       size="sm"
@@ -849,7 +823,9 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                       className="text-blue-600 border-blue-300 hover:bg-blue-50"
                     >
                       <RefreshCw className="h-4 w-4 sm:mr-1" />
-                      <span className="hidden sm:inline">再処理</span>
+                      <span className="hidden sm:inline">
+                        {document.status === 'processed' ? 'AIで再解析' : '再処理'}
+                      </span>
                     </Button>
                   )}
                   {canSplit && (
@@ -1609,13 +1585,25 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       </AlertDialogContent>
     </AlertDialog>
 
-    {/* 再処理確認ダイアログ */}
+    {/* 再処理確認ダイアログ (#524: 消去される項目を明示) */}
     <AlertDialog open={showReprocessDialog} onOpenChange={setShowReprocessDialog}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>再処理を実行しますか？</AlertDialogTitle>
-          <AlertDialogDescription>
-            この書類のOCR処理を再実行します。現在のOCR結果は削除されます。
+          <AlertDialogTitle>
+            {document?.status === 'processed' ? 'AIで再解析しますか？' : '再処理を実行しますか？'}
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>この書類のOCR処理を再実行します。以下の情報は削除され、AIが再抽出します。</p>
+              <ul className="list-disc pl-5 space-y-0.5">
+                <li>OCR結果・AI要約</li>
+                <li>顧客名・事業所・書類種別・書類日付・担当ケアマネ</li>
+                <li>確認済み状態（再抽出後にあらためて確認が必要になります）</li>
+              </ul>
+              <p className="text-xs text-gray-500">
+                再処理中は顧客別・担当CM別などのグループ分けから一時的に外れます。
+              </p>
+            </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -1632,7 +1620,7 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
             ) : (
               <RefreshCw className="mr-1 h-4 w-4" />
             )}
-            {isReprocessing ? '処理中...' : '再処理を実行'}
+            {isReprocessing ? '処理中...' : document?.status === 'processed' ? '再解析を実行' : '再処理を実行'}
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/frontend/src/components/views/CustomerSubGroup.tsx
+++ b/frontend/src/components/views/CustomerSubGroup.tsx
@@ -10,9 +10,11 @@ import {
   ChevronDown,
   FileText,
   Users,
+  RefreshCw,
 } from 'lucide-react';
 import { Timestamp } from 'firebase/firestore';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
 import { getStatusConfig, formatTimestamp } from '@/lib/documentUtils';
 import type { Document } from '@shared/types';
@@ -25,6 +27,8 @@ interface CustomerSubGroupProps {
   documents: Document[];
   furiganaMap?: Map<string, string>;
   onDocumentSelect?: (documentId: string) => void;
+  /** error 書類の「再試行」(#524)。未指定時はボタン非表示 */
+  onRetry?: (document: Document) => void;
 }
 
 interface CustomerGroup {
@@ -88,9 +92,10 @@ function groupByCustomer(
 interface DocumentRowProps {
   document: Document;
   onClick: () => void;
+  onRetry?: (document: Document) => void;
 }
 
-function DocumentRow({ document, onClick }: DocumentRowProps) {
+function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
   const statusConfig = getStatusConfig(document.status);
 
   // 選択待ち判定
@@ -136,6 +141,20 @@ function DocumentRow({ document, onClick }: DocumentRowProps) {
             未確認
           </Badge>
         )}
+        {document.status === 'error' && onRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 px-2 text-xs text-blue-600 border-blue-300 hover:bg-blue-50"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRetry(document);
+            }}
+          >
+            <RefreshCw className="h-3 w-3 sm:mr-1" />
+            <span className="hidden sm:inline">再試行</span>
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -150,6 +169,7 @@ interface CustomerGroupItemProps {
   isExpanded: boolean;
   onToggle: () => void;
   onDocumentSelect?: (documentId: string) => void;
+  onRetry?: (document: Document) => void;
 }
 
 function CustomerGroupItem({
@@ -157,6 +177,7 @@ function CustomerGroupItem({
   isExpanded,
   onToggle,
   onDocumentSelect,
+  onRetry,
 }: CustomerGroupItemProps) {
   return (
     <div className="border-b border-gray-100 last:border-0">
@@ -194,6 +215,7 @@ function CustomerGroupItem({
               key={doc.id}
               document={doc}
               onClick={() => onDocumentSelect?.(doc.id)}
+              onRetry={onRetry}
             />
           ))}
         </div>
@@ -210,6 +232,7 @@ export function CustomerSubGroup({
   documents,
   furiganaMap,
   onDocumentSelect,
+  onRetry,
 }: CustomerSubGroupProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
@@ -248,6 +271,7 @@ export function CustomerSubGroup({
           isExpanded={expandedGroups.has(group.customerKey)}
           onToggle={() => toggleGroup(group.customerKey)}
           onDocumentSelect={onDocumentSelect}
+          onRetry={onRetry}
         />
       ))}
     </div>

--- a/frontend/src/components/views/GroupDocumentList.tsx
+++ b/frontend/src/components/views/GroupDocumentList.tsx
@@ -5,11 +5,22 @@
  * 無限スクロール対応
  */
 
-import { useMemo } from 'react';
-import { FileText, Loader2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { FileText, Loader2, RefreshCw } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { LoadMoreIndicator } from '@/components/LoadMoreIndicator';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useReprocessDocument } from '@/hooks/useDocuments';
 import {
   useGroupDocuments,
   type GroupType,
@@ -42,9 +53,11 @@ interface DocumentRowProps {
   document: Document;
   groupType: GroupType;
   onClick: () => void;
+  /** error 書類の「再試行」(#524)。未指定時はボタン非表示 */
+  onRetry?: (document: Document) => void;
 }
 
-function DocumentRow({ document, groupType, onClick }: DocumentRowProps) {
+function DocumentRow({ document, groupType, onClick, onRetry }: DocumentRowProps) {
   const statusConfig = getStatusConfig(document.status);
 
   // 選択待ち判定（顧客・事業所）
@@ -104,6 +117,20 @@ function DocumentRow({ document, groupType, onClick }: DocumentRowProps) {
             未確認
           </Badge>
         )}
+        {document.status === 'error' && onRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 px-2 text-xs text-blue-600 border-blue-300 hover:bg-blue-50"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRetry(document);
+            }}
+          >
+            <RefreshCw className="h-3 w-3 sm:mr-1" />
+            <span className="hidden sm:inline">再試行</span>
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -154,6 +181,15 @@ export function GroupDocumentList({
   });
   const { loadMoreRef } = useInfiniteScroll({ hasNextPage: !!hasNextPage, isFetchingNextPage, fetchNextPage });
 
+  // error 書類の「再試行」(#524): 行ボタン → 確認ダイアログ → 再処理
+  const { reprocess, reprocessingId } = useReprocessDocument();
+  const [retryTarget, setRetryTarget] = useState<Document | null>(null);
+  const handleRetryConfirm = async () => {
+    if (!retryTarget) return;
+    const ok = await reprocess(retryTarget.id);
+    if (ok) setRetryTarget(null);
+  };
+
   // 全ページのドキュメントを結合 + 日付フィルター適用
   const allDocuments = useMemo(
     () => filterByDate(data?.pages.flatMap((page) => page.documents) ?? [], dateFilter),
@@ -188,6 +224,41 @@ export function GroupDocumentList({
     );
   }
 
+  // error 書類の再試行確認ダイアログ (#524)
+  const retryDialog = (
+    <AlertDialog open={retryTarget !== null} onOpenChange={(open) => !open && setRetryTarget(null)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>再処理を実行しますか？</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p className="break-all">対象: {retryTarget ? getDisplayFileName(retryTarget) : ''}</p>
+              <p>
+                エラー状態の書類のOCR処理を再実行します。抽出済みのメタ情報・確認状態はリセットされ、
+                AIが再抽出します。再処理中はグループ分けから一時的に外れます。
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={reprocessingId !== null}>キャンセル</AlertDialogCancel>
+          <Button
+            onClick={handleRetryConfirm}
+            disabled={reprocessingId !== null}
+            className="bg-blue-600 hover:bg-blue-700"
+          >
+            {reprocessingId !== null ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1 h-4 w-4" />
+            )}
+            {reprocessingId !== null ? '処理中...' : '再処理を実行'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
   // 担当CM別の場合は顧客サブグループで表示
   if (groupType === 'careManager') {
     return (
@@ -196,6 +267,7 @@ export function GroupDocumentList({
           documents={allDocuments}
           furiganaMap={furiganaMap}
           onDocumentSelect={onDocumentSelect}
+          onRetry={setRetryTarget}
         />
 
         <LoadMoreIndicator
@@ -204,6 +276,7 @@ export function GroupDocumentList({
           isFetchingNextPage={isFetchingNextPage}
           className="border-t border-gray-100"
         />
+        {retryDialog}
       </div>
     );
   }
@@ -219,6 +292,7 @@ export function GroupDocumentList({
             document={doc}
             groupType={groupType}
             onClick={() => onDocumentSelect?.(doc.id)}
+            onRetry={setRetryTarget}
           />
         ))}
       </div>
@@ -228,6 +302,7 @@ export function GroupDocumentList({
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
       />
+      {retryDialog}
     </div>
   );
 }

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -20,6 +20,8 @@ import {
   startAfter,
   DocumentSnapshot,
 } from 'firebase/firestore'
+import { useState } from 'react'
+import { toast } from 'sonner'
 import { db } from '@/lib/firebase'
 import type { Document, DocumentStatus, DocumentMaster, CustomerMaster, OfficeMaster, SummaryField } from '@shared/types'
 
@@ -312,6 +314,59 @@ export function getReprocessClearFields() {
     errorRescueCount: df,
     lastRescuedAt: df,
   }
+}
+
+// ============================================
+// 個別再処理フック (#524)
+// ============================================
+
+/**
+ * 書類 1 件を再処理 (status: pending + メタ全クリア) するフック。
+ * DocumentDetailModal とグループビュー行の「再試行」で共通利用。
+ *
+ * 一覧・グループビューの両キャッシュを invalidate する
+ * (メタクリアで customerKey/careManagerKey が空になり、再処理中は
+ * グループ集計から外れるため、グループ側の再取得が必須)。
+ */
+export function useReprocessDocument() {
+  const queryClient = useQueryClient()
+  const [reprocessingId, setReprocessingId] = useState<string | null>(null)
+
+  const reprocess = async (documentId: string): Promise<boolean> => {
+    if (!documentId || reprocessingId) return false
+    setReprocessingId(documentId)
+    try {
+      await updateDoc(doc(db, 'documents', documentId), {
+        status: 'pending',
+        ...getReprocessClearFields(),
+      })
+      // 楽観的更新（即時UI反映）
+      updateDocumentInListCache(queryClient, documentId, {
+        status: 'pending',
+        ocrResult: '',
+        customerName: '',
+        officeName: '',
+        documentType: '',
+        customerConfirmed: false,
+        officeConfirmed: false,
+        verified: false,
+      })
+      queryClient.invalidateQueries({ queryKey: ['document', documentId] })
+      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
+      queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
+      queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+      toast.success('再処理をリクエストしました。処理完了まで画面が自動更新されます。', { duration: 5000 })
+      return true
+    } catch (err) {
+      console.error('Failed to reprocess:', err)
+      toast.error('再処理リクエストに失敗しました')
+      return false
+    } finally {
+      setReprocessingId(null)
+    }
+  }
+
+  return { reprocess, reprocessingId }
 }
 
 // ============================================

--- a/scripts/seed-e2e-data.js
+++ b/scripts/seed-e2e-data.js
@@ -316,6 +316,78 @@ async function seedMainFlowTestDocuments() {
   console.log(`✅ 主要フローテスト用書類 ${docs.length}件作成`);
 }
 
+/**
+ * グループビュー再試行テスト用データ (#524)
+ *
+ * 顧客「組合花子」+ 担当CM「五十嵐恵」配下に error 2 件 + processed 1 件を作成。
+ * E2E (CI) は functions emulator 込みで実行されるため、updateDocumentGroups トリガーが
+ * 正規化キー (customerKey/careManagerKey) と documentGroups を自動生成する。
+ * error 2 件の内訳: 1 件は顧客別タブの再処理実行テストで消費、もう 1 件は
+ * 担当CM別タブの表示確認テスト用 (並列実行でも干渉しない)。
+ */
+async function seedGroupRetryTestData() {
+  console.log('\n📄 グループ再試行テスト用データを作成中...');
+
+  await db.collection('masters').doc('customers').collection('items').doc('e2e-cust-group').set({
+    name: '組合花子',
+    furigana: 'くみあいはなこ',
+    careManagerName: '五十嵐恵',
+    notes: '',
+    createdAt: Timestamp.now(),
+  });
+
+  const base = {
+    mimeType: 'application/pdf',
+    customerId: 'e2e-cust-group',
+    customerName: '組合花子',
+    customerConfirmed: true,
+    officeId: 'office-001',
+    officeName: 'テスト第一事業所',
+    officeConfirmed: true,
+    careManager: '五十嵐恵',
+    documentType: '請求書',
+    totalPages: 1,
+    createdAt: Timestamp.now(),
+    processedAt: Timestamp.now(),
+  };
+  const docs = [
+    {
+      id: 'e2e-group-error-001',
+      data: {
+        ...base,
+        fileName: 'E2E_グループ再試行_エラー1.pdf',
+        fileUrl: 'gs://doc-split-dev-documents/test/e2e-group-error-1.pdf',
+        status: 'error',
+        errorMessage: 'OCR処理に失敗しました',
+      },
+    },
+    {
+      id: 'e2e-group-error-002',
+      data: {
+        ...base,
+        fileName: 'E2E_グループ再試行_エラー2.pdf',
+        fileUrl: 'gs://doc-split-dev-documents/test/e2e-group-error-2.pdf',
+        status: 'error',
+        errorMessage: 'OCR処理に失敗しました',
+      },
+    },
+    {
+      id: 'e2e-group-doc-003',
+      data: {
+        ...base,
+        fileName: 'E2E_グループ再試行_正常.pdf',
+        fileUrl: 'gs://doc-split-dev-documents/test/e2e-group-doc-3.pdf',
+        status: 'processed',
+      },
+    },
+  ];
+
+  for (const doc of docs) {
+    await db.collection('documents').doc(doc.id).set(doc.data);
+  }
+  console.log(`✅ グループ再試行テスト用書類 ${docs.length}件作成`);
+}
+
 async function main() {
   console.log('🚀 E2Eテスト用シードデータ作成開始');
   console.log(`プロジェクト: ${projectId}\n`);
@@ -325,6 +397,7 @@ async function main() {
   const customers = await seedCustomerMasters();
   await seedFilterTestDocuments(customers);
   await seedMainFlowTestDocuments();
+  await seedGroupRetryTestData();
 
   console.log('\n✅ シードデータ作成完了');
   console.log('\nテストユーザー情報:');


### PR DESCRIPTION
## Summary
kaname 要望 B（#524）対応。Codex セカンドオピニオン反映済みのスコープ（processed への行単位常設ボタンは置かない / チェックボックス一括はスコープ外）。

- **useReprocessDocument フック新設**（`useDocuments.ts`）: 詳細モーダルとグループビューで再処理ロジックを共通化。従来漏れていた `groupDocuments` / `documentGroups` キャッシュの invalidation を追加（再処理でメタが消えるとグループ集計から外れるため）
- **詳細モーダル**: 再処理ボタンを error 限定から解放。processed 書類では「AIで再解析」表記（破壊性の異なる操作として文言分離）
- **確認ダイアログ**: 従来「現在のOCR結果は削除されます」のみ → 消去される項目（OCR結果/AI要約、顧客名・事業所・書類種別・書類日付・担当ケアマネ、確認済み状態）と「再処理中はグループ分けから一時的に外れる」旨を明示
- **グループビュー行**（フラット表示 + 担当CM別の顧客サブグループ）: error 書類の行にのみ「再試行」ボタン（確認ダイアログ付き）

## 運用上の意味
processed への再処理開放により、E（#526 分割→再処理連携）完成前でも既存の「未登録」分割ドキュメントを詳細モーダルから手動で直せる応急手段になる。

## Test plan
- [x] `tsc --noEmit` PASS
- [x] frontend unit tests: 247 passed (14 files)
- [x] `npm run build` PASS
- [x] emulator E2E（CI 同一構成: auth/firestore/functions + seed + Playwright）: **7 passed**
  - 新規: 顧客別タブ error 行 → 再試行 → ダイアログ → 実行 → toast（functions ログでグループキー更新まで確認）
  - 新規: 担当CM別タブ顧客サブグループ配下の再試行表示 + キャンセル
  - 新規: processed 書類の「AIで再解析」ボタン + 消去項目列挙ダイアログ
  - 既存 4 テスト（#119/#120 回帰）green
- [x] `/code-review low`: findings なし
- [ ] マージ後: dev 自動デプロイで実機ブラウザ確認（seed error 書類でグループビュー再試行、#193 ルール）

Refs #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)