### PR TITLE
feat(cost): seed-dev-data.tsのdetail/mainサブコレクションdual-write化 (Issue #547 ADR-0018 Phase B)

### DIFF
--- a/functions/test/seedDevDataDetailDualWriteContract.test.ts
+++ b/functions/test/seedDevDataDetailDualWriteContract.test.ts
@@ -1,0 +1,57 @@
+/**
+ * scripts/seed-dev-data.ts の detail/main dual-write 配線契約テスト
+ * (ADR-0018 Phase B, Issue #547)
+ *
+ * processed/error 書類・pending 書類の投入時、本体docと同一batch内で
+ * detail/main へ ocrResult を dual-write する配線をソース文字列レベルでlock-in
+ * する(documentCreationDetailDualWriteContract.test.ts と同形式)。
+ */
+
+import { expect } from 'chai';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+describe('seed-dev-data.ts detail/main dual-write contract (ADR-0018 Phase B)', () => {
+  let source: string | null = null;
+
+  before(() => {
+    const fullPath = resolve(__dirname, '..', '..', 'scripts', 'seed-dev-data.ts');
+    source = existsSync(fullPath) ? readFileSync(fullPath, 'utf-8') : null;
+  });
+
+  it('ソースファイルが存在する', () => {
+    expect(source, 'scripts/seed-dev-data.ts must exist').to.not.be.null;
+  });
+
+  it('BATCH_SIZEは250 (書込み要素数の上限、1docあたり2writeのため実質125doc分)', () => {
+    expect(source).to.match(/const BATCH_SIZE = 250;/);
+  });
+
+  it('旧BATCH_SIZE=400の判定は残存しない (回帰防止)', () => {
+    expect(source).to.not.match(/const BATCH_SIZE = 400;/);
+  });
+
+  it('processed/error書類の投入でbulkDocsをflatMapしdetail/mainへocrResultをdual-writeする', () => {
+    const block = extractBraceBlock(
+      source,
+      /bulkDocs\.flatMap\(\(d\) => \{/,
+      { anchorMode: 'from-start' }
+    );
+    expect(block, 'bulkDocs.flatMap block must be found').to.not.be.null;
+    expect(block).to.match(/ref\.collection\('detail'\)\.doc\('main'\)/);
+    expect(block).to.match(/ocrResult:\s*d\.data\.ocrResult/);
+  });
+
+  it('pending書類の投入でdetail/mainへocrResultをdual-writeするpushがある', () => {
+    const loopBlock = extractBraceBlock(
+      source,
+      /for \(const d of pendingDocs\) \{/,
+      { anchorMode: 'from-start' }
+    );
+    expect(loopBlock, 'pendingDocs for-loop block must be found').to.not.be.null;
+    expect(loopBlock).to.match(/pendingWrites\.push\(\{\s*ref,\s*data:\s*d\.data,?\s*\}\)/);
+    expect(loopBlock).to.match(/ref\.collection\('detail'\)\.doc\('main'\)/);
+    expect(loopBlock).to.match(/ocrResult:\s*d\.data\.ocrResult/);
+  });
+});

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -429,7 +429,10 @@ function buildPendingDoc(mixed: (typeof MIXED_FAX_PDFS)[number], storageBucket: 
 // 投入
 // ============================================
 
-const BATCH_SIZE = 400;
+// ADR-0018 (Issue #547) Phase B: documents書込みはdetail/main分と合わせて
+// 1docあたり2writeになるため、batch内訳は2N<=500 → N<=250が安全な上限
+// (マスターデータ書込みは1write/docのため影響なし)
+const BATCH_SIZE = 250;
 
 async function commitInBatches(
   db: FirebaseFirestore.Firestore,
@@ -524,13 +527,22 @@ async function seed(): Promise<void> {
   await commitInBatches(db, masterWrites);
 
   // 3. processed / error 書類
+  // ADR-0018 (Issue #547) Phase B: 本体と同一batch内でdetail/mainへocrResultを
+  // dual-write (MUST: 原子性)。本体からの削除はPhase E。
   console.log('\n📄 processed/error 書類投入...');
   await commitInBatches(
     db,
-    bulkDocs.map((d) => ({ ref: db.collection('documents').doc(d.id), data: d.data })),
+    bulkDocs.flatMap((d) => {
+      const ref = db.collection('documents').doc(d.id);
+      return [
+        { ref, data: d.data },
+        { ref: ref.collection('detail').doc('main'), data: { ocrResult: d.data.ocrResult as string } },
+      ];
+    }),
   );
 
   // 4. pending 書類 (OCR パイプライン発火)。既存 doc は OCR 完了・検証済み状態の保護のためスキップ
+  // ADR-0018 (Issue #547) Phase B: 本体と同一batch内でdetail/mainへdual-write
   console.log('\n⏳ pending 書類投入...');
   const pendingWrites: Array<{ ref: FirebaseFirestore.DocumentReference; data: Record<string, unknown> }> = [];
   for (const d of pendingDocs) {
@@ -540,6 +552,10 @@ async function seed(): Promise<void> {
       continue;
     }
     pendingWrites.push({ ref, data: d.data });
+    pendingWrites.push({
+      ref: ref.collection('detail').doc('main'),
+      data: { ocrResult: d.data.ocrResult as string },
+    });
   }
   if (pendingWrites.length > 0) {
     await commitInBatches(db, pendingWrites);

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -429,9 +429,12 @@ function buildPendingDoc(mixed: (typeof MIXED_FAX_PDFS)[number], storageBucket: 
 // 投入
 // ============================================
 
-// ADR-0018 (Issue #547) Phase B: documents書込みはdetail/main分と合わせて
-// 1docあたり2writeになるため、batch内訳は2N<=500 → N<=250が安全な上限
-// (マスターデータ書込みは1write/docのため影響なし)
+// ADR-0018 (Issue #547) Phase B: commitInBatchesは既にflatMap後の生write配列
+// (parent+detail/mainのペアが連続2要素として並ぶ)をBATCH_SIZE単位でchunkする。
+// BATCH_SIZEは「doc数」ではなく「write要素数」の上限であり、偶数である限り
+// 各docのペアがchunk境界をまたぐことはない(250要素=processed/error等は125doc分)。
+// 250はFirestore 500 write上限の半分で、1write/docのmasterWritesにも同じ定数を
+// 適用しているため実質125doc分とやや保守的だが、安全側でありコストは無視できる。
 const BATCH_SIZE = 250;
 
 async function commitInBatches(


### PR DESCRIPTION
## Summary
- ADR-0018 Phase B (Issue #547) PR5(5PR構成の最終PR): dev環境seedスクリプトのdetail/main dual-write化
  - `buildBulkDocs()`(processed/error 148件) / `buildPendingDoc()`(pending 2件)が生成するdocの投入時、本体docと同一batch内で`detail/main`へ`ocrResult`をdual-write
  - `BATCH_SIZE`を400→250に変更(1docあたり2writeになるため)。Phase C以降のdevシードでdetail/main欠落によるdevリハーサル失敗を防ぐ(ADR-0018 Phase Bスコープの明示要件)
- 他4PR(PR2/PR3)と同様、grep-based契約テスト新規追加(`functions/test/seedDevDataDetailDualWriteContract.test.ts`、5テスト)でdual-write配線をlock-in
- `/code-review high`実施: 5角度並列finder → dedup → verify。CONFIRMED 2件を修正:
  1. `BATCH_SIZE`コメントの数値不整合(「2N<=500→N<=250」のNがdoc数のつもりだったが、実装は既にflatMap後の生write配列に対する要素数上限であり実質125doc/chunk。実害なし・安全側だが将来の変更時に誤った前提で変更されるリスクがあるため訂正)
  2. 契約テスト欠如(他4PRとのパターン不一致) → 追加
  PLAUSIBLE 2件(`as string`型キャストの型安全性、detail/mainパス文字列のヘルパー未抽出)はスコープ外・軽微と判断しskip(ヘルパー未抽出はPhase B全体を通じて繰り返し指摘されている設計判断、Phase B完了後の別リファクタリング候補として記録)
- Codexセカンドオピニオン実施: 追加指摘なし

## Test plan
- [x] `functions/test/seedDevDataDetailDualWriteContract.test.ts`新規追加(5テスト): BATCH_SIZE=250 + processed/pending両経路のdual-write配線をlock-in
- [x] `npm run test`(functions): 1640 passing(新規5件含む)
- [x] `npx tsc --noEmit -p tsconfig.json`(scripts): エラーなし
- [x] **実機確認(GitHub Actions経由でdev環境に実投入)**: dry-run(148件processed/error + 2件pending予定)確認後、実行モードで投入(148件→296件のコミット、2倍化を確認)。Firebase Consoleで`documents/seed-doc-0001/detail/main`ドキュメントの実在+ `ocrResult`が本体と同一値であることを直接確認

Closes #547 (Issue #547 ADR-0018 Phase B の5PR構成(PR1〜PR5)が本PRで完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Seeded document data now includes matching detail records with OCR results for both processed/error and pending items.

* **Bug Fixes**
  * Reduced batch write size to make large seed operations more reliable.
  * Existing pending records continue to be skipped unless forced, while new pending records now receive the full document detail data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->