### PR TITLE
docs(delivery): クライアント責任にAI取込時の個人情報同意取得を明記

### DIFF
--- a/docs/context/delivery-and-update-guide.md
+++ b/docs/context/delivery-and-update-guide.md
@@ -513,6 +513,7 @@ FIREBASE_PROJECT_ID=<new-client-project-id> node scripts/import-masters.js --off
 | ユーザー管理 | 許可ユーザーの追加・削除 |
 | 日常運用 | 書類処理・エラー対応 |
 | Gmail | 監視対象アカウントの管理 |
+| 個人情報の取扱い同意 | AI/デジタルシステムへの個人情報（要配慮個人情報を含む場合は特に）取込について、ご利用者からの同意取得 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Gemini 3.5移行に伴う個人情報コンプライアンス確認（アーキテクチャ層/法務層の切り分け）の結果、要配慮個人情報を含む場合の同意取得責任はクライアント（データ管理者、本人と直接契約関係を持つ主体）側にあり、ベンダー側では技術的対応（マスキング等）ではなく「推奨」までが適正範囲と整理
- `docs/context/delivery-and-update-guide.md` §責任分担 > クライアントの責任 表に1行追記

技術的な追加実装（マスキング等）は不要と判断済み。ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the delivery and update guide to clarify that customer responsibility includes obtaining user consent before importing personal information, especially sensitive personal data, into AI or digital systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->