### PR TITLE
feat(cost): Gemini 2.5/3.5 confirmed replay検証スクリプト追加 (Issue #548)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -92,6 +92,8 @@ on:
           - measure-field-byte-sizes --limit 300
           - measure-split-into-length
           - compare-gemini-ocr-models
+          - compare-gemini-ocr-models-confirmed --limit 30
+          - compare-gemini-ocr-models-confirmed --limit 300
           - measure-summary-cost --doc-id
           - create-pending-doc --doc-id --storage-path original/seed_generic_12p.pdf
       doc_id:
@@ -552,11 +554,13 @@ jobs:
                [ "$SCRIPT_NAME" = "verify-pdf-determinism" ] || \
                [ "$SCRIPT_NAME" = "seed-dev-data" ] || \
                [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ] || \
+               [ "$SCRIPT_NAME" = "compare-gemini-ocr-models-confirmed" ] || \
                [ "$SCRIPT_NAME" = "measure-summary-cost" ] || \
                [ "$SCRIPT_NAME" = "create-pending-doc" ]; then
             # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript)、seed-dev-data (#528) は
             # shared/*.ts に依存するため ts-node 経由で実行。compare-gemini-ocr-models (#548) は
             # functions/src/utils/* (extractors.ts/retry.ts) に依存するため同様に ts-node 経由。
+            # compare-gemini-ocr-models-confirmed (#548 confirmed replay方式) も同様の依存関係。
             # measure-summary-cost (#562) は functions/src/ocr/summaryGenerator.ts に依存するため同様。
             # create-pending-doc (#562) はfirebase-adminのみ依存(functions/src非依存)だが、
             # 統一的にscriptsディレクトリからts-node経由で実行する。

--- a/scripts/compare-gemini-ocr-models-confirmed.ts
+++ b/scripts/compare-gemini-ocr-models-confirmed.ts
@@ -1,0 +1,700 @@
+#!/usr/bin/env ts-node
+/**
+ * Gemini 2.5 Flash vs 3.5 Flash OCR精度+コスト比較スクリプト（confirmed replay方式、read-only、Issue #548）
+ *
+ * scripts/compare-gemini-ocr-models.ts（dev環境の合成フィクスチャ、正解ラベル付き2ファイル・
+ * 11ページ）はCodexセカンドオピニオンで「n=11は実運用判断の統計的根拠として不十分」と指摘された
+ * (rule of threeで劣化率上限27%までしか保証しない)。
+ *
+ * 本スクリプトは、kanameone/cocoro本番環境に存在する「確定済み文書」
+ * (customerConfirmed && officeConfirmed && documentTypeConfirmed が true、
+ * functions/src/ocr/confirmedFieldMerge.ts参照)を活用する。これらは既に人間検証済み
+ * (またはOCR高確信度自己判定済み)のcustomerName/officeName/documentTypeをFirestore上に
+ * 持っているため、新規ラベリングコストなしで大規模・実データでの精度検証ができる。
+ *
+ * **ground truthの限定(Codex review指摘反映)**: customerConfirmed/officeConfirmedはOCR自身の
+ * 高確信度自己判定でもtrueになりうる(confirmedFieldMerge.ts参照)。現行gemini-2.5-flash由来の
+ * 自己判定値をground truthに使うと、baseline(2.5)に有利なラベルリークになる。そのため
+ * customer/officeは`confirmedBy`/`officeConfirmedBy`が非nullの、真に人間が確定した文書のみを
+ * 対象とする(documentTypeConfirmedはユーザー選択専用で自己判定シグナルを持たないため対象外の
+ * フィルタ不要)。
+ *
+ * サンプリングした文書の元PDFを2.5-flash/3.5-flash両方で再OCRし、
+ * functions/src/utils/extractors.ts の抽出関数で書類種別/顧客/事業所を抽出、
+ * 確定値と突合する（ocrProcessor.ts の processDocument() と同じ「全ページ結合テキストに対して
+ * 抽出を1回実行」という文書単位の評価方式を踏襲。confirmed文書は既に分割済みの単一文書であり、
+ * compare-gemini-ocr-models.ts のようなページ単位の複数文書混在フィクスチャではないため）。
+ *
+ * read-only厳守: Firestore/Storageへの書込は一切行わない。マスターデータ読込は
+ * functions/src/utils/loadMasterData.ts を再利用せず、本スクリプト内に最小限の読込専用実装を
+ * 持つ（loadMasterDataはsanitize drop発生時にNODE_ENV=production等でFirestoreへの
+ * safeLogError書込を試みる分岐を持つため、read-only保証を書込非依存で担保するために意図的に
+ * 独立実装とする）。
+ *
+ * 個人情報保護: 個別文書の突合結果(氏名・事業所名等)はログ/artifactいずれにも出力しない。
+ * 出力するのは集計値のみ(一致率・トークン数・コスト・p50/p95/p99レイテンシ・リトライ率・失敗率)。
+ * 不一致が発生した場合も「件数」のみを記録し、doc IDや期待値/実際値は出力しない。深掘り調査が
+ * 必要な場合はdecision-makerがkanameone環境に直接アクセスして個別確認する運用とする。
+ * **Codex review指摘反映**: functions/src/utils/retry.ts の withRetry/withRetryResult は
+ * リトライ時に `lastError.message` をそのままconsole.logするため、Storageパス(元アップロード
+ * ファイル名を含みうる、sanitizeFilenameForStorage()は日本語等を除去しない)が漏洩する経路が
+ * あった。本スクリプトでは共通retryを使わず、エラーメッセージを一切ログ出力しない
+ * withSilentRetry() を独自実装する。
+ *
+ * 使用方法:
+ *   推奨: GitHub Actions "Run Operations Script" → environment: kanameone /
+ *         script: compare-gemini-ocr-models-confirmed --limit 30 (pilot)
+ *         script: compare-gemini-ocr-models-confirmed --limit 300 (本実行)
+ *   ローカル実行（フォールバック）:
+ *     gcloud auth application-default login (kanameone環境の管理者アカウントで)
+ *     GOOGLE_CLOUD_PROJECT=docsplit-kanameone STORAGE_BUCKET=docsplit-kanameone.firebasestorage.app \
+ *       npx ts-node scripts/compare-gemini-ocr-models-confirmed.ts --limit 30
+ */
+
+import { GoogleGenAI } from '@google/genai';
+import * as admin from 'firebase-admin';
+import { isTransientError, RETRY_CONFIGS, type RetryConfig } from '../functions/src/utils/retry';
+import { GEMINI_CONFIG } from '../functions/src/utils/config';
+import {
+  extractDocumentTypeEnhanced,
+  extractCustomerCandidates,
+  extractOfficeCandidates,
+  extractFilenameInfo,
+  type DocumentMaster,
+  type CustomerMaster,
+  type OfficeMaster,
+} from '../functions/src/utils/extractors';
+import {
+  sanitizeCustomerMasters,
+  sanitizeDocumentMasters,
+  sanitizeOfficeMasters,
+} from '../functions/src/utils/sanitizeMasterData';
+import { MASTER_PATHS } from '../functions/src/utils/masterPaths';
+import {
+  BASELINE_MODEL_CONFIG,
+  CANDIDATE_MODEL_CONFIG,
+  buildOcrPrompt,
+  extractAllPdfPages,
+  type ModelConfig,
+  type ModelRole,
+} from './lib/geminiOcrCompare';
+
+/**
+ * confirmed文書が実運用規模で存在する本番クライアント環境のみ許可する
+ * (compare-gemini-ocr-models.ts の ALLOWED_PROJECT_ID ガードの逆パターン: dev環境の
+ * seedフィクスチャにはconfirmed文書が十分な規模で存在しないため dev は明示的に拒否する)。
+ */
+const ALLOWED_PROJECT_IDS = ['docsplit-kanameone', 'docsplit-cocoro'];
+const LOCATION = 'asia-northeast1';
+/** Vertex AIレート制限を踏まえた保守的な同時実行数 */
+const CONCURRENCY = 5;
+const DEFAULT_LIMIT = 30;
+/**
+ * confirmedBy/officeConfirmedBy による人間確定フィルタで一部が弾かれる前提で、
+ * Firestoreクエリ自体は目標件数の3倍を上限にサンプリングする(Codex review指摘反映)。
+ * 大きすぎる無制限headroomによるread coストを避けるため上限をキャップする。
+ */
+const SAMPLE_HEADROOM_MULTIPLIER = 3;
+const SAMPLE_HEADROOM_CAP = 2000;
+
+const PROJECT_ID =
+  process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID || '';
+const STORAGE_BUCKET = process.env.STORAGE_BUCKET || '';
+
+if (!PROJECT_ID) {
+  console.error('GOOGLE_CLOUD_PROJECT (または FIREBASE_PROJECT_ID) を設定してください');
+  process.exit(1);
+}
+
+if (!ALLOWED_PROJECT_IDS.includes(PROJECT_ID)) {
+  console.error(
+    `❌ このスクリプトは ${ALLOWED_PROJECT_IDS.join('/')} 専用です (指定されたプロジェクト: ${PROJECT_ID})。` +
+      '確定済み文書(customerConfirmed/officeConfirmed/documentTypeConfirmed)を実運用規模で持つ' +
+      '本番クライアント環境でのみ意味を成す検証のため、他環境では実行できません。'
+  );
+  process.exit(1);
+}
+
+if (!STORAGE_BUCKET) {
+  // CLAUDE.md「Storageバケット名」: projectIdからの推測は禁止(.appspot.com/.firebasestorage.app混在)。
+  // scripts/clients/<env>.env の STORAGE_BUCKET を明示的に渡す必要がある(Codex review指摘反映、
+  // import-historical-gmail.js等の既存スクリプトと同じパターン)。
+  console.error('STORAGE_BUCKET 環境変数が必要です (例: docsplit-kanameone.firebasestorage.app)');
+  process.exit(1);
+}
+
+if (!admin.apps.length) {
+  admin.initializeApp({ projectId: PROJECT_ID, storageBucket: STORAGE_BUCKET });
+}
+const db = admin.firestore();
+const storage = admin.storage();
+
+/**
+ * エラーの種別のみを個人情報漏洩なくログ出力するためのヘルパー。
+ *
+ * GCS/Firestore SDKのエラーメッセージは対象オブジェクトのパス(例: "No such object:
+ * bucket/original/xxxx_田中太郎様_請求書.pdf")を含むことがある。fileUrl/storagePathは
+ * functions/src/utils/fileNaming.ts の sanitizeFilenameForStorage() が元のアップロード/
+ * 添付ファイル名から禁止文字を置換するのみで日本語文字等はそのまま残すため、氏名を含む
+ * 元ファイル名がストレージパスに埋め込まれている可能性がある。エラーメッセージを生のまま
+ * ログ出力しないよう、種別・コードのみを抽出する。
+ */
+function describeErrorSafely(err: unknown): string {
+  if (err instanceof Error) {
+    const withCode = err as Error & { code?: string | number; status?: number };
+    const code = withCode.code ?? withCode.status;
+    return code !== undefined ? `${err.constructor.name}(code=${code})` : err.constructor.name;
+  }
+  return typeof err;
+}
+
+type SilentRetryResult<T> = { success: true; data: T; attempts: number } | { success: false; error: Error; attempts: number };
+
+/**
+ * functions/src/utils/retry.ts の withRetry/withRetryResult と同じ exponential backoff だが、
+ * リトライ中に `lastError.message` を一切ログ出力しない(Codex review指摘反映、PII漏洩対策)。
+ * isTransientError() は純粋関数のため安全に再利用する。
+ */
+async function withSilentRetry<T>(fn: () => Promise<T>, config: RetryConfig): Promise<SilentRetryResult<T>> {
+  let delay = config.initialDelayMs;
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= config.maxRetries + 1; attempt++) {
+    try {
+      const data = await fn();
+      return { success: true, data, attempts: attempt };
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt > config.maxRetries || !isTransientError(error)) {
+        return { success: false, error: lastError, attempts: attempt };
+      }
+      // 個人情報保護のためエラー内容はログに出さない(件数・待機時間のみ)
+      console.log(`[withSilentRetry] attempt ${attempt}/${config.maxRetries + 1} failed, retrying in ${delay}ms`);
+      await new Promise((resolve) => setTimeout(resolve, Math.min(delay, config.maxDelayMs)));
+      delay *= config.backoffMultiplier;
+    }
+  }
+  return { success: false, error: lastError ?? new Error('Retry failed'), attempts: config.maxRetries + 1 };
+}
+
+function getLimitArg(): number {
+  const idx = process.argv.indexOf('--limit');
+  if (idx === -1) return DEFAULT_LIMIT;
+  const value = Number(process.argv[idx + 1]);
+  if (!Number.isFinite(value) || value <= 0) {
+    console.error('--limit には正の整数を指定してください');
+    process.exit(1);
+  }
+  return Math.floor(value);
+}
+
+/**
+ * マスターデータ読込 (read-only、functions/src/utils/loadMasterData.ts の書込分岐を避けるため独立実装)。
+ * sanitize*Masters は純粋関数のため安全に再利用する。drop発生時は console.warn のみ(Firestore書込なし)。
+ */
+async function loadMastersReadOnly(): Promise<{
+  documents: DocumentMaster[];
+  customers: CustomerMaster[];
+  offices: OfficeMaster[];
+}> {
+  const [documentSnap, customerSnap, officeSnap] = await Promise.all([
+    db.collection(MASTER_PATHS.documents).get(),
+    db.collection(MASTER_PATHS.customers).get(),
+    db.collection(MASTER_PATHS.offices).get(),
+  ]);
+
+  const documentRaw: DocumentMaster[] = documentSnap.docs.map((d) => ({
+    id: d.id,
+    name: d.data().name as string,
+    category: d.data().category as string | undefined,
+    keywords: d.data().keywords as string[] | undefined,
+    aliases: d.data().aliases as string[] | undefined,
+    dateMarker: d.data().dateMarker as string | undefined,
+  }));
+  const customerRaw: CustomerMaster[] = customerSnap.docs.map((d) => ({
+    id: d.id,
+    name: d.data().name as string,
+    furigana: d.data().furigana as string | undefined,
+    isDuplicate: d.data().isDuplicate as boolean | undefined,
+    careManagerName: d.data().careManagerName as string | undefined,
+    aliases: d.data().aliases as string[] | undefined,
+  }));
+  const officeRaw: OfficeMaster[] = officeSnap.docs.map((d) => ({
+    id: d.id,
+    name: d.data().name as string,
+    shortName: d.data().shortName as string | undefined,
+    isDuplicate: d.data().isDuplicate as boolean | undefined,
+    aliases: d.data().aliases as string[] | undefined,
+  }));
+
+  const documentResult = sanitizeDocumentMasters(documentRaw);
+  const customerResult = sanitizeCustomerMasters(customerRaw);
+  const officeResult = sanitizeOfficeMasters(officeRaw);
+
+  const droppedTotal =
+    documentResult.droppedIds.length + customerResult.droppedIds.length + officeResult.droppedIds.length;
+  if (droppedTotal > 0) {
+    console.warn(
+      `[loadMastersReadOnly] sanitize drop: documents=${documentResult.droppedIds.length} ` +
+        `customers=${customerResult.droppedIds.length} offices=${officeResult.droppedIds.length} ` +
+        '(read-only測定スクリプトのためFirestoreへのログ書込は行わない)'
+    );
+  }
+
+  return { documents: documentResult.items, customers: customerResult.items, offices: officeResult.items };
+}
+
+interface SampledDoc {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  totalPages: number;
+  confirmedDocumentType: string;
+  confirmedCustomerName: string;
+  confirmedOfficeName: string;
+}
+
+/**
+ * 確定済み文書をサンプリングする。orderBy('__name__') は measure-field-byte-sizes.js と同じ
+ * 前例パターン: documents の doc ID は db.collection('documents').doc() による Firestore
+ * auto-ID (ランダム文字列、functions/src/upload/uploadPdf.ts:203 等で確認済み) のため、
+ * ID順ソート+limitは真の乱数生成器なしで妥当な疑似ランダムサンプルになる。
+ *
+ * customerConfirmedBy/officeConfirmedByが非nullの(真に人間が確定した)文書のみを対象とする
+ * (Codex review指摘反映、上部doc comment参照)。documentTypeConfirmedはユーザー選択専用の
+ * ため追加フィルタ不要(confirmedFieldMerge.ts参照)。
+ */
+async function sampleConfirmedDocuments(limit: number): Promise<SampledDoc[]> {
+  const queryLimit = Math.min(limit * SAMPLE_HEADROOM_MULTIPLIER, SAMPLE_HEADROOM_CAP);
+  const snap = await db
+    .collection('documents')
+    .where('status', '==', 'processed')
+    .where('customerConfirmed', '==', true)
+    .where('officeConfirmed', '==', true)
+    .where('documentTypeConfirmed', '==', true)
+    .orderBy('__name__')
+    .limit(queryLimit)
+    .get();
+
+  const humanConfirmedOnly = snap.docs.filter((d) => {
+    const data = d.data();
+    return data.confirmedBy != null && data.officeConfirmedBy != null;
+  });
+
+  return humanConfirmedOnly.slice(0, limit).map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      fileName: data.fileName as string,
+      fileUrl: data.fileUrl as string,
+      totalPages: (data.totalPages as number) ?? 1,
+      confirmedDocumentType: data.documentType as string,
+      confirmedCustomerName: data.customerName as string,
+      confirmedOfficeName: data.officeName as string,
+    };
+  });
+}
+
+/** read-only: file.download() のみ、書込・削除は行わない */
+async function downloadOriginalPdf(fileUrl: string): Promise<Buffer> {
+  const bucket = storage.bucket();
+  const filePath = fileUrl.replace(`gs://${bucket.name}/`, '');
+  const file = bucket.file(filePath);
+  const result = await withSilentRetry(() => file.download(), RETRY_CONFIGS.storage);
+  if (!result.success) {
+    throw result.error;
+  }
+  return result.data[0];
+}
+
+/** 同時実行数を制限しつつ全アイテムを処理する (外部ライブラリ非依存の軽量実装) */
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function runner(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await worker(items[index], index);
+    }
+  }
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runner()));
+  return results;
+}
+
+interface PageOcrCallResult {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  anomalous: boolean;
+  retried: boolean;
+}
+
+/**
+ * API呼出が最終的に失敗した場合(リトライ上限到達)は throw する。呼出元
+ * processDocumentWithModel() の try/catch が文書単位の失敗として集計するため、
+ * ここで「空文字+anomalous」のような偽の成功値を返してはならない
+ * (Codex review指摘反映: 以前は success:true のまま集計され、10%失敗gateが機能せず
+ * 両モデルが同程度に異常終了した場合に「精度劣化なし」と誤判定されるリスクがあった)。
+ * anomalous は「APIは成功したが空応答/safetyブロック等の疑いがある」ケース専用に残す。
+ */
+async function ocrPage(
+  ai: InstanceType<typeof GoogleGenAI>,
+  modelConfig: ModelConfig,
+  pageBuffer: Buffer,
+  pageNumber: number
+): Promise<PageOcrCallResult> {
+  const base64Data = pageBuffer.toString('base64');
+
+  const result = await withSilentRetry(
+    () =>
+      ai.models.generateContent({
+        model: modelConfig.modelId,
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              { inlineData: { mimeType: 'application/pdf', data: base64Data } },
+              { text: buildOcrPrompt(pageNumber) },
+            ],
+          },
+        ],
+        config: {
+          maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
+          thinkingConfig: modelConfig.thinkingConfig,
+        },
+      }),
+    RETRY_CONFIGS.gemini
+  );
+
+  if (!result.success) {
+    throw result.error;
+  }
+
+  const response = result.data;
+  const text = response.text || '';
+  const usageMetadata = response.usageMetadata;
+
+  // compare-gemini-ocr-models.ts と同じ判定: 空応答は safetyブロック等のAPI異常の可能性がある
+  let anomalous = false;
+  if (!response.text) {
+    const candidate = response.candidates?.[0];
+    const finishReason = candidate?.finishReason;
+    const blockReason = response.promptFeedback?.blockReason;
+    if (blockReason || (finishReason && finishReason !== 'STOP')) {
+      anomalous = true;
+    }
+  }
+
+  return {
+    text,
+    inputTokens: usageMetadata?.promptTokenCount || 0,
+    outputTokens: usageMetadata?.candidatesTokenCount || 0,
+    thinkingTokens: usageMetadata?.thoughtsTokenCount || 0,
+    anomalous,
+    retried: result.attempts > 1,
+  };
+}
+
+interface DocOcrOutcome {
+  success: boolean;
+  inputTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  elapsedMs: number;
+  docTypeMatch: boolean;
+  customerMatch: boolean;
+  officeMatch: boolean;
+  anomalousPages: number;
+  hadRetry: boolean;
+}
+
+/**
+ * 1文書を指定モデルで再OCRし、確定値と突合する。個人情報(氏名等)を含む中間結果は
+ * この関数の戻り値にも含めない(bool一致フラグのみ)。ページOCRが最終的に失敗した場合は
+ * ocrPage()がthrowし、ここでcatchして文書単位の失敗(success:false)として扱う。
+ *
+ * pageBuffersは呼出元(processOneDocument)が1文書につき1回だけ抽出したものを渡す
+ * (code-review指摘反映: 以前はモデルごとにPDF全体を再パースしており、2モデル分で
+ * 冗長なCPU消費が発生していた)。
+ */
+async function processDocumentWithModel(
+  ai: InstanceType<typeof GoogleGenAI>,
+  modelConfig: ModelConfig,
+  sampled: SampledDoc,
+  pageBuffers: Buffer[],
+  masters: { documents: DocumentMaster[]; customers: CustomerMaster[]; offices: OfficeMaster[] }
+): Promise<DocOcrOutcome> {
+  const start = Date.now();
+  const pageTexts: string[] = [];
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalThinking = 0;
+  let anomalousPages = 0;
+  let hadRetry = false;
+
+  try {
+    for (let i = 0; i < pageBuffers.length; i++) {
+      const outcome = await ocrPage(ai, modelConfig, pageBuffers[i], i + 1);
+      pageTexts.push(outcome.text);
+      totalInput += outcome.inputTokens;
+      totalOutput += outcome.outputTokens;
+      totalThinking += outcome.thinkingTokens;
+      if (outcome.anomalous) anomalousPages++;
+      if (outcome.retried) hadRetry = true;
+    }
+
+    const combinedText = pageTexts.map((t, idx) => `--- Page ${idx + 1} ---\n${t}`).join('\n\n');
+    const filenameInfo = extractFilenameInfo(sampled.fileName);
+    const documentTypeResult = extractDocumentTypeEnhanced(combinedText, masters.documents);
+    const customerResult = extractCustomerCandidates(combinedText, masters.customers);
+    const officeResult = extractOfficeCandidates(combinedText, masters.offices, { filenameInfo });
+
+    return {
+      success: true,
+      inputTokens: totalInput,
+      outputTokens: totalOutput,
+      thinkingTokens: totalThinking,
+      elapsedMs: Date.now() - start,
+      docTypeMatch: documentTypeResult.documentType === sampled.confirmedDocumentType,
+      customerMatch: customerResult.bestMatch?.name === sampled.confirmedCustomerName,
+      officeMatch: officeResult.bestMatch?.name === sampled.confirmedOfficeName,
+      anomalousPages,
+      hadRetry,
+    };
+  } catch (err) {
+    // 1文書の失敗で全体を止めない。失敗件数として集計する(doc ID等はログに出さない)。
+    console.warn(`[processDocumentWithModel] 1文書の処理に失敗 (${modelConfig.label}): ${describeErrorSafely(err)}`);
+    return {
+      success: false,
+      inputTokens: totalInput,
+      outputTokens: totalOutput,
+      thinkingTokens: totalThinking,
+      elapsedMs: Date.now() - start,
+      docTypeMatch: false,
+      customerMatch: false,
+      officeMatch: false,
+      anomalousPages,
+      hadRetry,
+    };
+  }
+}
+
+function percentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) return 0;
+  const idx = Math.min(sortedValues.length - 1, Math.ceil((p / 100) * sortedValues.length) - 1);
+  return sortedValues[Math.max(0, idx)];
+}
+
+interface ModelSummary {
+  role: ModelRole;
+  label: string;
+  totalDocs: number;
+  succeededDocs: number;
+  failedDocs: number;
+  docTypePass: number;
+  customerPass: number;
+  officePass: number;
+  allPass: number;
+  anomalousPageCount: number;
+  retriedDocCount: number;
+  totalInput: number;
+  totalOutput: number;
+  totalThinking: number;
+  costUsd: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+}
+
+function summarize(modelConfig: ModelConfig, outcomes: DocOcrOutcome[]): ModelSummary {
+  const { role, label, pricing } = modelConfig;
+  const totalDocs = outcomes.length;
+  const succeeded = outcomes.filter((o) => o.success);
+  const failedDocs = totalDocs - succeeded.length;
+
+  const docTypePass = succeeded.filter((o) => o.docTypeMatch).length;
+  const customerPass = succeeded.filter((o) => o.customerMatch).length;
+  const officePass = succeeded.filter((o) => o.officeMatch).length;
+  const allPass = succeeded.filter((o) => o.docTypeMatch && o.customerMatch && o.officeMatch).length;
+  const anomalousPageCount = outcomes.reduce((s, o) => s + o.anomalousPages, 0);
+  const retriedDocCount = outcomes.filter((o) => o.hadRetry).length;
+
+  const totalInput = outcomes.reduce((s, o) => s + o.inputTokens, 0);
+  const totalOutput = outcomes.reduce((s, o) => s + o.outputTokens, 0);
+  const totalThinking = outcomes.reduce((s, o) => s + o.thinkingTokens, 0);
+  const billableOutput = totalOutput + totalThinking;
+  const costUsd = (totalInput * pricing.inputPer1MTokens + billableOutput * pricing.outputPer1MTokens) / 1_000_000;
+
+  const sortedMs = outcomes.map((o) => o.elapsedMs).sort((a, b) => a - b);
+
+  const summary: ModelSummary = {
+    role,
+    label,
+    totalDocs,
+    succeededDocs: succeeded.length,
+    failedDocs,
+    docTypePass,
+    customerPass,
+    officePass,
+    allPass,
+    anomalousPageCount,
+    retriedDocCount,
+    totalInput,
+    totalOutput,
+    totalThinking,
+    costUsd,
+    p50Ms: percentile(sortedMs, 50),
+    p95Ms: percentile(sortedMs, 95),
+    p99Ms: percentile(sortedMs, 99),
+  };
+
+  console.log(`\n=== ${label} ===`);
+  console.log(`対象文書数: ${totalDocs} (成功 ${succeeded.length} / 失敗 ${failedDocs}、失敗率 ${pct(failedDocs, totalDocs)}%)`);
+  console.log(`書類種別 一致率: ${docTypePass}/${succeeded.length} (${pct(docTypePass, succeeded.length)}%)`);
+  console.log(`顧客     一致率: ${customerPass}/${succeeded.length} (${pct(customerPass, succeeded.length)}%)`);
+  console.log(`事業所   一致率: ${officePass}/${succeeded.length} (${pct(officePass, succeeded.length)}%)`);
+  console.log(`全項目一致      : ${allPass}/${succeeded.length} (${pct(allPass, succeeded.length)}%)`);
+  console.log(`API異常疑いページ数: ${anomalousPageCount}`);
+  console.log(`リトライ発生文書数: ${retriedDocCount}/${totalDocs} (${pct(retriedDocCount, totalDocs)}%)`);
+  console.log(`トークン: input=${totalInput} output=${totalOutput} thinking=${totalThinking}`);
+  console.log(`概算コスト: $${costUsd.toFixed(4)}`);
+  console.log(`文書あたり処理時間: p50=${summary.p50Ms}ms p95=${summary.p95Ms}ms p99=${summary.p99Ms}ms`);
+
+  return summary;
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return '0.0';
+  return ((n / total) * 100).toFixed(1);
+}
+
+interface DocPairResult {
+  baseline: DocOcrOutcome;
+  candidate: DocOcrOutcome;
+}
+
+/**
+ * 1文書について、ダウンロード→両モデルでの処理→バッファ破棄までを1単位として扱う。
+ * (Codex review指摘反映: 以前はN件全PDFを一括ダウンロードして保持していたため、
+ * N=300規模でGitHub Actions runnerのメモリを圧迫するリスクがあった。文書単位で
+ * バッファのスコープを閉じることでrunner側のGCに任せられる。)
+ *
+ * aiClientsは呼出元(main)で1回だけ生成したものを再利用する(code-review指摘反映:
+ * GoogleGenAIクライアントはstateless設定オブジェクトのため、文書×モデルごとに毎回
+ * 新規生成するのはN=300規模で無駄なCPU/初期化コスト)。baseline/candidateの2モデル呼出は
+ * 互いに独立(同一pageBuffersを読むだけで状態を共有しない)のためPromise.allで並行実行し、
+ * 1文書あたりの処理時間を半減させる。
+ */
+async function processOneDocument(
+  doc: SampledDoc,
+  aiClients: Record<ModelRole, InstanceType<typeof GoogleGenAI>>,
+  masters: { documents: DocumentMaster[]; customers: CustomerMaster[]; offices: OfficeMaster[] }
+): Promise<DocPairResult | null> {
+  let pdfBuffer: Buffer;
+  try {
+    pdfBuffer = await downloadOriginalPdf(doc.fileUrl);
+  } catch (err) {
+    console.warn(`[processOneDocument] PDF取得失敗 (1件スキップ): ${describeErrorSafely(err)}`);
+    return null;
+  }
+
+  const pageBuffers = await extractAllPdfPages(pdfBuffer, doc.totalPages);
+
+  const [baseline, candidate] = await Promise.all([
+    processDocumentWithModel(aiClients.baseline, BASELINE_MODEL_CONFIG, doc, pageBuffers, masters),
+    processDocumentWithModel(aiClients.candidate, CANDIDATE_MODEL_CONFIG, doc, pageBuffers, masters),
+  ]);
+
+  return { baseline, candidate };
+}
+
+async function main(): Promise<void> {
+  const limit = getLimitArg();
+
+  console.log('=== Gemini 2.5 vs 3.5 Flash OCR比較 (confirmed replay方式, Issue #548) ===');
+  console.log(`プロジェクト: ${PROJECT_ID} / リージョン: ${LOCATION} / サンプル数上限: ${limit}`);
+  console.log('個人情報(氏名・事業所名等)はログに一切出力しません。集計値のみを出力します。');
+  console.log('顧客/事業所は人間確定(confirmedBy/officeConfirmedBy非null)の文書のみを対象とします。');
+
+  const [sampled, masters] = await Promise.all([sampleConfirmedDocuments(limit), loadMastersReadOnly()]);
+
+  if (sampled.length === 0) {
+    console.error(
+      '❌ 対象文書が見つかりませんでした (status=processed かつ customerConfirmed/officeConfirmed/' +
+        'documentTypeConfirmedが全てtrue、かつconfirmedBy/officeConfirmedByが非null)'
+    );
+    process.exit(1);
+  }
+  console.log(`サンプリングした文書数: ${sampled.length}`);
+
+  // GoogleGenAIクライアントはstateless設定オブジェクトのため実行全体で1個ずつ使い回す
+  // (code-review指摘反映: 文書×モデルごとの再生成は無駄なCPU/初期化コスト)。
+  const aiClients: Record<ModelRole, InstanceType<typeof GoogleGenAI>> = {
+    baseline: new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION }),
+    candidate: new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION }),
+  };
+
+  console.log('\n--- 文書ごとに処理中 (ダウンロード→2.5-flash/3.5-flash並行実行→バッファ破棄) ---');
+  const results = await runWithConcurrency(sampled, CONCURRENCY, (doc) => processOneDocument(doc, aiClients, masters));
+  const validResults = results.filter((r): r is DocPairResult => r !== null);
+
+  console.log(`処理成功: ${validResults.length}/${sampled.length} (PDF取得失敗分を除く)`);
+  if (validResults.length === 0) {
+    console.error('❌ 処理できた文書が1件もありませんでした');
+    process.exit(1);
+  }
+
+  const baseline = summarize(
+    BASELINE_MODEL_CONFIG,
+    validResults.map((r) => r.baseline)
+  );
+  const migrated = summarize(
+    CANDIDATE_MODEL_CONFIG,
+    validResults.map((r) => r.candidate)
+  );
+
+  console.log('\n=== 判定 (Issue #548 トリガー条件: 3.5の精度が2.5を下回らないこと。書類種別/顧客/事業所の3フィールド、日付は対象外) ===');
+  console.log(
+    '(dateフィールドはconfirmed相当のground truthがFirestore上に存在しないため、' +
+      'compare-gemini-ocr-models.tsと同様に本検証でも対象外)'
+  );
+  // code-review指摘反映: 絶対件数(allPass)ではなく成功文書中の一致率で比較する。
+  // モデルごとに失敗件数(succeededDocs)が異なりうるため、件数比較だと片方が失敗多めなだけで
+  // 誤って「精度劣化」と判定されうる(例: baseline 300成功/250一致=83.3% vs
+  // candidate 271成功/240一致=88.6%は実質candidateの方が高精度だが、240<250で誤FAILしていた)。
+  const baselineRate = baseline.succeededDocs > 0 ? baseline.allPass / baseline.succeededDocs : 0;
+  const candidateRate = migrated.succeededDocs > 0 ? migrated.allPass / migrated.succeededDocs : 0;
+  const regressed = candidateRate < baselineRate;
+  console.log(
+    `全項目一致率: baseline(2.5)=${(baselineRate * 100).toFixed(1)}% candidate(3.5)=${(candidateRate * 100).toFixed(1)}%`
+  );
+  console.log(regressed ? '❌ FAIL: 3.5 Flashで精度劣化を検出' : '✅ PASS: 精度劣化なし');
+  console.log(`コスト比 (N=${validResults.length}件): ${(migrated.costUsd / baseline.costUsd).toFixed(2)}倍`);
+
+  // Codex review指摘反映: API失敗(success:false)が正しくfailedDocsに集計されるようになったため、
+  // baseline/candidate双方の失敗率を個別にチェックする(片方だけ異常終了した場合を検知するため)。
+  const baselineFailureRateExceeded = baseline.failedDocs > baseline.totalDocs * 0.1;
+  const candidateFailureRateExceeded = migrated.failedDocs > migrated.totalDocs * 0.1;
+  if (baselineFailureRateExceeded) {
+    console.log(`⚠️ baseline(2.5-flash)の失敗率が10%を超過: ${baseline.failedDocs}/${baseline.totalDocs}`);
+  }
+  if (candidateFailureRateExceeded) {
+    console.log(`⚠️ candidate(3.5-flash)の失敗率が10%を超過: ${migrated.failedDocs}/${migrated.totalDocs}`);
+  }
+
+  if (regressed || baselineFailureRateExceeded || candidateFailureRateExceeded) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  // fatal error: 個人情報保護のため生のエラーメッセージはログに出さない (describeErrorSafely参照)
+  console.error('❌ エラー:', describeErrorSafely(err));
+  process.exit(1);
+});

