### PR TITLE
feat(cost): summary生成コスト実測スクリプト追加 (Issue #562)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -91,6 +91,7 @@ on:
           - measure-field-byte-sizes
           - measure-field-byte-sizes --limit 300
           - compare-gemini-ocr-models
+          - measure-summary-cost --doc-id
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false
@@ -548,10 +549,12 @@ jobs:
                [ "$SCRIPT_NAME" = "pdf-feature-survey" ] || \
                [ "$SCRIPT_NAME" = "verify-pdf-determinism" ] || \
                [ "$SCRIPT_NAME" = "seed-dev-data" ] || \
-               [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ]; then
+               [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ] || \
+               [ "$SCRIPT_NAME" = "measure-summary-cost" ]; then
             # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript)、seed-dev-data (#528) は
             # shared/*.ts に依存するため ts-node 経由で実行。compare-gemini-ocr-models (#548) は
             # functions/src/utils/* (extractors.ts/retry.ts) に依存するため同様に ts-node 経由。
+            # measure-summary-cost (#562) は functions/src/ocr/summaryGenerator.ts に依存するため同様。
             # STORAGE_BUCKET は resolve step で env 化済。
             EXTRA_ARGS=""
             if [ "$SCRIPT_NAME" = "classify-collision-docs" ]; then

--- a/scripts/measure-summary-cost.ts
+++ b/scripts/measure-summary-cost.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env ts-node
+/**
+ * summary生成経路(要約)の実コスト測定スクリプト(Issue #562)
+ *
+ * PR #561(Gemini 3.5 Flash移行)のレビューで、summary経路(`generateSummaryCore`)が
+ * OCR経路と異なりthinkingConfigを一切設定していないことが判明した。gemini-3.5-flashは
+ * thinkingトークンが常時発生しうるため、実際にどの程度のthinkingトークン/コストが
+ * 発生するかをdev環境の実文書で1回実測し、Issue #562の対応要否判断の材料とする。
+ *
+ * `generateSummaryCore`をFirestore上の既存文書のocrResultで直接1回呼び出す
+ * (`regenerateSummary` onCallと同じコア関数、認証層はバイパス)。実際にVertex AIへの
+ * 課金が発生し、trackGeminiUsage経由でstats/gemini/daily/{today}のsummary内訳が
+ * 更新される点に留意(measurement目的の実行のため許容)。文書自体への書込は行わない。
+ *
+ * 使用方法:
+ *   推奨: GitHub Actions "Run Operations Script" → environment: dev /
+ *         script: measure-summary-cost --doc-id
+ *   ローカル実行（フォールバック）:
+ *     gcloud auth application-default login (doc-split-dev環境のアカウントで)
+ *     FIREBASE_PROJECT_ID=doc-split-dev npx ts-node scripts/measure-summary-cost.ts --doc-id <docId>
+ */
+
+import * as admin from 'firebase-admin';
+import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from '../functions/src/ocr/summaryGenerator';
+
+const ALLOWED_PROJECT_ID = 'doc-split-dev';
+
+const projectId = process.env.FIREBASE_PROJECT_ID || process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || '';
+if (projectId !== ALLOWED_PROJECT_ID) {
+  console.error(
+    `❌ このスクリプトは ${ALLOWED_PROJECT_ID} 専用です (指定されたプロジェクト: ${projectId || '(未設定)'})。` +
+      '本番クライアント環境への実行は禁止です。'
+  );
+  process.exit(1);
+}
+
+const docIdIndex = process.argv.indexOf('--doc-id');
+const docId = docIdIndex >= 0 ? process.argv[docIdIndex + 1] : undefined;
+if (!docId) {
+  console.error('--doc-id <docId> を指定してください');
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+async function main(): Promise<void> {
+  const snap = await db.doc(`documents/${docId}`).get();
+  if (!snap.exists) {
+    console.error(`❌ documents/${docId} が見つかりません`);
+    process.exit(1);
+  }
+
+  const data = snap.data()!;
+  const ocrResult: string = data.ocrResult || '';
+  const documentType: string = data.documentType || '';
+
+  console.log(`対象文書: ${docId}`);
+  console.log(`documentType: ${documentType || '(なし)'}`);
+  console.log(`ocrResult文字数: ${ocrResult.length}`);
+
+  if (ocrResult.length < MIN_OCR_LENGTH_FOR_SUMMARY) {
+    console.error(
+      `❌ ocrResultが短すぎます (${ocrResult.length}文字 < 最小${MIN_OCR_LENGTH_FOR_SUMMARY}文字)。summary生成をスキップします。`
+    );
+    process.exit(1);
+  }
+
+  console.log('\n--- generateSummaryCore実行(実Gemini呼び出し) ---');
+  const result = await generateSummaryCore(ocrResult, documentType);
+  console.log('\n--- 結果 ---');
+  console.log(JSON.stringify(result, null, 2));
+  console.log(
+    '\n✅ 完了。stats/gemini/daily/{today}のbySource.summaryに実測値が記録されました。' +
+      '(check-gemini-cost-statsで確認可能)'
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('ERROR:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Issue #562(PR #561レビューで判明した、summary経路にthinkingConfig未設定でgemini-3.5-flash移行後のコスト影響が未検証な問題)の対応要否判断のため、実測用スクリプト`scripts/measure-summary-cost.ts`を追加
- `generateSummaryCore()`(`regenerateSummary` onCallと同じコア関数)を既存dev文書のocrResultで1回実行し、thinkingトークン/コストを実測する。文書自体への書込みは行わない(`trackGeminiUsage`経由でstats/gemini/daily/{today}のsummary内訳のみ更新)
- `run-ops-script.yml`に`measure-summary-cost --doc-id`選択肢を追加し、GitHub Actions経由(ADC不要)で実行可能にする
- dev環境専用ガード(`ALLOWED_PROJECT_ID`)あり。既存の`compare-gemini-ocr-models.ts`と同じ安全パターンを踏襲

## Test plan
- [x] `npx tsc --noEmit -p scripts/tsconfig.json` — 新規ファイルに起因するエラーなし(既存の無関係なpr-d4-backfill配下のエラーのみ残存)
- [x] YAML構文チェック(js-yaml)
- [ ] マージ後、実際に`measure-summary-cost --doc-id`をdev環境の既存文書(`seed-doc-pending-mixed-01`等)に対して実行し、summary経路のthinkingトークン/コストを実測する

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow option to run a summary-cost measurement script with a document ID.
  * Introduced a command-line utility to estimate the real cost of summary generation for a specific document.

* **Bug Fixes**
  * Added safety checks to prevent the new utility from running in the wrong environment.
  * Validates document readiness before processing and exits cleanly on errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->