### PR TITLE
feat(ci): GEMINI_MODEL_ID デプロイ時override入力を追加 (Issue #548)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -12,6 +12,15 @@ on:
           - dev
           - kanameone
           - cocoro
+      gemini_model_id_override:
+        description: 'GEMINI_MODEL_ID override (未指定=code-default(現在gemini-3.5-flash)。Issue #548の3.5移行検証が完了するまでkanameone等はgemini-2.5-flash固定を推奨)'
+        required: true
+        default: 'code-default'
+        type: choice
+        options:
+          - code-default
+          - gemini-2.5-flash
+          - gemini-3.5-flash
 
 jobs:
   deploy:
@@ -53,13 +62,24 @@ jobs:
 
       - name: Deploy to Firebase Functions
         run: |
-          # 環境に応じてプロジェクトを切り替え
+          # 環境に応じてプロジェクトを切り替え (.firebaserc参照)
           if [ "${{ github.event.inputs.environment }}" == "cocoro" ]; then
             PROJECT_ALIAS="cocoro"
+            PROJECT_ID="docsplit-cocoro"
           elif [ "${{ github.event.inputs.environment }}" == "kanameone" ]; then
             PROJECT_ALIAS="kanameone"
+            PROJECT_ID="docsplit-kanameone"
           else
             PROJECT_ALIAS="dev"
+            PROJECT_ID="doc-split-dev"
+          fi
+
+          # GEMINI_MODEL_ID override (任意): Firebase Functions v2は環境変数を
+          # functions/.env.<project-id> ファイルから読む(シェル環境変数は伝播しない)。
+          # 未指定(code-default)ならfunctions/src/utils/config.tsのコード既定値を使用。
+          if [ "${{ github.event.inputs.gemini_model_id_override }}" != "code-default" ]; then
+            echo "GEMINI_MODEL_ID=${{ github.event.inputs.gemini_model_id_override }}" > "functions/.env.${PROJECT_ID}"
+            echo "GEMINI_MODEL_ID override 適用: ${{ github.event.inputs.gemini_model_id_override }} (functions/.env.${PROJECT_ID})"
           fi
 
           echo "Deploying to: $PROJECT_ALIAS"


### PR DESCRIPTION
## Summary
- kanameoneをmainまで追従デプロイする際、Firebase CLI個人ログイン(systemkaname@kanameone.com)が未登録(login:addはブラウザ必須のためClaude Codeから実施不可)でローカルデプロイ不可 → GitHub Actions "Deploy Cloud Functions"経由(SA鍵認証)に切り替える必要がある
- しかしmainのコードは既に`GEMINI_MODEL_ID`の既定値が`gemini-3.5-flash`(Issue #548)。何も指定せずkanameoneへFunctionsデプロイすると、3.5移行の本番判断材料(confirmed replay検証)が完了する前に実処理も3.5へ切り替わってしまう
- `workflow_dispatch`に`gemini_model_id_override`選択肢(code-default/gemini-2.5-flash/gemini-3.5-flash)を追加し、指定時は`functions/.env.<project-id>`を動的生成してからデプロイする(Firebase Functions v2はシェル環境変数を伝播せず`.env.<project-id>`ファイルからのみ読むため)
- 検証完了後に3.5へ切り替える際も同じ仕組みを再利用できる設計

## Test plan
- [x] YAML構文検証(js-yaml)
- [ ] マージ後、`gemini_model_id_override=gemini-2.5-flash`でkanameoneへFunctionsデプロイし、実際にGEMINI_MODEL_ID=gemini-2.5-flashが反映されることを確認(次アクション、本PR自身がテストケース)

🤖 Generated with [Claude Code](https://claude.com/claude-code)