### PR TITLE
feat(firestore): OCR結果detail/mainサブコレクションへのdual-write実装 (Issue #547 ADR-0018 Phase B)

### DIFF
--- a/functions/src/gmail/checkGmailAttachments.ts
+++ b/functions/src/gmail/checkGmailAttachments.ts
@@ -389,6 +389,12 @@ async function processAttachment(
       status: 'pending',
       sourceType: 'gmail',
     });
+
+    // ADR-0018 (Issue #547) Phase B: detail/mainへ同一transactionでdual-write
+    // (MUST: 原子性)。未OCRのためocrResultは空文字で初期化。
+    transaction.set(docRef.collection('detail').doc('main'), {
+      ocrResult: '',
+    });
   });
 
   console.log(`Saved attachment: ${filename} → ${docRef.id}`);

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -296,6 +296,13 @@ export async function processDocument(
     savedOcrResult = '';
   }
 
+  // ADR-0018 (Issue #547) Phase B: 一覧系UI用の軽量抜粋。Storage offload済み
+  // (ocrResultUrlセット時)は既存のplaceholder文言をそのまま格納する
+  // (useProcessingHistory.getOcrExcerpt()と同じ出し分けロジック、Phase Dで読込元切替予定)。
+  const ocrExcerpt = ocrResultUrl
+    ? '（OCR結果はCloud Storageに保存されています）'
+    : ocrResult.slice(0, 200);
+
   // Issue #526 D1: 抽出結果の集約ロジックは ocrUpdatePayloadBuilder.ts の純粋関数に
   // 切り出し済み(挙動不変、ユニットテストで契約をlock-in)。displayFileNameはここでは
   // 生成しない(Issue #526 D2: confirmed保護マージ後の最終メタから生成する順序に変更)。
