### PR TITLE
feat(cost): AI要約の自動生成をスキップ (Issue #548-B1)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -26,12 +26,9 @@ import {
 } from '../utils/extractors';
 import { generateDisplayFileName } from '../../../shared/generateDisplayFileName';
 import { loadMasterData } from '../utils/loadMasterData';
-import { buildSummaryFields } from './summaryRequestBuilder';
-import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
 import {
   capPageResultsAggregate,
 } from '../utils/textCap';
-import type { SummaryField } from '../../../shared/types';
 import { buildPageResult, type RawPageOcrResult } from './buildPageResult';
 import { buildOcrExtractionUpdatePayload } from './ocrUpdatePayloadBuilder';
 import { validatePageResultsForReuse } from './pageResultsReuse';
@@ -250,23 +247,7 @@ export async function processDocument(
     .map((p) => `--- Page ${p.pageNumber} ---\n${p.text}`)
     .join('\n\n');
 
-  // マスターデータ取得（要約生成と並列実行）
-  // Issue #266: 通常は generateSummary 内部 catch で吸収されるため本 catch には到達しない。
-  // inner catch の regression や Promise 化されていない throw 経路に対する二重防御として残置。
-  // safeLogError 経由で silent failure を防ぎ、errors collection から検知可能にする。
-  const summaryPromise = generateSummary(ocrResult, '', { docId, functionName }).catch(
-    async (err) => {
-      console.error('Summary generation failed:', err);
-      await safeLogError({
-        error: err instanceof Error ? err : new Error(String(err)),
-        source: 'ocr',
-        functionName: `${functionName}:summaryPromise`,
-        documentId: docId,
-      });
-      return { text: '', truncated: false } satisfies SummaryField;
-    }
-  );
-
+  // マスターデータ取得
   const { documents, customers, offices } = await loadMasterData(db, {
     source: 'ocr',
     functionName: 'ocrProcessor',
@@ -311,9 +292,6 @@ export async function processDocument(
     ocrResultUrl = await saveOcrResult(docId, ocrResult);
     savedOcrResult = '';
   }
-
-  // 要約生成を待機
-  const summary = await summaryPromise;
 
   // Issue #526 D1: 抽出結果の集約ロジックは ocrUpdatePayloadBuilder.ts の純粋関数に
   // 切り出し済み(挙動不変、ユニットテストで契約をlock-in)。displayFileNameはここでは
@@ -381,13 +359,15 @@ export async function processDocument(
     });
 
     // ドキュメント更新
-    // Issue #215: summary を discriminated union ネスト型で書き込み、
-    // 旧フラット3フィールド (summaryTruncated / summaryOriginalLength) は削除。
-    // 旧 summary (string型) は新 summary (object型) で上書きされる。
+    // Issue #548-B1: 要約は自動生成しない (regenerateSummary onCall 経由の手動生成のみ)。
+    // OCR再実行のたびに summary を無効化することで、documentType/customerName/officeName等が
+    // 更新されたのに古い内容の要約が残存する不整合 (429自動rescue・fix-stuck-documents.js等、
+    // getReprocessClearFields()を経由しない再処理経路でも発生しうる) を構造的に防ぐ。
+    // 旧フラット3フィールド (summaryTruncated/summaryOriginalLength) も後方互換のため同時削除。
     tx.update(docRef, {
       ...merged,
       ...(displayFileName ? { displayFileName } : {}),
-      summary: buildSummaryFields(summary),
+      summary: admin.firestore.FieldValue.delete(),
       summaryTruncated: admin.firestore.FieldValue.delete(),
       summaryOriginalLength: admin.firestore.FieldValue.delete(),
       status: 'processed',
@@ -585,37 +565,6 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
   );
 
   return { text, inputTokens, outputTokens, thinkingTokens };
-}
-
-/**
- * OCR結果からAI要約を生成 (Issue #209, Issue #214, #258, #266)
- *
- * Precondition: core の `generateSummaryCore` は `length < MIN_OCR_LENGTH_FOR_SUMMARY` を許容しない。
- * 本 helper はその precondition を先に消化し、短文時は empty SummaryField を返して後続処理を継続する。
- * Vertex AI エラーは catch → empty 返却で best-effort (呼出元 `summaryPromise` の `.catch(empty)` と二重防御)。
- * Issue #266: catch 句で logError 呼出を追加し、silent failure を防ぐ。
- * @returns SummaryField - text(切り詰め後summary), truncated(切り詰めフラグ), originalLength(truncated=true 時のみ)
- */
-async function generateSummary(
-  ocrResult: string,
-  documentType: string,
-  logContext: { docId: string; functionName: string }
-): Promise<SummaryField> {
-  if (!ocrResult || ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {
-    return { text: '', truncated: false };
-  }
-  try {
-    return await generateSummaryCore(ocrResult, documentType);
-  } catch (error) {
-    console.error('Failed to generate summary:', error);
-    await safeLogError({
-      error: error instanceof Error ? error : new Error(String(error)),
-      source: 'ocr',
-      functionName: `${logContext.functionName}:generateSummary`,
-      documentId: logContext.docId,
-    });
-    return { text: '', truncated: false };
-  }
 }
 
 /**

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -363,7 +363,8 @@ export async function processDocument(
     // OCR再実行のたびに summary を無効化することで、documentType/customerName/officeName等が
     // 更新されたのに古い内容の要約が残存する不整合 (429自動rescue・fix-stuck-documents.js等、
     // getReprocessClearFields()を経由しない再処理経路でも発生しうる) を構造的に防ぐ。
-    // 旧フラット3フィールド (summaryTruncated/summaryOriginalLength) も後方互換のため同時削除。
+    // summary/summaryTruncated/summaryOriginalLengthの3フィールドを同時削除する。
+    // 後2者はIssue #215以前の旧フラット形式の残骸クリーンアップ(前方互換とは無関係)。
     tx.update(docRef, {
       ...merged,
       ...(displayFileName ? { displayFileName } : {}),

--- a/functions/src/ocr/summaryGenerator.ts
+++ b/functions/src/ocr/summaryGenerator.ts
@@ -1,9 +1,10 @@
 /**
  * OCR結果から Vertex AI Gemini で要約を生成する共通コア関数 (Issue #214)
  *
- * ocrProcessor.ts / regenerateSummary.ts に分散していた重複実装
- * (generateSummary / generateSummaryInternal) を集約。
- * 関数本体は完全同一で、差分は呼び出し元のエラー処理 (catch 返却 vs throw) のみ。
+ * 導入時 (#214) は ocrProcessor.ts / regenerateSummary.ts に分散していた重複実装
+ * (generateSummary / generateSummaryInternal) を集約したもの。
+ * Issue #548-B1: ocrProcessor.ts は自動要約生成を廃止し呼び出し元から外れたため、
+ * 現在の caller は regenerateSummary.ts のみ (SUMMARY_FREE_CALLERS契約でlock-in済)。
  * エラー伝搬は caller 側の try/catch で差別化する。
  *
  * 関連:
@@ -24,7 +25,7 @@ import { buildSummaryPrompt } from './summaryPromptBuilder';
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
 
-// 要約生成を行う最小 OCR 文字数。caller 側 (ocrProcessor / regenerateSummary) で
+// 要約生成を行う最小 OCR 文字数。caller 側 (regenerateSummary.ts) で
 // 閾値同期漏れが起きないよう単一定数化。
 export const MIN_OCR_LENGTH_FOR_SUMMARY = 100;
 
@@ -33,7 +34,6 @@ export const MIN_OCR_LENGTH_FOR_SUMMARY = 100;
  *
  * - 呼び出し前提: `ocrResult` は非空文字列。短文ガード (例: `length < 100`) は caller 責任。
  * - エラー時: throw する (catch は caller 責任)。
- *   - ocrProcessor: empty SummaryField を返して後続処理を継続
  *   - regenerateSummary: console.error 後 rethrow し onCall handler が internal error 化
  */
 export async function generateSummaryCore(
@@ -41,7 +41,7 @@ export async function generateSummaryCore(
   documentType: string
 ): Promise<SummaryField> {
   // 新 caller が短文ガードを忘れた場合の safety net (type-design-analyzer 指摘)。
-  // 既存 caller (ocrProcessor / regenerateSummary) は手前で同じ閾値チェック済のため到達しない。
+  // 既存 caller (regenerateSummary) は手前で同じ閾値チェック済のため到達しない。
   if (ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {
     throw new Error(
       `generateSummaryCore: ocrResult must be at least ${MIN_OCR_LENGTH_FOR_SUMMARY} chars (actual=${ocrResult.length})`

--- a/functions/test/summaryBuilderCallerContract.test.ts
+++ b/functions/test/summaryBuilderCallerContract.test.ts
@@ -5,12 +5,14 @@
  * summary 暴走再発防止)。builder 側 canary だけでは caller bypass を見逃すため、caller
  * 呼出パターンを静的に lock-in する。
  *
- * 背景 (#214 リファクタ): summaryGenerator.ts が唯一の Vertex AI caller、ocrProcessor /
- * regenerateSummary は generateSummaryCore() 経由に統一。
+ * 背景 (#214 リファクタ): summaryGenerator.ts が唯一の Vertex AI caller、regenerateSummary は
+ * generateSummaryCore() 経由に統一。Issue #548-B1: ocrProcessor.ts の自動要約生成は削除され、
+ * 要約生成は regenerateSummary (手動トリガー) のみに一本化された。
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。
  * 既知の limitation: 型 alias 経由 (const gen = xxx.generateContent; gen(...)) や分割代入は
- * 未検出。caller 追加時は CALLER_FILES / CORE_CALLERS への手動追記が必要 (grep 動的検出は未導入)。
+ * 未検出。caller 追加時は CALLER_FILES / CORE_CALLERS / SUMMARY_FREE_CALLERS への手動追記が
+ * 必要 (grep 動的検出は未導入)。
  * 昇格条件: false negative が 1 件でも実発生した時点で sinon spy (案A) へ切替。
  *
  * 将来委譲: false negative 実発生時に sinon spy 契約テスト (案A) へ切替予定。
@@ -33,7 +35,13 @@ const CORE_DELEGATE_PATTERN = /generateSummaryCore\s*\(/g;
 const CALLER_FILES = ['src/ocr/summaryGenerator.ts'];
 
 // Issue #214: 要約生成は generateSummaryCore に委譲される caller 群
-const CORE_CALLERS = ['src/ocr/ocrProcessor.ts', 'src/ocr/regenerateSummary.ts'];
+// Issue #548-B1: ocrProcessor.ts の自動要約生成は削除。要約生成は regenerateSummary
+// (手動トリガー) のみに集約された。
+const CORE_CALLERS = ['src/ocr/regenerateSummary.ts'];
+
+// Issue #548-B1: ocrProcessor.ts が要約生成に一切関与しない (bypass 復活防止) ことを
+// 別途 lock-in する caller 群。
+const SUMMARY_FREE_CALLERS = ['src/ocr/ocrProcessor.ts'];
 
 /**
  * 行頭 `//` コメント行を除去。コメントアウトされた呼び出しを「存在する」と
@@ -82,14 +90,38 @@ describe('generateSummary delegation contract (Issue #214)', () => {
     it(`${relPath} は model.generateContent を直接呼ばない (bypass 防止)`, () => {
       const absPath = resolve(process.cwd(), relPath);
       const source = stripLineComments(readFileSync(absPath, 'utf-8'));
-      // OCR 経路 (ocrProcessor.ts) は別目的で model.generateContent を呼ぶため、
-      // buildSummaryGenerationRequest と組み合わさった "summary 用" 呼び出しのみを禁止する。
       const summaryCallCount = countMatches(source, BUILDER_CALL_PATTERN);
       expect(summaryCallCount).to.equal(
         0,
         `${relPath} で model.generateContent(buildSummaryGenerationRequest(...)) の直接呼び出しを検出。` +
           'Issue #214 のリファクタ後、summary 生成は summaryGenerator.ts に集約されているため、' +
           'caller からの直接呼び出しは bypass と見なします。'
+      );
+    });
+  }
+});
+
+describe('generateSummary 不在契約 (Issue #548-B1)', () => {
+  // ocrProcessor.ts の自動要約生成 (summaryPromise) は削除済み。復活 (再bypass) を検知する。
+  for (const relPath of SUMMARY_FREE_CALLERS) {
+    it(`${relPath} は generateSummaryCore を呼ばない (自動要約生成の復活防止)`, () => {
+      const absPath = resolve(process.cwd(), relPath);
+      const source = stripLineComments(readFileSync(absPath, 'utf-8'));
+      const count = countMatches(source, CORE_DELEGATE_PATTERN);
+      expect(count).to.equal(
+        0,
+        `${relPath} で generateSummaryCore 呼び出しを検出。` +
+          'Issue #548-B1 で自動要約生成は削除された (要約は regenerateSummary 経由の手動生成のみ)。'
+      );
+    });
+
+    it(`${relPath} は buildSummaryGenerationRequest 経由で model.generateContent を呼ばない`, () => {
+      const absPath = resolve(process.cwd(), relPath);
+      const source = stripLineComments(readFileSync(absPath, 'utf-8'));
+      const count = countMatches(source, BUILDER_CALL_PATTERN);
+      expect(count).to.equal(
+        0,
+        `${relPath} で summary 用の model.generateContent 呼び出しを検出。Issue #548-B1 違反。`
       );
     });
   }

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -1,8 +1,11 @@
 /**
  * summary 経路 catch 句 logError 呼出契約テスト (Issue #266)
  *
- * 目的: ocrProcessor / regenerateSummary の summary 生成失敗 catch 句で、console.error だけで
+ * 目的: regenerateSummary の summary 生成失敗 catch 句で、console.error だけで
  * なく logError (errors collection + 通知) が呼ばれ続けることを静的に lock-in する。
+ * Issue #548-B1: ocrProcessor.ts の自動要約生成 (summaryPromise) は削除されたため、
+ * 本契約の対象は regenerateSummary.ts のみ。ocrProcessor.ts 自体の safeLogError 呼出は
+ * 下記 'logError/safeLogError params shape contract' で別途 lock-in する。
  *
  * 背景 (#178/#209 教訓): Vertex AI のクォータ枯渇・認証失効・暴走系エラーが silently swallow
  * されると、documents は status:processed で完了し「summary が空」としか見えない。6 ヶ月後の
@@ -27,16 +30,6 @@ import { SAFE_LOG_ERROR_CALL } from './helpers/patterns';
  * console.error を削除して logError のみに移行する場合は本契約の設計見直しが必要。
  */
 const SUMMARY_CATCH_ANCHORS = [
-  {
-    file: 'src/ocr/ocrProcessor.ts',
-    anchor: 'Summary generation failed',
-    context: 'summaryPromise.catch (best-effort, edge case safety net)',
-  },
-  {
-    file: 'src/ocr/ocrProcessor.ts',
-    anchor: 'Failed to generate summary',
-    context: 'generateSummary inner catch (main path)',
-  },
   {
     file: 'src/ocr/regenerateSummary.ts',
     anchor: 'Failed to generate summary',
@@ -156,8 +149,10 @@ describe('summary catch logError contract (#266)', () => {
         .map(({ idx }) => idx);
 
       expect(safeLogLines.length).to.be.greaterThanOrEqual(
-        2,
-        'ocrProcessor.ts で safeLogError 呼出が 2 箇所以上あることを想定 (summaryPromise + generateSummary inner)'
+        3,
+        'ocrProcessor.ts で safeLogError 呼出が 3 箇所以上あることを想定 ' +
+          '(aggregateCap:invariant, aggregateCap:truncated, handleProcessingError)。' +
+          'Issue #548-B1 で summaryPromise/generateSummary の catch 句は削除済み。'
       );
 
       for (const idx of safeLogLines) {

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -151,7 +151,9 @@ describe('summary catch logError contract (#266)', () => {
       expect(safeLogLines.length).to.be.greaterThanOrEqual(
         3,
         'ocrProcessor.ts で safeLogError 呼出が 3 箇所以上あることを想定 ' +
-          '(aggregateCap:invariant, aggregateCap:truncated, handleProcessingError)。' +
+          '(aggregateCap invariant検知時の functionName suffix ":aggregateCap:invariant"/' +
+          '":aggregateCap:unexpected"、aggregateCap truncated警告時の suffix ":aggregateCap"、' +
+          'handleProcessingError内の呼出元由来functionName)。' +
           'Issue #548-B1 で summaryPromise/generateSummary の catch 句は削除済み。'
       );
 

--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -1,11 +1,14 @@
 /**
  * summary 書込経路 caller-side 契約テスト (Issue #255 + #259)
  *
- * 目的: ocrProcessor / regenerateSummary の Firestore 書込呼出で 3 要素を同時保持することを
+ * 目的: regenerateSummary の Firestore 書込呼出で 3 要素を同時保持することを
  * lock-in する: (1) `summary: buildSummaryFields(...)` (新 discriminated union, #215),
  * (2) `summaryTruncated: FieldValue.delete()` (旧フラット削除), (3) `summaryOriginalLength:
  * FieldValue.delete()`。#259: builder bypass (object literal 直書込) / .set() / .create() /
  * merge:true 等のバイパス経路も検知対象。
+ * Issue #548-B1: ocrProcessor.ts は自動要約生成を行わないため対象外 (OCR完了のたびに
+ * summary/summaryTruncated/summaryOriginalLength を FieldValue.delete() で無効化するのみで、
+ * buildSummaryFields(...) は呼ばない。この無効化自体は本契約の検知パターンにマッチしない)。
  *
  * 背景 (#178 教訓): 派生フィールドの一括書込が壊れると FE 表示が崩れる。旧フィールド delete
  * 忘れで Firestore に残留し後方互換読込に無限依存するリスクを防ぐ。
@@ -52,13 +55,12 @@ const FIRESTORE_WRITE_CALL = /\.(?:update|set|create)\s*\(/;
 
 // #178 教訓: 派生フィールド 3 要素は同一 update() ブロック内で書き込む必要がある。
 // 本契約に含める caller ファイル。新規 caller 追加時は手動追記すること。
-const WRITE_PAYLOAD_CALLERS = [
-  'src/ocr/ocrProcessor.ts',
-  'src/ocr/regenerateSummary.ts',
-] as const;
+// Issue #548-B1: ocrProcessor.ts の自動要約生成は削除され、summary 書込は
+// regenerateSummary (手動トリガー) のみに一本化された。
+const WRITE_PAYLOAD_CALLERS = ['src/ocr/regenerateSummary.ts'] as const;
 
-// 同一 update() ブロック近接性の検証ウィンドウ。ocrProcessor の update は spread 含む
-// 大ブロック (~20 行)、regenerateSummary は ~4 行。30 行で両 caller を吸収。
+// 同一 update() ブロック近接性の検証ウィンドウ。regenerateSummary の update は ~4 行と
+// 短いが、将来 caller が増えた場合の余裕を持たせ 30 行のまま維持する。
 const ADJACENCY_WINDOW_LINES = 30;
 
 /**

--- a/functions/test/summaryWritePayloadContract.test.ts
+++ b/functions/test/summaryWritePayloadContract.test.ts
@@ -59,6 +59,16 @@ const FIRESTORE_WRITE_CALL = /\.(?:update|set|create)\s*\(/;
 // regenerateSummary (手動トリガー) のみに一本化された。
 const WRITE_PAYLOAD_CALLERS = ['src/ocr/regenerateSummary.ts'] as const;
 
+// review-pr 指摘対応 (pr-test-analyzer Critical + code-reviewer Suggestion, 収斂): ocrProcessor.ts は
+// buildSummaryFields(...) を呼ばないため WRITE_PAYLOAD_CALLERS 対象外だが、OCR完了のたびに
+// summary/summaryTruncated/summaryOriginalLength を FieldValue.delete() で無効化する行自体は
+// 本PRの核心的なバグ修正 (再処理経路での要約不整合防止) であり、これを検知する契約が
+// これまで存在しなかった。将来この delete() 呼出が誤って削除されても既存の
+// SUMMARY_FREE_CALLERS (generateSummaryCore 不在契約) では検知できないため、別途 lock-in する。
+const SUMMARY_INVALIDATE_CALLERS = ['src/ocr/ocrProcessor.ts'] as const;
+const SUMMARY_INVALIDATE_DELETE =
+  /summary:\s*(?:admin\.firestore\.)?FieldValue\.delete\s*\(\s*\)/;
+
 // 同一 update() ブロック近接性の検証ウィンドウ。regenerateSummary の update は ~4 行と
 // 短いが、将来 caller が増えた場合の余裕を持たせ 30 行のまま維持する。
 const ADJACENCY_WINDOW_LINES = 30;
@@ -172,6 +182,40 @@ describe('summary write-payload contract (#255)', () => {
       });
     });
   }
+
+  describe('ocrProcessor summary無効化 canary (Issue #548-B1)', () => {
+    for (const relPath of SUMMARY_INVALIDATE_CALLERS) {
+      describe(relPath, () => {
+        const absPath = resolve(process.cwd(), relPath);
+        const source = readFileWithContext(absPath, `caller-source:${relPath}`);
+
+        it('`summary: FieldValue.delete()` でOCR完了のたびに要約を無効化する', () => {
+          expect(source).to.match(
+            SUMMARY_INVALIDATE_DELETE,
+            `${relPath} に summary: FieldValue.delete() が見つからない。` +
+              'Issue #548-B1: 再処理経路 (429自動rescue・運用スクリプト等) で古い要約が' +
+              '残存する不整合を防ぐための必須の書込。'
+          );
+        });
+
+        it('`summaryTruncated`/`summaryOriginalLength` も同時に無効化する', () => {
+          expect(source).to.match(SUMMARY_TRUNCATED_DELETE);
+          expect(source).to.match(SUMMARY_ORIGINAL_LENGTH_DELETE);
+        });
+
+        it(`3 要素が同一 update() ブロック近接 (≤${ADJACENCY_WINDOW_LINES} 行) に共存する`, () => {
+          expect(
+            hasPatternsAdjacent(
+              source,
+              SUMMARY_INVALIDATE_DELETE,
+              SUMMARY_TRUNCATED_DELETE,
+              SUMMARY_ORIGINAL_LENGTH_DELETE
+            )
+          ).to.equal(true, '3 要素が散在している。同一 update() で書き込まれていない可能性あり');
+        });
+      });
+    }
+  });
 
   describe('caller 追加検知 (noUnused contract)', () => {
     // summary 書込パターンを持つファイルが WRITE_PAYLOAD_CALLERS と完全一致するか identity で検証。


### PR DESCRIPTION
## Summary
- `processDocument()`内の自動要約生成(`summaryPromise`)を削除。要約生成は既存の`regenerateSummary` onCall(手動トリガー、UIの「AI要約を生成」ボタン)経由のみに一本化する
- OCR完了のたびに`summary`/`summaryTruncated`/`summaryOriginalLength`を`FieldValue.delete()`で無効化する。再処理経路(手動再処理ボタン・429自動rescue・`fix-stuck-documents.js`等の運用スクリプト)によらず、古い内容の要約が新しいOCR結果と不整合のまま残存することを防ぐ(code-review medium で発見・修正)
- 契約テスト3件を追従: `summaryBuilderCallerContract.test.ts` / `summaryCatchLogErrorContract.test.ts` / `summaryWritePayloadContract.test.ts`の`CORE_CALLERS`/`WRITE_PAYLOAD_CALLERS`/`SUMMARY_CATCH_ANCHORS`から`ocrProcessor.ts`を除外し、自動要約生成が復活しないことを検知する新規contractを追加

## 背景
kanameoneの月次Gemini費用のうち要約生成が一定割合を占める。要約閲覧率は低い(推定10〜20%)ため、自動生成をやめてユーザーが必要な時だけ手動生成する方式に変更しコスト削減する(Issue #548-B1)。突合ロジック(customerName/officeName/documentType/date)は要約と構造的に独立しており、精度への影響はゼロ。

## 品質ゲート
- `/impl-plan` → 実装 → `/safe-refactor`(問題なし) → `/code-review medium`(8角度finder、1件の重大な設計ギャップを検出・修正: 再処理経路でのsummary不整合)
- `npm test`(functions配下): 1594 passing, 6 pending(既知skip), 0 failing

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` (対象4ファイルにwarning/error 0件)
- [x] `npm test` (functions配下全体、1594 passing / 0 failing)
- [ ] dev環境で実際にOCR処理させ、`summary`フィールドが書き込まれないこと・`stats/gemini/daily.bySource.summary.requestCount`が増分しないことを確認
- [ ] DocumentDetailModalで要約なし書類を開き「AI要約を生成」ボタンが表示・動作することを確認(既存機能の回帰なし確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OCR processing now stops clearing or recreating document summaries during field confirmation, reducing unexpected summary changes.
  * Summary generation is now kept separate from OCR document processing, helping prevent duplicate or inconsistent summary updates.

* **Tests**
  * Updated regression checks to lock in the new summary behavior and prevent the old OCR summary flow from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->