### PR TITLE
feat(cost): Gemini 2.5 vs 3.5 Flash OCR比較A/Bテストharness追加 (Issue #548)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -89,6 +89,7 @@ on:
           - check-gemini-cost-stats --days 3 --doc-limit 30
           - measure-field-byte-sizes
           - measure-field-byte-sizes --limit 300
+          - compare-gemini-ocr-models
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false
@@ -545,7 +546,8 @@ jobs:
                [ "$SCRIPT_NAME" = "setup-collision-fixture" ] || \
                [ "$SCRIPT_NAME" = "pdf-feature-survey" ] || \
                [ "$SCRIPT_NAME" = "verify-pdf-determinism" ] || \
-               [ "$SCRIPT_NAME" = "seed-dev-data" ]; then
+               [ "$SCRIPT_NAME" = "seed-dev-data" ] || \
+               [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ]; then
             # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript)、seed-dev-data (#528) は
             # shared/*.ts に依存するため ts-node 経由で実行。STORAGE_BUCKET は resolve step で env 化済。
             EXTRA_ARGS=""

--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -549,7 +549,9 @@ jobs:
                [ "$SCRIPT_NAME" = "seed-dev-data" ] || \
                [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ]; then
             # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript)、seed-dev-data (#528) は
-            # shared/*.ts に依存するため ts-node 経由で実行。STORAGE_BUCKET は resolve step で env 化済。
+            # shared/*.ts に依存するため ts-node 経由で実行。compare-gemini-ocr-models (#548) は
+            # functions/src/utils/* (extractors.ts/retry.ts) に依存するため同様に ts-node 経由。
+            # STORAGE_BUCKET は resolve step で env 化済。
             EXTRA_ARGS=""
             if [ "$SCRIPT_NAME" = "classify-collision-docs" ]; then
               # ログマスキングで `{` が `***` に置換されるため、plan JSON を

--- a/scripts/compare-gemini-ocr-models.ts
+++ b/scripts/compare-gemini-ocr-models.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env ts-node
+/**
+ * Gemini 2.5 Flash vs 3.5 Flash OCR精度+コスト比較スクリプト（read-only、Issue #548）
+ *
+ * dev環境のseedフィクスチャ（scripts/seed-dev-data.ts の MIXED_FAX_PDFS、正解ラベル付き
+ * 2ファイル・5segment・計11ページ）を両モデルでページ単位OCRし、extractors.ts の実突合
+ * ロジック（extractAllInformation）で書類種別/顧客/事業所の抽出精度を比較する。
+ *
+ * Issue #548 の必須トリガー条件「dev seedでの2.5 vs 3.5 A/B PASS」（3.5移行で精度が
+ * 劣化しないこと）を検証するための唯一の残工程。Firestore/Storageへの書込は一切行わない
+ * （ローカルfixture読込 + Vertex AI呼出のみ）。
+ *
+ * 使用方法:
+ *   GOOGLE_CLOUD_PROJECT=doc-split-dev npx ts-node scripts/compare-gemini-ocr-models.ts
+ *
+ * 前提: Vertex AI (Gemini) 呼出権限を持つGCP認証(ADC)が必要。
+ *   ローカル: gcloud auth application-default login (doc-split-dev環境のアカウントで)
+ *   注意: 本スクリプトはCLAUDE.md「運用スクリプトはGitHub Actions経由」の対象外
+ *   （Firestore/Storageを触らずVertex AI呼出のみのため、既存run-ops-script.ymlの
+ *   スコープと異なる。ローカルADCでの単発実行を想定）。
+ */
+
+import { GoogleGenAI, ThinkingLevel, type ThinkingConfig } from '@google/genai';
+import { PDFDocument } from 'pdf-lib';
+import { withRetry, RETRY_CONFIGS } from '../functions/src/utils/retry';
+import { extractAllInformation } from '../functions/src/utils/extractors';
+import type { DocumentMaster, CustomerMaster, OfficeMaster } from '../shared/types';
+import { MIXED_FAX_PDFS, readFixture, CUSTOMERS, OFFICES, DOC_TYPES, CARE_MANAGERS } from './seed-dev-data';
+
+const PROJECT_ID =
+  process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID || '';
+const LOCATION = 'asia-northeast1';
+
+if (!PROJECT_ID) {
+  console.error('GOOGLE_CLOUD_PROJECT (または FIREBASE_PROJECT_ID) を設定してください');
+  process.exit(1);
+}
+
+// functions/src/utils/config.ts の GEMINI_CONFIG.maxOutputTokens と同値 (Issue #205踏襲)
+const MAX_OUTPUT_TOKENS = 8192;
+
+interface ModelConfig {
+  label: string;
+  modelId: string;
+  thinkingConfig: ThinkingConfig;
+  pricing: { inputPer1MTokens: number; outputPer1MTokens: number };
+}
+
+/** 比較対象モデル定義。2.5は現行本番設定、3.5はIssue #548移行予定設定。単価は公式サイト確認済み(2026-07-06)。 */
+const MODEL_CONFIGS: ModelConfig[] = [
+  {
+    label: 'gemini-2.5-flash(現行)',
+    modelId: 'gemini-2.5-flash',
+    thinkingConfig: { thinkingBudget: 0 },
+    pricing: { inputPer1MTokens: 0.3, outputPer1MTokens: 2.5 },
+  },
+  {
+    label: 'gemini-3.5-flash(移行予定)',
+    modelId: 'gemini-3.5-flash',
+    thinkingConfig: { thinkingLevel: ThinkingLevel.LOW },
+    pricing: { inputPer1MTokens: 1.5, outputPer1MTokens: 9.0 },
+  },
+];
+
+// functions/src/ocr/ocrProcessor.ts の OCR プロンプトと同一 (比較条件を揃えるため)
+const OCR_PROMPT = `
+この画像/PDFの内容をOCRしてください。
+
+【指示】
+- テキストをそのまま正確に抽出してください
+- 表がある場合は、構造を保ってテキスト化してください
+- 手書き文字も可能な限り読み取ってください
+- 読み取れない部分は[判読不能]と記載してください
+- 余計な説明は不要です。抽出したテキストのみを出力してください
+`;
+
+interface PageGroundTruth {
+  fixtureId: string;
+  /** fixture内の1-basedページ番号 */
+  pageNumber: number;
+  docType: string;
+  customer: string;
+  office: string;
+}
+
+/** MIXED_FAX_PDFS の segments（累積ページ数）をページ単位の正解ラベルに展開する */
+function expandGroundTruth(): PageGroundTruth[] {
+  const pages: PageGroundTruth[] = [];
+  for (const mixed of MIXED_FAX_PDFS) {
+    let pageNumber = 0;
+    for (const seg of mixed.segments) {
+      for (let p = 0; p < seg.pages; p++) {
+        pageNumber += 1;
+        pages.push({
+          fixtureId: mixed.id,
+          pageNumber,
+          docType: seg.docType,
+          customer: seg.customer,
+          office: seg.office,
+        });
+      }
+    }
+  }
+  return pages;
+}
+
+/** PDFから単一ページを抽出 (functions/src/ocr/ocrProcessor.ts の extractPdfPage と同ロジック) */
+async function extractPdfPage(pdfBuffer: Buffer, pageIndex: number): Promise<Buffer> {
+  const pdfDoc = await PDFDocument.load(pdfBuffer);
+  const newPdf = await PDFDocument.create();
+  const [copiedPage] = await newPdf.copyPages(pdfDoc, [pageIndex]);
+  newPdf.addPage(copiedPage);
+  const pdfBytes = await newPdf.save();
+  return Buffer.from(pdfBytes);
+}
+
+function buildMasters(): { documents: DocumentMaster[]; customers: CustomerMaster[]; offices: OfficeMaster[] } {
+  return {
+    documents: DOC_TYPES.map((t) => ({
+      name: t.name,
+      category: t.category,
+      dateMarker: t.dateMarker,
+      keywords: t.keywords,
+    })),
+    customers: CUSTOMERS.map((c) => ({
+      id: c.id,
+      name: c.name,
+      furigana: c.furigana,
+      careManagerName: CARE_MANAGERS[c.cm].name,
+    })),
+    offices: OFFICES.map((o) => ({
+      id: o.id,
+      name: o.name,
+      shortName: o.shortName,
+    })),
+  };
+}
+
+interface PageOcrOutcome {
+  groundTruth: PageGroundTruth;
+  inputTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  docTypeMatch: boolean;
+  customerMatch: boolean;
+  officeMatch: boolean;
+}
+
+async function ocrPage(
+  ai: InstanceType<typeof GoogleGenAI>,
+  modelConfig: ModelConfig,
+  pageBuffer: Buffer
+): Promise<{ text: string; inputTokens: number; outputTokens: number; thinkingTokens: number }> {
+  const base64Data = pageBuffer.toString('base64');
+
+  const response = await withRetry(
+    () =>
+      ai.models.generateContent({
+        model: modelConfig.modelId,
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              { inlineData: { mimeType: 'application/pdf', data: base64Data } },
+              { text: OCR_PROMPT },
+            ],
+          },
+        ],
+        config: {
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          thinkingConfig: modelConfig.thinkingConfig,
+        },
+      }),
+    RETRY_CONFIGS.gemini
+  );
+
+  const text = response.text || '';
+  const usageMetadata = response.usageMetadata;
+  return {
+    text,
+    inputTokens: usageMetadata?.promptTokenCount || 0,
+    outputTokens: usageMetadata?.candidatesTokenCount || 0,
+    thinkingTokens: usageMetadata?.thoughtsTokenCount || 0,
+  };
+}
+
+async function runModel(
+  modelConfig: ModelConfig,
+  groundTruthPages: PageGroundTruth[],
+  masters: ReturnType<typeof buildMasters>
+): Promise<PageOcrOutcome[]> {
+  const ai = new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION });
+  const outcomes: PageOcrOutcome[] = [];
+
+  // fixtureごとにPDFを一度だけ読み込み、ページ抽出は都度行う (groundTruthのpageNumberはfixture内1-based)
+  const fixtureBuffers = new Map(MIXED_FAX_PDFS.map((m) => [m.id, readFixture(m.fixture)]));
+
+  for (const gt of groundTruthPages) {
+    const pdfBuffer = fixtureBuffers.get(gt.fixtureId);
+    if (!pdfBuffer) throw new Error(`fixture buffer not found for ${gt.fixtureId}`);
+
+    const pageBuffer = await extractPdfPage(pdfBuffer, gt.pageNumber - 1);
+    const { text, inputTokens, outputTokens, thinkingTokens } = await ocrPage(ai, modelConfig, pageBuffer);
+
+    const info = extractAllInformation(text, masters, {});
+    const docTypeMatch = info.document.documentType === gt.docType;
+    const customerMatch = info.customer.bestMatch?.name === gt.customer;
+    const officeMatch = info.office.officeName === gt.office;
+
+    outcomes.push({ groundTruth: gt, inputTokens, outputTokens, thinkingTokens, docTypeMatch, customerMatch, officeMatch });
+
+    console.log(
+      `  [${modelConfig.label}] ${gt.fixtureId} p${gt.pageNumber}: ` +
+        `docType=${docTypeMatch ? '✅' : '❌'} customer=${customerMatch ? '✅' : '❌'} office=${officeMatch ? '✅' : '❌'} ` +
+        `(in=${inputTokens}/out=${outputTokens}/thinking=${thinkingTokens})`
+    );
+  }
+
+  return outcomes;
+}
+
+interface ModelSummary {
+  label: string;
+  total: number;
+  docTypePass: number;
+  customerPass: number;
+  officePass: number;
+  allPass: number;
+  totalInput: number;
+  totalOutput: number;
+  totalThinking: number;
+  costUsd: number;
+}
+
+function summarize(
+  label: string,
+  outcomes: PageOcrOutcome[],
+  pricing: { inputPer1MTokens: number; outputPer1MTokens: number }
+): ModelSummary {
+  const total = outcomes.length;
+  const docTypePass = outcomes.filter((o) => o.docTypeMatch).length;
+  const customerPass = outcomes.filter((o) => o.customerMatch).length;
+  const officePass = outcomes.filter((o) => o.officeMatch).length;
+  const allPass = outcomes.filter((o) => o.docTypeMatch && o.customerMatch && o.officeMatch).length;
+
+  const totalInput = outcomes.reduce((s, o) => s + o.inputTokens, 0);
+  const totalOutput = outcomes.reduce((s, o) => s + o.outputTokens, 0);
+  const totalThinking = outcomes.reduce((s, o) => s + o.thinkingTokens, 0);
+  const billableOutput = totalOutput + totalThinking;
+  const costUsd = (totalInput * pricing.inputPer1MTokens + billableOutput * pricing.outputPer1MTokens) / 1_000_000;
+
+  console.log(`\n=== ${label} ===`);
+  console.log(`書類種別 一致率: ${docTypePass}/${total} (${((docTypePass / total) * 100).toFixed(1)}%)`);
+  console.log(`顧客     一致率: ${customerPass}/${total} (${((customerPass / total) * 100).toFixed(1)}%)`);
+  console.log(`事業所   一致率: ${officePass}/${total} (${((officePass / total) * 100).toFixed(1)}%)`);
+  console.log(`全項目一致      : ${allPass}/${total} (${((allPass / total) * 100).toFixed(1)}%)`);
+  console.log(`トークン: input=${totalInput} output=${totalOutput} thinking=${totalThinking}`);
+  console.log(`概算コスト(本テストのみ): $${costUsd.toFixed(6)}`);
+
+  return { label, total, docTypePass, customerPass, officePass, allPass, totalInput, totalOutput, totalThinking, costUsd };
+}
+
+async function main(): Promise<void> {
+  const groundTruthPages = expandGroundTruth();
+  const masters = buildMasters();
+
+  console.log('=== Gemini 2.5 vs 3.5 Flash OCR比較 (Issue #548) ===');
+  console.log(`プロジェクト: ${PROJECT_ID} / リージョン: ${LOCATION}`);
+  console.log(`対象ページ数: ${groundTruthPages.length} (${MIXED_FAX_PDFS.map((m) => m.id).join(', ')})`);
+
+  const summaries: ModelSummary[] = [];
+  for (const modelConfig of MODEL_CONFIGS) {
+    console.log(`\n--- ${modelConfig.label} 実行中... ---`);
+    const outcomes = await runModel(modelConfig, groundTruthPages, masters);
+    summaries.push(summarize(modelConfig.label, outcomes, modelConfig.pricing));
+  }
+
+  const [baseline, migrated] = summaries;
+  console.log('\n=== 判定 (Issue #548 トリガー条件: 3.5の精度が2.5を下回らないこと) ===');
+  const regressed = migrated.allPass < baseline.allPass;
+  console.log(regressed ? '❌ FAIL: 3.5 Flashで精度劣化を検出' : '✅ PASS: 精度劣化なし');
+  console.log(`コスト比 (このテストのみ、実運用スケールの参考値ではない): ${(migrated.costUsd / baseline.costUsd).toFixed(2)}倍`);
+}
+
+main().catch((err) => {
+  console.error('❌ エラー:', err);
+  process.exit(1);
+});

