### PR TITLE
fix(hooks): ui-change-merge-check を条件付き許可に更新 + すり抜け穴 2 件修正

### DIFF
--- a/.claude/hooks/ui-change-merge-check.sh
+++ b/.claude/hooks/ui-change-merge-check.sh
@@ -1,24 +1,60 @@
 #!/bin/bash
-# UI変更を含むPRマージ前にブラウザ確認を促すhook
+# UI変更を含むPRマージ前にブラウザ確認を必須化するhook
 # 背景: PR #193でUI変更をブラウザ確認なしにマージした教訓
+#   (tsc/test/buildのPASSだけではPopover位置・レイアウト崩れ・スクロール挙動を検出できない)
 #
-# 動作: gh pr merge 実行時にdiffを確認し、.tsx/.css変更があればブロック
-# Claudeにフィードバックされ、ブラウザ確認を促す
+# 動作: gh pr merge 実行時に対象PRのdiffを確認し、.tsx/.css変更を含む場合は
+#   1. PRのCI checksが全てPASSしている (gh pr checks は全成功時のみ exit 0)
+#   2. PRに ui-verified ラベルが付与されている
+#      (Playwright MCP/手動でのブラウザ確認済み宣言。確認証跡=確認内容・viewport・
+#       スクリーンショットをPRコメント/bodyに記録した上で付与すること)
+#   の両方を満たす場合のみマージを許可する。
+#
+# 2026-07-03 decision-maker指示によりアップデート:
+#   従来は無条件ブロック(人間がマージする運用)だったが、「AI側でテストやチェックが
+#   間違いなく通ったのであればマージを許可する」方針に変更。
+#   あわせて2つのすり抜け穴を修正:
+#   - PR番号抽出がコマンド全体の最初の数字を拾っていた
+#     (前段コマンドのポート番号等を誤認しチェックがすり抜ける。PR #530マージで実際に発生)
+#   - 番号なし `gh pr merge` (カレントブランチ形式) が無条件通過していた
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
-if [[ "$COMMAND" == *"gh pr merge"* ]]; then
-  PR_NUMBER=$(echo "$COMMAND" | grep -oE '[0-9]+' | head -1)
-  if [ -n "$PR_NUMBER" ]; then
-    UI_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null | grep -E '\.(tsx|css)$' || true)
-    if [ -n "$UI_FILES" ]; then
-      echo "UI変更を含むPRです。マージ前にdev環境(doc-split-dev.web.app)でブラウザ確認が必要です。" >&2
-      echo "変更UIファイル:" >&2
-      echo "$UI_FILES" >&2
-      echo "Playwright MCPまたは手動で変更箇所を操作し、問題ないことを確認してからマージしてください。" >&2
+# トリガーはコマンド位置 (行頭 / ; & | $( の直後) の "gh pr merge" のみ。
+# コミットメッセージや PR body 中の説明文 (`gh pr merge` 等のインライン記述) に
+# 反応する false positive を防ぐ
+MERGE_INVOCATION=$(echo "$COMMAND" | grep -oE '(^|[;&|]|\$\() *gh pr merge( +[0-9]+)?' | head -1)
+
+if [ -n "$MERGE_INVOCATION" ]; then
+  # PR番号は "gh pr merge" の直後から抽出する (コマンド先頭の無関係な数字を拾わない)
+  PR_NUMBER=$(echo "$MERGE_INVOCATION" | grep -oE '[0-9]+' | head -1)
+
+  if [ -z "$PR_NUMBER" ]; then
+    # 番号を特定できない形式は安全側でブロック
+    echo "gh pr merge のPR番号を特定できません。'gh pr merge <番号>' 形式で実行してください。" >&2
+    exit 2
+  fi
+
+  UI_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null | grep -E '\.(tsx|css)$' || true)
+  if [ -n "$UI_FILES" ]; then
+    # 条件1: CI checks 全PASS
+    if ! gh pr checks "$PR_NUMBER" >/dev/null 2>&1; then
+      echo "UI変更PR #${PR_NUMBER}: CI checksが未完了または失敗しています。全checks PASS後にマージしてください。" >&2
       exit 2
     fi