--- a/scripts/compare-gemini-ocr-models-confirmed.ts
+++ b/scripts/compare-gemini-ocr-models-confirmed.ts
@@ -264,6 +264,15 @@ interface SampledDoc {
  * (Codex review指摘反映、上部doc comment参照)。documentTypeConfirmedはユーザー選択専用の
  * ため追加フィルタ不要(confirmedFieldMerge.ts参照)。
  */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/** totalPagesが正の整数でない(欠損/0/負数/非数値)場合は1にフォールバックする */
+function toValidTotalPages(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 1;
+}
+
 async function sampleConfirmedDocuments(limit: number): Promise<SampledDoc[]> {
   const queryLimit = Math.min(limit * SAMPLE_HEADROOM_MULTIPLIER, SAMPLE_HEADROOM_CAP);
   const snap = await db
@@ -281,18 +290,38 @@ async function sampleConfirmedDocuments(limit: number): Promise<SampledDoc[]> {
     return data.confirmedBy != null && data.officeConfirmedBy != null;
   });
 
-  return humanConfirmedOnly.slice(0, limit).map((d) => {
+  // ground truth 3フィールドが有効な非空文字列でない文書は突合不能なため除外する
+  // (confirmedフラグがtrueでもデータドリフトで欠損しているケースを想定した防御)
+  const withValidGroundTruth: SampledDoc[] = [];
+  let skippedInvalidGroundTruth = 0;
+  for (const d of humanConfirmedOnly) {
     const data = d.data();
-    return {
+    if (
+      !isNonEmptyString(data.fileName) ||
+      !isNonEmptyString(data.fileUrl) ||
+      !isNonEmptyString(data.documentType) ||
+      !isNonEmptyString(data.customerName) ||
+      !isNonEmptyString(data.officeName)
+    ) {
+      skippedInvalidGroundTruth++;
+      continue;
+    }
+    withValidGroundTruth.push({
       id: d.id,
-      fileName: data.fileName as string,
-      fileUrl: data.fileUrl as string,
-      totalPages: (data.totalPages as number) ?? 1,
-      confirmedDocumentType: data.documentType as string,
-      confirmedCustomerName: data.customerName as string,
-      confirmedOfficeName: data.officeName as string,
-    };
-  });
+      fileName: data.fileName,
+      fileUrl: data.fileUrl,
+      totalPages: toValidTotalPages(data.totalPages),
+      confirmedDocumentType: data.documentType,
+      confirmedCustomerName: data.customerName,
+      confirmedOfficeName: data.officeName,
+    });
+    if (withValidGroundTruth.length >= limit) break;
+  }
+  if (skippedInvalidGroundTruth > 0) {
+    console.warn(`[sampleConfirmedDocuments] ground truthフィールド欠損のため${skippedInvalidGroundTruth}件を除外`);
+  }
+
+  return withValidGroundTruth;
 }
 
 /** read-only: file.download() のみ、書込・削除は行わない */
