### PR TITLE
chore(ops): 診断スクリプトにcanary検証用ドキュメントID取得を追加 (Issue #548)

### DIFF
--- a/scripts/diagnose-confirmed-replay-sampling.ts
+++ b/scripts/diagnose-confirmed-replay-sampling.ts
@@ -84,6 +84,24 @@ async function main(): Promise<void> {
     console.log('  (3条件ANDが0件のため、confirmedBy/officeConfirmedByの内訳確認は省略)');
   }
 
+  // kanameoneデプロイ後のcanary検証用: confirmedFieldProtection(再OCR時の確定フィールド保護)を
+  // 実データで確認するため、customerConfirmed/officeConfirmed両方trueの処理済み文書を1件選ぶ。
+  // ドキュメントIDのみを出力し、氏名等のPIIは一切取得・出力しない。
+  const canarySnap = await col
+    .where('status', '==', 'processed')
+    .where('customerConfirmed', '==', true)
+    .where('officeConfirmed', '==', true)
+    .orderBy('__name__')
+    .limit(1)
+    .select()
+    .get();
+  console.log('\n--- canary検証用ドキュメントID(confirmed済み1件、PII非出力) ---');
+  if (canarySnap.empty) {
+    console.log('該当文書なし');
+  } else {
+    console.log(`CANARY_DOC_ID=${canarySnap.docs[0].id}`);
+  }
+
   console.log('\n=== 診断完了 ===');
 }
 


### PR DESCRIPTION
## Summary
- kanameoneデプロイ後のcanary検証(段階デプロイ手順、Codexセカンドオピニオン推奨)で、confirmedFieldProtection(再OCR時の確定フィールド保護)を実データで確認するため、customerConfirmed/officeConfirmed両方trueの処理済み文書を1件選びドキュメントIDのみを出力する機能を追加
- PII(氏名等)は取得・出力しない(select()でフィールド無指定=ドキュメントIDのみ取得)

## Test plan
- [x] `tsc --project scripts/tsconfig.json`エラーなし
- [ ] マージ後、GitHub Actions経由でkanameone実行しcanary対象ドキュメントIDを取得(次アクション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an extra diagnostic check that verifies whether a matching processed record exists.
  * The script now reports a clear “no matching record” message or outputs a single matching record ID when found.
  * Existing counting and completion messages remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->