### PR TITLE
feat(documents): 一覧・グループビューにページ数を表示 (#525)

### DIFF
--- a/frontend/e2e/reprocess-button.spec.ts
+++ b/frontend/e2e/reprocess-button.spec.ts
@@ -48,6 +48,24 @@ test.describe('再処理ボタン @emulator', () => {
     await loginWithTestUser(page);
   });
 
+  test('書類一覧にページ数列が表示され、0 は「-」になる（#525）', async ({ page }) => {
+    // デフォルト viewport 1280px = xl なのでページ数列が表示される
+    await expect(page.locator('th:has-text("ページ数")')).toBeVisible({ timeout: 10000 });
+
+    // ページ数は 6 列目 (ファイル名/顧客名/事業所/登録日/書類日付/ページ数/ステータス/✓)
+    const PAGE_COUNT_COL = 5;
+
+    // totalPages: 3 の書類（e2e-detail-001）は「3」
+    const row3 = page.locator('tbody tr', { hasText: 'E2E_テスト請求書_詳細確認用' });
+    await expect(row3).toBeVisible({ timeout: 10000 });
+    await expect(row3.locator('td').nth(PAGE_COUNT_COL)).toHaveText('3');
+
+    // totalPages: 0 の書類（e2e-group-doc-003）は「-」
+    const row0 = page.locator('tbody tr', { hasText: 'E2E_グループ再試行_正常' });
+    await expect(row0).toBeVisible({ timeout: 10000 });
+    await expect(row0.locator('td').nth(PAGE_COUNT_COL)).toHaveText('-');
+  });
+
   test('エラー書類の詳細モーダルに再処理ボタンが表示される', async ({ page }) => {
     const modal = await openErrorDocument(page);
 

--- a/frontend/src/components/views/CustomerSubGroup.tsx
+++ b/frontend/src/components/views/CustomerSubGroup.tsx
@@ -124,6 +124,12 @@ function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
         </p>
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">
+        {/* ページ数 (#525): 0 (旧形式 doc) は非表示 */}
+        {document.totalPages > 0 && (
+          <span className="text-xs text-gray-400 hidden sm:inline">
+            {document.totalPages}ページ
+          </span>
+        )}
         <span className="text-xs text-gray-500 hidden sm:inline">
           {formatTimestamp(document.fileDate)}
         </span>

--- a/frontend/src/components/views/GroupDocumentList.tsx
+++ b/frontend/src/components/views/GroupDocumentList.tsx
@@ -100,6 +100,12 @@ function DocumentRow({ document, groupType, onClick, onRetry }: DocumentRowProps
         <p className="text-xs text-gray-500 truncate">{getSubInfo()}</p>
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">
+        {/* ページ数 (#525): 0 (旧形式 doc) は非表示 */}
+        {document.totalPages > 0 && (
+          <span className="text-xs text-gray-400 hidden sm:inline">
+            {document.totalPages}ページ
+          </span>
+        )}
         <span className="text-xs text-gray-500 hidden sm:inline">
           {formatTimestamp(document.fileDate)}
         </span>

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -270,6 +270,10 @@ function DocumentRow({
       <td className="hidden px-4 py-3 text-gray-700 lg:table-cell">{document.officeName || '-'}</td>
       <td className="px-2 py-2 text-xs text-gray-700 sm:px-4 sm:py-3 sm:text-sm">{formatDateTime(document.processedAt)}</td>
       <td className="hidden px-4 py-3 text-gray-700 lg:table-cell">{formatTimestamp(document.fileDate)}</td>
+      {/* ページ数 (#525): 0 は旧形式 doc (OCR 前の初期値) のため「-」表示 */}
+      <td className="hidden px-4 py-3 text-gray-700 xl:table-cell">
+        {document.totalPages > 0 ? `${document.totalPages}` : '-'}
+      </td>
       <td className="px-2 py-2 sm:px-4 sm:py-3">
         {needsReview ? (
           <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
@@ -879,6 +883,8 @@ export function DocumentsPage() {
                       <SortableHeader label="事業所" field="officeName" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} hideOnMobile />
                       <SortableHeader label="登録日" field="processedAt" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} />
                       <SortableHeader label="書類日付" field="fileDate" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} hideOnMobile />
+                      {/* ページ数 (#525): xl 未満は非表示 (#424 教訓 — lg 帯 1024px は 7 列 940px + スクロールバーで限界のため列を増やさない) */}
+                      <th className="hidden px-4 py-3 text-left text-sm font-medium text-gray-700 xl:table-cell">ページ数</th>
                       <SortableHeader label="ステータス" field="status" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} />
                       <th className="px-2 py-2 text-center text-xs font-medium text-gray-700 sm:px-3 sm:py-3 sm:text-sm w-12">
                         <CheckCircle2 className="h-4 w-4 text-gray-400 inline-block" />

--- a/scripts/seed-e2e-data.js
+++ b/scripts/seed-e2e-data.js
@@ -378,6 +378,8 @@ async function seedGroupRetryTestData() {
         fileName: 'E2E_グループ再試行_正常.pdf',
         fileUrl: 'gs://doc-split-dev-documents/test/e2e-group-doc-3.pdf',
         status: 'processed',
+        // #525: totalPages 0 = 旧形式 doc 相当。一覧のページ数列「-」表示の検証用
+        totalPages: 0,
       },
     },
   ];


### PR DESCRIPTION
## Summary
kaname 要望 D（#525）対応。FAX は複数書類が 1 PDF に混在するため、一覧時点でページ数が見えれば開かずに分割要否・書類量を判断できる。

- 書類一覧テーブルにページ数列を追加（**xl (1280px) 以上のみ表示**。#424 教訓: lg 帯 1024px は 7 列 940px + 縦スクロールバーで限界のため列を増やさない設計判断）
- グループビュー行（フラット + 担当CM別顧客サブグループ）に「Nページ」の補助表示
- `totalPages: 0`（OCR 完了前の旧形式 doc）は一覧で「-」、グループ行では非表示
- ソートは非対応（Firestore 複合インデックス増設を避けるため。要望はあくまで「見えること」）

## Test plan
- [x] `tsc --noEmit` PASS / unit 247 passed / build PASS
- [x] `/trace-dataflow` 相当: `firestoreToDocument()` の totalPages マッピング到達確認（useDocuments.ts:159）
- [x] emulator E2E: **8 passed**（新規: ページ数列の値「3」/ 0→「-」の列位置ベース assert + 既存回帰 7）
- [x] Playwright MCP 実機確認（viewport 3 種、#424 再発検証）:
  - 1280px: ページ数列表示、「3」/「-」正常、横 overflow なし
  - 1024px: ページ数列は非表示（7 列維持）、table 958px = container 958px で **overflow なし（#424 回帰なし）**
  - 768px: 5 列維持。既存の 15px overflow を検出したが、**stash 比較で変更前と同一値（733 vs 718）を実証** — 長い E2E seed ファイル名の min-content 起因の既存事象で本 PR の回帰ではない
  - グループビュー行の「3ページ」表示確認

Refs #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)