### PR TITLE
feat(cost): Gemini 3.5 Flash移行スイッチ本体 (Issue #548)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -15,7 +15,7 @@ import {
 } from '../utils/retry';
 import { safeLogError } from '../utils/errorLogger';
 import { getRateLimiter } from '../utils/rateLimiter';
-import { GCP_CONFIG, GEMINI_CONFIG } from '../utils/config';
+import { GCP_CONFIG, GEMINI_CONFIG, isThreePointFiveModel } from '../utils/config';
 import {
   extractDocumentTypeEnhanced,
   extractCustomerCandidates,
@@ -47,6 +47,9 @@ const storage = admin.storage();
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
 const MODEL_ID = GEMINI_CONFIG.modelId;
+// Issue #548: gemini-3.5-flashはthinkingBudget非対応でthinkingLevel方式のみサポートのため、
+// generateContent呼び出し時のthinkingConfig形式をモデル別に分岐する。
+const IS_35_MODEL = isThreePointFiveModel(MODEL_ID);
 
 // 定数
 const OCR_RESULT_MAX_LENGTH = 100000;
@@ -502,7 +505,7 @@ async function ocrWithGemini(
 
   // @google/genai はESM専用パッケージのため、CJSビルドのこのファイルからは
   // 静的importでなく動的importで読み込む(TS1479回避)。
-  const { GoogleGenAI } = await import('@google/genai');
+  const { GoogleGenAI, ThinkingLevel } = await import('@google/genai');
   const ai = new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION });
 
   const base64Data = buffer.toString('base64');
@@ -541,12 +544,14 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
           // Issue #205: ハルシネーション/暴走による1.1M chars応答を防止する根本対策
           maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
           // Issue #546: OCR転記はテキストの正確な書き起こしのみで推論を要さないため、
-          // デフォルト有効(dynamic)のthinkingを無効化しコストを削減する(既定値0)。
-          // dev環境の個人アカウント権限制約により事前のOCRテキストdiff検証は未実施のため、
-          // GEMINI_OCR_THINKING_BUDGET環境変数でfeature flag化(GEMINI_CONFIG参照)。
-          // deploy後に少数サンプルで手動diff確認し、精度劣化が見つかれば環境変数の再設定+
-          // functions再deployのみ(コード変更不要)で即時ロールバック可能(#546 Task D)。
-          thinkingConfig: { thinkingBudget: GEMINI_CONFIG.ocrThinkingBudget },
+          // thinkingを最小化しコストを削減する。gemini-2.5-flashはthinkingBudget方式
+          // (既定0、GEMINI_OCR_THINKING_BUDGET環境変数でfeature flag化、GEMINI_CONFIG参照)。
+          // Issue #548: gemini-3.5-flashはthinkingBudget非対応でthinkingLevel方式のみサポートのため、
+          // A/Bテストharness(PR #559、実機3回PASS・精度劣化なし)で実証済みのthinkingLevel.LOWを使用する。
+          // ロールバックは`GEMINI_MODEL_ID=gemini-2.5-flash`設定+functions再deployのみ(コード変更不要)。
+          thinkingConfig: IS_35_MODEL
+            ? { thinkingLevel: ThinkingLevel.LOW }
+            : { thinkingBudget: GEMINI_CONFIG.ocrThinkingBudget },
         },
       });
     },

--- a/functions/src/utils/config.ts
+++ b/functions/src/utils/config.ts
@@ -39,10 +39,40 @@ export function parseOcrThinkingBudget(envValue: string | undefined): number {
   return 0;
 }
 
