### PR TITLE
chore(ci): diagnose-confirmed-replay-sampling --doc-id 選択肢を追加 (Issue #548)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -95,6 +95,7 @@ on:
           - compare-gemini-ocr-models-confirmed --limit 30
           - compare-gemini-ocr-models-confirmed --limit 300
           - diagnose-confirmed-replay-sampling
+          - diagnose-confirmed-replay-sampling --doc-id
           - measure-summary-cost --doc-id
           - create-pending-doc --doc-id --storage-path original/seed_generic_12p.pdf
       doc_id:


### PR DESCRIPTION
## Summary
- PR #583でスクリプト本体に`--doc-id`対応(canary検証用の非PIIフィールド確認)を追加したが、`run-ops-script.yml`のscript選択肢は`diagnose-confirmed-replay-sampling`(引数なし)のみ登録されていたため、`doc_id`入力がSCRIPT_ARGSに反映されず機能しなかった
- `--doc-id`という文字列がSCRIPT_ARGSに含まれる場合のみsed置換される既存ロジック(`fix-stuck-documents --doc-id`等と同じパターン)のため、新しい選択肢`diagnose-confirmed-replay-sampling --doc-id`を追加して解消

## Test plan
- [x] YAML構文検証(js-yaml)
- [ ] マージ後、GitHub Actions経由でkanameone実行しcanary対象文書の詳細確認が機能することを確認(次アクション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)