### PR TITLE
fix(hooks): ui-change-merge-check の pipe 誤検知を修正

### DIFF
--- a/.claude/hooks/ui-change-merge-check.sh
+++ b/.claude/hooks/ui-change-merge-check.sh
@@ -21,10 +21,14 @@
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
-# トリガーはコマンド位置 (行頭 / ; & | $( の直後) の "gh pr merge" のみ。
+# トリガーはコマンド位置 (行頭 / ; & $( の直後) の "gh pr merge" のみ。
 # コミットメッセージや PR body 中の説明文 (`gh pr merge` 等のインライン記述) に
-# 反応する false positive を防ぐ
-MERGE_INVOCATION=$(echo "$COMMAND" | grep -oE '(^|[;&|]|\$\() *gh pr merge( +[0-9]+)?' | head -1)
+# 反応する false positive を防ぐ。
+# 注意: "|" (パイプ) はトリガーに含めない。ダブルクォート文字列内の grep OR 構文
+# (例: grep "foo\|gh pr merge bar") がシェルのパイプ区切りと誤認され、無関係な
+# コマンドを誤ブロックする実例が2026-07-03に発覚したため除外。gh pr merge は stdin を
+# 読まないため "cmd | gh pr merge" という実用パターンは存在せず、除外による見逃しリスクはない
+MERGE_INVOCATION=$(echo "$COMMAND" | grep -oE '(^|[;&]|\$\() *gh pr merge( +[0-9]+)?' | head -1)
 
 if [ -n "$MERGE_INVOCATION" ]; then
   # PR番号は "gh pr merge" の直後から抽出する (コマンド先頭の無関係な数字を拾わない)


### PR DESCRIPTION
## Summary
PR #532（マージ済み）で追加した UI 変更マージチェックの新たな誤検知パターンが、本 handoff セッション中に発覚したため修正。

grep の OR 構文 (`foo\|bar`) がダブルクォート文字列内にあるだけで、シェルのパイプ区切り文字と誤認され、無関係なコマンド（grep/find -exec 等）が「gh pr merge のPR番号を特定できません」で誤ブロックされていた。

検出トリガー文字からパイプを除外。マージコマンド自体は標準入力を読まないため、パイプ経由呼び出しの実用例は存在せず、除外による見逃しリスクはない。

## 既知の制約（今回は対応範囲外）
複数行コマンド文字列内で、たまたま改行の直後に「gh pr merge」という文字列が来る行（例: hook の説明を書いたコミットメッセージ本文）がある場合、行頭マッチにより誤検知しうる。構文解析なしの正規表現判定の原理的限界で、対応には heredoc 検出等の複雑な実装が必要。頻度が低い自己言及的エッジケースのため、今回は見送り。

## Test plan
- [x] 実際に発覚した2ケース（find -exec + grep OR、単純な grep OR）で誤検知解消を確認
- [x] 既存の防御（番号なし拒否 / 前段数字混入時の正しい番号認識 / 対象外PRの通過）は回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)