@@ -374,8 +381,16 @@ export async function processDocument(
       summary: admin.firestore.FieldValue.delete(),
       summaryTruncated: admin.firestore.FieldValue.delete(),
       summaryOriginalLength: admin.firestore.FieldValue.delete(),
+      ocrExcerpt,
       status: 'processed',
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    // ADR-0018 (Issue #547) Phase B: 本体updateと同一transactionでdetail/mainへ
+    // dual-write (MUST: 原子性、2回の独立書込は禁止)。本体からの削除はPhase E。
+    tx.set(docRef.collection('detail').doc('main'), {
+      ocrResult: savedOcrResult,
+      pageResults,
     });
 
     console.log(

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -333,13 +333,14 @@ export const splitPdf = onCall(
     if (!Array.isArray(segments) || segments.length === 0) {
       throw new HttpsError('invalid-argument', 'segments must be a non-empty array');
     }
-    // Codex post-impl review Low 1 反映: Firestore batch.commit() は 500 writes の hard limit。
-    // batch 内訳は child set × N + parent update × 1 = N+1 ≤ 500 → N ≤ 499 が安全な上限。
-    // 実運用で 500 segment 分割は非現実的だが明示的に弾く (UI / API 双方への防御線)。
-    if (segments.length > 499) {
+    // ADR-0018 (Issue #547) Phase B: 子ドキュメントごとに本体set + detail/main setの
+    // 2書込になったため、batch内訳は child(本体+detail/main) set × 2N + parent update × 1
+    // = 2N+1 ≤ 500 → N ≤ 249 が安全な上限 (Firestore batch.commit() は 500 writes の hard limit)。
+    // 実測(kanameone, PR #568): splitInto配列の実データ最大長は17件で249に十分な余裕あり。
+    if (segments.length > 249) {
       throw new HttpsError(
         'invalid-argument',
-        `segments.length=${segments.length} exceeds Firestore batch write limit (max 499 to allow 1 parent update in same commit)`
+        `segments.length=${segments.length} exceeds Firestore batch write limit (max 249 to allow child + detail/main set per segment + 1 parent update in same commit)`
       );
     }
     for (let i = 0; i < segments.length; i++) {
@@ -716,6 +717,12 @@ export const splitPdf = onCall(
       const batch = db.batch();
       for (const item of accumulated) {
         batch.set(item.newDocRef, item.payload);
+        // ADR-0018 (Issue #547) Phase B: 子docのocrResult/pageResultsをdetail/mainへ
+        // 同一batchでdual-write (MUST: 原子性)。本体からの削除はPhase E。
+        batch.set(item.newDocRef.collection('detail').doc('main'), {
+          ocrResult: item.payload.ocrResult,
+          pageResults: item.payload.pageResults,
+        });
       }
       // 元ドキュメントのステータスを更新 (分割済みフラグ) — child set と同一 batch
       batch.update(docRef, {

--- a/functions/src/upload/uploadPdf.ts
+++ b/functions/src/upload/uploadPdf.ts
@@ -235,6 +235,12 @@ export const uploadPdf = onCall(
           status: 'pending',
           sourceType: 'upload',
         });
+
+        // ADR-0018 (Issue #547) Phase B: detail/mainへ同一transactionでdual-write
+        // (MUST: 原子性)。未OCRのためocrResultは空文字で初期化。
+        transaction.set(docRef.collection('detail').doc('main'), {
+          ocrResult: '',
+        });
       });
     } catch (error) {
       console.error('Firestore transaction error:', error);

--- a/functions/test/documentCreationDetailDualWriteContract.test.ts
+++ b/functions/test/documentCreationDetailDualWriteContract.test.ts
@@ -1,0 +1,104 @@
+/**
+ * 新規doc作成3箇所(checkGmailAttachments/uploadPdf/import-historical-gmail)の
+ * detail/main dual-write配線契約テスト (ADR-0018 Phase B, Issue #547)
+ *
+ * ADR書込表#4: 新規doc作成時にocrResultを空文字初期化する3箇所全てで、同一transaction内
+ * でdetail/mainにも `ocrResult: ''` を書込む(dual-write原則)ことをlock-inする。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const TARGETS = [
+  {
+    label: 'checkGmailAttachments.ts',
+    path: 'src/gmail/checkGmailAttachments.ts',
+    setCall: 'transaction.set(docRef, {',
+  },
+  {
+    label: 'uploadPdf.ts',
+    path: 'src/upload/uploadPdf.ts',
+    setCall: 'transaction.set(docRef, {',
+  },
+];
+
+describe('新規doc作成箇所の detail/main dual-write contract (ADR-0018 Phase B)', () => {
+  for (const target of TARGETS) {
+    describe(target.label, () => {
+      let source: string | null = null;
+
+      before(() => {
+        const fullPath = resolve(__dirname, '..', target.path);
+        source = existsSync(fullPath) ? readFileSync(fullPath, 'utf-8') : null;
+      });
+
+      it('ソースファイルが存在する', () => {
+        expect(source, `${target.path} must exist`).to.not.be.null;
+      });
+
+      it("detail/mainへ transaction.set(docRef.collection('detail').doc('main'), { ocrResult: '' }) が存在する", () => {
+        const detailBlock = extractBraceBlock(
+          source,
+          /transaction\.set\(\s*docRef\.collection\('detail'\)\.doc\('main'\),\s*/,
+          { anchorMode: 'after-match' }
+        );
+        expect(detailBlock, 'detail/main transaction.set(...) block must be found')
+          .to.not.be.null;
+        expect(detailBlock).to.match(/ocrResult:\s*''/);
+      });
+
+      it('detail/main setは本体docの transaction.set より後、同一 transaction コールバック内にある', () => {
+        expect(source).to.not.be.null;
+        const mainSetIdx = source!.indexOf(target.setCall);
+        const detailSetIdx = source!.indexOf(
+          "transaction.set(docRef.collection('detail').doc('main')"
+        );
+        expect(mainSetIdx).to.be.greaterThan(-1);
+        expect(detailSetIdx).to.be.greaterThan(mainSetIdx);
+      });
+    });
+  }
+
+  describe('import-historical-gmail.js', () => {
+    let source: string | null = null;
+
+    before(() => {
+      const fullPath = resolve(
+        __dirname,
+        '..',
+        '..',
+        'scripts',
+        'import-historical-gmail.js'
+      );
+      source = existsSync(fullPath) ? readFileSync(fullPath, 'utf-8') : null;
+    });
+
+    it('ソースファイルが存在する', () => {
+      expect(source, 'scripts/import-historical-gmail.js must exist').to.not.be
+        .null;
+    });
+
+    it("detail/mainへ transaction.set(docRef.collection('detail').doc('main'), { ocrResult: '' }) が存在する", () => {
+      const detailBlock = extractBraceBlock(
+        source,
+        /transaction\.set\(\s*docRef\.collection\('detail'\)\.doc\('main'\),\s*/,
+        { anchorMode: 'after-match' }
+      );
+      expect(detailBlock, 'detail/main transaction.set(...) block must be found').to
+        .not.be.null;
+      expect(detailBlock).to.match(/ocrResult:\s*''/);
+    });
+
+    it('detail/main setは本体docの transaction.set より後、同一 transaction コールバック内にある', () => {
+      expect(source).to.not.be.null;
+      const mainSetIdx = source!.indexOf('transaction.set(docRef, {');
+      const detailSetIdx = source!.indexOf(
+        "transaction.set(docRef.collection('detail').doc('main')"
+      );
+      expect(mainSetIdx).to.be.greaterThan(-1);
+      expect(detailSetIdx).to.be.greaterThan(mainSetIdx);
+    });
+  });
+});

