### PR TITLE
feat(cost): 既存Storage fixtureからpending文書を作成するスクリプト追加 (Issue #562)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -92,6 +92,7 @@ on:
           - measure-field-byte-sizes --limit 300
           - compare-gemini-ocr-models
           - measure-summary-cost --doc-id
+          - create-pending-doc --doc-id --storage-path original/seed_generic_12p.pdf
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false
@@ -550,11 +551,14 @@ jobs:
                [ "$SCRIPT_NAME" = "verify-pdf-determinism" ] || \
                [ "$SCRIPT_NAME" = "seed-dev-data" ] || \
                [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ] || \
-               [ "$SCRIPT_NAME" = "measure-summary-cost" ]; then
+               [ "$SCRIPT_NAME" = "measure-summary-cost" ] || \
+               [ "$SCRIPT_NAME" = "create-pending-doc" ]; then
             # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript)、seed-dev-data (#528) は
             # shared/*.ts に依存するため ts-node 経由で実行。compare-gemini-ocr-models (#548) は
             # functions/src/utils/* (extractors.ts/retry.ts) に依存するため同様に ts-node 経由。
             # measure-summary-cost (#562) は functions/src/ocr/summaryGenerator.ts に依存するため同様。
+            # create-pending-doc (#562) はfirebase-adminのみ依存(functions/src非依存)だが、
+            # 統一的にscriptsディレクトリからts-node経由で実行する。
             # STORAGE_BUCKET は resolve step で env 化済。
             EXTRA_ARGS=""
             if [ "$SCRIPT_NAME" = "classify-collision-docs" ]; then

--- a/scripts/create-pending-doc.ts
+++ b/scripts/create-pending-doc.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env ts-node
+/**
+ * dev環境のStorage上にある既存fixtureを指すpending文書を1件作成する(Issue #562)
+ *
+ * Issue #562(summary経路のthinkingConfig未設定によるコスト影響評価)で、既存の
+ * MIXED_FAX_PDFS(5〜6ページ)より長い文書での挙動を確認するため、既にStorageへ
+ * アップロード済みの`seed_generic_12p.pdf`(12ページ、seed-dev-data.tsのGENERIC_PDFS)を
+ * 指すpending文書を1件だけ作成する。実OCRパイプライン(processOCR)が処理を開始する。
+ *
+ * scripts/seed-dev-data.tsのbuildPendingDoc()と同じスキーマ形状を使用。
+ * 特定の文書IDに縛られない汎用スクリプトとして実装(既存Storage fixtureを指す
+ * pending文書の単発作成という操作自体は今後の同種の実測ニーズでも再利用できる)。
+ *
+ * 使用方法:
+ *   推奨: GitHub Actions "Run Operations Script" → environment: dev /
+ *         script: create-pending-doc --doc-id
+ *   ローカル実行（フォールバック）:
+ *     gcloud auth application-default login (doc-split-dev環境のアカウントで)
+ *     FIREBASE_PROJECT_ID=doc-split-dev npx ts-node scripts/create-pending-doc.ts \
+ *       --doc-id <docId> --storage-path original/seed_generic_12p.pdf
+ */
+
+import * as admin from 'firebase-admin';
+
+const ALLOWED_PROJECT_ID = 'doc-split-dev';
+
+const projectId = process.env.FIREBASE_PROJECT_ID || process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || '';
+if (projectId !== ALLOWED_PROJECT_ID) {
+  console.error(
+    `❌ このスクリプトは ${ALLOWED_PROJECT_ID} 専用です (指定されたプロジェクト: ${projectId || '(未設定)'})。` +
+      '本番クライアント環境への実行は禁止です。'
+  );
+  process.exit(1);
+}
+
+function getArg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+const docId = getArg('--doc-id');
+const storagePath = getArg('--storage-path');
+const storageBucket = process.env.STORAGE_BUCKET || `${projectId}.firebasestorage.app`;
+
+if (!docId || !storagePath) {
+  console.error('--doc-id <docId> --storage-path <original/xxx.pdf> を指定してください');
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+async function main(): Promise<void> {
+  const ref = db.collection('documents').doc(docId!);
+  const existing = await ref.get();
+  if (existing.exists) {
+    console.error(`❌ documents/${docId} は既に存在します。別のdoc-idを指定してください。`);
+    process.exit(1);
+  }
+
+  const fileName = storagePath!.split('/').pop() || storagePath!;
+
+  await ref.set({
+    id: docId,
+    processedAt: admin.firestore.Timestamp.now(),
+    fileId: docId,
+    fileName,
+    mimeType: 'application/pdf',
+    ocrResult: '',
+    documentType: '',
+    customerName: '',
+    officeName: '',
+    fileUrl: `gs://${storageBucket}/${storagePath}`,
+    fileDate: null,
+    isDuplicateCustomer: false,
+    totalPages: 0,
+    targetPageNumber: 1,
+    status: 'pending',
+    sourceType: 'upload',
+  });
+
+  console.log(`✅ documents/${docId} をpendingで作成しました (fileUrl: gs://${storageBucket}/${storagePath})`);
+  console.log('processOCR(毎分ポーリング)が処理を開始します。');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('ERROR:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Issue #562(summary経路のthinkingConfig未設定によるコスト影響評価)のサンプル追加のため、既存のdev fixture(`seed_generic_12p.pdf`、12ページ、既にStorageへアップロード済み)を指すpending文書を1件作成するスクリプト`scripts/create-pending-doc.ts`を追加
- 既存の`MIXED_FAX_PDFS`(5〜6ページ)より長い文書で、要約生成時のthinkingトークン発生傾向に差が出るかを実測する
- 特定fixture専用ではなく、既存Storage上のPDFを指すpending文書を単発作成する汎用スクリプトとして実装(`--doc-id --storage-path`)
- `run-ops-script.yml`に`create-pending-doc --doc-id --storage-path original/seed_generic_12p.pdf`選択肢を追加
- dev環境専用ガード(`ALLOWED_PROJECT_ID`)あり

## Test plan
- [x] `npx tsc --noEmit -p scripts/tsconfig.json` — 新規ファイルに起因するエラーなし
- [x] YAML構文チェック(js-yaml)
- [ ] マージ後、実際に`create-pending-doc`を実行してpending文書を作成し、実OCRパイプラインが処理を開始することを確認。その後`measure-summary-cost`で要約コストを実測

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)