+/**
+ * 使用するGeminiモデルIDを環境変数から解決する (Issue #548)。
+ *
+ * 既定は'gemini-3.5-flash'(2026-07-06、A/Bテストharness実機3回PASSにより移行決定。
+ * gemini-2.5-flashは2026-10-16廃止予定)。dev環境で精度劣化等の問題が見つかった場合、
+ * 環境変数 `GEMINI_MODEL_ID` に`gemini-2.5-flash`を設定してfunctionsを再deployするだけで
+ * コード変更・PRなしに即時ロールバックできる(GEMINI_OCR_THINKING_BUDGETと同じパターン)。
+ *
+ * ドキュメント化された2値(gemini-3.5-flash/gemini-2.5-flash)以外は、全OCR/summaryリクエストが
+ * 存在しないモデルIDでエラーになることを避けるため、安全側の既定値(移行後の3.5-flash)にフォールバックする。
+ */
+export function parseModelId(envValue: string | undefined): string {
+  const trimmed = envValue?.trim();
+  if (trimmed === 'gemini-2.5-flash' || trimmed === 'gemini-3.5-flash') return trimmed;
+  if (trimmed !== undefined && trimmed !== '') {
+    console.warn(
+      `[config] GEMINI_MODEL_ID="${envValue}" is not a supported value (expected "gemini-3.5-flash" or "gemini-2.5-flash"). Falling back to gemini-3.5-flash.`
+    );
+  }
+  return 'gemini-3.5-flash';
+}
+
+/**
+ * modelIdがGemini 3.5系かどうかを判定する (Issue #548)。
+ * thinkingConfigの形式分岐(3.5系=thinkingLevel / 2.5系=thinkingBudget)に使用する。
+ */
+export function isThreePointFiveModel(modelId: string): boolean {
+  return modelId === 'gemini-3.5-flash';
+}
+
 // Vertex AI / Gemini設定
 export const GEMINI_CONFIG = {
-  /** 使用するGeminiモデルID */
-  modelId: 'gemini-2.5-flash',
+  /** 使用するGeminiモデルID (Issue #548: `GEMINI_MODEL_ID`で上書き可能、既定gemini-3.5-flash) */
+  modelId: parseModelId(process.env.GEMINI_MODEL_ID),
   /** モデルのリージョン */
   location: GCP_CONFIG.location,
   /**
@@ -51,6 +81,37 @@ export const GEMINI_CONFIG = {
    * OCR 経路・summary 経路の両方で必須設定。
    */
   maxOutputTokens: 8192,
-  /** OCR転記の thinkingBudget (Issue #546)。既定0、`GEMINI_OCR_THINKING_BUDGET`で上書き可能。 */
+  /** OCR転記の thinkingBudget (Issue #546)。既定0、`GEMINI_OCR_THINKING_BUDGET`で上書き可能。gemini-2.5-flash使用時のみ参照される。 */
   ocrThinkingBudget: parseOcrThinkingBudget(process.env.GEMINI_OCR_THINKING_BUDGET),
 } as const;
+
+/** Gemini 1モデル分の料金(100万トークンあたりの単価USD) */
+interface GeminiPricing {
+  inputPer1MTokens: number;
+  outputPer1MTokens: number;
+}
+
+/**
+ * モデル別料金テーブル (2026年7月時点、公式単価: ai.google.dev)
+ *
+ * Issue #546: gemini-2.5-flash実単価($0.30/$2.50)。
+ * Issue #548: gemini-3.5-flash実単価($1.50/$9.00、2.5-flash比で入力5倍/出力3.6倍)。
+ */
+const GEMINI_PRICING_BY_MODEL: Record<string, GeminiPricing> = Object.freeze({
+  'gemini-2.5-flash': { inputPer1MTokens: 0.3, outputPer1MTokens: 2.5 },
+  'gemini-3.5-flash': { inputPer1MTokens: 1.5, outputPer1MTokens: 9.0 },
+});
+
+/** 指定modelIdの料金を解決する。未知のmodelIdはgemini-2.5-flash単価にフォールバックする (Issue #548)。 */
+export function resolveGeminiPricing(modelId: string): GeminiPricing {
+  return GEMINI_PRICING_BY_MODEL[modelId] ?? GEMINI_PRICING_BY_MODEL['gemini-2.5-flash'];
+}
+
+/**
+ * 料金定数（GEMINI_CONFIG.modelIdに応じた実単価、Issue #546/#548）
+ *
+ * Issue #546: 旧値($0.075/$0.30)はgemini-1.5-flash相当の単価が残置されており、
+ * アプリ内コスト表示が実請求の約1/8に過小評価されていた。
+ * Issue #548: 固定値からGEMINI_CONFIG.modelId依存の解決に変更（3.5 Flash移行）。
+ */
+export const GEMINI_PRICING = Object.freeze(resolveGeminiPricing(GEMINI_CONFIG.modelId));