@@ -585,30 +614,32 @@ interface DocPairResult {
  * N=300規模でGitHub Actions runnerのメモリを圧迫するリスクがあった。文書単位で
  * バッファのスコープを閉じることでrunner側のGCに任せられる。)
  *
- * aiClientsは呼出元(main)で1回だけ生成したものを再利用する(code-review指摘反映:
+ * aiは呼出元(main)で1回だけ生成したものを再利用する(code-review指摘反映:
  * GoogleGenAIクライアントはstateless設定オブジェクトのため、文書×モデルごとに毎回
- * 新規生成するのはN=300規模で無駄なCPU/初期化コスト)。baseline/candidateの2モデル呼出は
- * 互いに独立(同一pageBuffersを読むだけで状態を共有しない)のためPromise.allで並行実行し、
- * 1文書あたりの処理時間を半減させる。
+ * 新規生成するのはN=300規模で無駄なCPU/初期化コスト。モデル選択はgenerateContent呼出時の
+ * modelIdパラメータで行うためクライアント自体はbaseline/candidateで共有できる、
+ * review-pr指摘反映: 完全に同一引数で構築される2インスタンスは冗長だったため1個に統一)。
+ * baseline/candidateの2モデル呼出は互いに独立(同一pageBuffersを読むだけで状態を共有しない)
+ * のためPromise.allで並行実行し、1文書あたりの処理時間を半減させる。
  */
 async function processOneDocument(
   doc: SampledDoc,
-  aiClients: Record<ModelRole, InstanceType<typeof GoogleGenAI>>,
+  ai: InstanceType<typeof GoogleGenAI>,
   masters: { documents: DocumentMaster[]; customers: CustomerMaster[]; offices: OfficeMaster[] }
 ): Promise<DocPairResult | null> {
   let pdfBuffer: Buffer;
+  let pageBuffers: Buffer[];
   try {
     pdfBuffer = await downloadOriginalPdf(doc.fileUrl);
+    pageBuffers = await extractAllPdfPages(pdfBuffer, doc.totalPages);
   } catch (err) {
-    console.warn(`[processOneDocument] PDF取得失敗 (1件スキップ): ${describeErrorSafely(err)}`);
+    console.warn(`[processOneDocument] PDF取得/ページ抽出失敗 (1件スキップ): ${describeErrorSafely(err)}`);
     return null;
   }
 
-  const pageBuffers = await extractAllPdfPages(pdfBuffer, doc.totalPages);
-
   const [baseline, candidate] = await Promise.all([
-    processDocumentWithModel(aiClients.baseline, BASELINE_MODEL_CONFIG, doc, pageBuffers, masters),
-    processDocumentWithModel(aiClients.candidate, CANDIDATE_MODEL_CONFIG, doc, pageBuffers, masters),
+    processDocumentWithModel(ai, BASELINE_MODEL_CONFIG, doc, pageBuffers, masters),
+    processDocumentWithModel(ai, CANDIDATE_MODEL_CONFIG, doc, pageBuffers, masters),
   ]);
 
   return { baseline, candidate };
@@ -633,18 +664,23 @@ async function main(): Promise<void> {
   }
   console.log(`サンプリングした文書数: ${sampled.length}`);
 
-  // GoogleGenAIクライアントはstateless設定オブジェクトのため実行全体で1個ずつ使い回す
-  // (code-review指摘反映: 文書×モデルごとの再生成は無駄なCPU/初期化コスト)。
-  const aiClients: Record<ModelRole, InstanceType<typeof GoogleGenAI>> = {
-    baseline: new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION }),
-    candidate: new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION }),
-  };
+  // 実行全体で1個だけ生成し使い回す(理由はprocessOneDocument()のJSDoc参照)。
+  const ai = new GoogleGenAI({ vertexai: true, project: PROJECT_ID, location: LOCATION });
 
   console.log('\n--- 文書ごとに処理中 (ダウンロード→2.5-flash/3.5-flash並行実行→バッファ破棄) ---');
