### PR TITLE
fix(scripts): measure-summary-costのadmin初期化順序バグを修正

### DIFF
--- a/scripts/measure-summary-cost.ts
+++ b/scripts/measure-summary-cost.ts
@@ -21,7 +21,6 @@
  */
 
 import * as admin from 'firebase-admin';
-import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from '../functions/src/ocr/summaryGenerator';
 
 const ALLOWED_PROJECT_ID = 'doc-split-dev';
 
@@ -45,6 +44,13 @@ admin.initializeApp({ projectId });
 const db = admin.firestore();
 
 async function main(): Promise<void> {
+  // functions/src/utils/rateLimiter.ts はモジュールトップレベルで admin.firestore()
+  // を参照するため(GEMINI_PRICING経由でsummaryGenerator.tsから間接importされる)、
+  // 静的importだとadmin.initializeApp()より先に評価されてFirebaseAppError(no-app)に
+  // なる。動的importでadmin初期化後まで評価を遅延させる
+  // (rateLimiterIntegration.test.tsの./helpers/initFirestoreEmulator分離と同種の対策)。
+  const { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } = await import('../functions/src/ocr/summaryGenerator');
+
   const snap = await db.doc(`documents/${docId}`).get();
   if (!snap.exists) {
     console.error(`❌ documents/${docId} が見つかりません`);


### PR DESCRIPTION
## Summary
- PR #564でマージした`scripts/measure-summary-cost.ts`をGitHub Actionsで実行したところ、`FirebaseAppError: The default Firebase app does not exist`で失敗することを実機で確認
- 原因: `generateSummaryCore`の静的importが、`functions/src/utils/rateLimiter.ts`(`GEMINI_PRICING`経由で`summaryGenerator.ts`から間接import)のモジュールトップレベル`admin.firestore()`呼び出しを`admin.initializeApp()`実行前に評価してしまうため
- 動的import(`await import(...)`)で`main()`関数内、`admin.initializeApp()`実行後まで評価を遅延させることで解消。`functions/test/rateLimiterIntegration.test.ts`が同種の問題を`./helpers/initFirestoreEmulator`分離で回避しているのと同種の対策

## Test plan
- [x] `npx tsc --noEmit -p scripts/tsconfig.json` — 新規エラーなし
- [ ] マージ後、実際に`measure-summary-cost --doc-id`を再実行し、正常終了・summary経路のthinkingトークン/コストが実測できることを確認

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)