### PR TITLE
feat(reprocess): 再処理3経路でdetail/mainを同一batchクリア (Issue #547 Phase D PR-D1)

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -1,6 +1,7 @@
 ---
 updated: 2026-07-09
 ---
+<!-- session108: Phase C完遂+#548 close+Phase D計画承認を反映 -->
 
 ## 現在のミッション
 運用コスト圧縮2トラック — #547 Firestore読取egress削減（ADR-0018 detail/main分離）と #548 Gemini 3.5 Flash移行 — を、本番2環境（kanameone / cocoro）で安全に完遂する。
@@ -19,15 +20,19 @@ updated: 2026-07-09
 ## 進行中のtasks
 - [x] #548 confirmed-replay 統計検証（kanameone 実データ N=60、2.5/3.5 確定2項目完全同値 36.7% PASS、手法上限到達）
 - [x] #547 Phase C backfill スクリプト実装・マージ（PR #595、3層レビュー通過）
-- [x] #547 dev リハーサル前半（--audit 160件整合 / --dry-run 件数一致）
-- [ ] #547 dev リハーサル後半（canary `--execute --limit 10` → 全量 → 2周目書込0件=冪等 → `--verify` PASS。9項目チェックリストは PR #595 コメント）
-- [ ] #547 cocoro backfill 実行（trigger: dev リハーサル全PASS + 番号単位認可 + バックアップ鮮度確認）
-- [ ] #547 kanameone backfill 実行（trigger: 同上。9,355件）
-- [ ] #548 kanameone / cocoro 本番展開 → Issue #548 close（trigger: 番号単位展開認可。検証材料は充足済み）
-- [ ] #547 Phase D dual-read cutover → Phase E 親doc大容量フィールド削除（egress実削減）→ Issue #547 close（ADR-0018 ロードマップ。着手時に /impl-plan 必須）
+- [x] #547 dev リハーサル完了（2026-07-09、7項目PASS + stale/並行競合2項目は本番ログ注視で代替。kill→再開の再開安全性実証。記録: PR #595 コメント）
+- [x] #547 cocoro backfill 完了（2026-07-09、1,039件・verify PASS）
+- [x] #547 kanameone backfill 完了（2026-07-09、9,341件・verify PASS 9,389件 parity一致）
+- [x] #548 kanameone / cocoro 本番展開 → **Issue #548 close 済み**（2026-07-09。kanameone=2.5 pin解除、cocoro=1ヶ月分一括反映+Hosting+rules。ロールバック: gemini_model_id_override=gemini-2.5-flash）
+- [ ] #547 Phase D **PR-D1**: FE reprocess-clear の detail/main 同時クリア化（3箇所の既存writeBatchに detail deleteField 追加。計画: session108 承認済み impl-plan）
+- [ ] #547 Phase D **PR-D2**: Functions 読者切替（getOcrText/regenerateSummary=tx.getAll paired-read、pageResultsReuse/detectSplitPoints/splitPdf=detail読込、dual-readフォールバック）
+- [ ] #547 Phase D **PR-D3**: FE 読者切替（モーダルのオンデマンドdetail取得/PdfSplitModal/ocrExcerpt参照化/dead code防御除去）+ ui-verified 必須
+- [ ] #547 Phase D **PR-D4**: scripts 読者切替（reprocess-master-matching.js + measure-summary-cost.ts）+ AC9読者ゼロgrep契約テスト
+- [ ] #547 Phase D 展開（trigger: 全PR merge + dev AC確認 + 環境ごと番号単位認可。**環境内は Hosting先行 → stale/pending検証ゲート → Functions の順**（旧PWA由来stale再利用の封鎖））
+- [ ] #547 Phase E impl-plan 起票 → 実行 → Issue #547 close（trigger: Phase D 展開完了 + AC9ゲートPASS。destructive につき番号認可+devリハーサル必須）
 
 ## 🔄 中断点（in-flight）
-- 対象タスク: #547 dev リハーサル後半
-- 直前の状態: PR #595 マージ済み。dev で `--audit`（160件: detail+excerpt 12 / excerpt-only 148 / stale 0）と `--dry-run`（audit と件数一致）まで完了。実書込（--execute）は未実施
-- 次の一手: GitHub Actions "Run Operations Script" → 環境 dev → `backfill-detail-subcollection --execute --limit 10`（canary）を実行し、書込カウンタとログを確認
-- 検証コマンド: `gh run list --workflow=run-ops-script.yml --limit 3`（直近実行の成否）/ dev で `--audit` 再実行（残対象件数の減少確認）
+- 対象タスク: #547 Phase D PR-D1
+- 直前の状態: Phase D 計画承認済み（Codex plan review P1×3/P2×2 反映済み、計画全文: セッション scratchpad/phase-d-plan.md → 消失時は本GOAL.mdのタスク分解+ADR-0018で再構成可）。Phase B PR4a により3箇所は writeBatch/chunking/親ocrExcerptクリアまで実装済みで、PR-D1 の残作業は「既存batchへの detail/main deleteField 追加」のみ
+- 次の一手: feature ブランチで useDocuments.ts useReprocessDocument / useErrors.ts requestReprocess / DocumentsPage.tsx handleBulkReprocess の3箇所に `batch.update(doc(db,'documents',id,'detail','main'), {ocrResult: deleteField(), pageResults: deleteField()})` を追加（rules は deleteField のみ許可、値上書き不可に注意）
+- 検証コマンド: `cd frontend && npm test` / `cd functions && npm run test:rules`（detail update ルール適合）

--- a/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
+++ b/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
@@ -35,8 +35,9 @@ describe('reprocess-clear detail/main 配線契約 (ADR-0018 PR4b)', () => {
     const helper = useDocumentsSrc.match(
       /export async function appendReprocessClearToBatch[\s\S]*?\n\}/
     )![0]
-    // rules は detail の create を禁止しているため、不在 doc への update() は
-    // not-found で batch 全体を落とす。存在確認 → 条件付き update が必須配線
+    // 不在 doc への update() は not-found で batch 全体を落とす(Firestore 仕様)。
+    // rules が create を禁止しているため set() での回避も不可 — 存在確認 →
+    // 条件付き update が必須配線
     expect(helper).toMatch(/doc\(db, 'documents', documentId, 'detail', 'main'\)/)
     expect(helper).toMatch(/await getDoc\(detailRef\)/)
     expect(helper).toMatch(
@@ -56,9 +57,11 @@ describe('reprocess-clear detail/main 配線契約 (ADR-0018 PR4b)', () => {
     // useDocuments.ts では appendReprocessClearToBatch 内の1箇所のみ許可
     const detailPathCount = [...useDocumentsSrc.matchAll(/'detail', 'main'/g)].length
     expect(detailPathCount, 'useDocuments.ts の detail/main パス構築はヘルパー内の1箇所のみ').toBe(1)
-    // 他2ファイルは detail/main パスを直接構築しない (全てヘルパー委譲)
-    expect(useErrorsSrc).not.toMatch(/'detail'/)
-    expect(documentsPageSrc).not.toMatch(/'detail'/)
+    // 他2ファイルは detail/main パスを直接構築しない (全てヘルパー委譲)。
+    // テンプレート文字列パス (`documents/${id}/detail/main`) や collection(ref, 'detail')
+    // による迂回も含めて検出するため、引用符種を問わない緩い regex で網を張る
+    expect(useErrorsSrc).not.toMatch(/['"`/]detail['"`/]/)
+    expect(documentsPageSrc).not.toMatch(/['"`/]detail['"`/]/)
   })
 
   it('DocumentsPage: CHUNK_SIZE は 250 (最大500 update/チャンク。hard limitは2023年撤廃済みだが、payload上限と部分成功粒度の保守値として維持)', () => {

--- a/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
+++ b/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
@@ -3,8 +3,8 @@
  *
  * functions/test/ocrProcessorDetailDualWriteContract.test.ts /
  * scripts/lib/backfillScriptContract.test.ts と同じ grep-based 契約パターン。
- * 「親docクリアと detail/main クリアが同一 writeBatch に含まれる」配線を
- * ソース文字列レベルで lock-in する。
+ * 「再処理クリアは全経路 appendReprocessClearToBatch ヘルパー経由」という
+ * 1点への集約をソース文字列レベルで lock-in する。
  *
  * 1経路でも detail クリアが漏れると、そのパスで再処理された doc は
  * detail/main に再処理前の古い OCR 内容が残存し、Phase D 以降の detail-first
@@ -23,39 +23,45 @@ const useErrorsSrc = read('../useErrors.ts')
 const documentsPageSrc = read('../../pages/DocumentsPage.tsx')
 
 describe('reprocess-clear detail/main 配線契約 (ADR-0018 PR4b)', () => {
-  it('useReprocessDocument: 親update と同一batchで detail/main を getReprocessDetailClearFields でクリアする', () => {
-    expect(useDocumentsSrc).toMatch(
-      /batch\.update\(\s*doc\(db, 'documents', documentId, 'detail', 'main'\),\s*getReprocessDetailClearFields\(\)\s*\)/
+  it('ヘルパー: 親docの status:pending + getReprocessClearFields を batch に積む', () => {
+    const helper = useDocumentsSrc.match(
+      /export async function appendReprocessClearToBatch[\s\S]*?\n\}/
+    )
+    expect(helper, 'appendReprocessClearToBatch が定義されていること').not.toBeNull()
+    expect(helper![0]).toMatch(/status: 'pending',\s*\.\.\.getReprocessClearFields\(\)/)
+  })
+
+  it('ヘルパー: detail/main は存在確認(getDoc)の上、存在時のみ getReprocessDetailClearFields でクリアする', () => {
+    const helper = useDocumentsSrc.match(
+      /export async function appendReprocessClearToBatch[\s\S]*?\n\}/
+    )![0]
+    // rules は detail の create を禁止しているため、不在 doc への update() は
+    // not-found で batch 全体を落とす。存在確認 → 条件付き update が必須配線
+    expect(helper).toMatch(/doc\(db, 'documents', documentId, 'detail', 'main'\)/)
+    expect(helper).toMatch(/await getDoc\(detailRef\)/)
+    expect(helper).toMatch(
+      /if \(detailSnap\.exists\(\)\) \{\s*batch\.update\(detailRef, getReprocessDetailClearFields\(\)\)/
     )
   })
 
-  it('useErrors requestReprocess: firstDoc 存在時に detail/main を同一batchでクリアする', () => {
-    expect(useErrorsSrc).toMatch(
-      /batch\.update\(\s*doc\(db, 'documents', firstDoc\.id, 'detail', 'main'\),\s*getReprocessDetailClearFields\(\)\s*\)/
-    )
+  it.each([
+    ['useDocuments.ts useReprocessDocument', () => useDocumentsSrc, /await appendReprocessClearToBatch\(batch, documentId\)/],
+    ['useErrors.ts requestReprocess', () => useErrorsSrc, /await appendReprocessClearToBatch\(batch, firstDoc\.id\)/],
+    ['DocumentsPage.tsx handleBulkReprocess', () => documentsPageSrc, /chunk\.map\(\(docId\) => appendReprocessClearToBatch\(batch, docId\)\)/],
+  ])('%s はヘルパー経由でクリアする', (_name, getSrc, pattern) => {
+    expect(getSrc()).toMatch(pattern)
   })
 
-  it('DocumentsPage handleBulkReprocess: チャンクループ内で doc ごとに detail/main をクリアする', () => {
-    expect(documentsPageSrc).toMatch(
-      /const detailClearFields = getReprocessDetailClearFields\(\)/
-    )
-    expect(documentsPageSrc).toMatch(
-      /batch\.update\(doc\(db, 'documents', docId, 'detail', 'main'\), detailClearFields\)/
-    )
+  it("ヘルパーの外に detail/main への書込配線が存在しない (経路追加時のクリア漏れ・rules違反の値設定を構造的に防ぐ)", () => {
+    // useDocuments.ts では appendReprocessClearToBatch 内の1箇所のみ許可
+    const detailPathCount = [...useDocumentsSrc.matchAll(/'detail', 'main'/g)].length
+    expect(detailPathCount, 'useDocuments.ts の detail/main パス構築はヘルパー内の1箇所のみ').toBe(1)
+    // 他2ファイルは detail/main パスを直接構築しない (全てヘルパー委譲)
+    expect(useErrorsSrc).not.toMatch(/'detail'/)
+    expect(documentsPageSrc).not.toMatch(/'detail'/)
   })
 
-  it('DocumentsPage: CHUNK_SIZE は 250 (1doc=2update で 500 ops = batch 上限ちょうど。増やすと commit が失敗する)', () => {
+  it('DocumentsPage: CHUNK_SIZE は 250 (最大500 update/チャンク。hard limitは2023年撤廃済みだが、payload上限と部分成功粒度の保守値として維持)', () => {
     expect(documentsPageSrc).toMatch(/const CHUNK_SIZE = 250/)
-  })
-
-  it("detail/main へ値を設定する batch.update が存在しない (rules は削除のみ許可、'''化は permission-denied)", () => {
-    // detail/main への update は全経路 getReprocessDetailClearFields (deleteFieldのみ) 経由。
-    // ocrResult: '' のような値設定が紛れ込むと rules 拒否で batch 全体が失敗する
-    for (const src of [useDocumentsSrc, useErrorsSrc, documentsPageSrc]) {
-      const detailUpdates = [...src.matchAll(/'detail', 'main'\),\s*\{([^}]*)\}/g)]
-      for (const m of detailUpdates) {
-        expect(m[1]).not.toMatch(/ocrResult:\s*['"`]/)
-      }
-    }
   })
 })

--- a/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
+++ b/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
@@ -1,0 +1,61 @@
+/**
+ * 再処理3経路の detail/main 同時クリア配線契約テスト (ADR-0018 Phase D PR4b, Issue #547)
+ *
+ * functions/test/ocrProcessorDetailDualWriteContract.test.ts /
+ * scripts/lib/backfillScriptContract.test.ts と同じ grep-based 契約パターン。
+ * 「親docクリアと detail/main クリアが同一 writeBatch に含まれる」配線を
+ * ソース文字列レベルで lock-in する。
+ *
+ * 1経路でも detail クリアが漏れると、そのパスで再処理された doc は
+ * detail/main に再処理前の古い OCR 内容が残存し、Phase D 以降の detail-first
+ * 読者(pageResultsReuse 等)が古いデータを「有効」と誤判定する品質破壊が起きる
+ * (Phase C で実在を確認した stale detail の新規発生経路)。
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf-8')
+
+const useDocumentsSrc = read('../useDocuments.ts')
+const useErrorsSrc = read('../useErrors.ts')
+const documentsPageSrc = read('../../pages/DocumentsPage.tsx')
+
+describe('reprocess-clear detail/main 配線契約 (ADR-0018 PR4b)', () => {
+  it('useReprocessDocument: 親update と同一batchで detail/main を getReprocessDetailClearFields でクリアする', () => {
+    expect(useDocumentsSrc).toMatch(
+      /batch\.update\(\s*doc\(db, 'documents', documentId, 'detail', 'main'\),\s*getReprocessDetailClearFields\(\)\s*\)/
+    )
+  })
+
+  it('useErrors requestReprocess: firstDoc 存在時に detail/main を同一batchでクリアする', () => {
+    expect(useErrorsSrc).toMatch(
+      /batch\.update\(\s*doc\(db, 'documents', firstDoc\.id, 'detail', 'main'\),\s*getReprocessDetailClearFields\(\)\s*\)/
+    )
+  })
+
+  it('DocumentsPage handleBulkReprocess: チャンクループ内で doc ごとに detail/main をクリアする', () => {
+    expect(documentsPageSrc).toMatch(
+      /const detailClearFields = getReprocessDetailClearFields\(\)/
+    )
+    expect(documentsPageSrc).toMatch(
+      /batch\.update\(doc\(db, 'documents', docId, 'detail', 'main'\), detailClearFields\)/
+    )
+  })
+
+  it('DocumentsPage: CHUNK_SIZE は 250 (1doc=2update で 500 ops = batch 上限ちょうど。増やすと commit が失敗する)', () => {
+    expect(documentsPageSrc).toMatch(/const CHUNK_SIZE = 250/)
+  })
+
+  it("detail/main へ値を設定する batch.update が存在しない (rules は削除のみ許可、'''化は permission-denied)", () => {
+    // detail/main への update は全経路 getReprocessDetailClearFields (deleteFieldのみ) 経由。
+    // ocrResult: '' のような値設定が紛れ込むと rules 拒否で batch 全体が失敗する
+    for (const src of [useDocumentsSrc, useErrorsSrc, documentsPageSrc]) {
+      const detailUpdates = [...src.matchAll(/'detail', 'main'\),\s*\{([^}]*)\}/g)]
+      for (const m of detailUpdates) {
+        expect(m[1]).not.toMatch(/ocrResult:\s*['"`]/)
+      }
+    }
+  })
+})

--- a/frontend/src/hooks/__tests__/useDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useDocuments.test.ts
@@ -6,8 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { deleteField } from 'firebase/firestore'
-import { Timestamp } from 'firebase/firestore'
+import { deleteField, Timestamp } from 'firebase/firestore'
 import { firestoreToDocument, normalizeSummary, getReprocessClearFields, getReprocessDetailClearFields } from '../useDocuments'
 
 describe('firestoreToDocument', () => {

--- a/frontend/src/hooks/__tests__/useDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useDocuments.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { deleteField } from 'firebase/firestore'
 import { Timestamp } from 'firebase/firestore'
-import { firestoreToDocument, normalizeSummary, getReprocessClearFields } from '../useDocuments'
+import { firestoreToDocument, normalizeSummary, getReprocessClearFields, getReprocessDetailClearFields } from '../useDocuments'
 
 describe('firestoreToDocument', () => {
   // 基本フィールドのモックデータ
@@ -476,5 +477,22 @@ describe('getReprocessClearFields (Issue #215: 旧3キー + 新summary 全て de
   it('documentTypeConfirmed を false にリセットする (Issue #526)', () => {
     const fields = getReprocessClearFields()
     expect(fields.documentTypeConfirmed).toBe(false)
+  })
+})
+
+describe('getReprocessDetailClearFields (ADR-0018 Phase D PR4b, Issue #547)', () => {
+  it('detail/main の update 対象は ocrResult / pageResults の2キーのみ (更新対象外フィールドに触れない)', () => {
+    const fields = getReprocessDetailClearFields()
+    // firestore.rules は affectedKeys().hasOnly(['ocrResult', 'pageResults']) を要求する。
+    // キーが増減すると permission-denied で再処理 batch 全体が失敗する
+    expect(Object.keys(fields).sort()).toEqual(['ocrResult', 'pageResults'])
+  })
+
+  it('両フィールドとも deleteField sentinel (値の設定は rules が拒否するため不可)', () => {
+    const fields = getReprocessDetailClearFields()
+    // rules は「フィールド削除または無変更」のみ許可。'' や null の設定は
+    // 値の上書きとして permission-denied になる
+    expect(deleteField().isEqual(fields.ocrResult)).toBe(true)
+    expect(deleteField().isEqual(fields.pageResults)).toBe(true)
   })
 })

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -251,9 +251,9 @@ export function updateDocumentInListCache(
 // ============================================
 
 /**
- * 再処理時にリセットすべき全フィールドを返すファクトリ関数
- * DocumentDetailModal, DocumentsPage, useErrors の3箇所で共通利用（DRY）
- * deleteField() はファクトリ関数内で毎回生成（安全性）
+ * 再処理時にリセットすべき親docの全フィールドを返すファクトリ関数
+ * 直接の呼出元は appendReprocessClearToBatch のみ（再処理3経路は
+ * ヘルパー経由で間接利用）。deleteField() はファクトリ関数内で毎回生成（安全性）
  */
 export function getReprocessClearFields() {
   const df = deleteField()
@@ -335,10 +335,8 @@ export function getReprocessClearFields() {
  * している(値の上書きは Functions 専有)ため、deleteField() のみで構成する。
  * `ocrResult: ''` のような値の設定は permission-denied で batch 全体が失敗する。
  *
- * detail/main の存在は doc 作成時の dual-write (Phase B) + 既存 doc の backfill
- * (Phase C、全環境 verify PASS) で保証されており、update() は常に成功する。
- * 旧ビルド期間に作成された doc が残る環境へは、本変更のデプロイ前に backfill を
- * 再実行(冪等)して隙間を埋める(デプロイゲート)。
+ * detail/main が不在の doc への挙動は appendReprocessClearToBatch の存在ガード参照
+ * (不在時は skip)。不在 detail の充填自体は backfill 再実行(冪等)で行う。
  */
 export function getReprocessDetailClearFields() {
   const df = deleteField()
@@ -355,9 +353,11 @@ export function getReprocessDetailClearFields() {
  * detail クリア漏れ(= stale detail 再発)を経路追加時に作り込みやすいため、
  * ペア不変条件をこの1点に集約する。
  *
- * detail/main は存在確認してから update に積む: rules が create を禁止しているため
- * 不在 doc への update() は not-found で batch 全体を落とす。不在 = クリアすべき
- * コンテンツが最初から無い(望む終端状態が既に成立)ので、skip が意味的にも正しい。
+ * detail/main は存在確認してから update に積む: 不在 doc への update() は
+ * not-found で batch 全体を落とす(Firestore 仕様)。rules が create を禁止している
+ * ため set() での upsert 回避も不可 — よって存在確認 → 条件付き update が必須。
+ * 不在 = クリアすべきコンテンツが最初から無い(望む終端状態が既に成立)ので、
+ * skip が意味的にも正しい。
  * 確認と commit の間に detail が作成されるレース(並行OCR完了)はあり得るが、その場合も
  * 親クリアで status:'pending' になった doc を次の OCR パイプラインが dual-write で
  * 上書きするため自己修復する。

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -15,6 +15,7 @@ import {
   getDoc,
   updateDoc,
   writeBatch,
+  type WriteBatch,
   deleteField,
   Timestamp,
   QueryConstraint,
@@ -347,6 +348,35 @@ export function getReprocessDetailClearFields() {
   }
 }
 
+/**
+ * 再処理クリア一式（親doc + detail/main）を writeBatch に積む共通ヘルパー
+ * (ADR-0018 Phase D PR4b、Issue #547)。3経路(useReprocessDocument / useErrors /
+ * DocumentsPage)はすべて本ヘルパー経由でクリアする — 経路ごとの手書き重複だと
+ * detail クリア漏れ(= stale detail 再発)を経路追加時に作り込みやすいため、
+ * ペア不変条件をこの1点に集約する。
+ *
+ * detail/main は存在確認してから update に積む: rules が create を禁止しているため
+ * 不在 doc への update() は not-found で batch 全体を落とす。不在 = クリアすべき
+ * コンテンツが最初から無い(望む終端状態が既に成立)ので、skip が意味的にも正しい。
+ * 確認と commit の間に detail が作成されるレース(並行OCR完了)はあり得るが、その場合も
+ * 親クリアで status:'pending' になった doc を次の OCR パイプラインが dual-write で
+ * 上書きするため自己修復する。
+ */
+export async function appendReprocessClearToBatch(
+  batch: WriteBatch,
+  documentId: string
+): Promise<void> {
+  batch.update(doc(db, 'documents', documentId), {
+    status: 'pending',
+    ...getReprocessClearFields(),
+  })
+  const detailRef = doc(db, 'documents', documentId, 'detail', 'main')
+  const detailSnap = await getDoc(detailRef)
+  if (detailSnap.exists()) {
+    batch.update(detailRef, getReprocessDetailClearFields())
+  }
+}
+
 // ============================================
 // 個別再処理フック (#524)
 // ============================================
@@ -368,16 +398,9 @@ export function useReprocessDocument() {
     setReprocessingId(documentId)
     try {
       // ADR-0018 Phase D PR4b (Issue #547): 親docクリアと detail/main クリアを
-      // 単一batchで原子的にコミット(他2箇所 useErrors/DocumentsPage と同一パターン)
+      // 単一batchで原子的にコミット(他2箇所 useErrors/DocumentsPage と同一ヘルパー)
       const batch = writeBatch(db)
-      batch.update(doc(db, 'documents', documentId), {
-        status: 'pending',
-        ...getReprocessClearFields(),
-      })
-      batch.update(
-        doc(db, 'documents', documentId, 'detail', 'main'),
-        getReprocessDetailClearFields()
-      )
+      await appendReprocessClearToBatch(batch, documentId)
       await batch.commit()
       // 楽観的更新（即時UI反映）
       updateDocumentInListCache(queryClient, documentId, {

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -324,6 +324,29 @@ export function getReprocessClearFields() {
   }
 }
 
+/**
+ * 再処理時に detail/main サブコレクションからクリアすべきフィールドを返すファクトリ関数
+ * (ADR-0018 Phase D PR4b、Issue #547)。親docと同じく3経路(useReprocessDocument /
+ * useErrors / DocumentsPage)で共通利用し、親クリアと同一 writeBatch に含めて
+ * 原子的にコミットする(片側だけクリアされた doc を作らない)。
+ *
+ * firestore.rules は detail/main の update を「フィールド削除または無変更」のみ許可
+ * している(値の上書きは Functions 専有)ため、deleteField() のみで構成する。
+ * `ocrResult: ''` のような値の設定は permission-denied で batch 全体が失敗する。
+ *
+ * detail/main の存在は doc 作成時の dual-write (Phase B) + 既存 doc の backfill
+ * (Phase C、全環境 verify PASS) で保証されており、update() は常に成功する。
+ * 旧ビルド期間に作成された doc が残る環境へは、本変更のデプロイ前に backfill を
+ * 再実行(冪等)して隙間を埋める(デプロイゲート)。
+ */
+export function getReprocessDetailClearFields() {
+  const df = deleteField()
+  return {
+    ocrResult: df,
+    pageResults: df,
+  }
+}
+
 // ============================================
 // 個別再処理フック (#524)
 // ============================================
@@ -344,13 +367,17 @@ export function useReprocessDocument() {
     if (!documentId || reprocessingId) return false
     setReprocessingId(documentId)
     try {
-      // ADR-0018 Phase B (Issue #547): 他2箇所(useErrors/DocumentsPage)との
-      // writeBatch統一。detail/main書込はPhase D以降(PR4b)に分離、本PRは親docのみ。
+      // ADR-0018 Phase D PR4b (Issue #547): 親docクリアと detail/main クリアを
+      // 単一batchで原子的にコミット(他2箇所 useErrors/DocumentsPage と同一パターン)
       const batch = writeBatch(db)
       batch.update(doc(db, 'documents', documentId), {
         status: 'pending',
         ...getReprocessClearFields(),
       })
+      batch.update(
+        doc(db, 'documents', documentId, 'detail', 'main'),
+        getReprocessDetailClearFields()
+      )
       await batch.commit()
       // 楽観的更新（即時UI反映）
       updateDocumentInListCache(queryClient, documentId, {

--- a/frontend/src/hooks/useErrors.ts
+++ b/frontend/src/hooks/useErrors.ts
@@ -22,7 +22,7 @@ import {
   QueryConstraint,
 } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
-import { getReprocessClearFields, getReprocessDetailClearFields } from './useDocuments'
+import { appendReprocessClearToBatch } from './useDocuments'
 import type { ErrorRecord, ErrorStatus, ErrorType } from '@shared/types'
 
 // ============================================
@@ -236,15 +236,7 @@ async function requestReprocess({ errorId, fileId }: ReprocessParams): Promise<v
   batch.update(errorRef, { status: 'pending' })
 
   if (firstDoc) {
-    const docRef = doc(db, 'documents', firstDoc.id)
-    batch.update(docRef, {
-      status: 'pending',
-      ...getReprocessClearFields(),
-    })
-    batch.update(
-      doc(db, 'documents', firstDoc.id, 'detail', 'main'),
-      getReprocessDetailClearFields()
-    )
+    await appendReprocessClearToBatch(batch, firstDoc.id)
   }
   await batch.commit()
 }

--- a/frontend/src/hooks/useErrors.ts
+++ b/frontend/src/hooks/useErrors.ts
@@ -22,7 +22,7 @@ import {
   QueryConstraint,
 } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
-import { getReprocessClearFields } from './useDocuments'
+import { getReprocessClearFields, getReprocessDetailClearFields } from './useDocuments'
 import type { ErrorRecord, ErrorStatus, ErrorType } from '@shared/types'
 
 // ============================================
@@ -229,9 +229,8 @@ async function requestReprocess({ errorId, fileId }: ReprocessParams): Promise<v
   const snapshot = await getDocs(docsQuery)
   const firstDoc = snapshot.docs[0]
 
-  // ADR-0018 Phase B (Issue #547): エラーstatus更新とdocumentクリアを単一batchで
-  // 原子的に実行 (途中失敗による不整合状態を防ぐ)。detail/main書込は
-  // Phase D以降(PR4b)に分離、本PRは親docのみ。
+  // ADR-0018 Phase D PR4b (Issue #547): エラーstatus更新・documentクリア・
+  // detail/main クリアを単一batchで原子的に実行 (途中失敗による不整合状態を防ぐ)
   const batch = writeBatch(db)
   const errorRef = doc(db, 'errors', errorId)
   batch.update(errorRef, { status: 'pending' })
@@ -242,6 +241,10 @@ async function requestReprocess({ errorId, fileId }: ReprocessParams): Promise<v
       status: 'pending',
       ...getReprocessClearFields(),
     })
+    batch.update(
+      doc(db, 'documents', firstDoc.id, 'detail', 'main'),
+      getReprocessDetailClearFields()
+    )
   }
   await batch.commit()
 }

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -51,7 +51,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { db } from '@/lib/firebase'
 import { callFunction } from '@/lib/callFunction'
 import { Checkbox } from '@/components/ui/checkbox'
-import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, getReprocessClearFields, getReprocessDetailClearFields, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
+import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, appendReprocessClearToBatch, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
 import { useCareManagers } from '@/hooks/useMasters'
 import { DateRangeFilter, type DateRange } from '@/components/DateRangeFilter'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
@@ -478,15 +478,14 @@ export function DocumentsPage() {
 
   // 一括再処理
   // ADR-0018 Phase D PR4b (Issue #547): 親doc + detail/main を同一batchでクリア。
-  // 1docあたり2 update のため CHUNK_SIZE=250 で 500 ops = Firestore batch 上限ちょうど。
-  // 本ループに per-doc の書込を追加する場合は CHUNK_SIZE の引き下げが必須。
+  // CHUNK_SIZE=250 (最大500 update/チャンク) は保守値: Firestoreのbatch 500件hard limitは
+  // 2023年に撤廃済みだが、request payloadサイズ上限と部分成功の粒度(チャンク単位の
+  // 成否がユーザーに報告される)を考慮して据え置く。
   const handleBulkReprocess = useCallback(async () => {
     if (selectedIds.size === 0) return
 
     setIsBulkOperating(true)
     try {
-      const clearFields = getReprocessClearFields()
-      const detailClearFields = getReprocessDetailClearFields()
       const ids = Array.from(selectedIds)
       const CHUNK_SIZE = 250
       let succeededCount = 0
@@ -499,14 +498,8 @@ export function DocumentsPage() {
         // succeededCountの情報が失われるのを防ぐ)
         try {
           const batch = writeBatch(db)
-          for (const docId of chunk) {
-            const docRef = doc(db, 'documents', docId)
-            batch.update(docRef, {
-              status: 'pending',
-              ...clearFields,
-            })
-            batch.update(doc(db, 'documents', docId, 'detail', 'main'), detailClearFields)
-          }
+          // detail/main の存在確認(ヘルパー内のgetDoc)はチャンク内で並列実行
+          await Promise.all(chunk.map((docId) => appendReprocessClearToBatch(batch, docId)))
           await batch.commit()
           succeededCount += chunk.length
         } catch (chunkError) {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -51,7 +51,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { db } from '@/lib/firebase'
 import { callFunction } from '@/lib/callFunction'
 import { Checkbox } from '@/components/ui/checkbox'
-import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, getReprocessClearFields, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
+import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, getReprocessClearFields, getReprocessDetailClearFields, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
 import { useCareManagers } from '@/hooks/useMasters'
 import { DateRangeFilter, type DateRange } from '@/components/DateRangeFilter'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
@@ -477,14 +477,16 @@ export function DocumentsPage() {
   }, [selectedIds, user, queryClient, clearSelection])
 
   // 一括再処理
-  // ADR-0018 Phase B (Issue #547): 250件チャンク化。detail/main書込は
-  // Phase D以降(PR4b)に分離、本PRは親docのみ+ocrExcerptクリア。
+  // ADR-0018 Phase D PR4b (Issue #547): 親doc + detail/main を同一batchでクリア。
+  // 1docあたり2 update のため CHUNK_SIZE=250 で 500 ops = Firestore batch 上限ちょうど。
+  // 本ループに per-doc の書込を追加する場合は CHUNK_SIZE の引き下げが必須。
   const handleBulkReprocess = useCallback(async () => {
     if (selectedIds.size === 0) return
 
     setIsBulkOperating(true)
     try {
       const clearFields = getReprocessClearFields()
+      const detailClearFields = getReprocessDetailClearFields()
       const ids = Array.from(selectedIds)
       const CHUNK_SIZE = 250
       let succeededCount = 0
@@ -503,6 +505,7 @@ export function DocumentsPage() {
               status: 'pending',
               ...clearFields,
             })
+            batch.update(doc(db, 'documents', docId, 'detail', 'main'), detailClearFields)
           }
           await batch.commit()
           succeededCount += chunk.length


### PR DESCRIPTION
## 概要
ADR-0018 Phase D の PR-D1（通称PR4b）。FE再処理クリアを親docのみ→親+detail/main の同一batchクリアに拡張し、stale detail（親のみクリア→OCR失敗→detail残存）の新規発生経路を封鎖する。Phase D の detail-first 読者（PR-D2/D3）投入の前提。

計画: session108 承認済み /impl-plan（Codex plan review P1×3/P2×2 反映済み）

## 実装
- `appendReprocessClearToBatch(batch, docId)` 新設: 親クリア（status:pending + 全クリアフィールド）+ detail/main クリアを1点に集約。3経路（useReprocessDocument / useErrors requestReprocess / DocumentsPage handleBulkReprocess）は全てヘルパー経由
- detail クリアは `{ocrResult: deleteField(), pageResults: deleteField()}`（firestore.rules は削除または無変更のみ許可、値上書きは permission-denied）
- **detail 存在ガード**: 不在docへの update() は not-found で batch 全体を落とすため getDoc 確認の上、存在時のみ積む（不在=クリア対象なし=望む終端状態が既に成立）。レースは次OCRパイプラインの dual-write で自己修復
- 一括再処理は既存 CHUNK_SIZE=250 を維持（500件 hard limit は 2023年撤廃済み — 根拠コメントを現行仕様に訂正、payload上限と部分成功粒度の保守値として据え置き）

## 品質ゲート（計画準拠）
- /safe-refactor: 検出0件
- /code-review high（finder 5系統）: CONFIRMED 4クラスタ → 全反映（detail存在ガード / ヘルパー集約 / 契約テストvacuous穴 / batch上限の事実性）
- Codex review-diff（effort=high）: **No actionable correctness issues**（1ラウンド収束）

## Test plan
- [x] frontend unit + 契約テスト 290件 PASS（factory 2件 + 配線契約6件を新設）
- [x] tsc --noEmit / eslint / vite build PASS
- [x] rules 適合は functions/test/firestore.rules.test.ts の既存テストがカバー（deleteField両フィールドupdate成功・値上書き拒否）→ CI の test:rules で実行
- [ ] dev 実機で再処理1回実行し detail/main クリア + 再OCR完走を確認（ui-verified）

## デプロイ前提条件（本番展開時、承認済み計画の展開ゲート）
- 各環境で pending=0 + `--verify` stale=0 確認
- 旧ビルド期間 doc の隙間は backfill 再実行（冪等）で充填

Refs #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reprocessing now clears related document content more consistently, including linked detail content when present.
  * Bulk reprocess actions now handle multiple items more reliably in batches.

* **Bug Fixes**
  * Fixed cases where stale content could remain after a reprocess request.
  * Improved consistency between parent records and their associated details during reprocessing.

* **Tests**
  * Added coverage to help prevent regressions in reprocess behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->