--- a/scripts/compare-gemini-ocr-models.ts
+++ b/scripts/compare-gemini-ocr-models.ts
@@ -3,27 +3,36 @@
  * Gemini 2.5 Flash vs 3.5 Flash OCR精度+コスト比較スクリプト（read-only、Issue #548）
  *
  * dev環境のseedフィクスチャ（scripts/seed-dev-data.ts の MIXED_FAX_PDFS、正解ラベル付き
- * 2ファイル・5segment・計11ページ）を両モデルでページ単位OCRし、extractors.ts の実突合
- * ロジック（extractAllInformation）で書類種別/顧客/事業所の抽出精度を比較する。
+ * 2ファイル・5segment・計11ページ）を両モデルでページ単位OCRし、functions/src/utils/extractors.ts
+ * の各抽出関数（extractDocumentTypeEnhanced / extractCustomerCandidates / extractOfficeCandidates）を
+ * functions/src/ocr/ocrProcessor.ts の processDocument() と同じ呼出形（filenameInfo込み）で使い、
+ * 書類種別/顧客/事業所の3フィールドの抽出精度を比較する。日付(date)は対象外
+ * （Issue #548本文が言及する4フィールドのうち3つのみを検証。理由: 正解の期待日付文字列を
+ * ground truthとして別途モデリングする必要があり本スクリプトのスコープ外としたため）。
  *
