### PR TITLE
feat(firestore): FE再処理リクエスト3箇所をwriteBatch化 (Issue #547 ADR-0018 Phase B)

### DIFF
--- a/frontend/src/hooks/__tests__/useDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useDocuments.test.ts
@@ -38,6 +38,19 @@ describe('firestoreToDocument', () => {
       expect(result.officeName).toBe('テスト事業所')
       expect(result.status).toBe('processed')
     })
+
+    // ADR-0018 Phase B (Issue #547, #178教訓): ocrExcerptがfirestoreToDocument()で
+    // マッピングされないと、Functions側が書込んでもFEで永久に読めなくなる
+    it('ocrExcerpt を正しく変換する (ADR-0018 Phase B)', () => {
+      const data = { ...baseFirestoreData, ocrExcerpt: '抜粋テキスト' }
+      const result = firestoreToDocument('doc-001', data)
+      expect(result.ocrExcerpt).toBe('抜粋テキスト')
+    })
+
+    it('ocrExcerpt が未設定の場合は undefined', () => {
+      const result = firestoreToDocument('doc-001', baseFirestoreData)
+      expect(result.ocrExcerpt).toBeUndefined()
+    })
   })
 
   describe('顧客確定フィールド（Phase 7）', () => {
@@ -433,6 +446,13 @@ describe('getReprocessClearFields (Issue #215: 旧3キー + 新summary 全て de
     expect(fields).toHaveProperty('ocrResultUrl')
     expect(fields).toHaveProperty('pageResults')
     expect(fields).toHaveProperty('ocrExtraction')
+  })
+
+  // ADR-0018 Phase B (Issue #547): 一覧表示用軽量抜粋も再処理時にクリアしないと、
+  // OCR完了までの間、古いocrExcerptが一覧に残存する
+  it('ocrExcerpt も含む (ADR-0018 Phase B)', () => {
+    const fields = getReprocessClearFields()
+    expect(fields).toHaveProperty('ocrExcerpt')
   })
 
   it('確認ステータスのリセット値 (customerConfirmed=false, verified=false 等) を含む', () => {

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -14,6 +14,7 @@ import {
   doc,
   getDoc,
   updateDoc,
+  writeBatch,
   deleteField,
   Timestamp,
   QueryConstraint,
@@ -147,6 +148,8 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     mimeType: data.mimeType as string,
     ocrResult: data.ocrResult as string,
     ocrResultUrl: data.ocrResultUrl as string | undefined,
+    // 一覧表示用軽量抜粋 (ADR-0018 Phase B、Issue #547)
+    ocrExcerpt: data.ocrExcerpt as string | undefined,
     // Issue #209/#215: 切り詰めメタ込みの discriminated union (旧フラット形式も互換読込)
     summary: normalizeSummary(data),
     documentType: data.documentType as string,
@@ -257,6 +260,8 @@ export function getReprocessClearFields() {
     // OCR結果
     ocrResult: df,
     ocrResultUrl: df,
+    // 一覧表示用軽量抜粋 (ADR-0018 Phase B、Issue #547)
+    ocrExcerpt: df,
     // Issue #215: summary は discriminated union ネスト型に統一。旧フラット3フィールド
     // (summaryTruncated / summaryOriginalLength) は後方互換のため同時に delete し、
     // 既存 Firestore ドキュメントに残存する旧フィールドも再処理時にクリーン化する。
@@ -339,10 +344,14 @@ export function useReprocessDocument() {
     if (!documentId || reprocessingId) return false
     setReprocessingId(documentId)
     try {
-      await updateDoc(doc(db, 'documents', documentId), {
+      // ADR-0018 Phase B (Issue #547): 他2箇所(useErrors/DocumentsPage)との
+      // writeBatch統一。detail/main書込はPhase D以降(PR4b)に分離、本PRは親docのみ。
+      const batch = writeBatch(db)
+      batch.update(doc(db, 'documents', documentId), {
         status: 'pending',
         ...getReprocessClearFields(),
       })
+      await batch.commit()
       // 楽観的更新（即時UI反映）
       updateDocumentInListCache(queryClient, documentId, {
         status: 'pending',

--- a/frontend/src/hooks/useErrors.ts
+++ b/frontend/src/hooks/useErrors.ts
@@ -17,6 +17,7 @@ import {
   getDoc,
   doc,
   updateDoc,
+  writeBatch,
   Timestamp,
   QueryConstraint,
 } from 'firebase/firestore'
@@ -219,27 +220,30 @@ interface ReprocessParams {
 }
 
 async function requestReprocess({ errorId, fileId }: ReprocessParams): Promise<void> {
-  // 1. エラーステータスを「pending」に更新（BE値）
-  const errorRef = doc(db, 'errors', errorId)
-  await updateDoc(errorRef, { status: 'pending' })
-
-  // 2. 対応するドキュメントのステータスを「pending」に戻す + メタ情報・確認フラグをクリア
-  const clearFields = getReprocessClearFields()
+  // 対応するドキュメントを検索 (writeより先にread)
   const docsQuery = query(
     collection(db, 'documents'),
     where('fileId', '==', fileId),
     limit(1)
   )
   const snapshot = await getDocs(docsQuery)
-
   const firstDoc = snapshot.docs[0]
+
+  // ADR-0018 Phase B (Issue #547): エラーstatus更新とdocumentクリアを単一batchで
+  // 原子的に実行 (途中失敗による不整合状態を防ぐ)。detail/main書込は
+  // Phase D以降(PR4b)に分離、本PRは親docのみ。
+  const batch = writeBatch(db)
+  const errorRef = doc(db, 'errors', errorId)
+  batch.update(errorRef, { status: 'pending' })
+
   if (firstDoc) {
     const docRef = doc(db, 'documents', firstDoc.id)
-    await updateDoc(docRef, {
+    batch.update(docRef, {
       status: 'pending',
-      ...clearFields,
+      ...getReprocessClearFields(),
     })
   }
+  await batch.commit()
 }
 
 export function useReprocessError() {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -477,29 +477,58 @@ export function DocumentsPage() {
   }, [selectedIds, user, queryClient, clearSelection])
 
   // 一括再処理
+  // ADR-0018 Phase B (Issue #547): 250件チャンク化。detail/main書込は
+  // Phase D以降(PR4b)に分離、本PRは親docのみ+ocrExcerptクリア。
   const handleBulkReprocess = useCallback(async () => {
     if (selectedIds.size === 0) return
 
     setIsBulkOperating(true)
     try {
       const clearFields = getReprocessClearFields()
-      const batch = writeBatch(db)
-      for (const docId of selectedIds) {
-        const docRef = doc(db, 'documents', docId)
-        batch.update(docRef, {
-          status: 'pending',
-          ...clearFields,
-        })
-      }
-      const count = selectedIds.size
-      await batch.commit()
+      const ids = Array.from(selectedIds)
+      const CHUNK_SIZE = 250
+      let succeededCount = 0
+      let chunkFailed = false
 
-      // 一覧をリフレッシュ
+      for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+        const chunk = ids.slice(i, i + CHUNK_SIZE)
+        // code-review指摘: batch構築(doc()/batch.update())もtry内に含め、
+        // チャンク単位のエラーとして扱う(構築時エラーが外側catchに漏れて
+        // succeededCountの情報が失われるのを防ぐ)
+        try {
+          const batch = writeBatch(db)
+          for (const docId of chunk) {
+            const docRef = doc(db, 'documents', docId)
+            batch.update(docRef, {
+              status: 'pending',
+              ...clearFields,
+            })
+          }
+          await batch.commit()
+          succeededCount += chunk.length
+        } catch (chunkError) {
+          console.error('Bulk reprocess chunk error:', chunkError)
+          chunkFailed = true
+          break
+        }
+      }
+
+      // 一覧をリフレッシュ (部分的成功分も反映)
       queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
-      clearSelection()
       setBulkOperation(null)
-      toast.success(`${count}件を再処理キューに追加しました`)
+
+      if (chunkFailed) {
+        // Codexレビュー指摘: 成功済みチャンクのIDは選択から除外する。残すと
+        // 既にpending化済みの文書が再試行対象に残り、進行中のOCRと重複/競合しうる。
+        // 失敗+未処理分のみ選択に残し、ユーザーがその分だけ再試行できるようにする。
+        const succeededIds = new Set(ids.slice(0, succeededCount))
+        setSelectedIds(prev => new Set([...prev].filter(id => !succeededIds.has(id))))
+        toast.error(`一括再処理が途中で失敗しました（${succeededCount}/${ids.length}件完了）`)
+      } else {
+        clearSelection()
+        toast.success(`${succeededCount}件を再処理キューに追加しました`)
+      }
     } catch (error) {
       console.error('Bulk reprocess error:', error)
       toast.error('一括再処理に失敗しました')


### PR DESCRIPTION
## Summary
- ADR-0018 Phase B (Issue #547) PR4a: FE再処理リクエスト3経路をwriteBatch()に統一
  - `useReprocessDocument()`(useDocuments.ts): 単発updateDoc → writeBatch化
  - `useErrors.ts`の`requestReprocess()`: errors/documentsの2つの独立updateDocをwriteBatchで原子化
  - `DocumentsPage.tsx`の`handleBulkReprocess()`: 250件チャンク化+途中失敗時のtoast表示
  - detail/main書込はPhase D以降(PR4b)に分離、本PRは親docのみ+ocrExcerptクリア (LATEST.md session101 Fable5ピアレビューで確定済みスコープ)
- `getReprocessClearFields()`に`ocrExcerpt`を追加(再処理時クリア対象)
- **`firestoreToDocument()`に`ocrExcerpt`の読込マッピングを追加**(PR2で書込側のみ実装され読込側マッピングが欠落、CLAUDE.md #178教訓違反をcode-reviewで検出・修正)
- `/code-review high`実施: 5角度並列finder → dedup → verify。CONFIRMED 3件を修正:
  1. チャンク構築時エラーが外側catchに漏れsucceededCount情報が失われる問題
  2. 部分失敗時に無条件でclearSelection()が実行され再試行不能になる問題
  3. firestoreToDocument()のocrExcerptマッピング欠如
  PLAUSIBLE 2件(useReprocessDocument()のwriteBatch化がYAGNI/チャンク化ロジック非共有)はスコープ外・軽微と判断しskip
- Codexセカンドオピニオン実施: 部分失敗時に成功済みチャンクのIDが選択に残り再試行で重複処理される可能性(P2)を指摘 → 成功済みIDを選択から除外するよう修正、再レビューで追加指摘なし確認

## Test plan
- [x] `getReprocessClearFields`/`firestoreToDocument`のocrExcerptテスト新規追加(vitest)
- [x] `npm test`(frontend): 281 passing(新規4件含む)
- [x] `npx tsc --noEmit`(frontend): エラーなし
- [x] `npm run lint`(frontend): 0 errors
- [x] **実機確認(Firebase emulator + ローカルdev server + Playwright手動操作)**: ログイン→書類一覧15件選択→一括再処理実行→処理完了カウント15→0に変化を確認、Firestore実データで`status:pending`+`ocrResult`/`ocrExcerpt`/`customerName`が`deleteField()`されたことを確認
- [x] E2E既存テスト`reprocess-button.spec.ts`(6 tests)実行: `useReprocessDocument()`経路のwriteBatch化含め全PASS確認

Closes なし (Issue #547 は Phase B 全体(PR1〜PR5)完了までopenのまま継続)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk reprocessing now handles large selections in smaller chunks, improving reliability for big document sets.
  * Document previews now include a lightweight OCR excerpt when available.

* **Bug Fixes**
  * Reprocessing now clears OCR excerpt data consistently so stale content is not shown.
  * Reprocess actions now commit related updates together, reducing partial-update issues.

* **Improved Feedback**
  * Bulk reprocessing now shows clearer success/failure messages and keeps only unfinished items selected after a partial failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->