### PR TITLE
feat(cost): confirmed replayサンプリング0件の原因診断スクリプト追加 (Issue #548)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -94,6 +94,7 @@ on:
           - compare-gemini-ocr-models
           - compare-gemini-ocr-models-confirmed --limit 30
           - compare-gemini-ocr-models-confirmed --limit 300
+          - diagnose-confirmed-replay-sampling
           - measure-summary-cost --doc-id
           - create-pending-doc --doc-id --storage-path original/seed_generic_12p.pdf
       doc_id:
@@ -555,12 +556,15 @@ jobs:
                [ "$SCRIPT_NAME" = "seed-dev-data" ] || \
                [ "$SCRIPT_NAME" = "compare-gemini-ocr-models" ] || \
                [ "$SCRIPT_NAME" = "compare-gemini-ocr-models-confirmed" ] || \
+               [ "$SCRIPT_NAME" = "diagnose-confirmed-replay-sampling" ] || \
                [ "$SCRIPT_NAME" = "measure-summary-cost" ] || \
                [ "$SCRIPT_NAME" = "create-pending-doc" ]; then
             # Issue #432 PR-C 系 script は scripts/lib/* (TypeScript)、seed-dev-data (#528) は
             # shared/*.ts に依存するため ts-node 経由で実行。compare-gemini-ocr-models (#548) は
             # functions/src/utils/* (extractors.ts/retry.ts) に依存するため同様に ts-node 経由。
             # compare-gemini-ocr-models-confirmed (#548 confirmed replay方式) も同様の依存関係。
+            # diagnose-confirmed-replay-sampling (#548 pilot実行0件原因調査用) は firebase-admin
+            # のみ依存(functions/src非依存、STORAGE_BUCKET不使用)だが統一的にts-node経由で実行。
             # measure-summary-cost (#562) は functions/src/ocr/summaryGenerator.ts に依存するため同様。
             # create-pending-doc (#562) はfirebase-adminのみ依存(functions/src非依存)だが、
             # 統一的にscriptsディレクトリからts-node経由で実行する。

--- a/scripts/diagnose-confirmed-replay-sampling.ts
+++ b/scripts/diagnose-confirmed-replay-sampling.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env ts-node
+/**
+ * compare-gemini-ocr-models-confirmed.ts のサンプリング条件(#548 confirmed replay方式)が
+ * kanameone pilot実行(N=30)で0件だった原因を診断するための集計専用スクリプト。
+ *
+ * read-only厳守: Firestoreへの書込は一切行わない。count()集計クエリのみを使い、
+ * 個人情報を含むフィールド(customerName/officeName/fileName等)は取得しない
+ * (フォールバック集計でも .select('confirmedBy', 'officeConfirmedBy') で限定)。
+ * 出力するのは各条件段階での件数のみ。
+ */
+import * as admin from 'firebase-admin';
+
+const ALLOWED_PROJECT_IDS = ['docsplit-kanameone', 'docsplit-cocoro'];
+const PROJECT_ID =
+  process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID || '';
+
+if (!ALLOWED_PROJECT_IDS.includes(PROJECT_ID)) {
+  console.error(
+    `❌ このスクリプトは ${ALLOWED_PROJECT_IDS.join('/')} 専用です (指定されたプロジェクト: ${PROJECT_ID})。`
+  );
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId: PROJECT_ID });
+const db = admin.firestore();
+
+async function count(query: FirebaseFirestore.Query): Promise<number> {
+  const snap = await query.count().get();
+  return snap.data().count;
+}
+
+async function main(): Promise<void> {
+  const col = db.collection('documents');
+  console.log(`=== confirmed replay サンプリング条件診断 (${PROJECT_ID}) ===`);
+  console.log('個人情報は一切出力しません。各条件段階の件数のみを出力します。\n');
+
+  const totalDocs = await count(col);
+  console.log(`全文書数: ${totalDocs}`);
+
+  const processed = await count(col.where('status', '==', 'processed'));
+  console.log(`status=processed: ${processed}`);
+
+  const customerConfirmed = await count(
+    col.where('status', '==', 'processed').where('customerConfirmed', '==', true)
+  );
+  console.log(`+ customerConfirmed=true (単独): ${customerConfirmed}`);
+
+  const officeConfirmed = await count(col.where('status', '==', 'processed').where('officeConfirmed', '==', true));
+  console.log(`+ officeConfirmed=true (単独): ${officeConfirmed}`);
+
+  const documentTypeConfirmed = await count(
+    col.where('status', '==', 'processed').where('documentTypeConfirmed', '==', true)
+  );
+  console.log(`+ documentTypeConfirmed=true (単独): ${documentTypeConfirmed}`);
+
+  const allThreeQuery = col
+    .where('status', '==', 'processed')
+    .where('customerConfirmed', '==', true)
+    .where('officeConfirmed', '==', true)
+    .where('documentTypeConfirmed', '==', true);
+  const allThree = await count(allThreeQuery);
+  console.log(`3条件AND (customer/office/documentType全てtrue): ${allThree}`);
+
+  if (allThree > 0) {
+    // Firestoreのcount()集計クエリは != null 条件を直接サポートしないため、
+    // 3条件AND該当文書のみ取得し手元でconfirmedBy/officeConfirmedByの非null判定を行う。
+    // select()で対象2フィールドのみ取得しPII含有フィールドには一切触れない。
+    const snap = await allThreeQuery.select('confirmedBy', 'officeConfirmedBy').get();
+    const humanConfirmed = snap.docs.filter((d) => {
+      const data = d.data();
+      return data.confirmedBy != null && data.officeConfirmedBy != null;
+    }).length;
+    console.log(`  うちconfirmedBy/officeConfirmedBy両方非null: ${humanConfirmed}`);
+  } else {
+    console.log('  (3条件ANDが0件のため、confirmedBy/officeConfirmedByの内訳確認は省略)');
+  }
+
+  console.log('\n=== 診断完了 ===');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('❌ エラー:', err instanceof Error ? err.constructor.name : typeof err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- PR #577マージ後、kanameone pilot実行(N=30)が「対象文書0件」で終了(exit 1)。read-only保証・PII非出力は正常動作、Gemini API課金もゼロ
- 設計前提(status=processed + customerConfirmed/officeConfirmed/documentTypeConfirmed全てtrue + confirmedBy/officeConfirmedBy非nullの文書が実運用規模で存在する)が実データで成立しているか不明なため、条件を1段階ずつ絞り込んだ件数のみを出力する診断専用スクリプトを追加
- `run-ops-script.yml`のworkflow_dispatch選択肢に`diagnose-confirmed-replay-sampling`を登録

## Test plan
- [x] `tsc --project scripts/tsconfig.json`エラーなし
- [x] `GOOGLE_CLOUD_PROJECT=doc-split-dev`でのALLOWED_PROJECT_IDガード拒否パスを確認
- [x] YAML構文検証(js-yaml)
- [ ] マージ後、GitHub Actions経由でkanameone実行し集計結果を確認(次アクション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic command for inspecting replay sampling conditions in approved environments.
  * Expanded the workflow’s manual run options so this diagnostic can be launched directly from the actions UI.
  * The diagnostic reports high-level counts and, when relevant, a narrow follow-up breakdown for matching records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->