--- a/functions/src/utils/rateLimiter.ts
+++ b/functions/src/utils/rateLimiter.ts
@@ -5,6 +5,10 @@
  */
 
 import * as admin from 'firebase-admin';
+// 料金定数はGEMINI_CONFIG.modelIdに応じてconfig.tsで解決される (Issue #546/#548)。
+// config.tsはfirebase-adminに依存しないため、pure functionとして単体テスト可能。
+import { GEMINI_PRICING } from './config';
+export { GEMINI_PRICING };
 
 const db = admin.firestore();
 
@@ -123,17 +127,6 @@ export interface GeminiUsageStats {
   estimatedCostUsd: number;
   bySource: Record<GeminiUsageSource, GeminiSourceUsageStats>;
 }
-
-/**
- * 料金定数（2026年7月時点、gemini-2.5-flash実単価）
- *
- * Issue #546: 旧値($0.075/$0.30)はgemini-1.5-flash相当の単価が残置されており、
- * アプリ内コスト表示が実請求の約1/8に過小評価されていた。
- */
-export const GEMINI_PRICING = Object.freeze({
-  inputPer1MTokens: 0.3, // $0.30
-  outputPer1MTokens: 2.5, // $2.50（thinkingトークンも同単価で課金される）
-});
 
 /**
  * Gemini API使用量を追跡

--- a/functions/test/config.test.ts
+++ b/functions/test/config.test.ts
@@ -1,12 +1,18 @@
 /**
- * config.ts: parseOcrThinkingBudget テスト (Issue #546)
+ * config.ts: parseOcrThinkingBudget / parseModelId / isThreePointFiveModel /
+ * resolveGeminiPricing テスト (Issue #546, #548)
  *
- * GEMINI_CONFIG.ocrThinkingBudget はモジュール読み込み時に一度だけ評価されるため、
- * 環境変数の組み合わせを直接テストするには純粋関数として切り出した本関数を検証する。
+ * GEMINI_CONFIG.* はモジュール読み込み時に一度だけ評価されるため、
+ * 環境変数の組み合わせを直接テストするには純粋関数として切り出した各関数を検証する。
  */
 
 import { expect } from 'chai';
