### PR TITLE
feat(pdf): splitPdf子ドキュメントをpending生成へ切替 (Issue #526 PR4/5)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -617,7 +617,12 @@ export const splitPdf = onCall(
             fileDate: docData.fileDate,
             totalPages: endPage - startPage + 1,
             targetPageNumber: 1,
-            status: 'processed',
+            // Issue #526 PR4: 子ドキュメントをOCR再処理パイプライン(processOCRポーリング)に
+            // 乗せるため'pending'で生成する(旧実装は'processed'固定でパイプライン未到達だった)。
+            // parentDocumentId(直下)がPR3のpageResults再利用条件を満たすため、フルOCR再実行
+            // ではなくconfirmed保護マージのみが実行される想定(processedAtは既に設定済みのため
+            // 既存のprocessOCRクエリに追加配線なしで乗る)。
+            status: 'pending',
             parentDocumentId: documentId,
             splitFromPages: { start: startPage, end: endPage },
             provenance,

--- a/functions/test/splitPdfChildStatusPendingContract.test.ts
+++ b/functions/test/splitPdfChildStatusPendingContract.test.ts
@@ -1,0 +1,57 @@
+/**
+ * splitPdf 子ドキュメント status:'pending' 契約テスト (Issue #526 PR4)
+ *
+ * 背景: 子ドキュメントは以前 `status: 'processed'` で直接生成され、OCR再処理パイプライン
+ * (`processOCR`ポーリング)を経由しなかった。PR3で実装済みのconfirmed保護マージ/pageResults
+ * 再利用ロジックを実運用で到達させるため、子を`status: 'pending'`で生成しパイプラインに
+ * 乗せるよう変更した。
+ *
+ * このテストは、子ドキュメントpayload構築ブロックが`status: 'pending'`に固定されており、
+ * 旧実装の`status: 'processed'`直書きが残っていないことをsource文字列レベルでlock-inする
+ * (`splitPdfChildConfirmedAttributionContract.test.ts`と同形式)。
+ *
+ * 親ドキュメントの`status: 'split'`更新(`splitPdfPayloadContract.test.ts`が別途lock-in)とは
+ * 対象ブロックが異なるため、本テストは子payloadブロックに限定して検証する
+ * (ファイル全体走査だと親update側の`status: 'split'`等、無関係な箇所まで巻き込みうるため)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const SOURCE_PATH = 'src/pdf/pdfOperations.ts';
+const PAYLOAD_ANCHOR = /const payload: Record<string, unknown> = \{/;
+
+let payloadBlock: string | null = null;
+let sourceText = '';
+
+describe('splitPdf 子ドキュメント status:pending 契約 (Issue #526 PR4)', () => {
+  before(() => {
+    const path = resolve(__dirname, '..', SOURCE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Source file not found: ${SOURCE_PATH}`);
+    }
+    sourceText = readFileSync(path, 'utf-8');
+    payloadBlock = extractBraceBlock(sourceText, PAYLOAD_ANCHOR, {
+      anchorMode: 'from-start',
+    });
+    expect(payloadBlock, 'splitPdf 子ドキュメント payload block not found').to.not.equal(null);
+  });
+
+  it('子payloadブロックに status: \'pending\' が含まれる', () => {
+    expect(payloadBlock).to.match(/status:\s*'pending'/);
+  });
+
+  it('子payloadブロックに status: \'processed\' の直書きが残っていない(旧実装の巻き戻り防止)', () => {
+    expect(payloadBlock).to.not.match(/status:\s*'processed'/);
+  });
+
+  it('子payloadブロックに processedAt が設定されている(processOCRポーリングクエリのorderBy対象)', () => {
+    expect(payloadBlock).to.match(/processedAt:\s*admin\.firestore\.FieldValue\.serverTimestamp\(\)/);
+  });
+
+  it('子payloadブロックに parentDocumentId: documentId が設定されている(pageResults再利用条件)', () => {
+    expect(payloadBlock).to.match(/parentDocumentId:\s*documentId/);
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #526 (kaname要望E: 手動分割後の子ドキュメントをOCR再処理パイプラインに乗せる) の実装計画PR4/5
- `splitPdf`(`functions/src/pdf/pdfOperations.ts`)が子ドキュメントを`status: 'processed'`で直接生成していた箇所を`status: 'pending'`へ変更
- `processedAt`は既にpayloadに設定済みのため、`processOCR`ポーリング(`status=='pending'`をorderBy('processedAt')でクエリ、1分間隔)に追加配線なしで自然に乗る
- これによりPR3(#543)で実装済みの`confirmedFieldMerge.ts`(confirmed保護マージ)+`pageResultsReuse.ts`(pageResults再利用判定)が実運用で初めて到達可能になる

## 事前調査で確認した事実(変更不要と判断した箇所)
- 子ドキュメントpayloadは既に`parentDocumentId`+1..N連番の`pageResults`を構築済みで、PR3のreuse条件(連番・非空・parentDocumentId必須)を構造的に満たす
- `buildSplitDocumentData()`(PR1で確定フラグをフロントエンド送信値のまま反映するよう修正済み)によるsegment値ベースの初期構築は、confirmed=trueのフィールドがconfirmed保護マージ時に「子ドキュメント自身の初期値」から継承される設計のため変更不要
- 親ドキュメントの`status: 'split'`/`splitInto`/`isSplitSource`更新は本変更と無関係(既存契約テストで別途lock-in済み)
- フロントエンド(`PdfSplitModal.tsx`/`usePdfSplit.ts`/`DocumentDetailModal.tsx`)は分割成功時に子ドキュメントが`processed`である前提のUIを持たず、既存の汎用ステータス表示(「処理中」ラベル、3秒間隔ポーリング)がそのまま機能するため変更不要
- Issue #432安全策(docId namespace分離・3段階snapshot drift検知・Storage rollback・batch atomic commit)は全てchild payloadの`status`値と無関係

## レビュープロセス
Codex(`mcp__codex__codex`, plan mode, effort=high)へ計画段階でセカンドオピニオンを依頼し、2件のHigh指摘を実地検証した:
1. **デプロイ順序リスク**: `deploy.yml`(dev自動)/`deploy-functions.yml`(cocoro/kaname手動)はいずれも`firebase deploy --only functions`でfunctions全体を一括デプロイする構造のため、「splitPdfだけ新・processOCRだけ旧」という部分的デプロイは発生しないことを確認。ただし**cocoro/kanameoneは現在mainより19コミット遅れており(最終デプロイ2026-06-12、headSha `2a27844`)、Issue #526のPR1〜4は未反映**であることを確認(`gh run list --workflow=deploy-functions.yml`で検証)。本PRのmerge・devデプロイのみでは実運用影響はなく、cocoro/kaname展開は別途判断が必要
2. **pendingキューのhead-of-line blocking**: `processOCR.ts:88-93`の`BATCH_SIZE=5`固定ポーリングで、先頭5件全てが`retryAfter`未到達の場合に後続ドキュメント(新規分割子含む)が滞留しうる既存の構造的制限を確認。PR4固有の新規バグではないため本PRスコープには含めず、監視対象として記録(実際に滞留が観測された場合のみ別Issue化)

## Test plan
- [x] `npm run type-check:test` PASS
- [x] `npm test` (functions全体、統合テスト除く) 1585 passing / 6 pending / 0 failing
- [x] `npm run lint` 0 errors (既存warningのみ)
- [x] `npm run build` (tsc) PASS
- [x] 新規grep契約テスト(`splitPdfChildStatusPendingContract.test.ts`)で子payloadブロック内の`status: 'pending'`固定+旧実装`'processed'`の巻き戻り防止をlock-in
- [x] 既存契約テスト(`splitPdfPayloadContract`/`splitPdfDocIdNamespace`/`splitPdfProvenanceContract`/`splitPdfChildConfirmedAttributionContract`/`splitDocumentBuilder`)全てPASS継続を確認(53 passing)
- [x] dev環境デプロイ後、合成PDFアップロード→手動分割→約1分待機→`pending→processing→processed`遷移+confirmed値保持+displayFileName再生成をログ・実機で確認(マージ後に実施)

### dev実機検証結果 (2026-07-04)
Playwright MCPで3ページ合成PDFをアップロード→2セグメントに手動分割(セグメント1は顧客「鈴木一郎」を明示選択=confirmed=true、セグメント2は未選択のまま)→約1分待機。

Cloud Loggingで確認した実際のログ:
```
Found 2 pending documents
Processing document: Cg3Lsx0s9w8cRQCfHQR0
Reusing existing pageResults for Cg3Lsx0s9w8cRQCfHQR0 (1 pages), skipping page OCR
Document Cg3Lsx0s9w8cRQCfHQR0 processed: 未判定, 鈴木一郎
Processing document: RRfuLs2A4UXpvGx4xqbh
Reusing existing pageResults for RRfuLs2A4UXpvGx4xqbh (2 pages), skipping page OCR
Document RRfuLs2A4UXpvGx4xqbh processed: 未判定, 不明顧客
```

UI確認: confirmed選択したセグメント1は最終的に顧客名「鈴木一郎」+担当ケアマネ「佐藤花子」(鈴木一郎のマスターデータ由来)を保持したまま`processed`に到達し、displayFileNameも`鈴木一郎.pdf`へ再生成された。未確定のセグメント2は「不明顧客」のままOCR自己判定に委ねられた。pageResults再利用によりフルOCR再実行なしで完走しており、pendingキューの滞留も発生しなかった。検証後、テストデータ(親+子2件)はUIから削除しdev環境を元の154件に復元済み。

⚠️ **本PR単独ではcocoro/kaname環境の実運用には反映されません**(上記の通りデプロイが19コミット遅れているため)。cocoro/kaname展開は別途デプロイ判断が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated newly split documents to start in a pending state, helping ensure they follow the correct downstream processing flow.
* **Tests**
  * Added coverage to protect the expected split-document status and related payload fields from regressing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