--- a/functions/test/ocrProcessorDetailDualWriteContract.test.ts
+++ b/functions/test/ocrProcessorDetailDualWriteContract.test.ts
@@ -1,0 +1,63 @@
+/**
+ * ocrProcessor.ts の detail/main dual-write 配線契約テスト (ADR-0018 Phase B, Issue #547)
+ *
+ * `db.runTransaction` 内で本体update + `detail/main` set が単一transactionにまとまって
+ * いること、および `ocrExcerpt` の算出・書込配線をソース文字列レベルでlock-inする
+ * (docs/context/test-strategy.md §2.1 のgrep-based契約パターン踏襲、
+ * ocrProcessorConfirmedFieldWiringContract.test.ts が同種の前例)。
+ *
+ * 原子性(ADR MUST)の検証観点: 本体update/detail set が同一 `db.runTransaction(...)` の
+ * コールバック内にあること(2回の独立書込ではないこと)を anchor 位置の前後関係で確認する。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+describe('ocrProcessor detail/main dual-write contract (ADR-0018 Phase B)', () => {
+  const source = readFileSync(
+    resolve(process.cwd(), 'src/ocr/ocrProcessor.ts'),
+    'utf-8'
+  );
+
+  it('ocrExcerptはStorage offload時にplaceholder文言、それ以外はocrResult先頭200字', () => {
+    expect(source).to.match(
+      /const ocrExcerpt = ocrResultUrl\s*\n?\s*\?\s*['"]（OCR結果はCloud Storageに保存されています）['"]\s*\n?\s*:\s*ocrResult\.slice\(0,\s*200\)/
+    );
+  });
+
+  it('tx.update(docRef, ...) のペイロードに ocrExcerpt が含まれる', () => {
+    const txUpdateBlock = extractBraceBlock(
+      source,
+      /tx\.update\(docRef,\s*/,
+      { anchorMode: 'after-match' }
+    );
+    expect(txUpdateBlock, 'tx.update(docRef, ...) block must be found').to.not
+      .be.null;
+    expect(txUpdateBlock).to.match(/\bocrExcerpt\s*,/);
+  });
+
+  it('tx.set(docRef.collection(\'detail\').doc(\'main\'), ...) が存在し ocrResult/pageResults を含む', () => {
+    const detailSetBlock = extractBraceBlock(
+      source,
+      /tx\.set\(\s*docRef\.collection\('detail'\)\.doc\('main'\),\s*/,
+      { anchorMode: 'after-match' }
+    );
+    expect(detailSetBlock, 'detail/main tx.set(...) block must be found').to
+      .not.be.null;
+    expect(detailSetBlock).to.match(/ocrResult:\s*savedOcrResult/);
+    expect(detailSetBlock).to.match(/\bpageResults\s*,/);
+  });
+
+  it('detail/main への tx.set は db.runTransaction コールバック内 (本体updateと同一transaction) にある', () => {
+    const txStartIdx = source.indexOf('await db.runTransaction(async (tx) => {');
+    const detailSetIdx = source.indexOf(
+      "tx.set(docRef.collection('detail').doc('main'),"
+    );
+    const txEndIdx = source.indexOf('});', detailSetIdx);
+    expect(txStartIdx).to.be.greaterThan(-1);
+    expect(detailSetIdx).to.be.greaterThan(txStartIdx);
+    expect(txEndIdx).to.be.greaterThan(detailSetIdx);
+  });
+});

