### PR TITLE
docs(deploy): cocoroのFunctions CI経路+Firestoreルールデプロイ手順を追記

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -82,7 +82,16 @@ rm frontend/.env.local
 
 Functionsデプロイ：
 ```bash
+# ローカル手動実行
 firebase deploy --only functions -P cocoro
+
+# GitHub Actions経由（推奨、SA鍵はGitHub Secretsから自動取得されるためローカルSA activate不要）
+gh workflow run "Deploy Cloud Functions" -f environment=cocoro
+```
+
+Firestore/Storageルール + インデックスデプロイ（**MUST**: schema変更時。Firebase CLIログインアカウント`hy.unimail.11@gmail.com`のまま実行可能なはず、`deploy-to-project.sh`のgcloud認証チェック(SA前提)を経由しない単純な`firebase`コマンドのため。**未検証**、実行時に要確認）：
+```bash
+firebase deploy --only firestore:rules,firestore:indexes,storage -P cocoro
 ```
 
 ### 全クライアント一括


### PR DESCRIPTION
## Summary
- Issue #526 PR5計画中に、`/deploy` skillのcocoroセクションに以下の空白があることが判明したため修正
- functionsのGitHub Actions経由デプロイ(`gh workflow run "Deploy Cloud Functions" -f environment=cocoro`)がSA鍵をGitHub Secretsから自動取得できることが明記されていなかった
- Firestore/Storageルール+インデックスのcocoro向けデプロイコマンド自体が未記載だった(hosting/functionsの手動手順のみ記載)

## 根拠
`scripts/deploy-to-project.sh`の実装を確認したところ、rulesデプロイの実体は`firebase deploy --only firestore:rules,firestore:indexes,storage -P <alias>`という単純なfirebaseコマンドで、gcloud認証チェック(SA前提)はスクリプト側の安全装置に過ぎない。hostingのcocoro手動手順が同様の理屈でeditorアカウント(`hy.unimail.11@gmail.com`)のFirebase CLIログインのまま実行できているため、rulesも同じパターンで通るはずと判断した。**ただし実際にcocoroへ試したことはないため、SKILL.md上も「未検証、実行時に要確認」と明記している。**

## Test plan
- [x] ドキュメントのみの変更のため、構文確認(Markdown)で十分と判断
- [ ] 次回cocoroへのrules展開時(Issue #526 PR5想定)に実際にこのコマンドで通るか確認し、失敗した場合はSKILL.mdを追って修正する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment instructions to include both local manual execution and the GitHub Actions workflow.
  * Added guidance for deploying Firestore rules, indexes, and Storage settings alongside Functions.
  * Clarified the available deployment options with updated notes for safer, more complete releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->