+
+    # 条件2: ui-verified ラベル (ブラウザ確認済み宣言)
+    if ! gh pr view "$PR_NUMBER" --json labels -q '.labels[].name' 2>/dev/null | grep -qx 'ui-verified'; then
+      echo "UI変更PR #${PR_NUMBER}: ブラウザ確認が未宣言です。" >&2
+      echo "変更UIファイル:" >&2
+      echo "$UI_FILES" >&2
+      echo "Playwright MCPまたは手動で変更箇所を操作確認し、証跡(確認内容・viewport・スクリーンショット)を" >&2
+      echo "PRコメント/bodyに記録した上で 'gh pr edit ${PR_NUMBER} --add-label ui-verified' を実行してからマージしてください。" >&2
+      exit 2
+    fi
+
+    echo "UI変更PR #${PR_NUMBER}: CI全PASS + ui-verified確認済み。マージを許可します。" >&2
   fi
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,11 +156,12 @@ FIREBASE_PROJECT_ID=<project-id> node scripts/import-masters.js --all scripts/sa
 
 ## UIコンポーネント変更時の確認（#193教訓）
 
-Select、Combobox、Modal、Popover等のUIコンポーネントを変更・置き換えた場合、**マージ前に**dev環境（`doc-split-dev.web.app`）でブラウザ確認すること。
+Select、Combobox、Modal、Popover等のUIコンポーネントを変更・置き換えた場合、**マージ前に**ブラウザ確認すること（ローカル emulator + vite でも dev 環境でも可）。
 
 - tsc・テスト・ビルドのpassだけでは不十分（Popover位置、レイアウト崩れ、スクロール挙動は検出できない）
 - Playwright MCPまたは手動で、変更箇所を最低1回操作してスクリーンショットを残す
-- devはmainへのpush時にCI自動デプロイされるため、push後すぐに確認可能
+- **マージフロー（2026-07-03〜）**: `.tsx/.css` を含む PR は `ui-change-merge-check.sh` hook が「CI 全 PASS + `ui-verified` ラベル」の両方を満たす場合のみマージを許可する。確認証跡（確認内容・viewport・スクリーンショット）を PR コメント/body に記録した上で `gh pr edit <番号> --add-label ui-verified` を付与してからマージする
+- devはmainへのpush時にCI自動デプロイされるため、push後の実環境確認も可能
 
 ## 危険な操作の禁止事項
 


### PR DESCRIPTION
## Summary
decision-maker 指示（2026-07-03）「AI側でテストやチェックが間違いなく通ったのであればマージを許可する」に基づく hook 更新。

**新しい許可条件（.tsx/.css を含む PR のマージ時）:**
1. CI checks 全 PASS（gh pr checks が exit 0）
2. `ui-verified` ラベル付与済み（Playwright MCP/手動のブラウザ確認済み宣言。確認証跡 = 確認内容・viewport・スクリーンショットを PR コメント/body に記録した上で付与）

**すり抜け穴の修正（安全性向上）:**
- PR 番号抽出がコマンド全体の最初の数字を拾っていた → 前段コマンドのポート番号等を PR 番号と誤認して UI チェックがすり抜ける（**PR #530 のマージで実際に発生**。当該 PR のブラウザ確認自体は実施済み）→ コマンド位置の invocation から抽出
- 番号なしマージ（カレントブランチ形式）が無条件通過 → 安全側でブロック
- トリガーをコマンド位置（行頭 / `;` `&` `|` `$(` 直後）に限定し、コミットメッセージ・PR body 中の説明文への false positive を防止

CLAUDE.md「UIコンポーネント変更時の確認（#193教訓）」を新フローに同期。

## Test plan（self-verifying、実 PR に対して検証済み）
- [x] UI PR #531・ラベルなし → ブロック（本セッションの実マージ試行で live 検証）
- [x] UI PR #531・CI green + ui-verified → 許可（exit 0）
- [x] 前段に数字を含む複合コマンド（旧バグ再現）→ #531 を正しく認識
- [x] 番号なしマージ → ブロック / 非 UI PR #529 → 通過
- [x] コミットメッセージ中の文字列・バッククォート説明文 → false positive なし（本 PR のコミット自体が実証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)