### PR TITLE
chore(ops): 診断スクリプトにstatus別内訳を追加 (kanameoneデプロイ前ベースライン取得用)

### DIFF
--- a/scripts/diagnose-confirmed-replay-sampling.ts
+++ b/scripts/diagnose-confirmed-replay-sampling.ts
@@ -37,6 +37,15 @@ async function main(): Promise<void> {
   const totalDocs = await count(col);
   console.log(`全文書数: ${totalDocs}`);
 
+  // kanameone本番デプロイ前のベースライン取得用(status別内訳)。デプロイ後の異常検知の
+  // 比較対象として使う(処理中/エラー件数が急増していないか等)。
+  console.log('\n--- status別内訳(デプロイ前ベースライン) ---');
+  for (const s of ['pending', 'processing', 'processed', 'error']) {
+    const c = await count(col.where('status', '==', s));
+    console.log(`status=${s}: ${c}`);
+  }
+  console.log('');
+
   const processed = await count(col.where('status', '==', 'processed'));
   console.log(`status=processed: ${processed}`);
 


### PR DESCRIPTION
## Summary
- kanameone本番デプロイ(#526/#547 Phase B/#548、50コミット分)前の安全確認として、Codexセカンドオピニオンの推奨に従いpending/processing/processed/error件数のベースラインを取得できるようにする
- `scripts/diagnose-confirmed-replay-sampling.ts`にstatus別内訳の出力を追加（read-only count()集計のみ、PII非出力）

## Test plan
- [x] `tsc --project scripts/tsconfig.json`エラーなし
- [ ] マージ後、GitHub Actions経由でkanameone実行しベースライン記録(デプロイ前に実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an additional status-by-status breakdown to the diagnostic sampling output, showing counts for pending, processing, processed, and error items before the existing confirmed breakdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->