--- a/functions/test/splitPdfDetailDualWriteContract.test.ts
+++ b/functions/test/splitPdfDetailDualWriteContract.test.ts
@@ -1,0 +1,68 @@
+/**
+ * splitPdf の detail/main dual-write + segments 上限249 契約テスト
+ * (ADR-0018 Phase B, Issue #547)
+ *
+ * batch内訳が child(本体+detail/main) set × 2N + parent update × 1 = 2N+1 ≤ 500 と
+ * なるよう、上限が249であること、および子docごとの detail/main batch.set 配線を
+ * ソース文字列レベルでlock-inする(splitPdfPayloadContract.test.ts と同形式)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const SOURCE_PATH = 'src/pdf/pdfOperations.ts';
+
+let sourceText = '';
+
+describe('splitPdf detail/main dual-write contract (ADR-0018 Phase B)', () => {
+  before(() => {
+    const path = resolve(__dirname, '..', SOURCE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Source file not found: ${SOURCE_PATH}`);
+    }
+    sourceText = readFileSync(path, 'utf-8');
+  });
+
+  it('segments.length 上限は249 (2N+1<=500、child set + detail/main set の2書込)', () => {
+    expect(sourceText).to.match(/if \(segments\.length > 249\) \{/);
+    expect(sourceText).to.match(
+      /segments\.length=\$\{segments\.length\} exceeds Firestore batch write limit \(max 249/
+    );
+  });
+
+  it('旧上限499の判定は残存しない (回帰防止)', () => {
+    expect(sourceText).to.not.match(/segments\.length > 499/);
+  });
+
+  it('batch内で子docごとに detail/main へ batch.set し ocrResult/pageResults をミラーする', () => {
+    const loopBlock = extractBraceBlock(
+      sourceText,
+      /for \(const item of accumulated\) \{/,
+      { anchorMode: 'from-start' }
+    );
+    expect(loopBlock, 'accumulated batch.set loop block must be found').to.not
+      .be.null;
+    expect(loopBlock).to.match(/batch\.set\(item\.newDocRef,\s*item\.payload\)/);
+    expect(loopBlock).to.match(
+      /batch\.set\(\s*item\.newDocRef\.collection\('detail'\)\.doc\('main'\),/
+    );
+    expect(loopBlock).to.match(/ocrResult:\s*item\.payload\.ocrResult/);
+    expect(loopBlock).to.match(/pageResults:\s*item\.payload\.pageResults/);
+  });
+
+  it('detail/main への batch.set は親 docRef.update と同一 batch (T4) 内にある', () => {
+    const loopIdx = sourceText.indexOf('for (const item of accumulated) {');
+    const detailSetIdx = sourceText.indexOf(
+      "batch.set(item.newDocRef.collection('detail').doc('main'),"
+    );
+    const parentUpdateIdx = sourceText.indexOf('batch.update(docRef, {');
+    const commitIdx = sourceText.indexOf('await batch.commit();');
+    expect(loopIdx).to.be.greaterThan(-1);
+    expect(detailSetIdx, 'detail/main batch.set call site must be found').to
+      .be.greaterThan(loopIdx);
+    expect(parentUpdateIdx).to.be.greaterThan(detailSetIdx);
+    expect(commitIdx).to.be.greaterThan(parentUpdateIdx);
+  });
+});

--- a/scripts/import-historical-gmail.js
+++ b/scripts/import-historical-gmail.js
@@ -289,6 +289,12 @@ async function processAttachment(gmail, userId, messageId, part, subject, emailB
       officeConfirmed: false,
       officeCandidates: []
     });
+
+    // ADR-0018 (Issue #547) Phase B: detail/mainへ同一transactionでdual-write
+    // (MUST: 原子性)。未OCRのためocrResultは空文字で初期化。
+    transaction.set(docRef.collection('detail').doc('main'), {
+      ocrResult: ''
+    });
   });
 
   console.log(`  ✅ 保存完了: ${filename} → ${docRef.id}`);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -40,6 +40,13 @@ export interface Document {
   mimeType: string;
   ocrResult: string;
   ocrResultUrl?: string; // 長い場合はCloud Storage参照
+  /**
+   * OCR結果の軽量抜粋 (ADR-0018 Phase B、Issue #547)。
+   * `ocrProcessor.ts` のメインtransaction内で算出・書込。`ocrResultUrl` セット時
+   * (Storage offload済み) は既存のplaceholder文言をそのまま格納する。
+   * Phase D以降、一覧系UI(`useProcessingHistory.getOcrExcerpt()`)の読込元をこちらに切替予定。
+   */
+  ocrExcerpt?: string;
   summary?: SummaryField; // AI生成の要約 (Issue #209/#215)
   documentType: string;
   customerName: string;