- * Issue #548 の必須トリガー条件「dev seedでの2.5 vs 3.5 A/B PASS」（3.5移行で精度が
- * 劣化しないこと）を検証するための唯一の残工程。Firestore/Storageへの書込は一切行わない
- * （ローカルfixture読込 + Vertex AI呼出のみ）。
+ * Issue #548 の必須トリガー条件「dev seedでの2.5 vs 3.5 A/B PASS」のうち、上記3フィールドの
+ * 精度非劣化を検証する。Firestore/Storageへの書込は一切行わない（ローカルfixture読込 +
+ * Vertex AI呼出のみ）。
  *
  * 使用方法:
- *   GOOGLE_CLOUD_PROJECT=doc-split-dev npx ts-node scripts/compare-gemini-ocr-models.ts
- *
- * 前提: Vertex AI (Gemini) 呼出権限を持つGCP認証(ADC)が必要。
- *   ローカル: gcloud auth application-default login (doc-split-dev環境のアカウントで)
- *   注意: 本スクリプトはCLAUDE.md「運用スクリプトはGitHub Actions経由」の対象外
- *   （Firestore/Storageを触らずVertex AI呼出のみのため、既存run-ops-script.ymlの
- *   スコープと異なる。ローカルADCでの単発実行を想定）。
+ *   推奨: GitHub Actions "Run Operations Script" → environment: dev /
+ *         script: compare-gemini-ocr-models で実行（docsplit-cloud-build SAに
+ *         roles/aiplatform.user 付与済み、ADC不要）。
+ *   ローカル実行（フォールバック）:
+ *     gcloud auth application-default login (doc-split-dev環境のアカウントで)
+ *     GOOGLE_CLOUD_PROJECT=doc-split-dev npx ts-node scripts/compare-gemini-ocr-models.ts
  */
 
 import { GoogleGenAI, ThinkingLevel, type ThinkingConfig } from '@google/genai';
 import { PDFDocument } from 'pdf-lib';
 import { withRetry, RETRY_CONFIGS } from '../functions/src/utils/retry';
