### PR TITLE
feat(ocr): confirmed保護マージ+transaction化+pageResults再利用 (Issue #526 PR3/5, D2/D3)

### DIFF
--- a/functions/src/ocr/confirmedFieldMerge.ts
+++ b/functions/src/ocr/confirmedFieldMerge.ts
@@ -2,14 +2,22 @@
  * confirmed保護フィールドマージの純粋関数。(Issue #526 D2)
  *
  * OCR再解析(processDocument)は通常、抽出結果でcustomerName/officeName/documentType等を
- * 上書きするが、分割画面でユーザーが実際に選択した値(customerConfirmed/officeConfirmed/
- * documentTypeConfirmed = true)は保護し、フレッシュなOCR抽出結果で上書きしない。
+ * 上書きする。`customerConfirmed`/`officeConfirmed`はユーザーが分割画面で実際に選択した
+ * 場合だけでなく、OCR自身の確信度に基づく自己判定(候補が一意に定まった場合、
+ * `ocrUpdatePayloadBuilder.ts`の`!needsManualSelection`)でも true になりうる
+ * (`documentTypeConfirmed`のみユーザー選択専用、対応する自己判定シグナルを持たない)。
+ * この関数はどちらの経路でtrueになったかを区別せず、trueである限り同じ規約で保護する。
+ *
+ * この設計が安全に成立するのは、手動再処理(`frontend/src/hooks/useDocuments.ts`の
+ * `getReprocessClearFields()`)が再処理開始時に3フラグを明示的にfalseへリセットして
+ * いるため。このリセットが将来失われると、OCR自身の低確信度な自己判定が本関数により
+ * 恒久的に凍結される回帰リスクがある(コメント削除・簡略化時は要注意)。
  *
  * 保護はフィールド単位(セグメント単位ではない、Issue #526本文)。各confirmedフラグは
  * 以下をまとめて保護する:
- * - フラグ自体(customerConfirmed等) — 保護しないと、OCRが今回導き出した「確信度に基づく
- *   自己判定」で上書きされ、ユーザーが確定した状態が静かに未確定へ後退してしまう
- * - 対応する「ユーザー確定値」フィールド(customerName/officeName/documentType等)
+ * - フラグ自体(customerConfirmed等) — 保護しないと、OCRが今回導き出した自己判定で
+ *   上書きされ、確定済みの状態が静かに未確定へ後退してしまう
+ * - 対応する「確定値」フィールド(customerName/officeName/documentType等)
  * - 確定者情報(confirmedBy/confirmedAt等) — documentTypeConfirmedのみBy/Atを持たない
  * - そのフィールドの状態を表すUI直結フィールド(isDuplicateCustomer等、customerConfirmed
  *   の値と無関係にFEで警告バナーを出すため保護しないと矛盾した表示になる)
@@ -22,6 +30,13 @@
  * 読み込んだ直後に呼び出す想定(stale snapshotによる編集競合を避けるため)。
  */
 
+import type { Timestamp } from 'firebase-admin/firestore';
+
+/** 確定者UID (人間が確定した場合のみ設定、システム自動確定時はnull) */
+type ConfirmedByValue = string | null;
+/** 確定日時。Firestoreから読み戻したTimestampを解釈せずそのまま透過する */
+type ConfirmedAtValue = Timestamp | null;
+
 export interface ConfirmedProtectionSnapshot {
   customerConfirmed?: boolean;
   officeConfirmed?: boolean;
@@ -31,13 +46,12 @@ export interface ConfirmedProtectionSnapshot {
   careManager?: string | null;
   isDuplicateCustomer?: boolean;
   needsManualCustomerSelection?: boolean;
-  /** Firestore Timestampまたはnull。この関数は値を解釈せずそのまま透過する */
-  confirmedBy?: unknown;
-  confirmedAt?: unknown;
+  confirmedBy?: ConfirmedByValue;
+  confirmedAt?: ConfirmedAtValue;
   officeName?: string;
   officeId?: string | null;
-  officeConfirmedBy?: unknown;
-  officeConfirmedAt?: unknown;
+  officeConfirmedBy?: ConfirmedByValue;
+  officeConfirmedAt?: ConfirmedAtValue;
   documentType?: string;
   category?: string | null;
 }
@@ -54,13 +68,13 @@ export interface ConfirmedProtectableFields {
   careManager: string | null;
   isDuplicateCustomer: boolean;
   needsManualCustomerSelection: boolean;
-  confirmedBy: unknown;
-  confirmedAt: unknown;
+  confirmedBy: ConfirmedByValue;
+  confirmedAt: ConfirmedAtValue;
   officeConfirmed: boolean;
   officeName: string;
   officeId: string | null;
-  officeConfirmedBy: unknown;
-  officeConfirmedAt: unknown;
+  officeConfirmedBy: ConfirmedByValue;
+  officeConfirmedAt: ConfirmedAtValue;
   documentTypeConfirmed: boolean;
   documentType: string;
   category: string | null;

--- a/functions/src/ocr/confirmedFieldMerge.ts
+++ b/functions/src/ocr/confirmedFieldMerge.ts
@@ -1,0 +1,105 @@
+/**
+ * confirmed保護フィールドマージの純粋関数。(Issue #526 D2)
+ *
+ * OCR再解析(processDocument)は通常、抽出結果でcustomerName/officeName/documentType等を
+ * 上書きするが、分割画面でユーザーが実際に選択した値(customerConfirmed/officeConfirmed/
+ * documentTypeConfirmed = true)は保護し、フレッシュなOCR抽出結果で上書きしない。
+ *
+ * 保護はフィールド単位(セグメント単位ではない、Issue #526本文)。各confirmedフラグは
+ * 以下をまとめて保護する:
+ * - フラグ自体(customerConfirmed等) — 保護しないと、OCRが今回導き出した「確信度に基づく
+ *   自己判定」で上書きされ、ユーザーが確定した状態が静かに未確定へ後退してしまう
+ * - 対応する「ユーザー確定値」フィールド(customerName/officeName/documentType等)
+ * - 確定者情報(confirmedBy/confirmedAt等) — documentTypeConfirmedのみBy/Atを持たない
+ * - そのフィールドの状態を表すUI直結フィールド(isDuplicateCustomer等、customerConfirmed
+ *   の値と無関係にFEで警告バナーを出すため保護しないと矛盾した表示になる)
+ *
+ * 候補一覧(customerCandidates等)や診断用フィールド(extractionScores/extractionDetails/
+ * ocrExtraction)は編集UIの選択肢提示に使われ続けるため、confirmed状態によらず常に
+ * 最新のOCR結果へ更新する。
+ *
+ * この関数は呼出元(ocrProcessor.ts)が Firestore transaction 内で最新ドキュメントを
+ * 読み込んだ直後に呼び出す想定(stale snapshotによる編集競合を避けるため)。
+ */
+
+export interface ConfirmedProtectionSnapshot {
+  customerConfirmed?: boolean;
+  officeConfirmed?: boolean;
+  documentTypeConfirmed?: boolean;
+  customerName?: string;
+  customerId?: string | null;
+  careManager?: string | null;
+  isDuplicateCustomer?: boolean;
+  needsManualCustomerSelection?: boolean;
+  /** Firestore Timestampまたはnull。この関数は値を解釈せずそのまま透過する */
+  confirmedBy?: unknown;
+  confirmedAt?: unknown;
+  officeName?: string;
+  officeId?: string | null;
+  officeConfirmedBy?: unknown;
+  officeConfirmedAt?: unknown;
+  documentType?: string;
+  category?: string | null;
+}
+
+/**
+ * マージ対象となるproposed値の型。呼出元(buildOcrExtractionUpdatePayloadの戻り値)は
+ * これよりフィールドが多いが、TypeScriptの構造的部分型により余剰フィールドはそのまま
+ * 呼出元の型で保持される(この関数はマージ対象フィールドのみを型として要求する)。
+ */
+export interface ConfirmedProtectableFields {
+  customerConfirmed: boolean;
+  customerName: string;
+  customerId: string | null;
+  careManager: string | null;
+  isDuplicateCustomer: boolean;
+  needsManualCustomerSelection: boolean;
+  confirmedBy: unknown;
+  confirmedAt: unknown;
+  officeConfirmed: boolean;
+  officeName: string;
+  officeId: string | null;
+  officeConfirmedBy: unknown;
+  officeConfirmedAt: unknown;
+  documentTypeConfirmed: boolean;
+  documentType: string;
+  category: string | null;
+}
+
+/**
+ * confirmed保護を適用したマージ結果を返す。保護対象フィールドのみ
+ * `proposed` を書き換えたコピーとして返す(破壊的変更はしない)。
+ */
+export function applyConfirmedFieldProtection<T extends ConfirmedProtectableFields>(
+  proposed: T,
+  current: ConfirmedProtectionSnapshot
+): T {
+  const merged = { ...proposed };
+
+  if (current.customerConfirmed === true) {
+    merged.customerConfirmed = true;
+    merged.customerName = current.customerName ?? proposed.customerName;
+    merged.customerId = current.customerId ?? null;
+    merged.careManager = current.careManager ?? null;
+    merged.isDuplicateCustomer = current.isDuplicateCustomer ?? false;
+    merged.needsManualCustomerSelection = current.needsManualCustomerSelection ?? false;
+    merged.confirmedBy = current.confirmedBy ?? null;
+    merged.confirmedAt = current.confirmedAt ?? null;
+  }
+
+  if (current.officeConfirmed === true) {
+    merged.officeConfirmed = true;
+    merged.officeName = current.officeName ?? proposed.officeName;
+    merged.officeId = current.officeId ?? null;
+    merged.officeConfirmedBy = current.officeConfirmedBy ?? null;
+    merged.officeConfirmedAt = current.officeConfirmedAt ?? null;
+  }
+
+  if (current.documentTypeConfirmed === true) {
+    merged.documentTypeConfirmed = true;
+    merged.documentType = current.documentType ?? proposed.documentType;
+    merged.category = current.category ?? null;
+  }
+
+  return merged;
+}

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -114,7 +114,7 @@ export async function processDocument(
 ): Promise<OcrProcessingResult> {
   console.log(`Processing document: ${docId}`);
 
-  // Issue #526 D3: 分割子ドキュメント(parentDocumentIdを持つ、#445 provenance)が
+  // Issue #526 D3: 分割子ドキュメント(#445で確立済みのparentDocumentIdを持つ)が
   // 親から継承した有効なpageResultsを持つ場合、ページOCRを再実行せず再利用する(コスト削減)。
   const existingPageResults = docData.pageResults as RawPageOcrResult[] | undefined;
   const reuseCheck = validatePageResultsForReuse(existingPageResults, docData.parentDocumentId);
@@ -126,13 +126,13 @@ export async function processDocument(
 
   if (reuseCheck.reusable && existingPageResults) {
     console.log(
-      `[Issue #526] Reusing existing pageResults for ${docId} (${existingPageResults.length} pages), skipping page OCR`
+      `Reusing existing pageResults for ${docId} (${existingPageResults.length} pages), skipping page OCR`
     );
     pageResults = existingPageResults;
     totalPages = existingPageResults.length;
   } else {
-    if (existingPageResults && existingPageResults.length > 0) {
-      console.log(`[Issue #526] pageResults reuse skipped for ${docId}: ${reuseCheck.reason}`);
+    if (!reuseCheck.reusable && existingPageResults && existingPageResults.length > 0) {
+      console.log(`pageResults reuse skipped for ${docId}: ${reuseCheck.reason}`);
     }
 
     // ファイル取得
@@ -336,7 +336,16 @@ export async function processDocument(
 
   await db.runTransaction(async (tx) => {
     const freshSnap = await tx.get(docRef);
-    const freshData = freshSnap.data() ?? {};
+    // tryStartProcessing() (本ファイル78行目付近) と同じ存在チェックパターン。
+    // ドキュメントが処理中に削除されると tx.update() は NOT_FOUND を投げるが、
+    // ここで明示的に検知することで handleProcessingError() の lastErrorMessage に
+    // 原因不明な NOT_FOUND ではなく具体的な状況が残る(silent-failure-hunter指摘)。
+    if (!freshSnap.exists) {
+      throw new Error(
+        `Document ${docId} was deleted during OCR processing, aborting confirmed-merge update`
+      );
+    }
+    const freshData = freshSnap.data()!;
 
     const merged = applyConfirmedFieldProtection(extractionFields, {
       customerConfirmed: freshData.customerConfirmed,

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -35,6 +35,8 @@ import {
 import type { SummaryField } from '../../../shared/types';
 import { buildPageResult, type RawPageOcrResult } from './buildPageResult';
 import { buildOcrExtractionUpdatePayload } from './ocrUpdatePayloadBuilder';
+import { validatePageResultsForReuse } from './pageResultsReuse';
+import { applyConfirmedFieldProtection } from './confirmedFieldMerge';
 
 // #267: buildPageResult / 型は ./buildPageResult モジュールに移設。
 // #278: 型名 PageOcrResult → RawPageOcrResult にリネーム (shared/types.ts の post-processed
@@ -112,46 +114,63 @@ export async function processDocument(
 ): Promise<OcrProcessingResult> {
   console.log(`Processing document: ${docId}`);
 
-  // ファイル取得
-  const fileUrl = docData.fileUrl as string;
-  const bucket = storage.bucket();
-  const filePath = fileUrl.replace(`gs://${bucket.name}/`, '');
-  const file = bucket.file(filePath);
-
-  const [buffer] = await withRetry(
-    () => file.download(),
-    RETRY_CONFIGS.storage
-  );
-  const mimeType = docData.mimeType as string;
+  // Issue #526 D3: 分割子ドキュメント(parentDocumentIdを持つ、#445 provenance)が
+  // 親から継承した有効なpageResultsを持つ場合、ページOCRを再実行せず再利用する(コスト削減)。
+  const existingPageResults = docData.pageResults as RawPageOcrResult[] | undefined;
+  const reuseCheck = validatePageResultsForReuse(existingPageResults, docData.parentDocumentId);
 
   let pageResults: RawPageOcrResult[] = [];
   let totalPages = 1;
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
 
-  if (mimeType === 'application/pdf') {
-    const pdfDoc = await PDFDocument.load(buffer);
-    totalPages = pdfDoc.getPageCount();
-
-    console.log(`PDF has ${totalPages} pages`);
-
-    for (let i = 0; i < totalPages; i++) {
-      const pageNumber = i + 1;
-      console.log(`Processing page ${pageNumber}/${totalPages}`);
-
-      const pageBuffer = await extractPdfPage(buffer, i);
-      const result = await ocrWithGemini(pageBuffer, 'application/pdf', pageNumber);
-
-      pageResults.push(buildPageResult(result, pageNumber, `Page ${pageNumber}/${totalPages}`));
-
-      totalInputTokens += result.inputTokens;
-      totalOutputTokens += result.outputTokens;
-    }
+  if (reuseCheck.reusable && existingPageResults) {
+    console.log(
+      `[Issue #526] Reusing existing pageResults for ${docId} (${existingPageResults.length} pages), skipping page OCR`
+    );
+    pageResults = existingPageResults;
+    totalPages = existingPageResults.length;
   } else {
-    const result = await ocrWithGemini(buffer, mimeType);
-    pageResults.push(buildPageResult(result, 1, 'Image'));
-    totalInputTokens = result.inputTokens;
-    totalOutputTokens = result.outputTokens;
+    if (existingPageResults && existingPageResults.length > 0) {
+      console.log(`[Issue #526] pageResults reuse skipped for ${docId}: ${reuseCheck.reason}`);
+    }
+
+    // ファイル取得
+    const fileUrl = docData.fileUrl as string;
+    const bucket = storage.bucket();
+    const filePath = fileUrl.replace(`gs://${bucket.name}/`, '');
+    const file = bucket.file(filePath);
+
+    const [buffer] = await withRetry(
+      () => file.download(),
+      RETRY_CONFIGS.storage
+    );
+    const mimeType = docData.mimeType as string;
+
+    if (mimeType === 'application/pdf') {
+      const pdfDoc = await PDFDocument.load(buffer);
+      totalPages = pdfDoc.getPageCount();
+
+      console.log(`PDF has ${totalPages} pages`);
+
+      for (let i = 0; i < totalPages; i++) {
+        const pageNumber = i + 1;
+        console.log(`Processing page ${pageNumber}/${totalPages}`);
+
+        const pageBuffer = await extractPdfPage(buffer, i);
+        const result = await ocrWithGemini(pageBuffer, 'application/pdf', pageNumber);
+
+        pageResults.push(buildPageResult(result, pageNumber, `Page ${pageNumber}/${totalPages}`));
+
+        totalInputTokens += result.inputTokens;
+        totalOutputTokens += result.outputTokens;
+      }
+    } else {
+      const result = await ocrWithGemini(buffer, mimeType);
+      pageResults.push(buildPageResult(result, 1, 'Image'));
+      totalInputTokens = result.inputTokens;
+      totalOutputTokens = result.outputTokens;
+    }
   }
 
   // aggregate cap (Issue #205): per-page後にも合計サイズで二段防御。
@@ -292,30 +311,14 @@ export async function processDocument(
   // 要約生成を待機
   const summary = await summaryPromise;
 
-  // displayFileName 生成 (#178 Stage 1)
-  // デフォルト値（未判定/不明顧客）は渡さない。generateDisplayFileNameが除外するが、
-  // 日付だけで「20260315.pdf」のような識別不能な名前を防ぐため
-  const displayFileName = generateDisplayFileName({
-    documentType: documentTypeResult.documentType || undefined,
-    customerName: customerResult.bestMatch?.name || undefined,
-    officeName: officeResult.bestMatch?.name || undefined,
-    fileDate: dateResult.formattedDate ?? undefined,
-  });
-
-  // ドキュメント更新
-  // Issue #215: summary を discriminated union ネスト型で書き込み、
-  // 旧フラット3フィールド (summaryTruncated / summaryOriginalLength) は削除。
-  // 旧 summary (string型) は新 summary (object型) で上書きされる。
   // Issue #526 D1: 抽出結果の集約ロジックは ocrUpdatePayloadBuilder.ts の純粋関数に
-  // 切り出し済み(挙動不変、ユニットテストで契約をlock-in)。
-  // summary は summaryWritePayloadContract.test.ts の隣接性契約により、
-  // status/updatedAt はライフサイクル管理フィールドのため、ここで直接組み立てる。
+  // 切り出し済み(挙動不変、ユニットテストで契約をlock-in)。displayFileNameはここでは
+  // 生成しない(Issue #526 D2: confirmed保護マージ後の最終メタから生成する順序に変更)。
   const extractionFields = buildOcrExtractionUpdatePayload({
     documentTypeResult,
     customerResult,
     officeResult,
     dateResult,
-    displayFileName,
     savedOcrResult,
     ocrResultUrl,
     pageResults,
@@ -325,16 +328,63 @@ export async function processDocument(
     extractedAt: admin.firestore.FieldValue.serverTimestamp(),
   });
 
-  await db.doc(`documents/${docId}`).update({
-    ...extractionFields,
-    summary: buildSummaryFields(summary),
-    summaryTruncated: admin.firestore.FieldValue.delete(),
-    summaryOriginalLength: admin.firestore.FieldValue.delete(),
-    status: 'processed',
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  });
+  // Issue #526 D2: confirmed保護マージはFirestore transaction内で最新ドキュメントを
+  // 読み直してから行う。OCR/抽出処理は数秒〜数十秒かかるため、docData(呼出時点の
+  // スナップショット)をそのまま使うと、処理中にユーザーが編集した内容と競合する
+  // stale snapshot問題が起きる(Issue #526本文の設計要件)。
+  const docRef = db.doc(`documents/${docId}`);
 
-  console.log(`Document ${docId} processed: ${documentTypeResult.documentType}, ${customerResult.bestMatch?.name || '不明'}`);
+  await db.runTransaction(async (tx) => {
+    const freshSnap = await tx.get(docRef);
+    const freshData = freshSnap.data() ?? {};
+
+    const merged = applyConfirmedFieldProtection(extractionFields, {
+      customerConfirmed: freshData.customerConfirmed,
+      officeConfirmed: freshData.officeConfirmed,
+      documentTypeConfirmed: freshData.documentTypeConfirmed,
+      customerName: freshData.customerName,
+      customerId: freshData.customerId,
+      careManager: freshData.careManager,
+      isDuplicateCustomer: freshData.isDuplicateCustomer,
+      needsManualCustomerSelection: freshData.needsManualCustomerSelection,
+      confirmedBy: freshData.confirmedBy,
+      confirmedAt: freshData.confirmedAt,
+      officeName: freshData.officeName,
+      officeId: freshData.officeId,
+      officeConfirmedBy: freshData.officeConfirmedBy,
+      officeConfirmedAt: freshData.officeConfirmedAt,
+      documentType: freshData.documentType,
+      category: freshData.category,
+    });
+
+    // displayFileName 生成 (#178 Stage 1、Issue #526 D2でマージ後の最終メタから生成)
+    // 「未判定」「不明顧客」等のデフォルト値・日付のみでの識別不能な名前生成の抑制は
+    // generateDisplayFileName内部で行うため、ここでは merged の値をそのまま渡す。
+    const displayFileName = generateDisplayFileName({
+      documentType: merged.documentType,
+      customerName: merged.customerName,
+      officeName: merged.officeName,
+      fileDate: dateResult.formattedDate ?? undefined,
+    });
+
+    // ドキュメント更新
+    // Issue #215: summary を discriminated union ネスト型で書き込み、
+    // 旧フラット3フィールド (summaryTruncated / summaryOriginalLength) は削除。
+    // 旧 summary (string型) は新 summary (object型) で上書きされる。
+    tx.update(docRef, {
+      ...merged,
+      ...(displayFileName ? { displayFileName } : {}),
+      summary: buildSummaryFields(summary),
+      summaryTruncated: admin.firestore.FieldValue.delete(),
+      summaryOriginalLength: admin.firestore.FieldValue.delete(),
+      status: 'processed',
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    console.log(
+      `Document ${docId} processed: ${merged.documentType}, ${merged.customerName}`
+    );
+  });
 
   return {
     pagesProcessed: totalPages,

--- a/functions/src/ocr/ocrUpdatePayloadBuilder.ts
+++ b/functions/src/ocr/ocrUpdatePayloadBuilder.ts
@@ -18,7 +18,9 @@
  * この関数の入力として受け取っているのは、キー順序に安全性が依存する設計を避け、
  * 将来の並び替えで `extractedAt` が静かに失われるリスクを構造的に排除するため。
  *
- * Issue #526 では後続PRで、この戻り値を元にconfirmed保護マージロジックを追加する予定。
+ * Issue #526 D2: この戻り値は呼出元でconfirmedFieldMerge.tsのconfirmed保護マージを
+ * 経てから書き込まれる(customerConfirmed等がtrueのフィールドはこの関数の提案値ではなく
+ * 既存ドキュメントの確定値が優先される)。
  */
 
 import type {
@@ -35,7 +37,6 @@ export interface OcrUpdatePayloadInputs {
   customerResult: CustomerExtractionResult;
   officeResult: OfficeExtractionResultWithCandidates;
   dateResult: DateExtractionResult;
-  displayFileName: string | null;
   savedOcrResult: string;
   ocrResultUrl: string | null;
   pageResults: RawPageOcrResult[];
@@ -70,9 +71,13 @@ export interface OcrExtractionMeta {
   };
 }
 
-/** summary/summaryTruncated/summaryOriginalLength/status/updatedAt は含まない (呼出元が追加する) */
+/**
+ * summary/summaryTruncated/summaryOriginalLength/status/updatedAt は含まない (呼出元が追加する)。
+ * displayFileNameも含まない: Issue #526 D2でconfirmed保護マージ後の最終メタから生成する
+ * 順序に変更されたため、この関数の戻り値(マージ前のOCR提案値)からは生成できない。
+ * 呼出元(ocrProcessor.ts)がconfirmed保護マージ後にgenerateDisplayFileName()を呼び出す。
+ */
 export interface OcrExtractionUpdateFields {
-  displayFileName?: string;
   ocrResult: string;
   ocrResultUrl: string | null;
   pageResults: RawPageOcrResult[];
@@ -111,6 +116,12 @@ export interface OcrExtractionUpdateFields {
   }>;
   suggestedNewOffice: string | null;
   totalPages: number;
+  /**
+   * Issue #526 D2: documentTypeにはcustomerConfirmed/officeConfirmedのような
+   * 確信度ベースの自己判定シグナル(needsManualSelection相当)が存在しないため、
+   * OCR自身は常にfalseを書く(documentTypeConfirmedは分割画面でのユーザー選択でのみtrueになる)。
+   */
+  documentTypeConfirmed: boolean;
   category: string | null;
   extractionScores: {
     documentType: number;
@@ -140,7 +151,6 @@ export function buildOcrExtractionUpdatePayload(
     customerResult,
     officeResult,
     dateResult,
-    displayFileName,
     savedOcrResult,
     ocrResultUrl,
     pageResults,
@@ -155,7 +165,6 @@ export function buildOcrExtractionUpdatePayload(
     .map((c) => c.name);
 
   return {
-    ...(displayFileName ? { displayFileName } : {}),
     ocrResult: savedOcrResult,
     ocrResultUrl: ocrResultUrl ?? null,
     pageResults,
@@ -194,6 +203,7 @@ export function buildOcrExtractionUpdatePayload(
     })),
     suggestedNewOffice: suggestedNewOffice ?? null,
     totalPages,
+    documentTypeConfirmed: false,
     category: documentTypeResult.category ?? null,
     extractionScores: {
       documentType: documentTypeResult.score ?? 0,

--- a/functions/src/ocr/pageResultsReuse.ts
+++ b/functions/src/ocr/pageResultsReuse.ts
@@ -6,28 +6,36 @@
  * 親の`pageResults`から該当ページ分を継承済み)、そのOCRを再実行せず既存テキストを再利用する
  * ことでコスト・レイテンシを削減する。
  *
- * 再利用対象とみなす条件は以下の3点全て:
- * 1. `parentDocumentId`が設定されている(#445で確立済みのprovenanceフィールド、分割子
- *    ドキュメントであることの明示シグナル)。構造(連番/非空)だけを見て判定すると、将来
- *    マスターデータ移行や手動データ修復スクリプトが偶然この構造を満たすpageResultsを
- *    書き込んだ場合に、意図せずフルOCRがスキップされてしまう(evaluator指摘)
- * 2. ページ番号が1..Nの連番で揃っている
- * 3. 各ページのtextが非空
+ * 再利用対象とみなす条件は以下の4点全て:
+ * 1. `parentDocumentId`が設定されている(#445で確立済みの、分割元ドキュメントを指す識別
+ *    フィールド。ADR-0016の構造化`provenance`フィールドとは別物)。構造(連番/非空)だけを
+ *    見て判定すると、将来マスターデータ移行や手動データ修復スクリプトが偶然この構造を
+ *    満たすpageResultsを書き込んだ場合に、意図せずフルOCRがスキップされてしまう
+ * 2. 各要素がオブジェクトである(null/非オブジェクト混入時はfallback、throwしない。
+ *    unknown型を受け取る以上、不正データはreusable=falseでフルOCRへ委ねるべきで、
+ *    例外を投げてドキュメント処理全体を失敗させてはならない)
+ * 3. ページ番号が「配列の並び順どおり」1..Nの連番で揃っている(ソート後に連番と
+ *    一致するだけでは不十分。呼出元processDocument()は本関数がtrueを返した配列を
+ *    並び替えずそのまま使うため、ソートありきの判定だとページ順が入れ替わったまま
+ *    OCR結果を結合してしまう)
+ * 4. 各ページのtextが非空
  *
  * #524の手動再処理(`getReprocessClearFields()`)は`pageResults`自体をdeleteFieldで
  * 削除するため、このパスに到達する時点でpageResultsが存在するのは分割子ドキュメント
  * 由来のケースに限られる(条件1はこれを構造的に保証する)。
  */
 
-export interface PageResultsReuseCheck {
-  reusable: boolean;
-  /** reusable=falseの場合のみ設定 (ログ用) */
-  reason?: string;
-}
+export type PageResultsReuseCheck =
+  | { reusable: true }
+  | { reusable: false; reason: string };
 
 interface CandidatePage {
   pageNumber?: unknown;
   text?: unknown;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 export function validatePageResultsForReuse(
@@ -42,16 +50,21 @@ export function validatePageResultsForReuse(
     return { reusable: false, reason: 'pageResults is missing or empty' };
   }
 
+  if (!pageResults.every(isPlainObject)) {
+    return { reusable: false, reason: 'one or more page entries are not objects (null等)' };
+  }
+
   const pages = pageResults as CandidatePage[];
 
   const pageNumbers = pages.map((p) => p.pageNumber);
-  const isSequential =
+  const isInOrderSequential =
     pageNumbers.every((n): n is number => typeof n === 'number') &&
-    [...(pageNumbers as number[])]
-      .sort((a, b) => a - b)
-      .every((n, i) => n === i + 1);
-  if (!isSequential) {
-    return { reusable: false, reason: 'pageNumber is not a sequential 1..N series' };
+    (pageNumbers as number[]).every((n, i) => n === i + 1);
+  if (!isInOrderSequential) {
+    return {
+      reusable: false,
+      reason: 'pageNumber is not an in-order sequential 1..N series',
+    };
   }
 
   const allNonEmpty = pages.every(

--- a/functions/src/ocr/pageResultsReuse.ts
+++ b/functions/src/ocr/pageResultsReuse.ts
@@ -1,0 +1,65 @@
+/**
+ * 既存pageResultsの再利用可否を判定する純粋関数。(Issue #526 D3)
+ *
+ * processDocument()は通常、PDFをStorageからダウンロードしページ単位でOCRを実行するが、
+ * ドキュメントが既に有効なpageResultsを保持している場合(手動分割で生成された子ドキュメント、
+ * 親の`pageResults`から該当ページ分を継承済み)、そのOCRを再実行せず既存テキストを再利用する
+ * ことでコスト・レイテンシを削減する。
+ *
+ * 再利用対象とみなす条件は以下の3点全て:
+ * 1. `parentDocumentId`が設定されている(#445で確立済みのprovenanceフィールド、分割子
+ *    ドキュメントであることの明示シグナル)。構造(連番/非空)だけを見て判定すると、将来
+ *    マスターデータ移行や手動データ修復スクリプトが偶然この構造を満たすpageResultsを
+ *    書き込んだ場合に、意図せずフルOCRがスキップされてしまう(evaluator指摘)
+ * 2. ページ番号が1..Nの連番で揃っている
+ * 3. 各ページのtextが非空
+ *
+ * #524の手動再処理(`getReprocessClearFields()`)は`pageResults`自体をdeleteFieldで
+ * 削除するため、このパスに到達する時点でpageResultsが存在するのは分割子ドキュメント
+ * 由来のケースに限られる(条件1はこれを構造的に保証する)。
+ */
+
+export interface PageResultsReuseCheck {
+  reusable: boolean;
+  /** reusable=falseの場合のみ設定 (ログ用) */
+  reason?: string;
+}
+
+interface CandidatePage {
+  pageNumber?: unknown;
+  text?: unknown;
+}
+
+export function validatePageResultsForReuse(
+  pageResults: unknown,
+  parentDocumentId: unknown
+): PageResultsReuseCheck {
+  if (typeof parentDocumentId !== 'string' || parentDocumentId.length === 0) {
+    return { reusable: false, reason: 'parentDocumentId is missing (not a split child)' };
+  }
+
+  if (!Array.isArray(pageResults) || pageResults.length === 0) {
+    return { reusable: false, reason: 'pageResults is missing or empty' };
+  }
+
+  const pages = pageResults as CandidatePage[];
+
+  const pageNumbers = pages.map((p) => p.pageNumber);
+  const isSequential =
+    pageNumbers.every((n): n is number => typeof n === 'number') &&
+    [...(pageNumbers as number[])]
+      .sort((a, b) => a - b)
+      .every((n, i) => n === i + 1);
+  if (!isSequential) {
+    return { reusable: false, reason: 'pageNumber is not a sequential 1..N series' };
+  }
+
+  const allNonEmpty = pages.every(
+    (p) => typeof p.text === 'string' && p.text.trim().length > 0
+  );
+  if (!allNonEmpty) {
+    return { reusable: false, reason: 'one or more pages have empty text' };
+  }
+
+  return { reusable: true };
+}

--- a/functions/src/utils/retry.ts
+++ b/functions/src/utils/retry.ts
@@ -80,7 +80,10 @@ export function isTransientError(error: unknown): boolean {
       message.includes('too many requests') ||
       message.includes('resource exhausted') ||
       message.includes('resource_exhausted') ||
-      message.includes('exception posting request')
+      message.includes('exception posting request') ||
+      // Issue #526: db.runTransaction()の書込競合(gRPC ABORTED)は一時的エラー。
+      // 検知しないと、本来自動リトライ可能な競合がstatus:'error'に即確定してしまう。
+      message.includes('aborted')
     ) {
       return true;
     }

--- a/functions/src/utils/retry.ts
+++ b/functions/src/utils/retry.ts
@@ -42,6 +42,12 @@ const TRANSIENT_ERROR_CODES = [
 const TRANSIENT_STATUS_CODES = [429, 500, 502, 503, 504];
 
 /**
+ * gRPC ABORTED (Firestore transaction書込競合)。HTTPステータスとは体系が異なる
+ * ため TRANSIENT_STATUS_CODES とは別定数として明示する (Issue #526)。
+ */
+const GRPC_ABORTED_CODE = 10;
+
+/**
  * エラーが一時的（リトライ可能）かどうか判定
  */
 export function isTransientError(error: unknown): boolean {
@@ -59,7 +65,10 @@ export function isTransientError(error: unknown): boolean {
         }
       }
       if (typeof errorWithCode.code === 'number') {
-        if (TRANSIENT_STATUS_CODES.includes(errorWithCode.code)) {
+        if (
+          TRANSIENT_STATUS_CODES.includes(errorWithCode.code) ||
+          errorWithCode.code === GRPC_ABORTED_CODE
+        ) {
           return true;
         }
       }
@@ -81,9 +90,11 @@ export function isTransientError(error: unknown): boolean {
       message.includes('resource exhausted') ||
       message.includes('resource_exhausted') ||
       message.includes('exception posting request') ||
-      // Issue #526: db.runTransaction()の書込競合(gRPC ABORTED)は一時的エラー。
-      // 検知しないと、本来自動リトライ可能な競合がstatus:'error'に即確定してしまう。
-      message.includes('aborted')
+      // Issue #526: db.runTransaction()の書込競合(gRPC ABORTED)は一時的エラー。検知しないと、
+      // 本来自動リトライ可能な競合がstatus:'error'に即確定してしまう。数値codeが取れないSDK/
+      // テストダブル向けのfallbackとして、Firestoreの実メッセージ形式("10 ABORTED: ...")に
+      // 近い「数字+aborted」のみ許容し、AbortController等の無関係な中断エラーと区別する。
+      /\d+\s*aborted/.test(message)
     ) {
       return true;
     }

--- a/functions/test/confirmedFieldMerge.test.ts
+++ b/functions/test/confirmedFieldMerge.test.ts
@@ -1,0 +1,227 @@
+/**
+ * confirmedFieldMerge.ts のテスト (Issue #526 D2)
+ */
+
+import { expect } from 'chai';
+import {
+  applyConfirmedFieldProtection,
+  type ConfirmedProtectableFields,
+  type ConfirmedProtectionSnapshot,
+} from '../src/ocr/confirmedFieldMerge';
+
+function makeProposed(
+  overrides: Partial<ConfirmedProtectableFields> = {}
+): ConfirmedProtectableFields {
+  return {
+    customerConfirmed: false,
+    customerName: 'OCR顧客',
+    customerId: 'ocr-cust-id',
+    careManager: 'OCRケアマネ',
+    isDuplicateCustomer: true,
+    needsManualCustomerSelection: true,
+    confirmedBy: null,
+    confirmedAt: null,
+    officeConfirmed: false,
+    officeName: 'OCR事業所',
+    officeId: 'ocr-office-id',
+    officeConfirmedBy: null,
+    officeConfirmedAt: null,
+    documentTypeConfirmed: false,
+    documentType: 'OCR書類種別',
+    category: 'ocr-category',
+    ...overrides,
+  };
+}
+
+describe('applyConfirmedFieldProtection', () => {
+  it('全フィールドがconfirmed=falseの場合、proposedの値がそのまま使われる(既存挙動不変)', () => {
+    const proposed = makeProposed();
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: false,
+      officeConfirmed: false,
+      documentTypeConfirmed: false,
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+    expect(merged).to.deep.equal(proposed);
+  });
+
+  it('confirmedフラグが全てundefinedの場合も、proposedの値がそのまま使われる', () => {
+    const proposed = makeProposed();
+    const merged = applyConfirmedFieldProtection(proposed, {});
+    expect(merged).to.deep.equal(proposed);
+  });
+
+  it('customerConfirmed=trueの場合、フラグ自体・顧客関連フィールド・確定者情報がcurrentの値で保護される', () => {
+    const proposed = makeProposed({ customerConfirmed: true });
+    const fixedTimestamp = { seconds: 1234567890, nanoseconds: 0 };
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      customerName: '確定顧客',
+      customerId: 'confirmed-cust-id',
+      careManager: '確定ケアマネ',
+      isDuplicateCustomer: false,
+      needsManualCustomerSelection: false,
+      confirmedBy: 'user-uid-123',
+      confirmedAt: fixedTimestamp,
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+
+    expect(merged.customerConfirmed).to.equal(true);
+    expect(merged.customerName).to.equal('確定顧客');
+    expect(merged.customerId).to.equal('confirmed-cust-id');
+    expect(merged.careManager).to.equal('確定ケアマネ');
+    expect(merged.isDuplicateCustomer).to.equal(false);
+    expect(merged.needsManualCustomerSelection).to.equal(false);
+    expect(merged.confirmedBy).to.equal('user-uid-123');
+    expect(merged.confirmedAt).to.deep.equal(fixedTimestamp);
+    // 事業所・書類種別はOCR提案のまま(保護対象外)
+    expect(merged.officeName).to.equal('OCR事業所');
+    expect(merged.documentType).to.equal('OCR書類種別');
+  });
+
+  it('customerConfirmed=trueの場合、OCR自身のcustomerConfirmed=falseガイドを上書きして常にtrueを維持する', () => {
+    // フレッシュなOCR抽出結果は候補が曖昧で needsManualSelection=true → customerConfirmed=false と
+    // 自己判定するケース。既に確定済みのユーザー確定状態が、この自己判定で後退してはならない。
+    const proposed = makeProposed({ customerConfirmed: false });
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      customerName: '確定顧客',
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+    expect(merged.customerConfirmed).to.equal(true);
+  });
+
+  it('officeConfirmed=trueの場合、フラグ自体・事業所関連フィールド・確定者情報がcurrentの値で保護される', () => {
+    const proposed = makeProposed({ officeConfirmed: true });
+    const current: ConfirmedProtectionSnapshot = {
+      officeConfirmed: true,
+      officeName: '確定事業所',
+      officeId: 'confirmed-office-id',
+      officeConfirmedBy: 'user-uid-456',
+      officeConfirmedAt: { seconds: 1111111111, nanoseconds: 0 },
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+
+    expect(merged.officeConfirmed).to.equal(true);
+    expect(merged.officeName).to.equal('確定事業所');
+    expect(merged.officeId).to.equal('confirmed-office-id');
+    expect(merged.officeConfirmedBy).to.equal('user-uid-456');
+    expect(merged.officeConfirmedAt).to.deep.equal({ seconds: 1111111111, nanoseconds: 0 });
+    // 顧客・書類種別はOCR提案のまま
+    expect(merged.customerName).to.equal('OCR顧客');
+    expect(merged.documentType).to.equal('OCR書類種別');
+  });
+
+  it('documentTypeConfirmed=trueの場合、フラグ自体・documentType/categoryのみcurrentの値で保護される(By/Atは持たない)', () => {
+    const proposed = makeProposed({ documentTypeConfirmed: true });
+    const current: ConfirmedProtectionSnapshot = {
+      documentTypeConfirmed: true,
+      documentType: '確定書類種別',
+      category: 'confirmed-category',
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+
+    expect(merged.documentTypeConfirmed).to.equal(true);
+    expect(merged.documentType).to.equal('確定書類種別');
+    expect(merged.category).to.equal('confirmed-category');
+    // 顧客・事業所はOCR提案のまま
+    expect(merged.customerName).to.equal('OCR顧客');
+    expect(merged.officeName).to.equal('OCR事業所');
+  });
+
+  it('3フィールド全てconfirmed=trueの場合、全グループが独立して保護される', () => {
+    const proposed = makeProposed({
+      customerConfirmed: true,
+      officeConfirmed: true,
+      documentTypeConfirmed: true,
+    });
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      officeConfirmed: true,
+      documentTypeConfirmed: true,
+      customerName: '確定顧客',
+      customerId: 'confirmed-cust-id',
+      careManager: '確定ケアマネ',
+      isDuplicateCustomer: false,
+      needsManualCustomerSelection: false,
+      confirmedBy: 'user-uid',
+      confirmedAt: { seconds: 1, nanoseconds: 0 },
+      officeName: '確定事業所',
+      officeId: 'confirmed-office-id',
+      officeConfirmedBy: 'user-uid',
+      officeConfirmedAt: { seconds: 2, nanoseconds: 0 },
+      documentType: '確定書類種別',
+      category: 'confirmed-category',
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+
+    expect(merged.customerConfirmed).to.equal(true);
+    expect(merged.officeConfirmed).to.equal(true);
+    expect(merged.documentTypeConfirmed).to.equal(true);
+    expect(merged.customerName).to.equal('確定顧客');
+    expect(merged.officeName).to.equal('確定事業所');
+    expect(merged.documentType).to.equal('確定書類種別');
+  });
+
+  it('customerConfirmed=trueだがcurrent.customerIdがundefinedの場合、nullにフォールバックする(OCR値を継承しない)', () => {
+    const proposed = makeProposed({
+      customerConfirmed: true,
+      customerId: 'ocr-cust-id-should-not-leak',
+    });
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      customerName: '確定顧客',
+      // customerId未設定
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+
+    expect(merged.customerName).to.equal('確定顧客');
+    expect(merged.customerId).to.equal(null);
+  });
+
+  it('customerConfirmed=trueだがcurrent.confirmedBy/confirmedAtがundefinedの場合、nullにフォールバックする', () => {
+    const proposed = makeProposed({ customerConfirmed: true, confirmedBy: 'stale-uid' });
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      customerName: '確定顧客',
+      // confirmedBy/confirmedAt未設定
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+    expect(merged.confirmedBy).to.equal(null);
+    expect(merged.confirmedAt).to.equal(null);
+  });
+
+  it('customerConfirmed=trueだがcurrent.customerNameがundefinedの場合、proposedのcustomerNameにフォールバックする', () => {
+    const proposed = makeProposed({
+      customerConfirmed: true,
+      customerName: 'フォールバック顧客名',
+    });
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      // customerName未設定
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+    expect(merged.customerName).to.equal('フォールバック顧客名');
+  });
+
+  it('proposedオブジェクトを破壊的に変更しない(イミュータブル)', () => {
+    const proposed = makeProposed();
+    const proposedSnapshot = { ...proposed };
+    applyConfirmedFieldProtection(proposed, { customerConfirmed: true, customerName: '確定顧客' });
+    expect(proposed).to.deep.equal(proposedSnapshot);
+  });
+
+  it('proposedに保護対象外の余剰フィールドが含まれていても、そのまま保持される', () => {
+    const proposed = {
+      ...makeProposed(),
+      customerCandidates: [{ customerId: 'x', customerName: 'y' }],
+      extractionScores: { documentType: 90, customerName: 80, officeName: 70, date: 60 },
+    };
+    const merged = applyConfirmedFieldProtection(proposed, {
+      customerConfirmed: true,
+      customerName: '確定顧客',
+    });
+    expect(merged.customerCandidates).to.deep.equal(proposed.customerCandidates);
+    expect(merged.extractionScores).to.deep.equal(proposed.extractionScores);
+  });
+});

--- a/functions/test/confirmedFieldMerge.test.ts
+++ b/functions/test/confirmedFieldMerge.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { expect } from 'chai';
+import { Timestamp } from 'firebase-admin/firestore';
 import {
   applyConfirmedFieldProtection,
   type ConfirmedProtectableFields,
@@ -53,7 +54,7 @@ describe('applyConfirmedFieldProtection', () => {
 
   it('customerConfirmed=trueの場合、フラグ自体・顧客関連フィールド・確定者情報がcurrentの値で保護される', () => {
     const proposed = makeProposed({ customerConfirmed: true });
-    const fixedTimestamp = { seconds: 1234567890, nanoseconds: 0 };
+    const fixedTimestamp = Timestamp.fromMillis(1234567890 * 1000);
     const current: ConfirmedProtectionSnapshot = {
       customerConfirmed: true,
       customerName: '確定顧客',
@@ -98,7 +99,7 @@ describe('applyConfirmedFieldProtection', () => {
       officeName: '確定事業所',
       officeId: 'confirmed-office-id',
       officeConfirmedBy: 'user-uid-456',
-      officeConfirmedAt: { seconds: 1111111111, nanoseconds: 0 },
+      officeConfirmedAt: Timestamp.fromMillis(1111111111 * 1000),
     };
     const merged = applyConfirmedFieldProtection(proposed, current);
 
@@ -106,7 +107,7 @@ describe('applyConfirmedFieldProtection', () => {
     expect(merged.officeName).to.equal('確定事業所');
     expect(merged.officeId).to.equal('confirmed-office-id');
     expect(merged.officeConfirmedBy).to.equal('user-uid-456');
-    expect(merged.officeConfirmedAt).to.deep.equal({ seconds: 1111111111, nanoseconds: 0 });
+    expect(merged.officeConfirmedAt).to.deep.equal(Timestamp.fromMillis(1111111111 * 1000));
     // 顧客・書類種別はOCR提案のまま
     expect(merged.customerName).to.equal('OCR顧客');
     expect(merged.documentType).to.equal('OCR書類種別');
@@ -145,11 +146,11 @@ describe('applyConfirmedFieldProtection', () => {
       isDuplicateCustomer: false,
       needsManualCustomerSelection: false,
       confirmedBy: 'user-uid',
-      confirmedAt: { seconds: 1, nanoseconds: 0 },
+      confirmedAt: Timestamp.fromMillis(1000),
       officeName: '確定事業所',
       officeId: 'confirmed-office-id',
       officeConfirmedBy: 'user-uid',
-      officeConfirmedAt: { seconds: 2, nanoseconds: 0 },
+      officeConfirmedAt: Timestamp.fromMillis(2000),
       documentType: '確定書類種別',
       category: 'confirmed-category',
     };
@@ -161,6 +162,31 @@ describe('applyConfirmedFieldProtection', () => {
     expect(merged.customerName).to.equal('確定顧客');
     expect(merged.officeName).to.equal('確定事業所');
     expect(merged.documentType).to.equal('確定書類種別');
+  });
+
+  it('customerConfirmed=trueかつofficeConfirmed=false・documentTypeConfirmed=falseの混在時、確定済みグループのみ保護され残りはOCR提案が使われる', () => {
+    const proposed = makeProposed({
+      customerConfirmed: true,
+      officeConfirmed: false,
+      documentTypeConfirmed: false,
+    });
+    const current: ConfirmedProtectionSnapshot = {
+      customerConfirmed: true,
+      officeConfirmed: false,
+      documentTypeConfirmed: false,
+      customerName: '確定顧客',
+      customerId: 'confirmed-cust-id',
+    };
+    const merged = applyConfirmedFieldProtection(proposed, current);
+
+    expect(merged.customerConfirmed).to.equal(true);
+    expect(merged.customerName).to.equal('確定顧客');
+    expect(merged.customerId).to.equal('confirmed-cust-id');
+    // 事業所・書類種別は未確定のためOCR提案のまま
+    expect(merged.officeConfirmed).to.equal(false);
+    expect(merged.officeName).to.equal('OCR事業所');
+    expect(merged.documentTypeConfirmed).to.equal(false);
+    expect(merged.documentType).to.equal('OCR書類種別');
   });
 
   it('customerConfirmed=trueだがcurrent.customerIdがundefinedの場合、nullにフォールバックする(OCR値を継承しない)', () => {

--- a/functions/test/ocrProcessor.test.ts
+++ b/functions/test/ocrProcessor.test.ts
@@ -304,9 +304,22 @@ describe('ocrProcessor', () => {
     });
 
     // Issue #526: db.runTransaction()導入により新たに発生しうる書込競合エラー
-    it('Firestore ABORTED (transaction書込競合)はtransientと判定される', () => {
+    it('Firestore ABORTED (transaction書込競合、数値code)はtransientと判定される', () => {
+      const error = new Error('Too much contention on these documents.') as Error & {
+        code: number;
+      };
+      error.code = 10;
+      expect(isTransientError(error)).to.be.true;
+    });
+
+    it('Firestore ABORTED (transaction書込競合、メッセージのみ)はtransientと判定される', () => {
       const error = new Error('10 ABORTED: Too much contention on these documents.');
       expect(isTransientError(error)).to.be.true;
+    });
+
+    it('AbortControllerによる無関係な中断("The operation was aborted")はtransientと判定しない(過剰な広域一致の防止)', () => {
+      const error = new Error('The operation was aborted');
+      expect(isTransientError(error)).to.be.false;
     });
 
     // Vertex AI固有エラー形式の検出テスト (#194)

--- a/functions/test/ocrProcessor.test.ts
+++ b/functions/test/ocrProcessor.test.ts
@@ -303,6 +303,12 @@ describe('ocrProcessor', () => {
       expect(isTransientError(error)).to.be.true;
     });
 
+    // Issue #526: db.runTransaction()導入により新たに発生しうる書込競合エラー
+    it('Firestore ABORTED (transaction書込競合)はtransientと判定される', () => {
+      const error = new Error('10 ABORTED: Too much contention on these documents.');
+      expect(isTransientError(error)).to.be.true;
+    });
+
     // Vertex AI固有エラー形式の検出テスト (#194)
     it('VertexAI 429 Too Many Requestsはtransientと判定される', () => {
       const error = new Error('VertexAI.ClientError: 429 Too Many Requests');

--- a/functions/test/ocrProcessorConfirmedFieldWiringContract.test.ts
+++ b/functions/test/ocrProcessorConfirmedFieldWiringContract.test.ts
@@ -1,0 +1,60 @@
+/**
+ * ocrProcessor.ts の confirmed保護マージ配線契約テスト (Issue #526 D2)
+ *
+ * `applyConfirmedFieldProtection()` に渡す `ConfirmedProtectionSnapshot` は
+ * `freshData`(`FirebaseFirestore.DocumentData`、実質 `{[field: string]: any}`)から
+ * フィールド名を手動で写経する。tscはこのマッピングのtypo(例:
+ * `customerConfirmed: freshData.customerConfirm`)を検知できず、常に`undefined`
+ * (=保護無効)として黙って動作してしまう。本テストはこの配線をソース文字列レベルで
+ * lock-inする(docs/context/test-strategy.md §2.1 のgrep-based契約パターン踏襲、
+ * `ocrProcessorAggregateCallerContract.test.ts`が同種の前例)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('ocrProcessor confirmedFieldMerge wiring contract (Issue #526)', () => {
+  const source = readFileSync(
+    resolve(process.cwd(), 'src/ocr/ocrProcessor.ts'),
+    'utf-8'
+  );
+
+  const EXPECTED_FIELD_MAPPINGS = [
+    'customerConfirmed: freshData.customerConfirmed',
+    'officeConfirmed: freshData.officeConfirmed',
+    'documentTypeConfirmed: freshData.documentTypeConfirmed',
+    'customerName: freshData.customerName',
+    'customerId: freshData.customerId',
+    'careManager: freshData.careManager',
+    'isDuplicateCustomer: freshData.isDuplicateCustomer',
+    'needsManualCustomerSelection: freshData.needsManualCustomerSelection',
+    'confirmedBy: freshData.confirmedBy',
+    'confirmedAt: freshData.confirmedAt',
+    'officeName: freshData.officeName',
+    'officeId: freshData.officeId',
+    'officeConfirmedBy: freshData.officeConfirmedBy',
+    'officeConfirmedAt: freshData.officeConfirmedAt',
+    'documentType: freshData.documentType',
+    'category: freshData.category',
+  ];
+
+  for (const mapping of EXPECTED_FIELD_MAPPINGS) {
+    it(`applyConfirmedFieldProtection呼出が \`${mapping}\` を含む`, () => {
+      expect(source).to.include(mapping);
+    });
+  }
+
+  it('applyConfirmedFieldProtection呼出はdb.runTransaction()内に存在する(stale snapshot対策)', () => {
+    const transactionIndex = source.indexOf('db.runTransaction(');
+    const callIndex = source.indexOf('applyConfirmedFieldProtection(');
+    expect(transactionIndex).to.be.greaterThan(-1);
+    expect(callIndex).to.be.greaterThan(-1);
+    expect(callIndex).to.be.greaterThan(transactionIndex);
+  });
+
+  it('freshDataはtx.get(docRef)の結果から取得される(呼出時docDataではない)', () => {
+    expect(source).to.match(/const freshSnap = await tx\.get\(docRef\)/);
+    expect(source).to.match(/const freshData = freshSnap\.data\(\)/);
+  });
+});

--- a/functions/test/ocrProcessorPageResultsReuseWiringContract.test.ts
+++ b/functions/test/ocrProcessorPageResultsReuseWiringContract.test.ts
@@ -1,0 +1,42 @@
+/**
+ * ocrProcessor.ts の pageResults再利用(D3)配線契約テスト (Issue #526)
+ *
+ * `validatePageResultsForReuse()`自体はpageResultsReuse.test.tsで純粋関数として
+ * 検証済みだが、ocrProcessor.ts側が実際にこの関数を呼び出し、戻り値で正しく
+ * 分岐しているかは別問題(呼出漏れ・分岐条件のtypoはtscで検知できない)。
+ * 本テストはこの配線をソース文字列レベルでlock-inする
+ * (`ocrProcessorConfirmedFieldWiringContract.test.ts`が同種の前例)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('ocrProcessor pageResultsReuse wiring contract (Issue #526 D3)', () => {
+  const source = readFileSync(resolve(process.cwd(), 'src/ocr/ocrProcessor.ts'), 'utf-8');
+
+  it('validatePageResultsForReuseがdocData.pageResults/parentDocumentIdを引数に呼ばれる', () => {
+    expect(source).to.include(
+      'validatePageResultsForReuse(existingPageResults, docData.parentDocumentId)'
+    );
+  });
+
+  it('reusable=trueの分岐でexistingPageResultsをpageResults/totalPagesへ反映しページOCRをスキップする', () => {
+    const reuseBranchMatch = source.match(
+      /if \(reuseCheck\.reusable && existingPageResults\) \{([\s\S]*?)\} else \{/
+    );
+    expect(reuseBranchMatch, 'reuse branch (if reuseCheck.reusable && existingPageResults) not found')
+      .to.not.equal(null);
+    const branchBody = reuseBranchMatch![1];
+    expect(branchBody).to.include('pageResults = existingPageResults');
+    expect(branchBody).to.include('totalPages = existingPageResults.length');
+  });
+
+  it('reusable=falseの分岐は既存のダウンロード+ページ単位OCRループへフォールバックする', () => {
+    const elseIndex = source.indexOf('} else {', source.indexOf('validatePageResultsForReuse('));
+    expect(elseIndex).to.be.greaterThan(-1);
+    const afterElse = source.slice(elseIndex, elseIndex + 2000);
+    expect(afterElse).to.include('bucket.file(filePath)');
+    expect(afterElse).to.include('PDFDocument.load(buffer)');
+  });
+});

--- a/functions/test/ocrUpdatePayloadBuilder.test.ts
+++ b/functions/test/ocrUpdatePayloadBuilder.test.ts
@@ -80,7 +80,6 @@ function makeInputs(overrides: Partial<OcrUpdatePayloadInputs> = {}): OcrUpdateP
       confidence: 80,
       allCandidates: [],
     },
-    displayFileName: '請求書_山田太郎_20260115.pdf',
     savedOcrResult: 'page1 text',
     ocrResultUrl: null,
     pageResults,
@@ -96,7 +95,6 @@ describe('buildOcrExtractionUpdatePayload', () => {
   it('抽出結果が正常な場合、全フィールドを期待通りに構築する', () => {
     const payload = buildOcrExtractionUpdatePayload(makeInputs());
 
-    expect(payload.displayFileName).to.equal('請求書_山田太郎_20260115.pdf');
     expect(payload.ocrResult).to.equal('page1 text');
     expect(payload.ocrResultUrl).to.equal(null);
     expect(payload.pageResults).to.have.lengthOf(1);
@@ -139,6 +137,8 @@ describe('buildOcrExtractionUpdatePayload', () => {
     ]);
     expect(payload.suggestedNewOffice).to.equal(null);
     expect(payload.totalPages).to.equal(1);
+    // Issue #526 D2: OCR自身は確信度ベースのdocumentType自己確定シグナルを持たないため常にfalse
+    expect(payload.documentTypeConfirmed).to.equal(false);
     expect(payload.category).to.equal('billing');
     expect(payload.extractionScores).to.deep.equal({
       documentType: 90,
@@ -176,11 +176,6 @@ describe('buildOcrExtractionUpdatePayload', () => {
         matchType: 'exact',
       },
     });
-  });
-
-  it('displayFileNameがnullの場合、フィールド自体を含めない', () => {
-    const payload = buildOcrExtractionUpdatePayload(makeInputs({ displayFileName: null }));
-    expect(payload).to.not.have.property('displayFileName');
   });
 
   it('customerResult.bestMatchがnullの場合、デフォルト値(不明顧客/null)にフォールバックする', () => {

--- a/functions/test/pageResultsReuse.test.ts
+++ b/functions/test/pageResultsReuse.test.ts
@@ -4,8 +4,17 @@
 
 import { expect } from 'chai';
 import { validatePageResultsForReuse } from '../src/ocr/pageResultsReuse';
+import type { PageResultsReuseCheck } from '../src/ocr/pageResultsReuse';
 
 const PARENT_ID = 'parent-doc-1';
+
+function expectNotReusable(result: PageResultsReuseCheck, pattern: RegExp): void {
+  expect(result.reusable).to.equal(false);
+  if (result.reusable) {
+    throw new Error('unreachable: result.reusable was expected to be false');
+  }
+  expect(result.reason).to.match(pattern);
+}
 
 describe('validatePageResultsForReuse', () => {
   it('parentDocumentIdありでpageNumberが1..Nの連番かつ全ページ非空テキストなら再利用可能', () => {
@@ -28,44 +37,32 @@ describe('validatePageResultsForReuse', () => {
       ],
       undefined
     );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/not a split child/);
+    expectNotReusable(result, /not a split child/);
   });
 
   it('parentDocumentIdが空文字の場合、再利用不可', () => {
-    const result = validatePageResultsForReuse(
-      [{ pageNumber: 1, text: 'page1 text' }],
-      ''
-    );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/not a split child/);
+    const result = validatePageResultsForReuse([{ pageNumber: 1, text: 'page1 text' }], '');
+    expectNotReusable(result, /not a split child/);
   });
 
   it('parentDocumentIdが文字列でない場合、再利用不可', () => {
-    const result = validatePageResultsForReuse(
-      [{ pageNumber: 1, text: 'page1 text' }],
-      12345
-    );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/not a split child/);
+    const result = validatePageResultsForReuse([{ pageNumber: 1, text: 'page1 text' }], 12345);
+    expectNotReusable(result, /not a split child/);
   });
 
   it('pageResultsがundefinedの場合、再利用不可', () => {
     const result = validatePageResultsForReuse(undefined, PARENT_ID);
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/missing or empty/);
+    expectNotReusable(result, /missing or empty/);
   });
 
   it('pageResultsが空配列の場合、再利用不可', () => {
     const result = validatePageResultsForReuse([], PARENT_ID);
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/missing or empty/);
+    expectNotReusable(result, /missing or empty/);
   });
 
   it('pageResultsが配列でない場合、再利用不可', () => {
     const result = validatePageResultsForReuse('not-an-array', PARENT_ID);
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/missing or empty/);
+    expectNotReusable(result, /missing or empty/);
   });
 
   it('pageNumberに欠番がある場合(1,3のみ)、再利用不可', () => {
@@ -76,8 +73,7 @@ describe('validatePageResultsForReuse', () => {
       ],
       PARENT_ID
     );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/sequential/);
+    expectNotReusable(result, /sequential/);
   });
 
   it('pageNumberに重複がある場合(1,1,2)、再利用不可', () => {
@@ -89,11 +85,10 @@ describe('validatePageResultsForReuse', () => {
       ],
       PARENT_ID
     );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/sequential/);
+    expectNotReusable(result, /sequential/);
   });
 
-  it('pageNumberの並び順が入力配列内で前後していても、ソート後に連番なら再利用可能', () => {
+  it('pageNumberの並び順が配列内で前後している場合、再利用不可(呼出元は配列を並び替えずそのまま使うため、ソートありきの判定は誤ったページ順でのOCR結果結合を招く)', () => {
     const result = validatePageResultsForReuse(
       [
         { pageNumber: 2, text: 'page2' },
@@ -102,23 +97,29 @@ describe('validatePageResultsForReuse', () => {
       ],
       PARENT_ID
     );
-    expect(result.reusable).to.equal(true);
+    expectNotReusable(result, /in-order sequential/);
+  });
+
+  it('pageResultsにnull要素が混入している場合、例外を投げずreusable=falseを返す', () => {
+    const result = validatePageResultsForReuse([{ pageNumber: 1, text: 'page1' }, null], PARENT_ID);
+    expectNotReusable(result, /not objects/);
+  });
+
+  it('pageResultsに非オブジェクト要素(文字列)が混入している場合、例外を投げずreusable=falseを返す', () => {
+    const result = validatePageResultsForReuse(
+      [{ pageNumber: 1, text: 'page1' }, 'not-an-object'],
+      PARENT_ID
+    );
+    expectNotReusable(result, /not objects/);
   });
 
   it('pageNumberが数値でない場合、再利用不可', () => {
-    const result = validatePageResultsForReuse(
-      [{ pageNumber: '1', text: 'page1' }],
-      PARENT_ID
-    );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/sequential/);
+    const result = validatePageResultsForReuse([{ pageNumber: '1', text: 'page1' }], PARENT_ID);
+    expectNotReusable(result, /sequential/);
   });
 
   it('1件だけのpageResults(pageNumber=1)は正しく再利用可能と判定される', () => {
-    const result = validatePageResultsForReuse(
-      [{ pageNumber: 1, text: 'single page' }],
-      PARENT_ID
-    );
+    const result = validatePageResultsForReuse([{ pageNumber: 1, text: 'single page' }], PARENT_ID);
     expect(result.reusable).to.equal(true);
   });
 
@@ -130,8 +131,7 @@ describe('validatePageResultsForReuse', () => {
       ],
       PARENT_ID
     );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/empty text/);
+    expectNotReusable(result, /empty text/);
   });
 
   it('いずれかのページのtextが空白のみの場合、再利用不可', () => {
@@ -142,22 +142,16 @@ describe('validatePageResultsForReuse', () => {
       ],
       PARENT_ID
     );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/empty text/);
+    expectNotReusable(result, /empty text/);
   });
 
   it('textフィールドが欠落している場合、再利用不可', () => {
     const result = validatePageResultsForReuse([{ pageNumber: 1 }], PARENT_ID);
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/empty text/);
+    expectNotReusable(result, /empty text/);
   });
 
   it('textが文字列でない場合、再利用不可', () => {
-    const result = validatePageResultsForReuse(
-      [{ pageNumber: 1, text: 123 }],
-      PARENT_ID
-    );
-    expect(result.reusable).to.equal(false);
-    expect(result.reason).to.match(/empty text/);
+    const result = validatePageResultsForReuse([{ pageNumber: 1, text: 123 }], PARENT_ID);
+    expectNotReusable(result, /empty text/);
   });
 });

--- a/functions/test/pageResultsReuse.test.ts
+++ b/functions/test/pageResultsReuse.test.ts
@@ -1,0 +1,163 @@
+/**
+ * pageResultsReuse.ts のテスト (Issue #526 D3)
+ */
+
+import { expect } from 'chai';
+import { validatePageResultsForReuse } from '../src/ocr/pageResultsReuse';
+
+const PARENT_ID = 'parent-doc-1';
+
+describe('validatePageResultsForReuse', () => {
+  it('parentDocumentIdありでpageNumberが1..Nの連番かつ全ページ非空テキストなら再利用可能', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 1, text: 'page1 text' },
+        { pageNumber: 2, text: 'page2 text' },
+        { pageNumber: 3, text: 'page3 text' },
+      ],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(true);
+  });
+
+  it('parentDocumentIdがundefinedの場合、構造が有効でも再利用不可(分割子ドキュメントでない)', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 1, text: 'page1 text' },
+        { pageNumber: 2, text: 'page2 text' },
+      ],
+      undefined
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/not a split child/);
+  });
+
+  it('parentDocumentIdが空文字の場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [{ pageNumber: 1, text: 'page1 text' }],
+      ''
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/not a split child/);
+  });
+
+  it('parentDocumentIdが文字列でない場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [{ pageNumber: 1, text: 'page1 text' }],
+      12345
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/not a split child/);
+  });
+
+  it('pageResultsがundefinedの場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(undefined, PARENT_ID);
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/missing or empty/);
+  });
+
+  it('pageResultsが空配列の場合、再利用不可', () => {
+    const result = validatePageResultsForReuse([], PARENT_ID);
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/missing or empty/);
+  });
+
+  it('pageResultsが配列でない場合、再利用不可', () => {
+    const result = validatePageResultsForReuse('not-an-array', PARENT_ID);
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/missing or empty/);
+  });
+
+  it('pageNumberに欠番がある場合(1,3のみ)、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 1, text: 'page1' },
+        { pageNumber: 3, text: 'page3' },
+      ],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/sequential/);
+  });
+
+  it('pageNumberに重複がある場合(1,1,2)、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 1, text: 'a' },
+        { pageNumber: 1, text: 'b' },
+        { pageNumber: 2, text: 'c' },
+      ],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/sequential/);
+  });
+
+  it('pageNumberの並び順が入力配列内で前後していても、ソート後に連番なら再利用可能', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 2, text: 'page2' },
+        { pageNumber: 1, text: 'page1' },
+        { pageNumber: 3, text: 'page3' },
+      ],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(true);
+  });
+
+  it('pageNumberが数値でない場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [{ pageNumber: '1', text: 'page1' }],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/sequential/);
+  });
+
+  it('1件だけのpageResults(pageNumber=1)は正しく再利用可能と判定される', () => {
+    const result = validatePageResultsForReuse(
+      [{ pageNumber: 1, text: 'single page' }],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(true);
+  });
+
+  it('いずれかのページのtextが空文字の場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 1, text: 'page1' },
+        { pageNumber: 2, text: '' },
+      ],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/empty text/);
+  });
+
+  it('いずれかのページのtextが空白のみの場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [
+        { pageNumber: 1, text: 'page1' },
+        { pageNumber: 2, text: '   ' },
+      ],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/empty text/);
+  });
+
+  it('textフィールドが欠落している場合、再利用不可', () => {
+    const result = validatePageResultsForReuse([{ pageNumber: 1 }], PARENT_ID);
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/empty text/);
+  });
+
+  it('textが文字列でない場合、再利用不可', () => {
+    const result = validatePageResultsForReuse(
+      [{ pageNumber: 1, text: 123 }],
+      PARENT_ID
+    );
+    expect(result.reusable).to.equal(false);
+    expect(result.reason).to.match(/empty text/);
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #526 (kaname要望E: 手動分割後の子ドキュメントをOCR再処理パイプラインに乗せる) の実装計画PR3/5
- `processDocument()`に以下3機能を追加(D1=既存後段処理切出し[PR2]、D2=confirmed保護マージ+transaction化、D3=pageResults再利用、の略記をコミットメッセージ内で使用):
  1. **confirmed保護マージ [D2]** (`confirmedFieldMerge.ts`新規): `customerConfirmed`/`officeConfirmed`/`documentTypeConfirmed`とその関連フィールド(customerName/customerId/careManager/isDuplicateCustomer/needsManualCustomerSelection/confirmedBy/confirmedAt等)を、フレッシュなOCR抽出結果で上書きしないよう保護
  2. **Firestore transaction化 [D2]**: マージ判定をtransaction内で処理完了直前に再読み込みした最新ドキュメント状態に基づいて実施(stale snapshot対策)。`displayFileName`もマージ後の最終メタから生成する順序に変更
  3. **pageResults再利用 [D3]** (`pageResultsReuse.ts`新規): 分割子ドキュメント(`parentDocumentId`を持つ)が親から継承した`pageResults`が構造的に有効(連番・非空)なら、Storageダウンロード+ページ単位OCRをスキップして再利用(コスト削減)

## ⚠️ 重要な注記
**本PR単独ではkaname要望Eの実運用解消には至りません。** `splitPdf`(`pdfOperations.ts`)が子ドキュメントを`status: 'processed'`で生成する現状は本PRでは未変更のため、本PRで実装したロジック(pageResults再利用・confirmed保護マージ)は後続PR(splitPdf統合、`status: 'pending'`への切替)が実装されるまで実運用では到達しません。Issue #526の完了には後続PRが必須です。

## レビュープロセス
1. **evaluator** (Acceptance Criteria 10項目、前提知識なしで独立評価): AC1〜10全てPASS。2件のMEDIUM指摘を受け修正:
   - pageResults再利用が構造チェック(連番+非空)のみに依存 → `parentDocumentId`(#445 provenance)の存在を必須条件に追加
   - `db.runTransaction()`化で新たに生じるFirestore ABORTED競合が`isTransientError()`未対応 → 追加
2. **`/review-pr` (5エージェント並列) + `codex review --base main`**: 検出事項を全て反映:
   - (codex) pageResults再利用のページ順序チェックがソートベースで、呼出元が並び替えない配列に対して誤った結合順を許してしまう不備 → 配列内での「並び順どおりの連番」を必須化
   - (codex) `pageResults`要素の型ガード欠如(null/非オブジェクト混入時に例外) → `isPlainObject`ガード追加
   - (type-design-analyzer) `confirmedBy`/`confirmedAt`等が`unknown`型で緩すぎる → `string | null` / `Timestamp | null`へ精密化
   - (type-design-analyzer) `PageResultsReuseCheck`を`{reusable: boolean; reason?: string}`から判別可能なunion型へ変更
   - (comment-analyzer) `parentDocumentId`と構造化`provenance`フィールド(ADR-0016)の用語混同、レビュー内部プロセスへの言及コメントを解消
   - (pr-test-analyzer) D3(pageResults再利用)のocrProcessor.ts配線契約テストがD2非対称で欠如 → 追加
   - (pr-test-analyzer) confirmedフラグの混在パターン(customerConfirmed=true かつ他2つ=false)のテストが欠如 → 追加
   - (silent-failure-hunter) Firestore ABORTED (gRPC code 10)が`isTransientError()`未対応で自動リトライされず即エラー確定 → 追加(`retry.ts`)
   - (silent-failure-hunter) transaction内でドキュメントが削除された場合の扱いが未定義 → `!freshSnap.exists`チェック追加
3. **pr-review-toolkit code-reviewer**: Critical/Important指摘なし。Suggestion 1件(displayFileName生成の冗長なガード)を反映済み

## Test plan
- [x] `npm run type-check:test` PASS
- [x] `npm test` (functions全体、統合テスト除く) 1581 passing / 6 pending / 0 failing
- [x] `npm run lint` 0 errors (既存warningのみ)
- [x] `npm run build` (tsc) PASS
- [x] 新規純粋関数(`validatePageResultsForReuse`: 18ケース、`applyConfirmedFieldProtection`: 14ケース)を正常系・境界値・異常系で網羅
- [x] `ocrProcessorConfirmedFieldWiringContract.test.ts` (D2) / `ocrProcessorPageResultsReuseWiringContract.test.ts` (D3、新規) の2本のgrep契約テストで配線コードのtypo検知をlock-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCR processing can now reuse previously extracted page results when they are valid, reducing repeat work.
  * Confirmed OCR fields are now protected during updates, helping preserve user-verified values.
  * Retry handling now treats write-contention “aborted” errors as transient, improving recovery from temporary failures.

* **Bug Fixes**
  * OCR updates now use a safer transaction-based write flow to reduce stale-data conflicts.
  * Document type confirmation is now consistently reset in new extraction updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