-  const results = await runWithConcurrency(sampled, CONCURRENCY, (doc) => processOneDocument(doc, aiClients, masters));
+  const results = await runWithConcurrency(sampled, CONCURRENCY, (doc) => processOneDocument(doc, ai, masters));
   const validResults = results.filter((r): r is DocPairResult => r !== null);
 
-  console.log(`処理成功: ${validResults.length}/${sampled.length} (PDF取得失敗分を除く)`);
+  // review-pr指摘反映: PDF取得/ページ抽出失敗(processOneDocumentがnullを返す)はvalidResultsから
+  // 除外されるため、summarize()の失敗率ゲートには一切現れない。サンプル全体に対する比率で
+  // 別途ゲートする(モデル分岐前の共通失敗のため、baseline/candidate個別ではなくsampled基準)。
+  const downloadFailedCount = sampled.length - validResults.length;
+  const downloadFailureRateExceeded = downloadFailedCount > sampled.length * 0.1;
+
+  console.log(`処理成功: ${validResults.length}/${sampled.length} (PDF取得/ページ抽出失敗分を除く)`);
+  if (downloadFailureRateExceeded) {
+    console.log(`⚠️ PDF取得/ページ抽出の失敗率が10%を超過: ${downloadFailedCount}/${sampled.length}`);
+  }
   if (validResults.length === 0) {
     console.error('❌ 処理できた文書が1件もありませんでした');
     process.exit(1);
@@ -674,7 +710,6 @@ async function main(): Promise<void> {
   console.log(
     `全項目一致率: baseline(2.5)=${(baselineRate * 100).toFixed(1)}% candidate(3.5)=${(candidateRate * 100).toFixed(1)}%`
   );
-  console.log(regressed ? '❌ FAIL: 3.5 Flashで精度劣化を検出' : '✅ PASS: 精度劣化なし');
   console.log(`コスト比 (N=${validResults.length}件): ${(migrated.costUsd / baseline.costUsd).toFixed(2)}倍`);
 
   // Codex review指摘反映: API失敗(success:false)が正しくfailedDocsに集計されるようになったため、
@@ -688,7 +723,17 @@ async function main(): Promise<void> {
     console.log(`⚠️ candidate(3.5-flash)の失敗率が10%を超過: ${migrated.failedDocs}/${migrated.totalDocs}`);
   }
 
-  if (regressed || baselineFailureRateExceeded || candidateFailureRateExceeded) {
+  // review-pr指摘反映: 以前はregressedのみでヘッドラインを表示しており、失敗率ゲート超過時も
+  // 「✅ PASS」と表示されてしまい、下の⚠️行を見落とすと誤って安全と判断しうる状態だった。
+  // 全ゲートを反映した単一の総合判定行にする。
+  const overallPass = !regressed && !baselineFailureRateExceeded && !candidateFailureRateExceeded && !downloadFailureRateExceeded;
+  console.log(
+    overallPass
+      ? '✅ PASS: 精度劣化なし、失敗率ゲートも全て許容範囲内'
+      : '❌ FAIL: 精度劣化または失敗率ゲート超過を検出(詳細は上記⚠️行を参照)'
+  );
+
+  if (!overallPass) {
     process.exitCode = 1;
   }
 }

--- a/scripts/compare-gemini-ocr-models-confirmed.ts
+++ b/scripts/compare-gemini-ocr-models-confirmed.ts
@@ -81,6 +81,7 @@ import {
 import {
   isNonEmptyString,
   pct,
+  describeErrorSafely,
   computeModelSummaryStats,
   computeMatchRate,
   computeOverallPass,
@@ -140,25 +141,6 @@ if (!admin.apps.length) {
 }
 const db = admin.firestore();
 const storage = admin.storage();
-
-/**
- * エラーの種別のみを個人情報漏洩なくログ出力するためのヘルパー。
- *
- * GCS/Firestore SDKのエラーメッセージは対象オブジェクトのパス(例: "No such object:
- * bucket/original/xxxx_田中太郎様_請求書.pdf")を含むことがある。fileUrl/storagePathは
- * functions/src/utils/fileNaming.ts の sanitizeFilenameForStorage() が元のアップロード/
- * 添付ファイル名から禁止文字を置換するのみで日本語文字等はそのまま残すため、氏名を含む
- * 元ファイル名がストレージパスに埋め込まれている可能性がある。エラーメッセージを生のまま
- * ログ出力しないよう、種別・コードのみを抽出する。
- */
-function describeErrorSafely(err: unknown): string {
-  if (err instanceof Error) {
-    const withCode = err as Error & { code?: string | number; status?: number };
-    const code = withCode.code ?? withCode.status;
-    return code !== undefined ? `${err.constructor.name}(code=${code})` : err.constructor.name;
-  }
-  return typeof err;
-}
 
 type SilentRetryResult<T> = { success: true; data: T; attempts: number } | { success: false; error: Error; attempts: number };
 

--- a/scripts/compare-gemini-ocr-models-confirmed.ts
+++ b/scripts/compare-gemini-ocr-models-confirmed.ts
@@ -78,6 +78,15 @@ import {
   type ModelConfig,
   type ModelRole,
 } from './lib/geminiOcrCompare';
+import {
+  isNonEmptyString,
+  toValidTotalPages,
+  pct,
+  computeModelSummaryStats,
+  computeMatchRate,
+  computeOverallPass,
+  type ModelSummaryStats,
+} from './lib/confirmedReplayStats';
 
 /**
  * confirmed文書が実運用規模で存在する本番クライアント環境のみ許可する
@@ -264,15 +273,6 @@ interface SampledDoc {
  * (Codex review指摘反映、上部doc comment参照)。documentTypeConfirmedはユーザー選択専用の
  * ため追加フィルタ不要(confirmedFieldMerge.ts参照)。
  */
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
-}
-
-/** totalPagesが正の整数でない(欠損/0/負数/非数値)場合は1にフォールバックする */
-function toValidTotalPages(value: unknown): number {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 1;
-}
-
 async function sampleConfirmedDocuments(limit: number): Promise<SampledDoc[]> {
   const queryLimit = Math.min(limit * SAMPLE_HEADROOM_MULTIPLIER, SAMPLE_HEADROOM_CAP);
   const snap = await db
@@ -514,93 +514,36 @@ async function processDocumentWithModel(
   }
 }
 
-function percentile(sortedValues: number[], p: number): number {
-  if (sortedValues.length === 0) return 0;
-  const idx = Math.min(sortedValues.length - 1, Math.ceil((p / 100) * sortedValues.length) - 1);
-  return sortedValues[Math.max(0, idx)];
-}
-
-interface ModelSummary {
+interface ModelSummary extends ModelSummaryStats {
   role: ModelRole;
   label: string;
-  totalDocs: number;
-  succeededDocs: number;
-  failedDocs: number;
-  docTypePass: number;
-  customerPass: number;
-  officePass: number;
-  allPass: number;
-  anomalousPageCount: number;
-  retriedDocCount: number;
-  totalInput: number;
-  totalOutput: number;
-  totalThinking: number;
-  costUsd: number;
-  p50Ms: number;
-  p95Ms: number;
-  p99Ms: number;
 }
 
+/**
+ * 集計・判定の計算本体はscripts/lib/confirmedReplayStats.ts(純粋関数、unit test済み)に
+ * 委譲する。ここではモデル固有情報(role/label)の付与とコンソール出力のみを担う
+ * (pr-test-analyzer指摘反映: 集計ロジックはI/O非依存のため分離してテスト可能にした)。
+ */
 function summarize(modelConfig: ModelConfig, outcomes: DocOcrOutcome[]): ModelSummary {
   const { role, label, pricing } = modelConfig;
-  const totalDocs = outcomes.length;
-  const succeeded = outcomes.filter((o) => o.success);
-  const failedDocs = totalDocs - succeeded.length;
-
-  const docTypePass = succeeded.filter((o) => o.docTypeMatch).length;
-  const customerPass = succeeded.filter((o) => o.customerMatch).length;
-  const officePass = succeeded.filter((o) => o.officeMatch).length;
-  const allPass = succeeded.filter((o) => o.docTypeMatch && o.customerMatch && o.officeMatch).length;
-  const anomalousPageCount = outcomes.reduce((s, o) => s + o.anomalousPages, 0);
-  const retriedDocCount = outcomes.filter((o) => o.hadRetry).length;
-
-  const totalInput = outcomes.reduce((s, o) => s + o.inputTokens, 0);
-  const totalOutput = outcomes.reduce((s, o) => s + o.outputTokens, 0);
-  const totalThinking = outcomes.reduce((s, o) => s + o.thinkingTokens, 0);
-  const billableOutput = totalOutput + totalThinking;
-  const costUsd = (totalInput * pricing.inputPer1MTokens + billableOutput * pricing.outputPer1MTokens) / 1_000_000;
-
-  const sortedMs = outcomes.map((o) => o.elapsedMs).sort((a, b) => a - b);
-
-  const summary: ModelSummary = {
-    role,
-    label,
-    totalDocs,
-    succeededDocs: succeeded.length,
-    failedDocs,
-    docTypePass,
-    customerPass,
-    officePass,
-    allPass,
-    anomalousPageCount,
-    retriedDocCount,
-    totalInput,
-    totalOutput,
-    totalThinking,
-    costUsd,
-    p50Ms: percentile(sortedMs, 50),
-    p95Ms: percentile(sortedMs, 95),
-    p99Ms: percentile(sortedMs, 99),
-  };
+  const stats = computeModelSummaryStats(pricing, outcomes);
+  const summary: ModelSummary = { role, label, ...stats };
 
   console.log(`\n=== ${label} ===`);
-  console.log(`対象文書数: ${totalDocs} (成功 ${succeeded.length} / 失敗 ${failedDocs}、失敗率 ${pct(failedDocs, totalDocs)}%)`);
-  console.log(`書類種別 一致率: ${docTypePass}/${succeeded.length} (${pct(docTypePass, succeeded.length)}%)`);
-  console.log(`顧客     一致率: ${customerPass}/${succeeded.length} (${pct(customerPass, succeeded.length)}%)`);
-  console.log(`事業所   一致率: ${officePass}/${succeeded.length} (${pct(officePass, succeeded.length)}%)`);
-  console.log(`全項目一致      : ${allPass}/${succeeded.length} (${pct(allPass, succeeded.length)}%)`);
-  console.log(`API異常疑いページ数: ${anomalousPageCount}`);
-  console.log(`リトライ発生文書数: ${retriedDocCount}/${totalDocs} (${pct(retriedDocCount, totalDocs)}%)`);
-  console.log(`トークン: input=${totalInput} output=${totalOutput} thinking=${totalThinking}`);
-  console.log(`概算コスト: $${costUsd.toFixed(4)}`);
-  console.log(`文書あたり処理時間: p50=${summary.p50Ms}ms p95=${summary.p95Ms}ms p99=${summary.p99Ms}ms`);
+  console.log(
+    `対象文書数: ${stats.totalDocs} (成功 ${stats.succeededDocs} / 失敗 ${stats.failedDocs}、失敗率 ${pct(stats.failedDocs, stats.totalDocs)}%)`
+  );
+  console.log(`書類種別 一致率: ${stats.docTypePass}/${stats.succeededDocs} (${pct(stats.docTypePass, stats.succeededDocs)}%)`);
+  console.log(`顧客     一致率: ${stats.customerPass}/${stats.succeededDocs} (${pct(stats.customerPass, stats.succeededDocs)}%)`);
+  console.log(`事業所   一致率: ${stats.officePass}/${stats.succeededDocs} (${pct(stats.officePass, stats.succeededDocs)}%)`);
+  console.log(`全項目一致      : ${stats.allPass}/${stats.succeededDocs} (${pct(stats.allPass, stats.succeededDocs)}%)`);
+  console.log(`API異常疑いページ数: ${stats.anomalousPageCount}`);
+  console.log(`リトライ発生文書数: ${stats.retriedDocCount}/${stats.totalDocs} (${pct(stats.retriedDocCount, stats.totalDocs)}%)`);
+  console.log(`トークン: input=${stats.totalInput} output=${stats.totalOutput} thinking=${stats.totalThinking}`);
+  console.log(`概算コスト: $${stats.costUsd.toFixed(4)}`);
+  console.log(`文書あたり処理時間: p50=${stats.p50Ms}ms p95=${stats.p95Ms}ms p99=${stats.p99Ms}ms`);
 
   return summary;
-}
-
-function pct(n: number, total: number): string {
-  if (total === 0) return '0.0';
-  return ((n / total) * 100).toFixed(1);
 }
 
 interface DocPairResult {
@@ -704,8 +647,8 @@ async function main(): Promise<void> {
   // モデルごとに失敗件数(succeededDocs)が異なりうるため、件数比較だと片方が失敗多めなだけで
   // 誤って「精度劣化」と判定されうる(例: baseline 300成功/250一致=83.3% vs
   // candidate 271成功/240一致=88.6%は実質candidateの方が高精度だが、240<250で誤FAILしていた)。
-  const baselineRate = baseline.succeededDocs > 0 ? baseline.allPass / baseline.succeededDocs : 0;
-  const candidateRate = migrated.succeededDocs > 0 ? migrated.allPass / migrated.succeededDocs : 0;
+  const baselineRate = computeMatchRate(baseline);
+  const candidateRate = computeMatchRate(migrated);
   const regressed = candidateRate < baselineRate;
   console.log(
     `全項目一致率: baseline(2.5)=${(baselineRate * 100).toFixed(1)}% candidate(3.5)=${(candidateRate * 100).toFixed(1)}%`
@@ -726,7 +669,12 @@ async function main(): Promise<void> {
   // review-pr指摘反映: 以前はregressedのみでヘッドラインを表示しており、失敗率ゲート超過時も
   // 「✅ PASS」と表示されてしまい、下の⚠️行を見落とすと誤って安全と判断しうる状態だった。
   // 全ゲートを反映した単一の総合判定行にする。
-  const overallPass = !regressed && !baselineFailureRateExceeded && !candidateFailureRateExceeded && !downloadFailureRateExceeded;
+  const overallPass = computeOverallPass({
+    regressed,
+    baselineFailureRateExceeded,
+    candidateFailureRateExceeded,
+    downloadFailureRateExceeded,
+  });
   console.log(
     overallPass
       ? '✅ PASS: 精度劣化なし、失敗率ゲートも全て許容範囲内'

--- a/scripts/compare-gemini-ocr-models-confirmed.ts
+++ b/scripts/compare-gemini-ocr-models-confirmed.ts
@@ -80,7 +80,6 @@ import {
 } from './lib/geminiOcrCompare';
 import {
   isNonEmptyString,
-  toValidTotalPages,
   pct,
   computeModelSummaryStats,
   computeMatchRate,
@@ -95,7 +94,11 @@ import {
  */
 const ALLOWED_PROJECT_IDS = ['docsplit-kanameone', 'docsplit-cocoro'];
 const LOCATION = 'asia-northeast1';
-/** Vertex AIレート制限を踏まえた保守的な同時実行数 */
+/**
+ * Vertex AIレート制限を踏まえた同時実行文書数(review-pr指摘反映: 1文書あたり
+ * baseline/candidateをPromise.allで並行実行するため、実際のgenerateContent同時実行数は
+ * この値の2倍になる点に注意)。
+ */
 const CONCURRENCY = 5;
 const DEFAULT_LIMIT = 30;
 /**
@@ -257,7 +260,6 @@ interface SampledDoc {
   id: string;
   fileName: string;
   fileUrl: string;
-  totalPages: number;
   confirmedDocumentType: string;
   confirmedCustomerName: string;
   confirmedOfficeName: string;
@@ -310,7 +312,6 @@ async function sampleConfirmedDocuments(limit: number): Promise<SampledDoc[]> {
       id: d.id,
       fileName: data.fileName,
       fileUrl: data.fileUrl,
-      totalPages: toValidTotalPages(data.totalPages),
       confirmedDocumentType: data.documentType,
       confirmedCustomerName: data.customerName,
       confirmedOfficeName: data.officeName,
@@ -574,7 +575,7 @@ async function processOneDocument(
   let pageBuffers: Buffer[];
   try {
     pdfBuffer = await downloadOriginalPdf(doc.fileUrl);
-    pageBuffers = await extractAllPdfPages(pdfBuffer, doc.totalPages);
+    pageBuffers = await extractAllPdfPages(pdfBuffer);
   } catch (err) {
     console.warn(`[processOneDocument] PDF取得/ページ抽出失敗 (1件スキップ): ${describeErrorSafely(err)}`);
     return null;
@@ -686,8 +687,16 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  // fatal error: 個人情報保護のため生のエラーメッセージはログに出さない (describeErrorSafely参照)
-  console.error('❌ エラー:', describeErrorSafely(err));
-  process.exit(1);
-});
+// review-pr指摘反映(HIGH): firebase-adminのFirestore/StorageクライアントはgRPCハンドルを
+// イベントループに残すため、main()がresolveしてもprocess.exitCodeを設定するだけでは
+// プロセスが自然終了しない。GitHub Actions側にtimeout-minutes設定が無いため、成功/失敗を
+// 問わずjobがdefaultの6時間ハングし続け、上で組んだoverallPassのexit-codeゲートが機能しなく
+// なる(他のfirebase-admin使用スクリプト4本は全て成功パスで明示exitしており、本スクリプトの
+// 抜けはこの規約からの逸脱だった)。process.exitCode(FAIL時1)を尊重した上で明示的にexitする。
+main()
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((err) => {
+    // fatal error: 個人情報保護のため生のエラーメッセージはログに出さない (describeErrorSafely参照)
+    console.error('❌ エラー:', describeErrorSafely(err));
+    process.exit(1);
+  });

--- a/scripts/compare-gemini-ocr-models.ts
+++ b/scripts/compare-gemini-ocr-models.ts
@@ -23,8 +23,7 @@
  *     GOOGLE_CLOUD_PROJECT=doc-split-dev npx ts-node scripts/compare-gemini-ocr-models.ts
  */
 
-import { GoogleGenAI, ThinkingLevel, type ThinkingConfig } from '@google/genai';
-import { PDFDocument } from 'pdf-lib';
+import { GoogleGenAI } from '@google/genai';
 import { withRetry, RETRY_CONFIGS } from '../functions/src/utils/retry';
 import { GEMINI_CONFIG } from '../functions/src/utils/config';
 import {
@@ -35,6 +34,7 @@ import {
 } from '../functions/src/utils/extractors';
 import type { DocumentMaster, CustomerMaster, OfficeMaster } from '../shared/types';
 import { MIXED_FAX_PDFS, readFixture, CUSTOMERS, OFFICES, DOC_TYPES, CARE_MANAGERS } from './seed-dev-data';
+import { MODEL_CONFIGS, buildOcrPrompt, extractPdfPage, type ModelConfig, type ModelRole } from './lib/geminiOcrCompare';
 
 /**
  * scripts/seed-dev-data.ts の ALLOWED_PROJECT_ID ガードと同じ意図: 本スクリプトは
@@ -61,60 +61,6 @@ if (PROJECT_ID !== ALLOWED_PROJECT_ID) {
       'dev環境seedフィクスチャの正解ラベル前提のため他環境では実行できません。'
   );
   process.exit(1);
-}
-
-type ModelRole = 'baseline' | 'candidate';
-
-interface ModelConfig {
-  role: ModelRole;
-  label: string;
-  modelId: string;
-  thinkingConfig: ThinkingConfig;
-  pricing: { inputPer1MTokens: number; outputPer1MTokens: number };
-}
-
-/**
- * 比較対象モデル定義。2.5は現行既定値(GEMINI_OCR_THINKING_BUDGET未設定時のデフォルト、
- * functions/src/utils/config.ts GEMINI_CONFIG.ocrThinkingBudget参照)、3.5はIssue #548
- * 移行予定設定(thinking完全無効化不可のため最小のlow)。
- * 単価は Vertex AI Gemini API 公式料金ページ(https://cloud.google.com/vertex-ai/generative-ai/pricing)
- * で確認済み(2026-07-06、gemini-2.5-flash/gemini-3.5-flash)。
- */
-const MODEL_CONFIGS: ModelConfig[] = [
-  {
-    role: 'baseline',
-    label: 'gemini-2.5-flash(現行)',
-    modelId: 'gemini-2.5-flash',
-    thinkingConfig: { thinkingBudget: 0 },
-    pricing: { inputPer1MTokens: 0.3, outputPer1MTokens: 2.5 },
-  },
-  {
-    role: 'candidate',
-    label: 'gemini-3.5-flash(移行予定)',
-    modelId: 'gemini-3.5-flash',
-    thinkingConfig: { thinkingLevel: ThinkingLevel.LOW },
-    pricing: { inputPer1MTokens: 1.5, outputPer1MTokens: 9.0 },
-  },
-];
-
-/**
- * functions/src/ocr/ocrProcessor.ts の OCR プロンプトと同一ベース + ページ番号suffix
- * (本番の ocrWithGemini はPDFの全ページで pageNumber を渡すため、常にsuffixが付与される。
- * 比較条件を揃えるためsuffixもページごとに付与する)。
- */
-function buildOcrPrompt(pageNumber: number): string {
-  return `
-この画像/PDFの内容をOCRしてください。
-
-【指示】
-- テキストをそのまま正確に抽出してください
-- 表がある場合は、構造を保ってテキスト化してください
-- 手書き文字も可能な限り読み取ってください
-- 読み取れない部分は[判読不能]と記載してください
-- 余計な説明は不要です。抽出したテキストのみを出力してください
-
-これは${pageNumber}ページ目です。
-`;
 }
 
 interface PageGroundTruth {
@@ -148,16 +94,6 @@ function expandGroundTruth(): PageGroundTruth[] {
     }
   }
   return pages;
-}
-
-/** PDFから単一ページを抽出 (functions/src/ocr/ocrProcessor.ts の extractPdfPage と同ロジック) */
-async function extractPdfPage(pdfBuffer: Buffer, pageIndex: number): Promise<Buffer> {
-  const pdfDoc = await PDFDocument.load(pdfBuffer);
-  const newPdf = await PDFDocument.create();
-  const [copiedPage] = await newPdf.copyPages(pdfDoc, [pageIndex]);
-  newPdf.addPage(copiedPage);
-  const pdfBytes = await newPdf.save();
-  return Buffer.from(pdfBytes);
 }
 
 function buildMasters(): { documents: DocumentMaster[]; customers: CustomerMaster[]; offices: OfficeMaster[] } {

--- a/scripts/lib/confirmedReplayStats.test.ts
+++ b/scripts/lib/confirmedReplayStats.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  percentile,
+  pct,
+  isNonEmptyString,
+  toValidTotalPages,
+  computeModelSummaryStats,
+  computeMatchRate,
+  computeOverallPass,
+  type DocOutcomeForSummary,
+} from './confirmedReplayStats';
+
+function makeOutcome(overrides: Partial<DocOutcomeForSummary> = {}): DocOutcomeForSummary {
+  return {
+    success: true,
+    inputTokens: 100,
+    outputTokens: 50,
+    thinkingTokens: 0,
+    elapsedMs: 1000,
+    docTypeMatch: true,
+    customerMatch: true,
+    officeMatch: true,
+    anomalousPages: 0,
+    hadRetry: false,
+    ...overrides,
+  };
+}
+
+test('percentile: 空配列は0を返す', () => {
+  assert.equal(percentile([], 50), 0);
+});
+
+test('percentile: 単一要素はp値によらずその値を返す', () => {
+  assert.equal(percentile([42], 50), 42);
+  assert.equal(percentile([42], 99), 42);
+});
+
+test('percentile: p50/p95/p99の境界', () => {
+  const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  assert.equal(percentile(sorted, 50), 5);
+  assert.equal(percentile(sorted, 95), 10);
+  assert.equal(percentile(sorted, 99), 10);
+});
+
+test('pct: totalが0の場合はゼロ除算せず"0.0"を返す', () => {
+  assert.equal(pct(0, 0), '0.0');
+  assert.equal(pct(5, 0), '0.0');
+});
+
+test('pct: 通常の割合計算', () => {
+  assert.equal(pct(1, 4), '25.0');
+});
+
+test('isNonEmptyString: 有効な非空文字列のみtrue', () => {
+  assert.equal(isNonEmptyString('a'), true);
+  assert.equal(isNonEmptyString(''), false);
+  assert.equal(isNonEmptyString(undefined), false);
+  assert.equal(isNonEmptyString(null), false);
+  assert.equal(isNonEmptyString(123), false);
+});
+
+test('toValidTotalPages: 正の整数はそのまま通す', () => {
+  assert.equal(toValidTotalPages(5), 5);
+  assert.equal(toValidTotalPages(1), 1);
+});
+
+test('toValidTotalPages: 0はFirestoreの??演算子では拾えないため明示ガードが必要(実バグ回帰防止)', () => {
+  assert.equal(toValidTotalPages(0), 1);
+});
+
+test('toValidTotalPages: 負数・非整数・非数値・欠損は1にフォールバック', () => {
+  assert.equal(toValidTotalPages(-3), 1);
+  assert.equal(toValidTotalPages(2.5), 1);
+  assert.equal(toValidTotalPages('5'), 1);
+  assert.equal(toValidTotalPages(undefined), 1);
+  assert.equal(toValidTotalPages(null), 1);
+});
+
+test('computeModelSummaryStats: 成功/失敗混在時、失敗文書はマッチ集計の分母から除外される', () => {
+  const outcomes: DocOutcomeForSummary[] = [
+    makeOutcome({ docTypeMatch: true, customerMatch: true, officeMatch: true }),
+    makeOutcome({ docTypeMatch: false, customerMatch: true, officeMatch: true }),
+    makeOutcome({ success: false, docTypeMatch: false, customerMatch: false, officeMatch: false }),
+  ];
+  const stats = computeModelSummaryStats({ inputPer1MTokens: 1, outputPer1MTokens: 1 }, outcomes);
+  assert.equal(stats.totalDocs, 3);
+  assert.equal(stats.succeededDocs, 2);
+  assert.equal(stats.failedDocs, 1);
+  assert.equal(stats.allPass, 1);
+});
+
+test('computeMatchRate: 絶対件数ではなく一致率で比較できる(過去の誤判定バグの回帰防止)', () => {
+  // baseline 300成功/250一致=83.3% vs candidate 271成功/240一致=88.6%は
+  // 実質candidateの方が高精度だが、絶対件数(240<250)で比較すると誤って劣化判定していた。
+  const baselineRate = computeMatchRate({ allPass: 250, succeededDocs: 300 });
+  const candidateRate = computeMatchRate({ allPass: 240, succeededDocs: 271 });
+  assert.ok(candidateRate > baselineRate, 'candidateの一致率がbaselineを上回るべき');
+  assert.equal(candidateRate < baselineRate, false);
+});
+
+test('computeMatchRate: succeededDocsが0の場合はゼロ除算せず0を返す', () => {
+  assert.equal(computeMatchRate({ allPass: 0, succeededDocs: 0 }), 0);
+});
+
+test('computeOverallPass: 全ゲート通過時のみtrue', () => {
+  assert.equal(
+    computeOverallPass({
+      regressed: false,
+      baselineFailureRateExceeded: false,
+      candidateFailureRateExceeded: false,
+      downloadFailureRateExceeded: false,
+    }),
+    true
+  );
+});
+
+test('computeOverallPass: 精度劣化がなくても失敗率ゲート超過ならfalse(ヘッドライン不整合バグの回帰防止)', () => {
+  // 過去、regressedのみでヘッドラインを決定していたため、失敗率ゲート超過時も
+  // 「✅ PASS」と表示されてしまうバグがあった。
+  assert.equal(
+    computeOverallPass({
+      regressed: false,
+      baselineFailureRateExceeded: false,
+      candidateFailureRateExceeded: true,
+      downloadFailureRateExceeded: false,
+    }),
+    false
+  );
+});
+
+test('computeOverallPass: ダウンロード失敗率ゲート超過だけでもfalse', () => {
+  assert.equal(
+    computeOverallPass({
+      regressed: false,
+      baselineFailureRateExceeded: false,
+      candidateFailureRateExceeded: false,
+      downloadFailureRateExceeded: true,
+    }),
+    false
+  );
+});
+
+test('computeOverallPass: 精度劣化のみでもfalse', () => {
+  assert.equal(
+    computeOverallPass({
+      regressed: true,
+      baselineFailureRateExceeded: false,
+      candidateFailureRateExceeded: false,
+      downloadFailureRateExceeded: false,
+    }),
+    false
+  );
+});

--- a/scripts/lib/confirmedReplayStats.test.ts
+++ b/scripts/lib/confirmedReplayStats.test.ts
@@ -4,6 +4,7 @@ import {
   percentile,
   pct,
   isNonEmptyString,
+  describeErrorSafely,
   computeModelSummaryStats,
   computeMatchRate,
   computeOverallPass,
@@ -57,6 +58,27 @@ test('isNonEmptyString: 有効な非空文字列のみtrue', () => {
   assert.equal(isNonEmptyString(undefined), false);
   assert.equal(isNonEmptyString(null), false);
   assert.equal(isNonEmptyString(123), false);
+});
+
+test('describeErrorSafely: PII(氏名等)を含みうる生のerror.messageを絶対に含まない', () => {
+  const err = new Error('No such object: bucket/original/xxxx_田中太郎様_請求書.pdf');
+  const result = describeErrorSafely(err);
+  assert.ok(!result.includes('田中太郎'), 'エラーメッセージ中のPIIが出力に含まれてはならない');
+  assert.ok(!result.includes(err.message), 'error.messageの生文字列を含んではならない');
+  assert.equal(result, 'Error');
+});
+
+test('describeErrorSafely: code/statusプロパティ付きエラーはコード種別のみ出力する', () => {
+  const err = Object.assign(new Error('sensitive path info here'), { code: 'ENOENT' });
+  const result = describeErrorSafely(err);
+  assert.equal(result, 'Error(code=ENOENT)');
+  assert.ok(!result.includes('sensitive'));
+});
+
+test('describeErrorSafely: Error以外はtypeofのみ返す(オブジェクトの中身を漏らさない)', () => {
+  assert.equal(describeErrorSafely('plain string error'), 'string');
+  assert.equal(describeErrorSafely({ message: '田中太郎様の情報' }), 'object');
+  assert.equal(describeErrorSafely(undefined), 'undefined');
 });
 
 test('computeModelSummaryStats: 成功/失敗混在時、失敗文書はマッチ集計の分母から除外される', () => {

--- a/scripts/lib/confirmedReplayStats.test.ts
+++ b/scripts/lib/confirmedReplayStats.test.ts
@@ -4,7 +4,6 @@ import {
   percentile,
   pct,
   isNonEmptyString,
-  toValidTotalPages,
   computeModelSummaryStats,
   computeMatchRate,
   computeOverallPass,
@@ -58,23 +57,6 @@ test('isNonEmptyString: 有効な非空文字列のみtrue', () => {
   assert.equal(isNonEmptyString(undefined), false);
   assert.equal(isNonEmptyString(null), false);
   assert.equal(isNonEmptyString(123), false);
-});
-
-test('toValidTotalPages: 正の整数はそのまま通す', () => {
-  assert.equal(toValidTotalPages(5), 5);
-  assert.equal(toValidTotalPages(1), 1);
-});
-
-test('toValidTotalPages: 0はFirestoreの??演算子では拾えないため明示ガードが必要(実バグ回帰防止)', () => {
-  assert.equal(toValidTotalPages(0), 1);
-});
-
-test('toValidTotalPages: 負数・非整数・非数値・欠損は1にフォールバック', () => {
-  assert.equal(toValidTotalPages(-3), 1);
-  assert.equal(toValidTotalPages(2.5), 1);
-  assert.equal(toValidTotalPages('5'), 1);
-  assert.equal(toValidTotalPages(undefined), 1);
-  assert.equal(toValidTotalPages(null), 1);
 });
 
 test('computeModelSummaryStats: 成功/失敗混在時、失敗文書はマッチ集計の分母から除外される', () => {

--- a/scripts/lib/confirmedReplayStats.ts
+++ b/scripts/lib/confirmedReplayStats.ts
@@ -1,0 +1,133 @@
+/**
+ * compare-gemini-ocr-models-confirmed.ts の集計・判定ロジック(I/Oを一切伴わない純粋関数のみ)。
+ * Firestore/Storage/Vertex AI等の外部依存を持たないため、この関数群はモック不要でunit test
+ * できる。過去に同種のロジックで実バグが3件発生している(①API最終失敗がsuccess:trueのまま
+ * 集計され失敗率ゲートが機能しなかった/②精度比較を絶対件数で行い成功文書数の違いで誤判定
+ * していた/③失敗率ゲート超過時もヘッドラインが「✅ PASS」のままだった)ため、
+ * 回帰防止のため分離・重点的にテストする。
+ */
+
+export function percentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) return 0;
+  const idx = Math.min(sortedValues.length - 1, Math.ceil((p / 100) * sortedValues.length) - 1);
+  return sortedValues[Math.max(0, idx)];
+}
+
+export function pct(n: number, total: number): string {
+  if (total === 0) return '0.0';
+  return ((n / total) * 100).toFixed(1);
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/** totalPagesが正の整数でない(欠損/0/負数/非数値)場合は1にフォールバックする */
+export function toValidTotalPages(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 1;
+}
+
+export interface DocOutcomeForSummary {
+  success: boolean;
+  inputTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  elapsedMs: number;
+  docTypeMatch: boolean;
+  customerMatch: boolean;
+  officeMatch: boolean;
+  anomalousPages: number;
+  hadRetry: boolean;
+}
+
+export interface ModelSummaryStats {
+  totalDocs: number;
+  succeededDocs: number;
+  failedDocs: number;
+  docTypePass: number;
+  customerPass: number;
+  officePass: number;
+  allPass: number;
+  anomalousPageCount: number;
+  retriedDocCount: number;
+  totalInput: number;
+  totalOutput: number;
+  totalThinking: number;
+  costUsd: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+}
+
+/**
+ * 一致率(allPass/succeededDocs)ではなく絶対件数(allPass)で比較すると、モデル間で
+ * succeededDocsが異なる場合に誤判定しうる(例: baseline 300成功/250一致=83.3% vs
+ * candidate 271成功/240一致=88.6%は実質candidateの方が高精度だが、240<250で誤判定していた)。
+ * この関数はallPass/succeededDocsの一致率のみを返し、呼出元で比較させることで
+ * 絶対件数比較への回帰を防ぐ。
+ */
+export function computeMatchRate(stats: Pick<ModelSummaryStats, 'allPass' | 'succeededDocs'>): number {
+  return stats.succeededDocs > 0 ? stats.allPass / stats.succeededDocs : 0;
+}
+
+export function computeModelSummaryStats(
+  pricing: { inputPer1MTokens: number; outputPer1MTokens: number },
+  outcomes: DocOutcomeForSummary[]
+): ModelSummaryStats {
+  const totalDocs = outcomes.length;
+  const succeeded = outcomes.filter((o) => o.success);
+  const failedDocs = totalDocs - succeeded.length;
+
+  const docTypePass = succeeded.filter((o) => o.docTypeMatch).length;
+  const customerPass = succeeded.filter((o) => o.customerMatch).length;
+  const officePass = succeeded.filter((o) => o.officeMatch).length;
+  const allPass = succeeded.filter((o) => o.docTypeMatch && o.customerMatch && o.officeMatch).length;
+  const anomalousPageCount = outcomes.reduce((s, o) => s + o.anomalousPages, 0);
+  const retriedDocCount = outcomes.filter((o) => o.hadRetry).length;
+
+  const totalInput = outcomes.reduce((s, o) => s + o.inputTokens, 0);
+  const totalOutput = outcomes.reduce((s, o) => s + o.outputTokens, 0);
+  const totalThinking = outcomes.reduce((s, o) => s + o.thinkingTokens, 0);
+  const billableOutput = totalOutput + totalThinking;
+  const costUsd = (totalInput * pricing.inputPer1MTokens + billableOutput * pricing.outputPer1MTokens) / 1_000_000;
+
+  const sortedMs = outcomes.map((o) => o.elapsedMs).sort((a, b) => a - b);
+
+  return {
+    totalDocs,
+    succeededDocs: succeeded.length,
+    failedDocs,
+    docTypePass,
+    customerPass,
+    officePass,
+    allPass,
+    anomalousPageCount,
+    retriedDocCount,
+    totalInput,
+    totalOutput,
+    totalThinking,
+    costUsd,
+    p50Ms: percentile(sortedMs, 50),
+    p95Ms: percentile(sortedMs, 95),
+    p99Ms: percentile(sortedMs, 99),
+  };
+}
+
+/**
+ * 精度劣化(regressed)判定と3つの失敗率ゲートを1つの総合PASS/FAIL判定に統合する。
+ * 以前はregressedのみでヘッドラインを表示しており、失敗率ゲート超過時も「✅ PASS」と
+ * 表示されてしまい、ゲート警告行を見落とすと誤って安全と判断しうる状態だった。
+ */
+export function computeOverallPass(params: {
+  regressed: boolean;
+  baselineFailureRateExceeded: boolean;
+  candidateFailureRateExceeded: boolean;
+  downloadFailureRateExceeded: boolean;
+}): boolean {
+  return (
+    !params.regressed &&
+    !params.baselineFailureRateExceeded &&
+    !params.candidateFailureRateExceeded &&
+    !params.downloadFailureRateExceeded
+  );
+}

--- a/scripts/lib/confirmedReplayStats.ts
+++ b/scripts/lib/confirmedReplayStats.ts
@@ -22,11 +22,6 @@ export function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
-/** totalPagesが正の整数でない(欠損/0/負数/非数値)場合は1にフォールバックする */
-export function toValidTotalPages(value: unknown): number {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 1;
-}
-
 export interface DocOutcomeForSummary {
   success: boolean;
   inputTokens: number;

--- a/scripts/lib/confirmedReplayStats.ts
+++ b/scripts/lib/confirmedReplayStats.ts
@@ -18,6 +18,26 @@ export function pct(n: number, total: number): string {
   return ((n / total) * 100).toFixed(1);
 }
 
+/**
+ * エラーの種別のみを個人情報漏洩なくログ出力するためのヘルパー。
+ *
+ * GCS/Firestore SDKのエラーメッセージは対象オブジェクトのパス(例: "No such object:
+ * bucket/original/xxxx_田中太郎様_請求書.pdf")を含むことがある。fileUrl/storagePathは
+ * functions/src/utils/fileNaming.ts の sanitizeFilenameForStorage() が元のアップロード/
+ * 添付ファイル名から禁止文字を置換するのみで日本語文字等はそのまま残すため、氏名を含む
+ * 元ファイル名がストレージパスに埋め込まれている可能性がある。エラーメッセージを生のまま
+ * ログ出力しないよう、種別・コードのみを抽出する(pr-test-analyzer指摘反映: PII非漏洩の
+ * セキュリティ契約はテストで固定しないと将来の変更で静かに破られうるため)。
+ */
+export function describeErrorSafely(err: unknown): string {
+  if (err instanceof Error) {
+    const withCode = err as Error & { code?: string | number; status?: number };
+    const code = withCode.code ?? withCode.status;
+    return code !== undefined ? `${err.constructor.name}(code=${code})` : err.constructor.name;
+  }
+  return typeof err;
+}
+
 export function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }

--- a/scripts/lib/geminiOcrCompare.ts
+++ b/scripts/lib/geminiOcrCompare.ts
@@ -91,15 +91,19 @@ export async function extractPdfPage(pdfBuffer: Buffer, pageIndex: number): Prom
 }
 
 /**
- * 同一PDFから先頭totalPages件のページを抽出する(呼出元がFirestore等の外部値をtotalPagesに
- * 渡す場合、実PDFの実ページ数と一致する保証は呼出元の責任。不一致(totalPagesが実ページ数を
- * 超える)場合はcopyPagesがrange errorでthrowする)。extractPdfPage()をページ数分呼ぶと`PDFDocument.load()`
+ * 同一PDFの全ページを抽出する。ページ数はロード済みPDFの`getPageCount()`から取得する
+ * (functions/src/ocr/ocrProcessor.ts の processDocument() と同じ方式。review-pr指摘反映:
+ * 以前はFirestore保存済みのtotalPagesフィールドを呼出元から受け取っていたが、保存値と
+ * 実PDFの実ページ数がドリフトしている場合(欠損/更新漏れ等)、複数ページ文書がwarningなく
+ * 一部ページのみOCRされ精度測定が静かに歪むリスクがあった。実PDFから直接取得することで
+ * このドリフト依存を排除する)。extractPdfPage()をページ数分呼ぶと`PDFDocument.load()`
  * (PDF全体のパース)がページ数だけ繰り返されるため、1文書を複数モデルで処理する場合は
  * 全ページを一度だけロードして抽出するここのバッチ版を使う(code-review指摘: N=300規模で
  * 2モデル分の冗長パースはCPU浪費)。
  */
-export async function extractAllPdfPages(pdfBuffer: Buffer, totalPages: number): Promise<Buffer[]> {
+export async function extractAllPdfPages(pdfBuffer: Buffer): Promise<Buffer[]> {
   const pdfDoc = await PDFDocument.load(pdfBuffer);
+  const totalPages = pdfDoc.getPageCount();
   const pages: Buffer[] = [];
   for (let i = 0; i < totalPages; i++) {
     const newPdf = await PDFDocument.create();

--- a/scripts/lib/geminiOcrCompare.ts
+++ b/scripts/lib/geminiOcrCompare.ts
@@ -91,7 +91,9 @@ export async function extractPdfPage(pdfBuffer: Buffer, pageIndex: number): Prom
 }
 
 /**
- * 同一PDFの全ページを抽出する。extractPdfPage()をページ数分呼ぶと`PDFDocument.load()`
+ * 同一PDFから先頭totalPages件のページを抽出する(呼出元がFirestore等の外部値をtotalPagesに
+ * 渡す場合、実PDFの実ページ数と一致する保証は呼出元の責任。不一致(totalPagesが実ページ数を
+ * 超える)場合はcopyPagesがrange errorでthrowする)。extractPdfPage()をページ数分呼ぶと`PDFDocument.load()`
  * (PDF全体のパース)がページ数だけ繰り返されるため、1文書を複数モデルで処理する場合は
  * 全ページを一度だけロードして抽出するここのバッチ版を使う(code-review指摘: N=300規模で
  * 2モデル分の冗長パースはCPU浪費)。

--- a/scripts/lib/geminiOcrCompare.ts
+++ b/scripts/lib/geminiOcrCompare.ts
@@ -1,0 +1,110 @@
+/**
+ * Gemini 2.5 Flash vs 3.5 Flash OCR比較の共通ロジック (Issue #548)
+ *
+ * scripts/compare-gemini-ocr-models.ts (dev環境の合成フィクスチャ) と
+ * scripts/compare-gemini-ocr-models-confirmed.ts (kanameone/cocoro confirmed replay方式) の
+ * 両方が使う、モデル定義・プロンプト構築・PDFページ抽出を一元管理する。
+ *
+ * プロンプト文言・ページ抽出ロジックは functions/src/ocr/ocrProcessor.ts の対応箇所
+ * (`prompt` 変数 / `extractPdfPage`) と同一だが、ocrProcessor.ts 側は非exportのため
+ * ここに複製する。乖離を防ぐため、本番プロンプトを変更する場合は本ファイルも同期すること。
+ *
+ * OCR呼出自体(リトライ挙動・異常検知の扱い)は2スクリプトで意図的に異なる
+ * (dev版=n=11の少数サンプルで即失敗させたい / confirmed版=N=300規模で1文書の失敗が
+ * 全体を止めないようにしたい) ため、本モジュールでは共通化しない。
+ */
+
+import { ThinkingLevel, type ThinkingConfig } from '@google/genai';
+import { PDFDocument } from 'pdf-lib';
+
+export type ModelRole = 'baseline' | 'candidate';
+
+export interface ModelConfig {
+  role: ModelRole;
+  label: string;
+  modelId: string;
+  thinkingConfig: ThinkingConfig;
+  pricing: { inputPer1MTokens: number; outputPer1MTokens: number };
+}
+
+/**
+ * 比較対象モデル定義。2.5は現行既定値(GEMINI_OCR_THINKING_BUDGET未設定時のデフォルト、
+ * functions/src/utils/config.ts GEMINI_CONFIG.ocrThinkingBudget参照)、3.5はIssue #548
+ * 移行予定設定(thinking完全無効化不可のため最小のlow)。
+ * 単価は Vertex AI Gemini API 公式料金ページ(https://cloud.google.com/vertex-ai/generative-ai/pricing)
+ * で確認済み(2026-07-06、gemini-2.5-flash/gemini-3.5-flash、functions/src/utils/config.ts の
+ * GEMINI_PRICING_BY_MODEL と同期)。
+ */
+export const BASELINE_MODEL_CONFIG: ModelConfig = {
+  role: 'baseline',
+  label: 'gemini-2.5-flash(現行)',
+  modelId: 'gemini-2.5-flash',
+  thinkingConfig: { thinkingBudget: 0 },
+  pricing: { inputPer1MTokens: 0.3, outputPer1MTokens: 2.5 },
+};
+
+export const CANDIDATE_MODEL_CONFIG: ModelConfig = {
+  role: 'candidate',
+  label: 'gemini-3.5-flash(移行予定)',
+  modelId: 'gemini-3.5-flash',
+  thinkingConfig: { thinkingLevel: ThinkingLevel.LOW },
+  pricing: { inputPer1MTokens: 1.5, outputPer1MTokens: 9.0 },
+};
+
+/**
+ * 配列としての反復が必要な呼出元(compare-gemini-ocr-models.tsのforループ等)向け。
+ * baseline/candidateの解決には配列の.find()ではなくBASELINE_MODEL_CONFIG/
+ * CANDIDATE_MODEL_CONFIGを直接参照すること(code-review指摘: 配列+.find()+型キャストの
+ * 組合せはMODEL_CONFIGS変更時に安全に壊れない)。
+ */
+export const MODEL_CONFIGS: ModelConfig[] = [BASELINE_MODEL_CONFIG, CANDIDATE_MODEL_CONFIG];
+
+/**
+ * functions/src/ocr/ocrProcessor.ts の OCR プロンプトと同一(pageNumberありのケースのみ、
+ * 本比較スクリプトは常にページ単位呼出のため)。本番はページ番号なしの単一画像呼出も
+ * サポートするが(`${pageNumber ? ... : ''}`)、本比較スクリプトはPDF文書のみを対象とし
+ * 常にページ番号を渡すため、その分岐は含めない。
+ */
+export function buildOcrPrompt(pageNumber: number): string {
+  return `
+この画像/PDFの内容をOCRしてください。
+
+【指示】
+- テキストをそのまま正確に抽出してください
+- 表がある場合は、構造を保ってテキスト化してください
+- 手書き文字も可能な限り読み取ってください
+- 読み取れない部分は[判読不能]と記載してください
+- 余計な説明は不要です。抽出したテキストのみを出力してください
+
+これは${pageNumber}ページ目です。
+`;
+}
+
+/** functions/src/ocr/ocrProcessor.ts の extractPdfPage と同ロジック */
+export async function extractPdfPage(pdfBuffer: Buffer, pageIndex: number): Promise<Buffer> {
+  const pdfDoc = await PDFDocument.load(pdfBuffer);
+  const newPdf = await PDFDocument.create();
+  const [copiedPage] = await newPdf.copyPages(pdfDoc, [pageIndex]);
+  newPdf.addPage(copiedPage);
+  const pdfBytes = await newPdf.save();
+  return Buffer.from(pdfBytes);
+}
+
+/**
+ * 同一PDFの全ページを抽出する。extractPdfPage()をページ数分呼ぶと`PDFDocument.load()`
+ * (PDF全体のパース)がページ数だけ繰り返されるため、1文書を複数モデルで処理する場合は
+ * 全ページを一度だけロードして抽出するここのバッチ版を使う(code-review指摘: N=300規模で
+ * 2モデル分の冗長パースはCPU浪費)。
+ */
+export async function extractAllPdfPages(pdfBuffer: Buffer, totalPages: number): Promise<Buffer[]> {
+  const pdfDoc = await PDFDocument.load(pdfBuffer);
+  const pages: Buffer[] = [];
+  for (let i = 0; i < totalPages; i++) {
+    const newPdf = await PDFDocument.create();
+    const [copiedPage] = await newPdf.copyPages(pdfDoc, [i]);
+    newPdf.addPage(copiedPage);
+    const pdfBytes = await newPdf.save();
+    pages.push(Buffer.from(pdfBytes));
+  }
+  return pages;
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,8 @@
     "import:offices": "node import-masters.js --offices",
     "import:all": "node import-masters.js --all",
     "backfill:displayname": "ts-node backfill-display-filename.ts",
-    "seed:dev": "ts-node seed-dev-data.ts"
+    "seed:dev": "ts-node seed-dev-data.ts",
+    "test": "node --require ts-node/register --test lib/*.test.ts"
   },
   "dependencies": {
     "@google-cloud/logging": "^11.2.1",


### PR DESCRIPTION
## Summary
- kanameone/cocoro本番の確定済み文書(customerConfirmed/officeConfirmed/documentTypeConfirmedがtrue、かつ`confirmedBy`/`officeConfirmedBy`が非null=真に人間確定済み)をサンプリングし、元PDFをGemini 2.5-flash/3.5-flash両方で再OCRして精度を比較する**read-only**検証スクリプトを追加
- 既存のdev環境A/Bテスト(`compare-gemini-ocr-models.ts`、n=11)がCodexセカンドオピニオンで「実運用判断の統計的根拠として不十分(rule of threeで劣化率上限27%までしか保証しない)」と指摘されたため、実運用規模・実データでの追加検証として実装。Issue #548の3.5移行kanameone/cocoro本番展開判断材料とする
- `scripts/lib/geminiOcrCompare.ts`を新規作成し、`MODEL_CONFIGS`/`buildOcrPrompt`/`extractPdfPage`を2スクリプト間で共通化(既存devスクリプトの挙動は不変、ts-node実行で回帰確認済み)
- `.github/workflows/run-ops-script.yml`に`--limit 30`(pilot)/`--limit 300`(本実行)の2 choiceを登録

## read-only・個人情報保護の設計
- Firestore/Storageへの書込は一切行わない(write/update/delete系API呼出なし、Codex reviewで確認済み)
- 個別文書の突合結果(氏名・事業所名等)はログ/artifactいずれにも出力しない。集計値のみ出力
- エラーメッセージ経由のPII漏洩(Storageパスに元アップロードファイル名が残存しうる)を防ぐため、共通retryを使わず独自の`withSilentRetry()`でエラー内容を一切ログ出力しない設計
- `STORAGE_BUCKET`はprojectIdから推測せず環境変数で明示必須化(CLAUDE.md準拠)

## 品質ゲート
1. `/safe-refactor`: DRY解消(共通lib抽出)、この過程で本番プロンプトとの差異(バグ)を発見・修正
2. Codex review(`codex exec`、read-only保証+PII非出力の重点確認): 4件の実質指摘(リトライ時PII漏洩・API失敗の集計漏れ・Storage bucket未設定・ground truthのラベルリークリスク)を検証の上修正
3. `/code-review medium`(8角度finder、1-vote verify): 8件検出、6件修正(判定ロジックのrate比較化、並行実行化、クライアント再利用、PDF再パース排除、dead field削除、型安全性改善)。2件(共通retry/loadMasterDataとの重複)は本番Cloud Functions全体に影響する共有ファイル変更が必要なため、コストに見合わないと判断しあえて見送り(docコメントで理由明記)

## Test plan
- [x] `npx ts-node` でのローカル実行によるガード動作確認(dev環境拒否・STORAGE_BUCKET未設定拒否)
- [x] `compare-gemini-ocr-models.ts`(既存devスクリプト)の回帰確認(共有lib化後も正常動作)
- [x] `functions/`配下の型チェック(`tsc --noEmit`)
- [ ] マージ後、GitHub Actions経由でkanameone環境に対しpilot実行(`--limit 30`)し、実際の精度比較結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new comparison workflow for OCR model evaluations with additional run options for smaller or larger sample sizes.
  * Introduced a confirmed-documents comparison job that reports accuracy, latency, and estimated cost for two OCR models.
  * Improved the existing comparison flow so it uses a shared, consistent execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->