-import { parseOcrThinkingBudget } from '../src/utils/config';
+import {
+  parseOcrThinkingBudget,
+  parseModelId,
+  isThreePointFiveModel,
+  resolveGeminiPricing,
+} from '../src/utils/config';
 
 describe('config: parseOcrThinkingBudget (Issue #546)', () => {
   it('未設定(undefined)の場合は既定値0を返す', () => {
@@ -54,5 +60,64 @@ describe('config: parseOcrThinkingBudget (Issue #546)', () => {
 
   it('前後空白付き"0"("  0  ")はtrimして0として扱われる', () => {
     expect(parseOcrThinkingBudget('  0  ')).to.equal(0);
+  });
+});
+
+describe('config: parseModelId (Issue #548)', () => {
+  it('未設定(undefined)の場合は既定値gemini-3.5-flashを返す(移行後の既定モデル)', () => {
+    expect(parseModelId(undefined)).to.equal('gemini-3.5-flash');
+  });
+
+  it('空文字列の場合は既定値gemini-3.5-flashを返す', () => {
+    expect(parseModelId('')).to.equal('gemini-3.5-flash');
+  });
+
+  it('"gemini-3.5-flash"を指定した場合はそのまま返す', () => {
+    expect(parseModelId('gemini-3.5-flash')).to.equal('gemini-3.5-flash');
+  });
+
+  it('"gemini-2.5-flash"を指定した場合はそのまま返す(ロールバック用途)', () => {
+    expect(parseModelId('gemini-2.5-flash')).to.equal('gemini-2.5-flash');
+  });
+
+  it('未サポートの値は既定値gemini-3.5-flashにフォールバックする(誤設定時の安全側動作)', () => {
+    expect(parseModelId('gemini-1.5-flash')).to.equal('gemini-3.5-flash');
+  });
+
+  it('前後空白付き"gemini-2.5-flash"はtrimしてそのまま扱われる', () => {
+    expect(parseModelId('  gemini-2.5-flash  ')).to.equal('gemini-2.5-flash');
+  });
+});
+
+describe('config: isThreePointFiveModel (Issue #548)', () => {
+  it('"gemini-3.5-flash"はtrueを返す', () => {
+    expect(isThreePointFiveModel('gemini-3.5-flash')).to.equal(true);
+  });
+
+  it('"gemini-2.5-flash"はfalseを返す', () => {
+    expect(isThreePointFiveModel('gemini-2.5-flash')).to.equal(false);
+  });
+});
+
+describe('config: resolveGeminiPricing (Issue #548)', () => {
+  it('"gemini-3.5-flash"は実単価(入力$1.50/出力$9.00)を返す', () => {
+    expect(resolveGeminiPricing('gemini-3.5-flash')).to.deep.equal({
+      inputPer1MTokens: 1.5,
+      outputPer1MTokens: 9.0,
+    });
+  });
+
+  it('"gemini-2.5-flash"は実単価(入力$0.30/出力$2.50)を返す', () => {
+    expect(resolveGeminiPricing('gemini-2.5-flash')).to.deep.equal({
+      inputPer1MTokens: 0.3,
+      outputPer1MTokens: 2.5,
+    });
+  });
+
+  it('未知のmodelIdはgemini-2.5-flash単価にフォールバックする(安全側動作)', () => {
+    expect(resolveGeminiPricing('gemini-1.5-flash')).to.deep.equal({
+      inputPer1MTokens: 0.3,
+      outputPer1MTokens: 2.5,
+    });
   });
 });

--- a/functions/test/rateLimiterIntegration.test.ts
+++ b/functions/test/rateLimiterIntegration.test.ts
@@ -31,13 +31,16 @@ describe('rateLimiter 統合テスト (エミュレータ, Issue #546)', () => {
     await cleanupCollections(db, ['stats/gemini/daily']);
   });
 
+  // Issue #548: 既定モデルがgemini-2.5-flashからgemini-3.5-flashへ移行したため、
+  // GEMINI_PRICINGもGEMINI_CONFIG.modelId(既定gemini-3.5-flash)に応じた実単価を返す。
+  // modelId別の解決ロジック自体の網羅テストはconfig.test.tsのresolveGeminiPricingで実施。
   describe('GEMINI_PRICING', () => {
-    it('inputPer1MTokens は gemini-2.5-flash 実単価 $0.30 で固定', () => {
-      expect(GEMINI_PRICING.inputPer1MTokens).to.equal(0.3);
+    it('inputPer1MTokens は既定モデル(gemini-3.5-flash)の実単価 $1.50 で固定', () => {
+      expect(GEMINI_PRICING.inputPer1MTokens).to.equal(1.5);
     });
 
-    it('outputPer1MTokens は gemini-2.5-flash 実単価 $2.50 で固定', () => {
-      expect(GEMINI_PRICING.outputPer1MTokens).to.equal(2.5);
+    it('outputPer1MTokens は既定モデル(gemini-3.5-flash)の実単価 $9.00 で固定', () => {
+      expect(GEMINI_PRICING.outputPer1MTokens).to.equal(9.0);
     });
   });
 
@@ -55,8 +58,9 @@ describe('rateLimiter 統合テスト (エミュレータ, Issue #546)', () => {
       expect(data?.bySource?.ocr?.outputTokens).to.equal(500);
       expect(data?.bySource?.ocr?.thinkingTokens).to.equal(100);
       expect(data?.bySource?.ocr?.requestCount).to.equal(1);
-      // input: 1000*$0.30/1M + output(500+thinking100=600件分): 600*$2.50/1M
-      expect(data?.bySource?.ocr?.estimatedCostUsd).to.be.closeTo(0.0018, 1e-9);
+      // Issue #548: 既定モデルgemini-3.5-flash実単価。
+      // input: 1000*$1.50/1M + output(500+thinking100=600件分): 600*$9.00/1M
+      expect(data?.bySource?.ocr?.estimatedCostUsd).to.be.closeTo(0.0069, 1e-9);
       expect(data?.bySource?.summary).to.be.undefined;
     });
 
@@ -64,14 +68,15 @@ describe('rateLimiter 統合テスト (エミュレータ, Issue #546)', () => {
       await trackGeminiUsage(1_000_000, 1_000_000, 0, 'ocr');
 
       const withoutThinking = (await todayDocRef().get()).data()?.estimatedCostUsd;
-      // input: 1M tokens * $0.30/1M = $0.30、output: 1M tokens * $2.50/1M = $2.50 → 合計$2.80
-      expect(withoutThinking).to.be.closeTo(2.8, 1e-9);
+      // Issue #548: 既定モデルgemini-3.5-flash実単価。
+      // input: 1M tokens * $1.50/1M = $1.50、output: 1M tokens * $9.00/1M = $9.00 → 合計$10.50
+      expect(withoutThinking).to.be.closeTo(10.5, 1e-9);
 
       await todayDocRef().delete();
       await trackGeminiUsage(0, 0, 1_000_000, 'ocr');
       const onlyThinking = (await todayDocRef().get()).data()?.estimatedCostUsd;
-      // thinkingTokens は output と同単価 ($2.50/1M) で課金される
-      expect(onlyThinking).to.be.closeTo(2.5, 1e-9);
+      // thinkingTokens は output と同単価 ($9.00/1M) で課金される
+      expect(onlyThinking).to.be.closeTo(9.0, 1e-9);
     });
 
     it('ocr と summary の呼び出しは bySource 内で独立して集計される', async () => {


### PR DESCRIPTION
## Summary
- `GEMINI_CONFIG.modelId` を環境変数 `GEMINI_MODEL_ID` 経由で解決するように変更し、既定値を `gemini-3.5-flash` に切替(`gemini-2.5-flash` は2026-10-16廃止予定)
- A/Bテストharness(PR #559、実機3回PASS・精度劣化なし)で実証済みの `thinkingConfig: { thinkingLevel: 'LOW' }` を `gemini-3.5-flash` 使用時に適用。`gemini-2.5-flash` 使用時は既存の `thinkingBudget` 方式(Issue #546)を維持するモデル別分岐とした
- 料金定数(`GEMINI_PRICING`)をモデル別テーブル(`gemini-2.5-flash`: 入力$0.30/出力$2.50、`gemini-3.5-flash`: 入力$1.50/出力$9.00)から解決するように変更
- ロールバック手段: `GEMINI_MODEL_ID=gemini-2.5-flash` を設定してfunctionsを再デプロイするだけで、コード変更・PRなしに即時ロールバック可能(Issue #546の `GEMINI_OCR_THINKING_BUDGET` と同じfeature flagパターンを踏襲)
- 対象は現状dev環境での適用まで。kanameone/cocoro本番環境への展開は「dev固め→検証→段階展開」の方針で合意済みのため本PRのスコープ外

## スコープ外(Issue #548の残タスク)
- kanameone/cocoro本番環境への展開
- B3(ページ単位チェックポイント)、B4(再処理「再突合のみ」モード)

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm run lint` — 0エラー(既存警告26件のみ、変更ファイルとは無関係)
- [x] `npm test` — 1608 passing(新規テスト11件: `parseModelId`6件/`isThreePointFiveModel`2件/`resolveGeminiPricing`3件)
- [x] `firebase emulators:exec --only firestore "npm run test:integration"` — 77 passing(`GEMINI_PRICING`/`trackGeminiUsage`のコスト計算アサーションを新単価に合わせて更新済み)
- [x] `/safe-refactor` → LOW3件検出・修正(型リテラル重複解消/不要export削除/import-export整理)
- [x] `/code-review low` → 指摘0件
- [ ] マージ後、dev環境CI自動デプロイを確認し、既存dev文書のreprocessでmodelId切替・抽出精度・Firestore `stats/gemini/daily` の新単価反映を実機確認

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between Gemini model variants at runtime.
  * Pricing and cost estimates now adjust automatically based on the active model.

* **Bug Fixes**
  * Improved handling of unsupported or missing model settings with a safe fallback.
  * Updated OCR processing to use the appropriate “thinking” behavior for each model.

* **Tests**
  * Expanded test coverage for model parsing, model detection, pricing resolution, and usage cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->