### PR TITLE
fix(ci): deploy-functions.ymlにSTORAGE_BUCKET設定を追加 (kanameone canary実機検証で判明した本番バグ)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -74,11 +74,32 @@ jobs:
             PROJECT_ID="doc-split-dev"
           fi
 
+          # STORAGE_BUCKET (必須): functions/src/index.ts の admin.initializeApp() が
+          # process.env.STORAGE_BUCKET に依存しているが、functions/.env.<project-id> は
+          # これまで一度も生成されておらず、kanameone実機で undefined のまま運用されていた
+          # (2026-07-08 canary検証で発覚: storage.bucket()を引数無しで呼ぶ再OCR時の
+          # 再ダウンロード経路(ocrProcessor.ts, Issue #526 pageResults再利用フォールバック)
+          # で "Bucket name not specified or invalid" エラーが発生することを実機確認)。
+          # scripts/clients/<alias>.env の値が正解(CLAUDE.md: プロジェクトIDからの推測禁止、
+          # .appspot.com/.firebasestorage.app の形式は環境ごとに異なる)。
+          ENV_FILE="scripts/clients/${PROJECT_ALIAS}.env"
+          if [ ! -f "$ENV_FILE" ]; then
+            echo "ERROR: $ENV_FILE が見つかりません" >&2
+            exit 1
+          fi
+          STORAGE_BUCKET=$(grep -E '^STORAGE_BUCKET=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+          if [ -z "$STORAGE_BUCKET" ]; then
+            echo "ERROR: $ENV_FILE に STORAGE_BUCKET が見つかりません" >&2
+            exit 1
+          fi
+          echo "STORAGE_BUCKET=${STORAGE_BUCKET}" > "functions/.env.${PROJECT_ID}"
+          echo "STORAGE_BUCKET 設定: ${STORAGE_BUCKET} (functions/.env.${PROJECT_ID})"
+
           # GEMINI_MODEL_ID override (任意): Firebase Functions v2は環境変数を
           # functions/.env.<project-id> ファイルから読む(シェル環境変数は伝播しない)。
           # 未指定(code-default)ならfunctions/src/utils/config.tsのコード既定値を使用。
           if [ "${{ github.event.inputs.gemini_model_id_override }}" != "code-default" ]; then
-            echo "GEMINI_MODEL_ID=${{ github.event.inputs.gemini_model_id_override }}" > "functions/.env.${PROJECT_ID}"
+            echo "GEMINI_MODEL_ID=${{ github.event.inputs.gemini_model_id_override }}" >> "functions/.env.${PROJECT_ID}"
             echo "GEMINI_MODEL_ID override 適用: ${{ github.event.inputs.gemini_model_id_override }} (functions/.env.${PROJECT_ID})"
           fi
 


### PR DESCRIPTION
## Summary
- kanameoneのcanary検証(#548段階デプロイ手順)で、既存確定済み文書1件を再OCR処理させたところ**status=errorで実際に失敗**した
- 実機Cloud Functionsログで根本原因を確認: `storage/invalid-argument: Bucket name not specified or invalid`
- `functions/src/index.ts`の`admin.initializeApp({storageBucket: process.env.STORAGE_BUCKET})`が依存する`STORAGE_BUCKET`環境変数が、kanameoneのデプロイ済みFunctionsに一度も設定されたことがなく`undefined`だった(`gcloud functions describe`で実環境変数を確認済み)
- 失敗した経路(`ocrProcessor.ts:142`、pageResults再利用不可時の元PDF再ダウンロードフォールバック)はIssue #526で新規追加された機能のため、今回のデプロイまで一度も実行されておらず問題が表面化していなかった
- **影響範囲**: この修正なしでは「再処理」操作(手動再処理ボタン・自動リトライ・エラーrescue等、分割以外の文書の再OCR全般)が全て失敗する状態だった

## Fix
- `scripts/clients/<alias>.env`の正解値(CLAUDE.md「Storageバケット名」rule準拠)から`STORAGE_BUCKET`を解決し、`functions/.env.<project-id>`に書き込んでからデプロイする
- dev/cocoro/kanameone全環境に適用

## Test plan
- [x] YAML構文検証(js-yaml)
- [ ] マージ後、kanameoneへ再デプロイし実環境変数にSTORAGE_BUCKETが反映されることを確認
- [ ] canary文書を再度pendingに戻し、再OCRが成功することを確認(次アクション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment setup to ensure required environment settings are generated correctly.
  * Added validation to catch missing configuration earlier and prevent incomplete deploys.
  * Preserved existing deployment settings when adding optional overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->