### PR TITLE
chore(cost): confirmed-replay検証のサンプル上限を全母集団カバー可能な値に引き上げ (Issue #548)

### DIFF
--- a/scripts/compare-gemini-ocr-models-confirmed.ts
+++ b/scripts/compare-gemini-ocr-models-confirmed.ts
@@ -112,9 +112,15 @@ const DEFAULT_LIMIT = 30;
  * confirmedBy/officeConfirmedBy による人間確定フィルタで一部が弾かれる前提で、
  * Firestoreクエリ自体は目標件数の3倍を上限にサンプリングする(Codex review指摘反映)。
  * 大きすぎる無制限headroomによるread coストを避けるため上限をキャップする。
+ *
+ * **2026-07-08判明**: kanameone実データでconfirmedBy/officeConfirmedByが非nullの
+ * 歩留まりは約1.3%(900件照会→12件)と低く、旧上限2000だと最大でも約26件しか
+ * 到達できなかった。母集団の真の上限を確認するため、kanameone全processed件数
+ * (9,355件、2026-07-08時点)を上回る値に引き上げる(customerConfirmed&&officeConfirmed
+ * が真部分集合のため、この上限で全対象文書をカバーできる)。
  */
 const SAMPLE_HEADROOM_MULTIPLIER = 3;
-const SAMPLE_HEADROOM_CAP = 2000;
+const SAMPLE_HEADROOM_CAP = 10000;
 
 const PROJECT_ID =
   process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.FIREBASE_PROJECT_ID || '';


### PR DESCRIPTION
## Summary
- kanameone実データでconfirmedBy/officeConfirmedBy非nullの歩留まりが約1.3%(900件照会→12件)と低く、旧`SAMPLE_HEADROOM_CAP=2000`だと最大でも約26件しか到達できないと判明。
- 母集団の真の上限を確認するため、kanameone全processed件数(9,355件、2026-07-08時点)を上回る10000に引き上げる(1定数変更のみ)。

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm test`(scripts/) — 17 passing / 0 failing(既存テストへの影響なし、定数値のみの変更)
- [ ] マージ後、GitHub Actions経由でkanameone環境に対し`compare-gemini-ocr-models-confirmed --limit 9999`を実行し、真の母集団上限を確認(次アクション)

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)