### PR DESCRIPTION
## Summary
- ADR-0018 Phase B: 新規doc作成・OCR処理・PDF分割の各経路で、`documents`本体と同一transaction/batch内で`detail/main`サブコレクションへ`ocrResult`/`pageResults`を同時書込(dual-write)する
- `splitPdf`の子ドキュメント上限を499→249に変更(child+detail/main setの2書込化、`2N+1≤500`)。実測(kanameone, PR #568): splitInto配列の実データ最大長は17件で余裕十分と確認済み
- 一覧表示用の軽量`ocrExcerpt`フィールドを本体に新設(`ocrProcessor.ts`のメインtransaction内で算出・書込)

## 変更ファイル
- `functions/src/ocr/ocrProcessor.ts` — メインtx内でdetail/main set + ocrExcerpt算出
- `functions/src/pdf/pdfOperations.ts` — splitPdf: 上限249化 + batch内でdetail/main set
- `functions/src/gmail/checkGmailAttachments.ts` / `functions/src/upload/uploadPdf.ts` / `scripts/import-historical-gmail.js` — 新規doc作成時にdetail/mainへ`ocrResult: ''`初期化
- `shared/types.ts` — `Document.ocrExcerpt?: string`追加
- 新規contract test 3ファイル(grep-basedパターン踏襲、17テスト追加)

## 事前調査・監査
- splitInto実測(kanameone): avg 4.04 / median 3 / max 17 → 249件超は0件
- `documents/{id}`作成箇所の網羅監査(ADR §93 MUST): 対応必須4箇所以外の9箇所(seed-e2e-data.js×4/seed-office-pending.js/create-pending-doc.ts/setup-collision-fixture.ts/cleanup-ambiguous-collision-docs.ts×2)は全てdev/emulator専用ガード付きまたは`ocrResult`未設定でdual-write対象外と確認済み

## Test plan
- [x] `cd functions && npm run build` — TypeScriptビルド成功
- [x] `cd functions && npm test` — 既存1608件 + 新規17件 = 1625件全PASS(回帰なし)
- [x] `npm run lint:functions` — 0 errors
- [x] `cd frontend && npx tsc --noEmit` — 型エラーなし
- [x] `npm run build` — 全体ビルド成功
- [x] `/code-review high` — 8角度finder → verify、correctness bugなし。PLAUSIBLE 2件(detail/mainパス重複・ocrExcerpt算出ロジック重複、いずれも将来PhaseでのCleanup候補として記録、ブロッカーではない)
- [x] `codex review --base main -c model_reasoning_effort=high` — P2 2件、いずれもPR3(削除同期)/PR5(seed-dev-data)として既にスコープ分離済みと確認、対応不要と判断

## スコープ外(次PRで対応予定)
- `deleteDocument.ts`等の削除同期 → PR3
- FE `getReprocessClearFields()`のwriteBatch化 → PR4a
- `seed-dev-data.ts`のdual-write化 → PR5

Refs #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for showing a short OCR excerpt on documents, including when full OCR content is stored elsewhere.
  * Document creation and PDF splitting now consistently initialize and update document details alongside the main record.

* **Bug Fixes**
  * Improved consistency so OCR details are saved atomically during document creation and processing.
  * Tightened PDF split limits to match updated write behavior and avoid batch-size issues.

* **Tests**
  * Added contract tests to verify the new document-detail write behavior across upload, email import, OCR processing, and PDF splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->