### PR TITLE
feat(firestore): documents削除時のdetail/mainサブコレクション削除同期 (Issue #547 ADR-0018 Phase B)

### DIFF
--- a/functions/src/documents/deleteDocument.ts
+++ b/functions/src/documents/deleteDocument.ts
@@ -167,9 +167,14 @@ export const deleteDocument = onCall(
       }
     }
 
-    // 6. documents 削除
+    // 6. documents 削除 (ADR-0018 Phase B: detail/main サブコレクションを
+    // 同一batchで削除し、孤児化を防ぐ。detail/main が未作成のdocでも
+    // batch.delete()は存在しないdocに対して無害)
     try {
-      await docRef.delete();
+      const batch = db.batch();
+      batch.delete(docRef.collection('detail').doc('main'));
+      batch.delete(docRef);
+      await batch.commit();
       console.log(`Deleted document: ${documentId}`);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);

--- a/functions/test/deleteSyncDetailDualWriteContract.test.ts
+++ b/functions/test/deleteSyncDetailDualWriteContract.test.ts
@@ -1,0 +1,121 @@
+/**
+ * documents/{id} 削除経路3箇所(deleteDocument.ts / cleanup-duplicates.js /
+ * cleanup-ambiguous-collision-docs.ts)の detail/main 削除同期契約テスト
+ * (ADR-0018 Phase B, Issue #547)
+ *
+ * 本体docのみ削除しdetail/mainサブコレクションを残置すると孤児化する
+ * (Storage同様、audit-storage-mismatch的な検知漏れの温床になる)。
+ * 3経路すべてで本体削除と同一batch/commit内でdetail/mainも削除する配線を
+ * ソース文字列レベルでlock-inする(splitPdfDetailDualWriteContract.test.ts等と同形式)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+describe('documents 削除経路の detail/main dual-delete contract (ADR-0018 Phase B)', () => {
+  describe('deleteDocument.ts', () => {
+    let source: string | null = null;
+
+    before(() => {
+      const fullPath = resolve(__dirname, '..', 'src/documents/deleteDocument.ts');
+      source = existsSync(fullPath) ? readFileSync(fullPath, 'utf-8') : null;
+    });
+
+    it('ソースファイルが存在する', () => {
+      expect(source, 'src/documents/deleteDocument.ts must exist').to.not.be.null;
+    });
+
+    it('docRef削除と同一batchでdetail/mainを削除する', () => {
+      const batchBlock = extractBraceBlock(source, /const batch = db\.batch\(\);/, {
+        anchorMode: 'from-start',
+      });
+      expect(batchBlock, 'batch construction block must be found').to.not.be.null;
+    });
+
+    it("batch.delete(docRef.collection('detail').doc('main')) が batch.delete(docRef) より前、同一 batch.commit() 内にある", () => {
+      expect(source).to.not.be.null;
+      const detailDeleteIdx = source!.indexOf(
+        "batch.delete(docRef.collection('detail').doc('main'));"
+      );
+      const docDeleteIdx = source!.indexOf('batch.delete(docRef);');
+      const commitIdx = source!.indexOf('await batch.commit();');
+      expect(detailDeleteIdx, 'detail/main batch.delete call site must be found').to
+        .be.greaterThan(-1);
+      expect(docDeleteIdx).to.be.greaterThan(detailDeleteIdx);
+      expect(commitIdx).to.be.greaterThan(docDeleteIdx);
+    });
+  });
+
+  describe('cleanup-duplicates.js', () => {
+    let source: string | null = null;
+
+    before(() => {
+      const fullPath = resolve(__dirname, '..', '..', 'scripts', 'cleanup-duplicates.js');
+      source = existsSync(fullPath) ? readFileSync(fullPath, 'utf-8') : null;
+    });
+
+    it('ソースファイルが存在する', () => {
+      expect(source, 'scripts/cleanup-duplicates.js must exist').to.not.be.null;
+    });
+
+    it('BATCH_SIZEは250 (本体+detail/mainの2書込のため2N<=500)', () => {
+      expect(source).to.match(/const BATCH_SIZE = 250;/);
+    });
+
+    it('旧BATCH_SIZE=500の判定は残存しない (回帰防止)', () => {
+      expect(source).to.not.match(/const BATCH_SIZE = 500;/);
+    });
+
+    it('削除ループ内でdocuments本体とdetail/main両方をbatch.deleteする', () => {
+      const loopBlock = extractBraceBlock(source, /for \(const doc of chunk\) \{/, {
+        anchorMode: 'from-start',
+      });
+      expect(loopBlock, 'delete loop block must be found').to.not.be.null;
+      expect(loopBlock).to.match(/batch\.delete\(db\.doc\(`documents\/\$\{doc\.id\}`\)\)/);
+      expect(loopBlock).to.match(
+        /batch\.delete\(db\.doc\(`documents\/\$\{doc\.id\}\/detail\/main`\)\)/
+      );
+    });
+  });
+
+  describe('cleanup-ambiguous-collision-docs.ts', () => {
+    let source: string | null = null;
+
+    before(() => {
+      const fullPath = resolve(
+        __dirname,
+        '..',
+        '..',
+        'scripts',
+        'cleanup-ambiguous-collision-docs.ts'
+      );
+      source = existsSync(fullPath) ? readFileSync(fullPath, 'utf-8') : null;
+    });
+
+    it('ソースファイルが存在する', () => {
+      expect(source, 'scripts/cleanup-ambiguous-collision-docs.ts must exist').to.not
+        .be.null;
+    });
+
+    it('単一batchのため削除対象件数の上限(250)チェックがある (本体+detail/mainの2書込)', () => {
+      expect(source).to.match(/if \(deletions\.length > 250\) \{/);
+    });
+
+    it('削除batchループ内で親docとdetail/main両方をbatch.deleteする', () => {
+      const loopBlock = extractBraceBlock(
+        source,
+        /const batch = db\.batch\(\);\s*\n\s*for \(const d of deletions\) \{/,
+        { anchorMode: 'from-start' }
+      );
+      expect(loopBlock, 'deletion batch loop block must be found').to.not.be.null;
+      expect(loopBlock).to.match(
+        /batch\.delete\(db\.collection\('documents'\)\.doc\(d\.docId\), \{ lastUpdateTime \}\)/
+      );
+      expect(loopBlock).to.match(
+        /db\.collection\('documents'\)\.doc\(d\.docId\)\.collection\('detail'\)\.doc\('main'\)/
+      );
+    });
+  });
+});

--- a/scripts/cleanup-ambiguous-collision-docs.ts
+++ b/scripts/cleanup-ambiguous-collision-docs.ts
@@ -426,6 +426,15 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
+  // ADR-0018 (Issue #547) Phase B: 本体+detail/main の2書込のため
+  // batch内訳は 2N ≤ 500 → N ≤ 250 が安全な上限 (cleanup-duplicates.js と同じ根拠)。
+  // 単一batch (chunking なし) のため、上限超過は明示的に abort する。
+  if (deletions.length > 250) {
+    console.error(
+      `❌ 削除対象件数=${deletions.length} が単一batchの上限(250、本体+detail/main の2書込のため)を超過しています。plan を分割してください。`
+    );
+    process.exit(1);
+  }
   const batch = db.batch();
   for (const d of deletions) {
     const lastUpdateTime = updateTimes.get(d.docId);
@@ -434,6 +443,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
     batch.delete(db.collection('documents').doc(d.docId), { lastUpdateTime });
+    // ADR-0018 (Issue #547) Phase B: detail/main サブコレクションを同一batchで削除
+    // (孤児化防止)。lastUpdateTime preconditionは親docのみで足りる
+    // (detail/mainは親と同一transaction/batchでのみ書込まれるため、親の
+    // precondition不一致で batch 全体が abort されればdetail/mainも道連れで残る)。
+    batch.delete(
+      db.collection('documents').doc(d.docId).collection('detail').doc('main')
+    );
   }
   try {
     await batch.commit();

--- a/scripts/cleanup-duplicates.js
+++ b/scripts/cleanup-duplicates.js
@@ -154,12 +154,15 @@ async function main() {
 
   // 実行モード: Firestoreから削除
   console.log(`\n削除実行中...`);
-  const BATCH_SIZE = 500;
+  // ADR-0018 (Issue #547) Phase B: 本体+detail/main の2書込のため
+  // batch内訳は 2N ≤ 500 → N ≤ 250 が安全な上限
+  const BATCH_SIZE = 250;
   for (let i = 0; i < allToDelete.length; i += BATCH_SIZE) {
     const batch = db.batch();
     const chunk = allToDelete.slice(i, i + BATCH_SIZE);
     for (const doc of chunk) {
       batch.delete(db.doc(`documents/${doc.id}`));
+      batch.delete(db.doc(`documents/${doc.id}/detail/main`));
     }
     await batch.commit();
     console.log(`  ${Math.min(i + BATCH_SIZE, allToDelete.length)}/${allToDelete.length} 件削除`);


### PR DESCRIPTION
## Summary
- ADR-0018 Phase B (Issue #547) PR3: `documents/{id}` 削除経路3箇所で `detail/main` サブコレクションを本体docと同一batch/commit内で削除し、孤児化(orphan)を防止
  - `functions/src/documents/deleteDocument.ts`: 単発`docRef.delete()` → `db.batch()`化
  - `scripts/cleanup-duplicates.js`: BATCH_SIZE 500→250 (本体+detail/mainの2書込のため2N<=500)
  - `scripts/cleanup-ambiguous-collision-docs.ts`: 削除ループに detail/main delete追加
- `/code-review high`実施: 5角度並列finder → dedup → verify。CONFIRMED 1件(cleanup-ambiguous-collision-docs.tsのbatchサイズ安全装置欠如、上限250のFATALガードを追加して対応済み)、PLAUSIBLE 3件(detail/mainヘルパー未共通化=Phase B全体の設計判断でPR3スコープ外、軽微なcleanup2件)は対応不要と判断
- Codexセカンドオピニオン(`codex review --base main --strict-config -c model_reasoning_effort=high`)実施: 追加指摘なし

## Test plan
- [x] `functions/test/deleteSyncDetailDualWriteContract.test.ts` 新規作成(grep-based契約テスト、10ケース): 3経路の dual-delete配線 + batch上限ガードをlock-in
- [x] `npm run test` (functions): 1635 passing / 6 pending (既存分含む全PASS)
- [x] `npx tsc --noEmit` (functions): エラーなし
- [x] `npm run lint` (functions): 0 errors
- [x] `npx tsc --noEmit -p tsconfig.json` (scripts): 既存の pre-existing 3件のみ(本PR変更ファイルとは無関係、変更前から存在確認済み)

Closes なし (Issue #547 は Phase B 全体(PR1〜PR5)完了までopenのまま継続)

🤖 Generated with [Claude Code](https://claude.com/claude-code)