-import { extractAllInformation } from '../functions/src/utils/extractors';
+import { GEMINI_CONFIG } from '../functions/src/utils/config';
+import {
+  extractDocumentTypeEnhanced,
+  extractCustomerCandidates,
+  extractOfficeCandidates,
+  extractFilenameInfo,
+} from '../functions/src/utils/extractors';
 import type { DocumentMaster, CustomerMaster, OfficeMaster } from '../shared/types';
 import { MIXED_FAX_PDFS, readFixture, CUSTOMERS, OFFICES, DOC_TYPES, CARE_MANAGERS } from './seed-dev-data';
 
@@ -36,25 +45,33 @@ if (!PROJECT_ID) {
   process.exit(1);
 }
 
-// functions/src/utils/config.ts の GEMINI_CONFIG.maxOutputTokens と同値 (Issue #205踏襲)
-const MAX_OUTPUT_TOKENS = 8192;
+type ModelRole = 'baseline' | 'candidate';
 
 interface ModelConfig {
+  role: ModelRole;
   label: string;
   modelId: string;
   thinkingConfig: ThinkingConfig;
   pricing: { inputPer1MTokens: number; outputPer1MTokens: number };
 }
 
-/** 比較対象モデル定義。2.5は現行本番設定、3.5はIssue #548移行予定設定。単価は公式サイト確認済み(2026-07-06)。 */
+/**
+ * 比較対象モデル定義。2.5は現行既定値(GEMINI_OCR_THINKING_BUDGET未設定時のデフォルト、
+ * functions/src/utils/config.ts GEMINI_CONFIG.ocrThinkingBudget参照)、3.5はIssue #548
+ * 移行予定設定(thinking完全無効化不可のため最小のlow)。
+ * 単価は Vertex AI Gemini API 公式料金ページ(https://cloud.google.com/vertex-ai/generative-ai/pricing)
+ * で確認済み(2026-07-06、gemini-2.5-flash/gemini-3.5-flash)。
+ */
 const MODEL_CONFIGS: ModelConfig[] = [
   {
+    role: 'baseline',
     label: 'gemini-2.5-flash(現行)',
     modelId: 'gemini-2.5-flash',
     thinkingConfig: { thinkingBudget: 0 },
     pricing: { inputPer1MTokens: 0.3, outputPer1MTokens: 2.5 },
   },
   {
+    role: 'candidate',
     label: 'gemini-3.5-flash(移行予定)',
     modelId: 'gemini-3.5-flash',
     thinkingConfig: { thinkingLevel: ThinkingLevel.LOW },
@@ -62,8 +79,13 @@ const MODEL_CONFIGS: ModelConfig[] = [
   },
 ];
 
-// functions/src/ocr/ocrProcessor.ts の OCR プロンプトと同一 (比較条件を揃えるため)
-const OCR_PROMPT = `
+/**
+ * functions/src/ocr/ocrProcessor.ts の OCR プロンプトと同一ベース + ページ番号suffix
+ * (本番の ocrWithGemini はPDFの全ページで pageNumber を渡すため、常にsuffixが付与される。
+ * 比較条件を揃えるためsuffixもページごとに付与する)。
+ */
+function buildOcrPrompt(pageNumber: number): string {
+  return `
 この画像/PDFの内容をOCRしてください。
 
 【指示】
@@ -72,12 +94,17 @@ const OCR_PROMPT = `
 - 手書き文字も可能な限り読み取ってください
 - 読み取れない部分は[判読不能]と記載してください
 - 余計な説明は不要です。抽出したテキストのみを出力してください
+
+これは${pageNumber}ページ目です。
 `;
+}
 
 interface PageGroundTruth {
   fixtureId: string;
   /** fixture内の1-basedページ番号 */
   pageNumber: number;
+  /** ファイル名から事業所推定するfilenameInfo生成用 (functions/src/ocr/ocrProcessor.ts と同じ経路) */
+  fileName: string;
   docType: string;
   customer: string;
   office: string;
@@ -94,6 +121,7 @@ function expandGroundTruth(): PageGroundTruth[] {
         pages.push({
           fixtureId: mixed.id,
           pageNumber,
+          fileName: mixed.fileName,
           docType: seg.docType,
           customer: seg.customer,
           office: seg.office,
@@ -144,13 +172,16 @@ interface PageOcrOutcome {
   docTypeMatch: boolean;
   customerMatch: boolean;
   officeMatch: boolean;
+  /** true の場合、空応答がsafetyブロック等のAPI異常由来の可能性があり、判定に含めるべきでない疑いがある */
+  anomalous: boolean;
 }
 
 async function ocrPage(
   ai: InstanceType<typeof GoogleGenAI>,
   modelConfig: ModelConfig,
-  pageBuffer: Buffer
-): Promise<{ text: string; inputTokens: number; outputTokens: number; thinkingTokens: number }> {
+  pageBuffer: Buffer,
+  pageNumber: number
+): Promise<{ text: string; inputTokens: number; outputTokens: number; thinkingTokens: number; anomalous: boolean }> {
   const base64Data = pageBuffer.toString('base64');
 
   const response = await withRetry(
@@ -162,12 +193,12 @@ async function ocrPage(
             role: 'user',
             parts: [
               { inlineData: { mimeType: 'application/pdf', data: base64Data } },
-              { text: OCR_PROMPT },
+              { text: buildOcrPrompt(pageNumber) },
             ],
           },
         ],
         config: {
-          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
           thinkingConfig: modelConfig.thinkingConfig,
         },
       }),
@@ -176,11 +207,31 @@ async function ocrPage(
 
   const text = response.text || '';
   const usageMetadata = response.usageMetadata;
+
+  // Issue #559 silent-failure-hunter指摘: response.text は safetyブロック/zero-candidate等
+  // API異常時にも例外を投げず単に undefined を返す (@google/genai getter実装)。空応答を
+  // 無言で「OCR誤読」と同一視すると、n=11の少数サンプルでPASS/FAIL判定が異常値に左右されうる。
+  let anomalous = false;
+  if (!response.text) {
+    const candidate = response.candidates?.[0];
+    const finishReason = candidate?.finishReason;
+    const blockReason = response.promptFeedback?.blockReason;
+    if (blockReason || (finishReason && finishReason !== 'STOP')) {
+      anomalous = true;
+      console.warn(
+        `⚠️ [${modelConfig.label}] p${pageNumber}: 空応答検出 (API異常の可能性) ` +
+          `finishReason=${finishReason ?? 'none'} blockReason=${blockReason ?? 'none'} — ` +
+          `この結果はモデルの読取精度ではなくAPI応答異常が原因の可能性があります`
+      );
+    }
+  }
+
   return {
     text,
     inputTokens: usageMetadata?.promptTokenCount || 0,
     outputTokens: usageMetadata?.candidatesTokenCount || 0,
     thinkingTokens: usageMetadata?.thoughtsTokenCount || 0,
+    anomalous,
   };
 }
 
@@ -200,32 +251,65 @@ async function runModel(
     if (!pdfBuffer) throw new Error(`fixture buffer not found for ${gt.fixtureId}`);
 
     const pageBuffer = await extractPdfPage(pdfBuffer, gt.pageNumber - 1);
-    const { text, inputTokens, outputTokens, thinkingTokens } = await ocrPage(ai, modelConfig, pageBuffer);
+    const { text, inputTokens, outputTokens, thinkingTokens, anomalous } = await ocrPage(
+      ai,
+      modelConfig,
+      pageBuffer,
+      gt.pageNumber
+    );
 
-    const info = extractAllInformation(text, masters, {});
-    const docTypeMatch = info.document.documentType === gt.docType;
-    const customerMatch = info.customer.bestMatch?.name === gt.customer;
-    const officeMatch = info.office.officeName === gt.office;
+    // functions/src/ocr/ocrProcessor.ts の processDocument() と同じ抽出関数・同じ呼出形
+    // (filenameInfo込みのextractOfficeCandidates) を使う。extractAllInformation() は内部で
+    // extractOfficeNameEnhanced (filenameInfo非対応) を使うため、本番の事業所抽出とは
+    // 別ロジックになってしまい使わない (Issue #559 Codex/comment-analyzer指摘)。
+    const filenameInfo = extractFilenameInfo(gt.fileName);
+    const documentTypeResult = extractDocumentTypeEnhanced(text, masters.documents);
+    const customerResult = extractCustomerCandidates(text, masters.customers);
+    const officeResult = extractOfficeCandidates(text, masters.offices, { filenameInfo });
 
-    outcomes.push({ groundTruth: gt, inputTokens, outputTokens, thinkingTokens, docTypeMatch, customerMatch, officeMatch });
+    const docTypeMatch = documentTypeResult.documentType === gt.docType;
+    const customerMatch = customerResult.bestMatch?.name === gt.customer;
+    const officeMatch = officeResult.bestMatch?.name === gt.office;
+
+    outcomes.push({
+      groundTruth: gt,
+      inputTokens,
+      outputTokens,
+      thinkingTokens,
+      docTypeMatch,
+      customerMatch,
+      officeMatch,
+      anomalous,
+    });
 
     console.log(
       `  [${modelConfig.label}] ${gt.fixtureId} p${gt.pageNumber}: ` +
         `docType=${docTypeMatch ? '✅' : '❌'} customer=${customerMatch ? '✅' : '❌'} office=${officeMatch ? '✅' : '❌'} ` +
         `(in=${inputTokens}/out=${outputTokens}/thinking=${thinkingTokens})`
     );
+    if (!docTypeMatch) {
+      console.log(`    docType不一致: expected="${gt.docType}" actual="${documentTypeResult.documentType ?? '(none)'}"`);
+    }
+    if (!customerMatch) {
+      console.log(`    customer不一致: expected="${gt.customer}" actual="${customerResult.bestMatch?.name ?? '(none)'}"`);
+    }
+    if (!officeMatch) {
+      console.log(`    office不一致: expected="${gt.office}" actual="${officeResult.bestMatch?.name ?? '(none)'}"`);
+    }
   }
 
   return outcomes;
 }
 
 interface ModelSummary {
+  role: ModelRole;
   label: string;
   total: number;
   docTypePass: number;
   customerPass: number;
   officePass: number;
   allPass: number;
+  anomalousCount: number;
   totalInput: number;
   totalOutput: number;
   totalThinking: number;
@@ -233,15 +317,16 @@ interface ModelSummary {
 }
 
 function summarize(
-  label: string,
-  outcomes: PageOcrOutcome[],
-  pricing: { inputPer1MTokens: number; outputPer1MTokens: number }
+  modelConfig: ModelConfig,
+  outcomes: PageOcrOutcome[]
 ): ModelSummary {
+  const { role, label, pricing } = modelConfig;
   const total = outcomes.length;
   const docTypePass = outcomes.filter((o) => o.docTypeMatch).length;
   const customerPass = outcomes.filter((o) => o.customerMatch).length;
   const officePass = outcomes.filter((o) => o.officeMatch).length;
   const allPass = outcomes.filter((o) => o.docTypeMatch && o.customerMatch && o.officeMatch).length;
+  const anomalousCount = outcomes.filter((o) => o.anomalous).length;
 
   const totalInput = outcomes.reduce((s, o) => s + o.inputTokens, 0);
   const totalOutput = outcomes.reduce((s, o) => s + o.outputTokens, 0);
@@ -254,10 +339,13 @@ function summarize(
   console.log(`顧客     一致率: ${customerPass}/${total} (${((customerPass / total) * 100).toFixed(1)}%)`);
   console.log(`事業所   一致率: ${officePass}/${total} (${((officePass / total) * 100).toFixed(1)}%)`);
   console.log(`全項目一致      : ${allPass}/${total} (${((allPass / total) * 100).toFixed(1)}%)`);
+  if (anomalousCount > 0) {
+    console.log(`⚠️ API異常疑いの空応答: ${anomalousCount}/${total} 件 (判定に影響している可能性、上記ログのwarning参照)`);
+  }
   console.log(`トークン: input=${totalInput} output=${totalOutput} thinking=${totalThinking}`);
   console.log(`概算コスト(本テストのみ): $${costUsd.toFixed(6)}`);
 
-  return { label, total, docTypePass, customerPass, officePass, allPass, totalInput, totalOutput, totalThinking, costUsd };
+  return { role, label, total, docTypePass, customerPass, officePass, allPass, anomalousCount, totalInput, totalOutput, totalThinking, costUsd };
 }
 
 async function main(): Promise<void> {
@@ -272,14 +360,29 @@ async function main(): Promise<void> {
   for (const modelConfig of MODEL_CONFIGS) {
     console.log(`\n--- ${modelConfig.label} 実行中... ---`);
     const outcomes = await runModel(modelConfig, groundTruthPages, masters);
-    summaries.push(summarize(modelConfig.label, outcomes, modelConfig.pricing));
+    summaries.push(summarize(modelConfig, outcomes));
   }
 
-  const [baseline, migrated] = summaries;
-  console.log('\n=== 判定 (Issue #548 トリガー条件: 3.5の精度が2.5を下回らないこと) ===');
+  // MODEL_CONFIGS の配列順序ではなく role で明示的に取得する (Issue #559 code-simplifier/
+  // type-design-analyzer指摘: 配列順への暗黙依存はMODEL_CONFIGS変更時に判定を静かに壊す)。
+  const baseline = summaries.find((s) => s.role === 'baseline');
+  const migrated = summaries.find((s) => s.role === 'candidate');
+  if (!baseline || !migrated) {
+    throw new Error(
+      `baseline/candidate の role を持つ ModelSummary が揃っていません (summaries: ${summaries.map((s) => s.role).join(',')})`
+    );
+  }
+
+  console.log('\n=== 判定 (Issue #548 トリガー条件: 3.5の精度が2.5を下回らないこと。書類種別/顧客/事業所の3フィールド、日付は対象外) ===');
   const regressed = migrated.allPass < baseline.allPass;
   console.log(regressed ? '❌ FAIL: 3.5 Flashで精度劣化を検出' : '✅ PASS: 精度劣化なし');
   console.log(`コスト比 (このテストのみ、実運用スケールの参考値ではない): ${(migrated.costUsd / baseline.costUsd).toFixed(2)}倍`);
+
+  // Issue #559 Codex P1指摘: 判定がFAILでもexit codeが0のままだとGitHub Actions上は
+  // 緑のままになり、実際には精度劣化を検出していても見た目上パスしたように誤読されうる。
+  if (regressed) {
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {

--- a/scripts/compare-gemini-ocr-models.ts
+++ b/scripts/compare-gemini-ocr-models.ts
@@ -36,12 +36,30 @@ import {
 import type { DocumentMaster, CustomerMaster, OfficeMaster } from '../shared/types';
 import { MIXED_FAX_PDFS, readFixture, CUSTOMERS, OFFICES, DOC_TYPES, CARE_MANAGERS } from './seed-dev-data';
 
+/**
+ * scripts/seed-dev-data.ts の ALLOWED_PROJECT_ID ガードと同じ意図: 本スクリプトは
+ * dev環境のseedフィクスチャ(scripts/fixtures/seed/)の正解ラベルを前提にしており、
+ * kanameone/cocoro等の他環境で実行しても意味を成さない。run-ops-script.yml は
+ * environment(dev/kanameone/cocoro) × script の組合せを自由に選べる共通ワークフローの
+ * ため、選択ミスでVertex AI課金が発生する事故を防ぐ (IAM権限の有無への間接依存ではなく
+ * スクリプト自身で明示的に弾く)。
+ */
+const ALLOWED_PROJECT_ID = 'doc-split-dev';
+
 const PROJECT_ID =
   process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID || '';
 const LOCATION = 'asia-northeast1';
 
 if (!PROJECT_ID) {
   console.error('GOOGLE_CLOUD_PROJECT (または FIREBASE_PROJECT_ID) を設定してください');
+  process.exit(1);
+}
+
+if (PROJECT_ID !== ALLOWED_PROJECT_ID) {
+  console.error(
+    `❌ このスクリプトは ${ALLOWED_PROJECT_ID} 専用です (指定されたプロジェクト: ${PROJECT_ID})。` +
+      'dev環境seedフィクスチャの正解ラベル前提のため他環境では実行できません。'
+  );
   process.exit(1);
 }
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@google-cloud/logging": "^11.2.1",
+    "@google/genai": "^2.10.0",
     "@pdf-lib/fontkit": "^1.1.1",
     "firebase-admin": "^12.7.0",
     "pdf-lib": "1.17.1"

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -54,18 +54,18 @@ const forcePending = process.argv.includes('--force-pending');
 // seed データ定義 (deterministic)
 // ============================================
 
-const CARE_MANAGERS = [
+export const CARE_MANAGERS = [
   { id: 'seed-cm-01', name: '佐々木恵子' },
   { id: 'seed-cm-02', name: '高橋誠' },
   { id: 'seed-cm-03', name: '森さくら' },
 ];
 
-const OFFICES = [
+export const OFFICES = [
   { id: 'seed-office-01', name: 'ひまわり訪問介護ステーション', shortName: 'ひまわり' },
   { id: 'seed-office-02', name: 'あおぞらデイサービスセンター', shortName: 'あおぞら' },
 ];
 
-const DOC_TYPES = [
+export const DOC_TYPES = [
   { id: 'seed-doctype-01', name: 'ケアプラン', category: '計画', dateMarker: '作成日', keywords: ['居宅サービス計画', 'ケアプラン'] },
   { id: 'seed-doctype-02', name: 'サービス提供票', category: '計画', dateMarker: '提供月', keywords: ['提供票', 'サービス提供'] },
   { id: 'seed-doctype-03', name: '訪問看護報告書', category: '医療', dateMarker: '報告日', keywords: ['訪問看護', '報告書'] },
@@ -73,7 +73,7 @@ const DOC_TYPES = [
 ];
 
 /** 顧客 12 名。CM1: 5 名 (配下 120 docs でページング境界)、CM2: 4 名、CM3: 3 名 */
-const CUSTOMERS = [
+export const CUSTOMERS = [
   { id: 'seed-cust-01', name: '相沢一郎', furigana: 'あいざわいちろう', cm: 0 },
   { id: 'seed-cust-02', name: '井上春子', furigana: 'いのうえはるこ', cm: 0 },
   { id: 'seed-cust-03', name: '内田健三', furigana: 'うちだけんぞう', cm: 0 },
@@ -113,7 +113,7 @@ function genericPdfFor(totalPages: number): string {
 }
 
 /** E 用: 複数書類混在 FAX PDF の構成定義 */
-const MIXED_FAX_PDFS = [
+export const MIXED_FAX_PDFS = [
   {
     id: 'seed-doc-pending-mixed-01',
     fixture: 'seed_mixed_fax_01.pdf',
@@ -232,7 +232,7 @@ async function generateFixtures(): Promise<void> {
   console.log('✅ 生成完了。git add scripts/fixtures/seed/ でコミットしてください。');
 }
 
-function readFixture(fixture: string): Buffer {
+export function readFixture(fixture: string): Buffer {
   const p = path.join(FIXTURE_SEED_DIR, fixture);
   if (!fs.existsSync(p)) {
     throw new Error(
@@ -554,9 +554,13 @@ async function seed(): Promise<void> {
   console.log(`  - E (分割): ${MIXED_FAX_PDFS.map((m) => m.id).join(', ')} の OCR 完了後、分割モーダルで検証`);
 }
 
-(generatePdfs ? generateFixtures() : seed())
-  .then(() => process.exit(0))
-  .catch((err) => {
-    console.error('❌ エラー:', err);
-    process.exit(1);
-  });
+// 他スクリプト(compare-gemini-ocr-models.ts等)からMIXED_FAX_PDFS/readFixture等を
+// import するだけでFirestore書込・PDF生成が走らないよう、直接実行時のみ起動する。
+if (require.main === module) {
+  (generatePdfs ? generateFixtures() : seed())
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error('❌ エラー:', err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- Issue #548のトリガー条件「dev seedでの2.5 vs 3.5 A/B PASS」を検証するA/Bテストharnessを新規追加
- `scripts/compare-gemini-ocr-models.ts`: seed-dev-dataのMIXED_FAX_PDFS(正解ラベル付き2ファイル・11ページ)を両モデルでページ単位OCRし、`extractors.ts`の実突合ロジックで書類種別/顧客/事業所の一致率+トークンコストを比較・レポート
- `scripts/seed-dev-data.ts`: 上記harnessから再利用するためMIXED_FAX_PDFS/readFixture/CUSTOMERS/OFFICES/DOC_TYPES/CARE_MANAGERSにexportを付与。importするだけでFirestore書込が走らないよう末尾の自動実行を`require.main === module`でガード
- `run-ops-script.yml`: `compare-gemini-ocr-models`を選択肢に追加(GitHub Actions経由・ADC不要の既存パターンを維持)
- `docsplit-cloud-build@doc-split-dev` SAに`roles/aiplatform.user`を付与(このharnessが初めてops-script SAから直接Vertex AI/Geminiを呼ぶケースのため)
- `scripts/package.json`: `@google/genai`を追加(CI環境でルートnode_modules hoistingに依存せず解決できるように)

Firestore/Storageへの書込は一切行わない(ローカルfixture読込 + Vertex AI呼出のみ)。実際のmodelId切替・本番投入は別途(#548条件待ちタスク)。

## Test plan
- [x] `npx tsc --noEmit -p scripts/tsconfig.json`: 新規/変更ファイルに型エラーなし
- [x] YAML構文チェック(js-yaml)
- [ ] GitHub Actions `Run Operations Script`(environment: dev, script: compare-gemini-ocr-models)で実行し、レポート出力を確認
- [ ] 結果をIssue #548にコメント記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ops script option for comparing OCR results across model versions.
  * Enabled the workflow to run this new comparison task directly from the manual trigger menu.

* **Bug Fixes**
  * Prevented the data-seeding script from running automatically when it’s imported elsewhere, reducing unintended side effects.
  * Improved script handling so the correct execution path is used for the new comparison task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->