### PR TITLE
feat(groups): 担当CM別タブを 担当CM→利用者→書類種別→書類 の4階層に変更 (#527)

### DIFF
--- a/frontend/e2e/group-retry.spec.ts
+++ b/frontend/e2e/group-retry.spec.ts
@@ -40,20 +40,33 @@ test.describe('グループビュー再試行 (#524) @emulator', () => {
     await expect(page.locator('text=再処理をリクエストしました')).toBeVisible({ timeout: 5000 });
   });
 
-  test('担当CM別タブの顧客サブグループ配下 error 行に再試行ボタンが表示されキャンセルできる', async ({ page }) => {
+  test('担当CM別タブは 4 階層 (CM→利用者→書類種別→書類) で遷移でき、error 行の再試行がキャンセルできる (#527/#524)', async ({ page }) => {
     await clickTab(page, '担当CM別');
 
-    // 担当CMグループを展開
+    // 第1階層: 担当CMグループを展開
     const cmHeader = page.locator('button', { hasText: '五十嵐恵' }).first();
     await expect(cmHeader).toBeVisible({ timeout: 10000 });
     await cmHeader.click();
 
-    // 顧客サブグループを展開
+    // 第2階層: 顧客サブグループを展開
     const customerHeader = page.locator('button', { hasText: '組合花子' }).first();
     await expect(customerHeader).toBeVisible({ timeout: 10000 });
     await customerHeader.click();
 
-    // error 行の「再試行」→ ダイアログ表示 → キャンセルで閉じる
+    // 第3階層 (#527): 書類種別グループ (請求書/ケアプラン) が分離して表示される。
+    // この時点で書類行はまだ見えない
+    // 注: エラー2 は先行の顧客別テストが再処理で消費する (workers=1 で順次実行) ため、
+    //     本テストは残存するエラー1 を対象にする
+    const docTypeHeader = page.locator('button', { hasText: '請求書' }).first();
+    await expect(docTypeHeader).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('button', { hasText: 'ケアプラン' }).first()).toBeVisible();
+    await expect(page.locator('text=E2E_グループ再試行_エラー1')).not.toBeVisible();
+
+    // 書類種別を展開すると第4階層の書類行が表示される
+    await docTypeHeader.click();
+    await expect(page.locator('text=E2E_グループ再試行_エラー1').first()).toBeVisible({ timeout: 10000 });
+
+    // error 行の「再試行」→ ダイアログ表示 → キャンセルで閉じる (#524)
     const retryButton = page.locator('button:has-text("再試行")').first();
     await expect(retryButton).toBeVisible({ timeout: 10000 });
     await retryButton.click();

--- a/frontend/src/components/views/CustomerSubGroup.tsx
+++ b/frontend/src/components/views/CustomerSubGroup.tsx
@@ -9,6 +9,7 @@ import {
   ChevronRight,
   ChevronDown,
   FileText,
+  FolderOpen,
   Users,
   RefreshCw,
 } from 'lucide-react';
@@ -167,6 +168,90 @@ function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
 }
 
 // ============================================
+// 書類種別サブグループ (#527: 担当CM → 利用者 → 書類種別 → 書類 の第3階層)
+// ============================================
+
+interface DocTypeGroup {
+  docType: string;
+  documents: Document[];
+}
+
+const UNKNOWN_DOC_TYPE = '未判定';
+
+/**
+ * 利用者配下の書類を書類種別ごとに集約する。
+ * 並びは名前順 (ja locale。開くたびに順序が変わらない紙ファイリングのメンタルモデル優先)、
+ * 「未判定」は末尾。件数は読み込み済みページ分のクライアント集約
+ * (既存の顧客サブグループと同一方式。未読分は LoadMoreIndicator で可視)。
+ */
+function groupByDocType(documents: Document[]): DocTypeGroup[] {
+  const groupMap = new Map<string, DocTypeGroup>();
+  for (const doc of documents) {
+    const docType = doc.documentType || UNKNOWN_DOC_TYPE;
+    if (!groupMap.has(docType)) {
+      groupMap.set(docType, { docType, documents: [] });
+    }
+    groupMap.get(docType)!.documents.push(doc);
+  }
+  return Array.from(groupMap.values()).sort((a, b) => {
+    if (a.docType === UNKNOWN_DOC_TYPE) return 1;
+    if (b.docType === UNKNOWN_DOC_TYPE) return -1;
+    return a.docType.localeCompare(b.docType, 'ja');
+  });
+}
+
+interface DocTypeGroupItemProps {
+  group: DocTypeGroup;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onDocumentSelect?: (documentId: string) => void;
+  onRetry?: (document: Document) => void;
+}
+
+function DocTypeGroupItem({
+  group,
+  isExpanded,
+  onToggle,
+  onDocumentSelect,
+  onRetry,
+}: DocTypeGroupItemProps) {
+  return (
+    <div className="border-b border-gray-50 last:border-0">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-gray-100"
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-4 w-4 flex-shrink-0 text-gray-400" />
+        ) : (
+          <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-400" />
+        )}
+        <FolderOpen className="h-4 w-4 flex-shrink-0 text-amber-500" />
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <span className="text-sm text-gray-800 truncate">{group.docType}</span>
+          <Badge variant="outline" className="text-xs">
+            {group.documents.length}件
+          </Badge>
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="bg-white ml-6">
+          {group.documents.map((doc) => (
+            <DocumentRow
+              key={doc.id}
+              document={doc}
+              onClick={() => onDocumentSelect?.(doc.id)}
+              onRetry={onRetry}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================
 // 顧客グループアイテムコンポーネント
 // ============================================
 
@@ -185,6 +270,22 @@ function CustomerGroupItem({
   onDocumentSelect,
   onRetry,
 }: CustomerGroupItemProps) {
+  // 書類種別サブグループの展開状態 (#527)。顧客を閉じると状態ごと破棄される
+  const [expandedDocTypes, setExpandedDocTypes] = useState<Set<string>>(new Set());
+  const docTypeGroups = useMemo(() => groupByDocType(group.documents), [group.documents]);
+
+  const toggleDocType = (docType: string) => {
+    setExpandedDocTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(docType)) {
+        next.delete(docType);
+      } else {
+        next.add(docType);
+      }
+      return next;
+    });
+  };
+
   return (
     <div className="border-b border-gray-100 last:border-0">
       {/* 顧客グループヘッダー */}
@@ -213,14 +314,16 @@ function CustomerGroupItem({
         </div>
       </button>
 
-      {/* 顧客グループ内ドキュメント（展開時） */}
+      {/* 顧客グループ内の書類種別サブグループ（展開時、#527: 4 階層化） */}
       {isExpanded && (
         <div className="bg-white border-t border-gray-50 ml-6">
-          {group.documents.map((doc) => (
-            <DocumentRow
-              key={doc.id}
-              document={doc}
-              onClick={() => onDocumentSelect?.(doc.id)}
+          {docTypeGroups.map((dtGroup) => (
+            <DocTypeGroupItem
+              key={dtGroup.docType}
+              group={dtGroup}
+              isExpanded={expandedDocTypes.has(dtGroup.docType)}
+              onToggle={() => toggleDocType(dtGroup.docType)}
+              onDocumentSelect={onDocumentSelect}
               onRetry={onRetry}
             />
           ))}

--- a/scripts/seed-e2e-data.js
+++ b/scripts/seed-e2e-data.js
@@ -380,6 +380,8 @@ async function seedGroupRetryTestData() {
         status: 'processed',
         // #525: totalPages 0 = 旧形式 doc 相当。一覧のページ数列「-」表示の検証用
         totalPages: 0,
+        // #527: 別種別を混ぜて書類種別サブグループ (請求書/ケアプラン) の分離を検証
+        documentType: 'ケアプラン',
       },
     },
   ];


### PR DESCRIPTION
## Summary
kaname 要望 F（#527）対応。「書類グループ」= **書類種別**のプロダクト判断（根拠: 「各種書類」の語感 / 紙ファイリングのメンタルモデル / 既存の書類種別マスター。契約外フィードバックのため確認往復せず自社仕様として決定）。

- `CustomerSubGroup` の利用者配下に**書類種別サブグループ（第3階層）**を挿入 → 担当CM → 利用者 → 書類種別 → 書類 の 4 階層
- 種別の並び: 名前順（ja locale、開くたびに順序が変わらない）、「未判定」は末尾
- 件数: 読み込み済みページ分のクライアント集約（既存の顧客サブグループと同一方式。未読分は LoadMoreIndicator で可視 — Issue #527 設計判断①の決定)
- 第4階層の書類行は #524 の「再試行」/ #525 の「Nページ」表示と共存

## Test plan
- [x] `tsc --noEmit` PASS / unit 247 passed / build PASS
- [x] emulator E2E: **8 passed** — 担当CM別テストを 4 階層遷移に更新（種別分離 ケアプラン1件/請求書2件・展開前は書類行非表示・展開後に再試行操作）
- [x] Playwright MCP 実機確認:
  - デスクトップ: 4 階層遷移（五十嵐恵 → 組合花子 → ケアプラン/請求書 → 書類行）、種別ごとの件数バッジ、第4階層行の再試行/ページ数共存
  - **モバイル 375px**: 4 階層のインデント描画正常・横 overflow なし・再試行ボタン動作（Issue #527 設計判断③のモバイル UX 確認）
- [x] `groupByDocType`: 「未判定」末尾配置をコードレベルで保証

Refs #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customer document lists can now be expanded one level further by document type, making it easier to browse large customer groups.
  * Document-type sections show item counts and can be expanded or collapsed independently.

* **Bug Fixes**
  * Improved visibility behavior in the group retry flow so documents appear only after the relevant document-type section is opened.
  * Updated retry-related end-to-end coverage to reflect the latest multi-level navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->