### PR TITLE
chore(ci): compare-gemini-ocr-models-confirmedに--limit 5000選択肢を追加 (Issue #548)

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -94,6 +94,7 @@ on:
           - compare-gemini-ocr-models
           - compare-gemini-ocr-models-confirmed --limit 30
           - compare-gemini-ocr-models-confirmed --limit 300
+          - compare-gemini-ocr-models-confirmed --limit 5000
           - diagnose-confirmed-replay-sampling
           - diagnose-confirmed-replay-sampling --doc-id
           - measure-summary-cost --doc-id


### PR DESCRIPTION
## Summary
- `SAMPLE_HEADROOM_CAP`引き上げ(PR #593)を受け、kanameone全母集団(9,355件)をスキャンできる`--limit 5000`(queryLimit=min(5000*3,10000)=10000)のworkflow_dispatch選択肢を追加。

## Test plan
- [x] YAML構文検証(node + js-yaml)— エラーなし
- [ ] マージ後、GitHub Actions経由でkanameone環境に対し新選択肢を実行(次アクション)

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)