### PR TITLE
chore(ci): run-ops-scriptにseed-dev-data --force-pending選択肢を追加

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -85,6 +85,7 @@ on:
           - verify-pdf-determinism --paths fixtures/simple.pdf,fixtures/with-ccittfaxdecode.pdf,fixtures/with-jbig2decode.pdf,fixtures/with-jpxdecode.pdf,fixtures/with-dctdecode.pdf,fixtures/encrypted.pdf
           - seed-dev-data --dry-run
           - seed-dev-data
+          - seed-dev-data --force-pending
           - check-gemini-cost-stats
           - check-gemini-cost-stats --days 3 --doc-limit 30
           - measure-field-byte-sizes


### PR DESCRIPTION
## Summary
- Issue #548 PR #561(Gemini 3.5 Flash移行)のdev実機確認のため、`run-ops-script.yml`のscript選択肢に`seed-dev-data --force-pending`を追加
- 既存の`seed-dev-data`(既存pending docはスキップ)とは別の明示的な選択肢とすることで、誤操作による再課金リスクを避ける
- スクリプト側(`scripts/seed-dev-data.ts`)は`--force-pending`フラグを既に実装済み(未変更)。ワークフローのenum選択肢に追加するのみ

## Test plan
- [x] YAML構文としてPRのCIが通ること
- [ ] マージ後、実際に`seed-dev-data --force-pending`を実行しdev環境で既存fixture(`seed-doc-pending-mixed-01/02`)がpending化・実OCRされることを確認

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)