### PR TITLE
feat(functions): 読者4箇所をdetail/main優先読みに切替 (Issue #547 Phase D PR-D2)

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -24,7 +24,7 @@ updated: 2026-07-09
 - [x] #547 cocoro backfill 完了（2026-07-09、1,039件・verify PASS）
 - [x] #547 kanameone backfill 完了（2026-07-09、9,341件・verify PASS 9,389件 parity一致）
 - [x] #548 kanameone / cocoro 本番展開 → **Issue #548 close 済み**（2026-07-09。kanameone=2.5 pin解除、cocoro=1ヶ月分一括反映+Hosting+rules。ロールバック: gemini_model_id_override=gemini-2.5-flash）
-- [ ] #547 Phase D **PR-D1**: FE reprocess-clear の detail/main 同時クリア化（3箇所の既存writeBatchに detail deleteField 追加。計画: session108 承認済み impl-plan）
+- [x] #547 Phase D **PR-D1**: FE reprocess-clear の detail/main 同時クリア化（**PR #598 マージ済み** 2026-07-09。appendReprocessClearToBatch ヘルパー集約 + detail存在ガード + ui-verified実機検証）
 - [ ] #547 Phase D **PR-D2**: Functions 読者切替（getOcrText/regenerateSummary=tx.getAll paired-read、pageResultsReuse/detectSplitPoints/splitPdf=detail読込、dual-readフォールバック）
 - [ ] #547 Phase D **PR-D3**: FE 読者切替（モーダルのオンデマンドdetail取得/PdfSplitModal/ocrExcerpt参照化/dead code防御除去）+ ui-verified 必須
 - [ ] #547 Phase D **PR-D4**: scripts 読者切替（reprocess-master-matching.js + measure-summary-cost.ts）+ AC9読者ゼロgrep契約テスト
@@ -32,7 +32,7 @@ updated: 2026-07-09
 - [ ] #547 Phase E impl-plan 起票 → 実行 → Issue #547 close（trigger: Phase D 展開完了 + AC9ゲートPASS。destructive につき番号認可+devリハーサル必須）
 
 ## 🔄 中断点（in-flight）
-- 対象タスク: #547 Phase D PR-D1
-- 直前の状態: Phase D 計画承認済み（Codex plan review P1×3/P2×2 反映済み、計画全文: セッション scratchpad/phase-d-plan.md → 消失時は本GOAL.mdのタスク分解+ADR-0018で再構成可）。Phase B PR4a により3箇所は writeBatch/chunking/親ocrExcerptクリアまで実装済みで、PR-D1 の残作業は「既存batchへの detail/main deleteField 追加」のみ
-- 次の一手: feature ブランチで useDocuments.ts useReprocessDocument / useErrors.ts requestReprocess / DocumentsPage.tsx handleBulkReprocess の3箇所に `batch.update(doc(db,'documents',id,'detail','main'), {ocrResult: deleteField(), pageResults: deleteField()})` を追加（rules は deleteField のみ許可、値上書き不可に注意）
-- 検証コマンド: `cd frontend && npm test` / `cd functions && npm run test:rules`（detail update ルール適合）
+- 対象タスク: #547 Phase D PR-D2（Functions 読者切替）
+- 直前の状態: 実装完了（documentDetail.ts新設 + getOcrText/regenerateSummary=tx.getAll paired-read + ocrProcessor pageResultsReuse/pdfOperations detectSplitPoints・splitPdf=detail優先読み）。tsc/lint/functions 1,661テスト PASS。ブランチ feature/547-phase-d2-functions-detail-read
+- 次の一手: 品質ゲート（/safe-refactor → /code-review high → Codex review-diff）→ PR作成 → CI → マージ認可依頼
+- 検証コマンド: `cd functions && npm test`（1,661 passing 確認）/ `git log --oneline -3`

--- a/functions/src/ocr/documentDetail.ts
+++ b/functions/src/ocr/documentDetail.ts
@@ -1,0 +1,35 @@
+/**
+ * detail/main サブコレクションの dual-read 解決ヘルパー (ADR-0018 Phase D, Issue #547)
+ *
+ * Phase D の読者切替は「detail優先 + 親フォールバック」の dual-read で行う:
+ * - detail/main は Phase B (作成時dual-write) + Phase C (backfill、全環境verify PASS)
+ *   で全docに存在するが、万一の欠落時も Phase E 完了までは親にデータが残存する
+ *   ため、旧経路で動作を継続できる(ロールバック安全性)
+ * - FE reprocess-clear (PR-D1 #598) は detail の ocrResult/pageResults を
+ *   deleteField で消すため、「detail doc は存在するがフィールド不在」の形がある。
+ *   フィールド単位で判定し、型が合う値のみ採用する
+ * - detail の ocrResult='' (Storage offload済み / backfill由来) は有効値として
+ *   そのまま返す(親へフォールバックしない — offload doc の真値は ''+ocrResultUrl)
+ *
+ * Phase F (cleanup) で親フォールバックを除去し detail 単独読みに単純化する予定。
+ */
+
+import type { DocumentDetail } from '../../../shared/types';
+
+export function resolveDetailFields(
+  detailData: FirebaseFirestore.DocumentData | undefined,
+  parentData: FirebaseFirestore.DocumentData
+): DocumentDetail {
+  const resolved: DocumentDetail = {};
+  if (typeof detailData?.ocrResult === 'string') {
+    resolved.ocrResult = detailData.ocrResult;
+  } else if (typeof parentData.ocrResult === 'string') {
+    resolved.ocrResult = parentData.ocrResult;
+  }
+  if (Array.isArray(detailData?.pageResults)) {
+    resolved.pageResults = detailData.pageResults;
+  } else if (Array.isArray(parentData.pageResults)) {
+    resolved.pageResults = parentData.pageResults;
+  }
+  return resolved;
+}

--- a/functions/src/ocr/documentDetail.ts
+++ b/functions/src/ocr/documentDetail.ts
@@ -1,5 +1,5 @@
 /**
- * detail/main サブコレクションの dual-read 解決ヘルパー (ADR-0018 Phase D, Issue #547)
+ * detail/main サブコレクションの dual-read ヘルパー (ADR-0018 Phase D, Issue #547)
  *
  * Phase D の読者切替は「detail優先 + 親フォールバック」の dual-read で行う:
  * - detail/main は Phase B (作成時dual-write) + Phase C (backfill、全環境verify PASS)
@@ -11,14 +11,27 @@
  * - detail の ocrResult='' (Storage offload済み / backfill由来) は有効値として
  *   そのまま返す(親へフォールバックしない — offload doc の真値は ''+ocrResultUrl)
  *
+ * 既知の時間窓 (Phase D 展開手順で対処、impl-plan デプロイゲート):
+ * PR-D1 未適用の旧FE (PWAキャッシュ残存) が親のみクリアした後 OCR が最終失敗すると
+ * detail に旧コンテンツが残存し、detail優先読みがそれを配信しうる。ランタイムでの
+ * stale 判定は「親不在 = 正常形」となる Phase E と非両立のため実装せず、環境ごとに
+ * 「Hosting(PR-D1) 先行デプロイ → backfill --verify で stale=0 確認 → Functions」の
+ * 展開順序で窓を閉じる。
+ *
  * Phase F (cleanup) で親フォールバックを除去し detail 単独読みに単純化する予定。
  */
 
+import type {
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  Firestore,
+} from 'firebase-admin/firestore';
 import type { DocumentDetail } from '../../../shared/types';
 
 export function resolveDetailFields(
-  detailData: FirebaseFirestore.DocumentData | undefined,
-  parentData: FirebaseFirestore.DocumentData
+  detailData: DocumentData | undefined,
+  parentData: DocumentData
 ): DocumentDetail {
   const resolved: DocumentDetail = {};
   if (typeof detailData?.ocrResult === 'string') {
@@ -32,4 +45,33 @@ export function resolveDetailFields(
     resolved.pageResults = parentData.pageResults;
   }
   return resolved;
+}
+
+/**
+ * 親doc + detail/main を read-only transaction の tx.getAll で
+ * 同一スナップショットとして読む (ADR-0018 Phase D #5/#6 + Codex/code-review 指摘反映)。
+ *
+ * 非トランザクションの db.getAll() は複数doc間のスナップショット一貫性を
+ * 公式保証しない(BatchGetDocuments は transaction/readTime 指定時のみ一貫)ため、
+ * dual-write 中の別処理が読取の間に commit すると「新しい親 + 古い detail」の
+ * 裂けた組合せを読みうる。全読者で本ヘルパーの transactional paired-read に統一する。
+ *
+ * @param fieldMask 転送フィールドの絞り込み(親・detail の両方に適用)。
+ *   detail/main は pageResults(ページ毎全文)を含む重量docのため、
+ *   ocrResult しか使わない読者は必ず指定して egress を抑える (#547 の趣旨)
+ */
+export async function readDocWithDetail(
+  db: Firestore,
+  docRef: DocumentReference,
+  fieldMask?: string[]
+): Promise<[DocumentSnapshot, DocumentSnapshot]> {
+  const detailRef = docRef.collection('detail').doc('main');
+  const snaps = await db.runTransaction(
+    async (tx) =>
+      fieldMask
+        ? tx.getAll(docRef, detailRef, { fieldMask })
+        : tx.getAll(docRef, detailRef),
+    { readOnly: true }
+  );
+  return [snaps[0], snaps[1]];
 }

--- a/functions/src/ocr/getOcrText.ts
+++ b/functions/src/ocr/getOcrText.ts
@@ -9,6 +9,7 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getStorage } from 'firebase-admin/storage';
 import { getFirestore } from 'firebase-admin/firestore';
+import { resolveDetailFields } from './documentDetail';
 
 /**
  * OCR全文取得 Callable Function
@@ -34,15 +35,24 @@ export const getOcrText = onCall(
     }
 
     // 2. ドキュメント取得・存在確認
+    // ADR-0018 Phase D (#5): 親 + detail/main を read-only transaction の
+    // tx.getAll で同一スナップショットとして読む。独立した2回の get() だと
+    // dual-write 中の別処理が間に commit した場合、「新しい親(ocrResultUrlセット済み)」
+    // +「古い detail(ocrResult空)」のような不整合な組合せを読みうる
     const db = getFirestore();
-    const docSnap = await db.doc(`documents/${documentId}`).get();
+    const docRef = db.doc(`documents/${documentId}`);
+    const detailRef = docRef.collection('detail').doc('main');
+    const [docSnap, detailSnap] = await db.runTransaction(
+      async (tx) => tx.getAll(docRef, detailRef),
+      { readOnly: true }
+    );
     if (!docSnap.exists) {
       throw new HttpsError('not-found', 'Document not found');
     }
 
     const data = docSnap.data()!;
-    const ocrResultUrl = data.ocrResultUrl as string | undefined;
-    const ocrResult = data.ocrResult as string | undefined;
+    const ocrResultUrl = data.ocrResultUrl as string | undefined; // offload判定は親から維持
+    const { ocrResult } = resolveDetailFields(detailSnap.data(), data);
 
     // 3. ocrResultUrl がない場合は ocrResult を返す
     if (!ocrResultUrl) {

--- a/functions/src/ocr/getOcrText.ts
+++ b/functions/src/ocr/getOcrText.ts
@@ -9,7 +9,7 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getStorage } from 'firebase-admin/storage';
 import { getFirestore } from 'firebase-admin/firestore';
-import { resolveDetailFields } from './documentDetail';
+import { resolveDetailFields, readDocWithDetail } from './documentDetail';
 
 /**
  * OCR全文取得 Callable Function
@@ -35,17 +35,15 @@ export const getOcrText = onCall(
     }
 
     // 2. ドキュメント取得・存在確認
-    // ADR-0018 Phase D (#5): 親 + detail/main を read-only transaction の
-    // tx.getAll で同一スナップショットとして読む。独立した2回の get() だと
-    // dual-write 中の別処理が間に commit した場合、「新しい親(ocrResultUrlセット済み)」
-    // +「古い detail(ocrResult空)」のような不整合な組合せを読みうる
+    // ADR-0018 Phase D (#5): 親 + detail/main の transactional paired-read
+    // (不整合な組合せ防止の根拠は readDocWithDetail の doc comment 参照)。
+    // fieldMask で pageResults 等の重量フィールドの転送を抑止
     const db = getFirestore();
     const docRef = db.doc(`documents/${documentId}`);
-    const detailRef = docRef.collection('detail').doc('main');
-    const [docSnap, detailSnap] = await db.runTransaction(
-      async (tx) => tx.getAll(docRef, detailRef),
-      { readOnly: true }
-    );
+    const [docSnap, detailSnap] = await readDocWithDetail(db, docRef, [
+      'ocrResult',
+      'ocrResultUrl',
+    ]);
     if (!docSnap.exists) {
       throw new HttpsError('not-found', 'Document not found');
     }

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -32,6 +32,7 @@ import {
 import { buildPageResult, type RawPageOcrResult } from './buildPageResult';
 import { buildOcrExtractionUpdatePayload } from './ocrUpdatePayloadBuilder';
 import { validatePageResultsForReuse } from './pageResultsReuse';
+import { resolveDetailFields } from './documentDetail';
 import { applyConfirmedFieldProtection } from './confirmedFieldMerge';
 import { buildOcrExcerpt } from './ocrExcerpt';
 
@@ -118,7 +119,12 @@ export async function processDocument(
 
   // Issue #526 D3: 分割子ドキュメント(#445で確立済みのparentDocumentIdを持つ)が
   // 親から継承した有効なpageResultsを持つ場合、ページOCRを再実行せず再利用する(コスト削減)。
-  const existingPageResults = docData.pageResults as RawPageOcrResult[] | undefined;
+  // ADR-0018 Phase D (#1): 再利用元は detail/main を優先読み(親フォールバック付き)。
+  // Phase E 後は親に pageResults が存在しなくなるため、切替しないと再利用が常に不成立になる
+  const detailSnap = await db.doc(`documents/${docId}/detail/main`).get();
+  const existingPageResults = resolveDetailFields(detailSnap.data(), docData).pageResults as
+    | RawPageOcrResult[]
+    | undefined;
   const reuseCheck = validatePageResultsForReuse(existingPageResults, docData.parentDocumentId);
 
   let pageResults: RawPageOcrResult[] = [];

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -120,11 +120,21 @@ export async function processDocument(
   // Issue #526 D3: 分割子ドキュメント(#445で確立済みのparentDocumentIdを持つ)が
   // 親から継承した有効なpageResultsを持つ場合、ページOCRを再実行せず再利用する(コスト削減)。
   // ADR-0018 Phase D (#1): 再利用元は detail/main を優先読み(親フォールバック付き)。
-  // Phase E 後は親に pageResults が存在しなくなるため、切替しないと再利用が常に不成立になる
-  const detailSnap = await db.doc(`documents/${docId}/detail/main`).get();
-  const existingPageResults = resolveDetailFields(detailSnap.data(), docData).pageResults as
-    | RawPageOcrResult[]
-    | undefined;
+  // Phase E 後は親に pageResults が存在しなくなるため、切替しないと再利用が常に不成立になる。
+  // detail read は分割子doc(parentDocumentId あり)に限定: validatePageResultsForReuse の
+  // 第一条件と同値のゲートで、大多数(Gmail/upload由来)の doc に重量 detail read と
+  // 新規失敗点を持ち込まない(code-review 4/5系統の独立指摘反映)
+  let detailData: FirebaseFirestore.DocumentData | undefined;
+  if (typeof docData.parentDocumentId === 'string' && docData.parentDocumentId) {
+    const [detailSnap] = await db.getAll(db.doc(`documents/${docId}/detail/main`), {
+      fieldMask: ['pageResults'],
+    });
+    detailData = detailSnap.data();
+  }
+  const existingPageResults: RawPageOcrResult[] | undefined = resolveDetailFields(
+    detailData,
+    docData
+  ).pageResults;
   const reuseCheck = validatePageResultsForReuse(existingPageResults, docData.parentDocumentId);
 
   let pageResults: RawPageOcrResult[] = [];

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -12,7 +12,7 @@ import { safeLogError } from '../utils/errorLogger';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
-import { resolveDetailFields } from './documentDetail';
+import { resolveDetailFields, readDocWithDetail } from './documentDetail';
 
 const LOCATION = GCP_CONFIG.location;
 
@@ -49,14 +49,14 @@ export const regenerateSummary = functions.https.onCall(
     }
 
     // ドキュメント取得
-    // ADR-0018 Phase D (#6): getOcrText と同じ transactional paired-read で
-    // 親 + detail/main を同一スナップショットとして読む(不整合な組合せの防止)
+    // ADR-0018 Phase D (#6): getOcrText と同じ transactional paired-read
+    // (根拠は readDocWithDetail の doc comment 参照)。fieldMask で転送を要約に必要な
+    // フィールドに限定
     const docRef = db.doc(`documents/${docId}`);
-    const detailRef = docRef.collection('detail').doc('main');
-    const [docSnap, detailSnap] = await db.runTransaction(
-      async (tx) => tx.getAll(docRef, detailRef),
-      { readOnly: true }
-    );
+    const [docSnap, detailSnap] = await readDocWithDetail(db, docRef, [
+      'ocrResult',
+      'documentType',
+    ]);
 
     if (!docSnap.exists) {
       throw new functions.https.HttpsError('not-found', 'ドキュメントが見つかりません');

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -12,6 +12,7 @@ import { safeLogError } from '../utils/errorLogger';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
+import { resolveDetailFields } from './documentDetail';
 
 const LOCATION = GCP_CONFIG.location;
 
@@ -48,15 +49,21 @@ export const regenerateSummary = functions.https.onCall(
     }
 
     // ドキュメント取得
+    // ADR-0018 Phase D (#6): getOcrText と同じ transactional paired-read で
+    // 親 + detail/main を同一スナップショットとして読む(不整合な組合せの防止)
     const docRef = db.doc(`documents/${docId}`);
-    const docSnap = await docRef.get();
+    const detailRef = docRef.collection('detail').doc('main');
+    const [docSnap, detailSnap] = await db.runTransaction(
+      async (tx) => tx.getAll(docRef, detailRef),
+      { readOnly: true }
+    );
 
     if (!docSnap.exists) {
       throw new functions.https.HttpsError('not-found', 'ドキュメントが見つかりません');
     }
 
     const docData = docSnap.data()!;
-    const ocrResult = docData.ocrResult as string | undefined;
+    const { ocrResult } = resolveDetailFields(detailSnap.data(), docData);
     // 空/未定義はそのまま core に渡し、core 内の DEFAULT_DOCUMENT_TYPE_LABEL で一本化。
     const documentType = (docData.documentType as string | undefined) ?? '';
 

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -66,10 +66,12 @@ interface SplitPageInput {
  * detail優先で解決した pageResults を SplitPageInput[] として返す
  * (ADR-0018 Phase D、detectSplitPoints/splitPdf 共用。unknown 経由キャストの一元点)。
  *
- * unknown 経由キャストの根拠: 保存された pageResults は SplitPageInput の検出系フィールド
- * (detectedDocumentType 等)を実データとして持つが、DocumentDetail の宣言型
- * PersistedPageOcrResult には含まれない(shared/types.ts の既知 schema drift 注記参照。
- * 従来は DocumentData の any 経由で暗黙に通っていた同じ実態への型付け)。
+ * unknown 経由キャストの根拠: SplitPageInput は保存データに存在しない検出系フィールド
+ * (detectedDocumentType 等)を宣言している(実際に永続化される shape は
+ * PersistedPageOcrResult 相当で、検出系フィールドを書いた writer は存在しない —
+ * git 履歴で確認済み)。下流の pdfAnalyzer は検出系を optional として undefined を許容し
+ * text+マスターから再検出するため、宣言型が実データより広い方向の不一致は無害。
+ * 従来は DocumentData の any 経由で暗黙に通っていた同じ実態への型付け。
  */
 function resolveSplitPageInputs(
   detailData: FirebaseFirestore.DocumentData | undefined,

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -25,6 +25,7 @@ import { timestampToDateString } from '../utils/timestampHelpers';
 import { loadMasterData } from '../utils/loadMasterData';
 import { sanitizeFilenameForStorage } from '../utils/fileNaming';
 import { createSplitProvenance, createRotationProvenance } from './provenance';
+import { resolveDetailFields } from '../ocr/documentDetail';
 import { mergeRotations } from './rotationMerge';
 import { shouldRejectRotateForBackfill } from './rotateGate';
 import { randomUUID } from 'node:crypto';
@@ -87,8 +88,12 @@ export const detectSplitPoints = onCall(
     }
 
     // ドキュメント取得
+    // ADR-0018 Phase D (#3): 親 + detail/main を getAll の同一バッチで読み、
+    // pageResults は detail 優先(親フォールバック付き)で解決する。
+    // 切替しないと Phase E 後に分割候補検出が常に0件になる
     const docRef = db.doc(`documents/${documentId}`);
-    const docSnapshot = await docRef.get();
+    const detailRef = docRef.collection('detail').doc('main');
+    const [docSnapshot, detailSnapshot] = await db.getAll(docRef, detailRef);
 
     if (!docSnapshot.exists) {
       console.log(`Document not found: ${documentId}`);
@@ -96,7 +101,14 @@ export const detectSplitPoints = onCall(
     }
 
     const docData = docSnapshot.data()!;
-    const pageResults: SplitPageInput[] = docData.pageResults || [];
+    // unknown 経由キャスト: 保存された pageResults は SplitPageInput の検出系フィールド
+    // (detectedDocumentType 等)を実データとして持つが、DocumentDetail の宣言型
+    // PersistedPageOcrResult には含まれない(shared/types.ts の既知 schema drift 注記参照。
+    // 従来は DocumentData の any 経由で暗黙に通っていた同じ実態への型付け)
+    const pageResults: SplitPageInput[] = (resolveDetailFields(
+      detailSnapshot.data(),
+      docData
+    ).pageResults ?? []) as unknown as SplitPageInput[];
     console.log(`pageResults count: ${pageResults.length}`);
 
     if (pageResults.length === 0) {
@@ -361,14 +373,22 @@ export const splitPdf = onCall(
     }
 
     // 元ドキュメント取得
+    // ADR-0018 Phase D (#2): 親 + detail/main を getAll の同一バッチで読む。
+    // splitPdf の整合性モデル(親doc取得→GCS snapshot→final drift check→batch commit)と
+    // 同一時点で detail を読むことで、親メタ・元PDF・detail の組合せずれを防ぐ
     const docRef = db.doc(`documents/${documentId}`);
-    const docSnapshot = await docRef.get();
+    const detailRef = docRef.collection('detail').doc('main');
+    const [docSnapshot, detailSnapshot] = await db.getAll(docRef, detailRef);
 
     if (!docSnapshot.exists) {
       throw new HttpsError('not-found', 'Document not found');
     }
 
     const docData = docSnapshot.data()!;
+    // 分割元の pageResults は detail 優先で解決し、以降の全用途(セグメント抽出/子doc用
+    // ocrResult 生成)で同一ソースを使う。unknown 経由キャストの根拠は detectSplitPoints 側と同じ
+    const sourcePageResults = (resolveDetailFields(detailSnapshot.data(), docData).pageResults ??
+      []) as unknown as SplitPageInput[];
     const fileUrl = docData.fileUrl as string;
 
     // Codex Medium 1: gs:// URI parser + bucket mismatch を failed-precondition で abort
@@ -521,8 +541,8 @@ export const splitPdf = onCall(
           inflightEntry.derivedGeneration = derivedGeneration;
           const derivedSha256 = sha256Hex(newPdfBytes);
 
-          // 分割後のページ結果を抽出
-          const segmentPageResults = (docData.pageResults || []).filter(
+          // 分割後のページ結果を抽出 (ADR-0018 Phase D: detail優先で解決済みのソースを使用)
+          const segmentPageResults = sourcePageResults.filter(
             (p: SplitPageInput) =>
               p.pageNumber >= startPage && p.pageNumber <= endPage
           );
@@ -588,7 +608,7 @@ export const splitPdf = onCall(
             fileName,
             mimeType: 'application/pdf',
             ocrResult: extractOcrResultForPages(
-              docData.pageResults || [],
+              sourcePageResults,
               startPage,
               endPage
             ),

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -25,7 +25,7 @@ import { timestampToDateString } from '../utils/timestampHelpers';
 import { loadMasterData } from '../utils/loadMasterData';
 import { sanitizeFilenameForStorage } from '../utils/fileNaming';
 import { createSplitProvenance, createRotationProvenance } from './provenance';
-import { resolveDetailFields } from '../ocr/documentDetail';
+import { resolveDetailFields, readDocWithDetail } from '../ocr/documentDetail';
 import { mergeRotations } from './rotationMerge';
 import { shouldRejectRotateForBackfill } from './rotateGate';
 import { randomUUID } from 'node:crypto';
@@ -63,6 +63,23 @@ interface SplitPageInput {
 }
 
 /**
+ * detail優先で解決した pageResults を SplitPageInput[] として返す
+ * (ADR-0018 Phase D、detectSplitPoints/splitPdf 共用。unknown 経由キャストの一元点)。
+ *
+ * unknown 経由キャストの根拠: 保存された pageResults は SplitPageInput の検出系フィールド
+ * (detectedDocumentType 等)を実データとして持つが、DocumentDetail の宣言型
+ * PersistedPageOcrResult には含まれない(shared/types.ts の既知 schema drift 注記参照。
+ * 従来は DocumentData の any 経由で暗黙に通っていた同じ実態への型付け)。
+ */
+function resolveSplitPageInputs(
+  detailData: FirebaseFirestore.DocumentData | undefined,
+  parentData: FirebaseFirestore.DocumentData
+): SplitPageInput[] {
+  return (resolveDetailFields(detailData, parentData).pageResults ??
+    []) as unknown as SplitPageInput[];
+}
+
+/**
  * 分割候補を検出（強化版 - pdfAnalyzer使用）
  */
 export const detectSplitPoints = onCall(
@@ -88,12 +105,11 @@ export const detectSplitPoints = onCall(
     }
 
     // ドキュメント取得
-    // ADR-0018 Phase D (#3): 親 + detail/main を getAll の同一バッチで読み、
+    // ADR-0018 Phase D (#3): 親 + detail/main を transactional paired-read で読み、
     // pageResults は detail 優先(親フォールバック付き)で解決する。
     // 切替しないと Phase E 後に分割候補検出が常に0件になる
     const docRef = db.doc(`documents/${documentId}`);
-    const detailRef = docRef.collection('detail').doc('main');
-    const [docSnapshot, detailSnapshot] = await db.getAll(docRef, detailRef);
+    const [docSnapshot, detailSnapshot] = await readDocWithDetail(db, docRef);
 
     if (!docSnapshot.exists) {
       console.log(`Document not found: ${documentId}`);
@@ -101,14 +117,7 @@ export const detectSplitPoints = onCall(
     }
 
     const docData = docSnapshot.data()!;
-    // unknown 経由キャスト: 保存された pageResults は SplitPageInput の検出系フィールド
-    // (detectedDocumentType 等)を実データとして持つが、DocumentDetail の宣言型
-    // PersistedPageOcrResult には含まれない(shared/types.ts の既知 schema drift 注記参照。
-    // 従来は DocumentData の any 経由で暗黙に通っていた同じ実態への型付け)
-    const pageResults: SplitPageInput[] = (resolveDetailFields(
-      detailSnapshot.data(),
-      docData
-    ).pageResults ?? []) as unknown as SplitPageInput[];
+    const pageResults = resolveSplitPageInputs(detailSnapshot.data(), docData);
     console.log(`pageResults count: ${pageResults.length}`);
 
     if (pageResults.length === 0) {
@@ -373,12 +382,12 @@ export const splitPdf = onCall(
     }
 
     // 元ドキュメント取得
-    // ADR-0018 Phase D (#2): 親 + detail/main を getAll の同一バッチで読む。
-    // splitPdf の整合性モデル(親doc取得→GCS snapshot→final drift check→batch commit)と
-    // 同一時点で detail を読むことで、親メタ・元PDF・detail の組合せずれを防ぐ
+    // ADR-0018 Phase D (#2): 親 + detail/main を transactional paired-read で読む。
+    // splitPdf は読んだ pageResults から子doc を実際に生成・commit するため、
+    // 「新しい親 + 古い detail」の裂けた組合せ読みは stale 子doc の固定化に直結する
+    // (防止根拠は readDocWithDetail の doc comment 参照)
     const docRef = db.doc(`documents/${documentId}`);
-    const detailRef = docRef.collection('detail').doc('main');
-    const [docSnapshot, detailSnapshot] = await db.getAll(docRef, detailRef);
+    const [docSnapshot, detailSnapshot] = await readDocWithDetail(db, docRef);
 
     if (!docSnapshot.exists) {
       throw new HttpsError('not-found', 'Document not found');
@@ -386,9 +395,8 @@ export const splitPdf = onCall(
 
     const docData = docSnapshot.data()!;
     // 分割元の pageResults は detail 優先で解決し、以降の全用途(セグメント抽出/子doc用
-    // ocrResult 生成)で同一ソースを使う。unknown 経由キャストの根拠は detectSplitPoints 側と同じ
-    const sourcePageResults = (resolveDetailFields(detailSnapshot.data(), docData).pageResults ??
-      []) as unknown as SplitPageInput[];
+    // ocrResult 生成)で同一ソースを使う
+    const sourcePageResults = resolveSplitPageInputs(detailSnapshot.data(), docData);
     const fileUrl = docData.fileUrl as string;
 
     // Codex Medium 1: gs:// URI parser + bucket mismatch を failed-precondition で abort

--- a/functions/test/detailReadCutoverContract.test.ts
+++ b/functions/test/detailReadCutoverContract.test.ts
@@ -3,7 +3,8 @@
  *
  * ocrProcessorDetailDualWriteContract.test.ts と同じ grep-based 契約パターン。
  * 「4読者すべてが resolveDetailFields (detail優先+親フォールバック) 経由で
- * ocrResult/pageResults を読む」配線をソース文字列レベルで lock-in する。
+ * ocrResult/pageResults を読み、paired-read は readDocWithDetail (read-only
+ * transaction) に統一されている」配線をソース文字列レベルで lock-in する。
  *
  * 1読者でも切替が漏れると、Phase E (親からの実フィールド削除) 後にその読者が
  * 空データを受け取り、silent な機能停止 (分割候補0件/要約不可/再利用不成立) が起きる。
@@ -15,39 +16,55 @@ import { resolve } from 'path';
 
 const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), 'utf-8');
 
+const documentDetailSrc = read('src/ocr/documentDetail.ts');
 const getOcrTextSrc = read('src/ocr/getOcrText.ts');
 const regenerateSummarySrc = read('src/ocr/regenerateSummary.ts');
 const ocrProcessorSrc = read('src/ocr/ocrProcessor.ts');
 const pdfOperationsSrc = read('src/pdf/pdfOperations.ts');
 
 describe('detail/main 読者切替 配線契約 (ADR-0018 Phase D PR-D2)', () => {
-  it('getOcrText: read-only transaction の tx.getAll で親+detailを同一スナップショット読みする (ADR #5)', () => {
+  it('readDocWithDetail: read-only transaction の tx.getAll で親+detailを同一スナップショット読みする', () => {
+    // 非トランザクション db.getAll() は複数doc間のスナップショット一貫性を公式保証しない
+    // (code-review 4/5系統の独立指摘)。paired-read は必ず readOnly transaction 経由
+    expect(documentDetailSrc).to.match(/db\.runTransaction\(/);
+    expect(documentDetailSrc).to.match(/tx\.getAll\(docRef, detailRef/);
+    expect(documentDetailSrc).to.match(/\{ readOnly: true \}/);
+  });
+
+  it('getOcrText: readDocWithDetail + fieldMask(重量フィールド転送抑止) + resolveDetailFields (ADR #5)', () => {
     expect(getOcrTextSrc).to.match(
-      /db\.runTransaction\(\s*async \(tx\) => tx\.getAll\(docRef, detailRef\),\s*\{ readOnly: true \}\s*\)/
+      /readDocWithDetail\(db, docRef, \[\s*'ocrResult',\s*'ocrResultUrl',\s*\]\)/
     );
     expect(getOcrTextSrc).to.match(/resolveDetailFields\(detailSnap\.data\(\), data\)/);
   });
 
-  it('regenerateSummary: 同上の transactional paired-read (ADR #6)', () => {
+  it('regenerateSummary: readDocWithDetail + fieldMask + resolveDetailFields (ADR #6)', () => {
     expect(regenerateSummarySrc).to.match(
-      /db\.runTransaction\(\s*async \(tx\) => tx\.getAll\(docRef, detailRef\),\s*\{ readOnly: true \}\s*\)/
+      /readDocWithDetail\(db, docRef, \[\s*'ocrResult',\s*'documentType',\s*\]\)/
     );
     expect(regenerateSummarySrc).to.match(/resolveDetailFields\(detailSnap\.data\(\), docData\)/);
   });
 
-  it('ocrProcessor: pageResultsReuse の読込元が detail 優先 (ADR #1)', () => {
+  it('ocrProcessor: detail read は parentDocumentId ゲート付き + fieldMask + detail優先解決 (ADR #1)', () => {
+    // 非分割doc(大多数)に重量 detail read と新規失敗点を持ち込まないゲート
     expect(ocrProcessorSrc).to.match(
-      /const existingPageResults = resolveDetailFields\(detailSnap\.data\(\), docData\)\.pageResults/
+      /if \(typeof docData\.parentDocumentId === 'string' && docData\.parentDocumentId\) \{/
+    );
+    expect(ocrProcessorSrc).to.match(/fieldMask: \['pageResults'\]/);
+    expect(ocrProcessorSrc).to.match(
+      /const existingPageResults: RawPageOcrResult\[\] \| undefined = resolveDetailFields\(/
     );
     // 旧経路 (docData.pageResults 直読み) が reuse 判定に残っていないこと
-    expect(ocrProcessorSrc).to.not.match(
-      /const existingPageResults = docData\.pageResults/
-    );
+    expect(ocrProcessorSrc).to.not.match(/const existingPageResults = docData\.pageResults/);
   });
 
-  it('pdfOperations: detectSplitPoints / splitPdf とも db.getAll(docRef, detailRef) の同一時点読み (ADR #2,#3)', () => {
-    const getAllCount = [...pdfOperationsSrc.matchAll(/db\.getAll\(docRef, detailRef\)/g)].length;
-    expect(getAllCount, 'detectSplitPoints と splitPdf の2箇所').to.equal(2);
+  it('pdfOperations: detectSplitPoints / splitPdf とも readDocWithDetail + resolveSplitPageInputs (ADR #2,#3)', () => {
+    const pairedReadCount = [...pdfOperationsSrc.matchAll(/readDocWithDetail\(db, docRef\)/g)]
+      .length;
+    expect(pairedReadCount, 'detectSplitPoints と splitPdf の2箇所').to.equal(2);
+    const resolveCount = [...pdfOperationsSrc.matchAll(/resolveSplitPageInputs\(detailSnapshot\.data\(\), docData\)/g)]
+      .length;
+    expect(resolveCount, '両読者とも共通アクセサで解決').to.equal(2);
     // 旧経路 (docData.pageResults 直読み) が残っていないこと
     expect(pdfOperationsSrc).to.not.match(/docData\.pageResults/);
   });
@@ -58,5 +75,13 @@ describe('detail/main 読者切替 配線契約 (ADR-0018 Phase D PR-D2)', () =>
     // (ocrResultUrl は Phase E 後も親に残る offload ポインタのため対象外)
     expect(getOcrTextSrc).to.not.match(/data\.ocrResult as string/);
     expect(regenerateSummarySrc).to.not.match(/docData\.ocrResult as string/);
+  });
+
+  it('非トランザクション db.getAll の paired-read が読者に存在しない (snapshot一貫性の偽装防止)', () => {
+    // 単一refの db.getAll(fieldMask付き) は許可(ocrProcessor のゲート付きdetail read)。
+    // 親+detail の2ref同時 db.getAll は snapshot 保証がないため禁止
+    for (const src of [getOcrTextSrc, regenerateSummarySrc, ocrProcessorSrc, pdfOperationsSrc]) {
+      expect(src).to.not.match(/db\.getAll\(docRef, detailRef\)/);
+    }
   });
 });

--- a/functions/test/detailReadCutoverContract.test.ts
+++ b/functions/test/detailReadCutoverContract.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Functions 読者の detail/main 切替 配線契約テスト (ADR-0018 Phase D PR-D2, Issue #547)
+ *
+ * ocrProcessorDetailDualWriteContract.test.ts と同じ grep-based 契約パターン。
+ * 「4読者すべてが resolveDetailFields (detail優先+親フォールバック) 経由で
+ * ocrResult/pageResults を読む」配線をソース文字列レベルで lock-in する。
+ *
+ * 1読者でも切替が漏れると、Phase E (親からの実フィールド削除) 後にその読者が
+ * 空データを受け取り、silent な機能停止 (分割候補0件/要約不可/再利用不成立) が起きる。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), 'utf-8');
+
+const getOcrTextSrc = read('src/ocr/getOcrText.ts');
+const regenerateSummarySrc = read('src/ocr/regenerateSummary.ts');
+const ocrProcessorSrc = read('src/ocr/ocrProcessor.ts');
+const pdfOperationsSrc = read('src/pdf/pdfOperations.ts');
+
+describe('detail/main 読者切替 配線契約 (ADR-0018 Phase D PR-D2)', () => {
+  it('getOcrText: read-only transaction の tx.getAll で親+detailを同一スナップショット読みする (ADR #5)', () => {
+    expect(getOcrTextSrc).to.match(
+      /db\.runTransaction\(\s*async \(tx\) => tx\.getAll\(docRef, detailRef\),\s*\{ readOnly: true \}\s*\)/
+    );
+    expect(getOcrTextSrc).to.match(/resolveDetailFields\(detailSnap\.data\(\), data\)/);
+  });
+
+  it('regenerateSummary: 同上の transactional paired-read (ADR #6)', () => {
+    expect(regenerateSummarySrc).to.match(
+      /db\.runTransaction\(\s*async \(tx\) => tx\.getAll\(docRef, detailRef\),\s*\{ readOnly: true \}\s*\)/
+    );
+    expect(regenerateSummarySrc).to.match(/resolveDetailFields\(detailSnap\.data\(\), docData\)/);
+  });
+
+  it('ocrProcessor: pageResultsReuse の読込元が detail 優先 (ADR #1)', () => {
+    expect(ocrProcessorSrc).to.match(
+      /const existingPageResults = resolveDetailFields\(detailSnap\.data\(\), docData\)\.pageResults/
+    );
+    // 旧経路 (docData.pageResults 直読み) が reuse 判定に残っていないこと
+    expect(ocrProcessorSrc).to.not.match(
+      /const existingPageResults = docData\.pageResults/
+    );
+  });
+
+  it('pdfOperations: detectSplitPoints / splitPdf とも db.getAll(docRef, detailRef) の同一時点読み (ADR #2,#3)', () => {
+    const getAllCount = [...pdfOperationsSrc.matchAll(/db\.getAll\(docRef, detailRef\)/g)].length;
+    expect(getAllCount, 'detectSplitPoints と splitPdf の2箇所').to.equal(2);
+    // 旧経路 (docData.pageResults 直読み) が残っていないこと
+    expect(pdfOperationsSrc).to.not.match(/docData\.pageResults/);
+  });
+
+  it('Phase E 前提ゲート(部分): 本PRの4読者ソースに親 ocrResult/pageResults の直読みが残っていない', () => {
+    // getOcrText/regenerateSummary の親 ocrResult 直読み(`data.ocrResult` / `docData.ocrResult`)が
+    // resolveDetailFields 経由に置き換わっていること。
+    // (ocrResultUrl は Phase E 後も親に残る offload ポインタのため対象外)
+    expect(getOcrTextSrc).to.not.match(/data\.ocrResult as string/);
+    expect(regenerateSummarySrc).to.not.match(/docData\.ocrResult as string/);
+  });
+});

--- a/functions/test/detailReadCutoverContract.test.ts
+++ b/functions/test/detailReadCutoverContract.test.ts
@@ -31,6 +31,14 @@ describe('detail/main 読者切替 配線契約 (ADR-0018 Phase D PR-D2)', () =>
     expect(documentDetailSrc).to.match(/\{ readOnly: true \}/);
   });
 
+  it('detail 読取パスの pin: サブコレクション/doc ID の typo は親フォールバックが Phase E まで隠蔽するため文字列レベルで固定 (pr-test-analyzer Critical反映)', () => {
+    // write 側契約 (ocrProcessorDetailDualWriteContract) と同じパス pin を read 側にも張る。
+    // パスがズレても detail 読取は undefined → 親フォールバックで全環境正常動作し、
+    // Phase E (親フィールド削除) の瞬間に silent 一斉停止する — この誤配線を merge 前に落とす
+    expect(documentDetailSrc).to.match(/docRef\.collection\('detail'\)\.doc\('main'\)/);
+    expect(ocrProcessorSrc).to.match(/documents\/\$\{docId\}\/detail\/main/);
+  });
+
   it('getOcrText: readDocWithDetail + fieldMask(重量フィールド転送抑止) + resolveDetailFields (ADR #5)', () => {
     expect(getOcrTextSrc).to.match(
       /readDocWithDetail\(db, docRef, \[\s*'ocrResult',\s*'ocrResultUrl',\s*\]\)/

--- a/functions/test/documentDetail.test.ts
+++ b/functions/test/documentDetail.test.ts
@@ -1,0 +1,64 @@
+/**
+ * resolveDetailFields (ADR-0018 Phase D dual-read解決) の単体テスト
+ */
+
+import { expect } from 'chai';
+import { resolveDetailFields } from '../src/ocr/documentDetail';
+
+describe('resolveDetailFields (ADR-0018 Phase D)', () => {
+  it('detail優先: detailに両フィールドがあれば親の値は使わない', () => {
+    const r = resolveDetailFields(
+      { ocrResult: 'detail-text', pageResults: [{ pageNumber: 1 }] },
+      { ocrResult: 'parent-text', pageResults: [{ pageNumber: 99 }] }
+    );
+    expect(r.ocrResult).to.equal('detail-text');
+    expect(r.pageResults).to.deep.equal([{ pageNumber: 1 }]);
+  });
+
+  it('親フォールバック: detail不在(undefined)なら親の値を使う', () => {
+    const r = resolveDetailFields(undefined, {
+      ocrResult: 'parent-text',
+      pageResults: [{ pageNumber: 2 }],
+    });
+    expect(r.ocrResult).to.equal('parent-text');
+    expect(r.pageResults).to.deep.equal([{ pageNumber: 2 }]);
+  });
+
+  it('フィールド単位フォールバック: FEクリア後(detail存在・フィールド不在)は親を参照', () => {
+    // PR-D1 (#598) のreprocess-clearはdetailのocrResult/pageResultsをdeleteFieldで消す
+    const r = resolveDetailFields({}, { ocrResult: 'parent-text', pageResults: [] });
+    expect(r.ocrResult).to.equal('parent-text');
+    expect(r.pageResults).to.deep.equal([]);
+  });
+
+  it("detailのocrResult=''は有効値(Storage offload済み): 親へフォールバックしない", () => {
+    const r = resolveDetailFields(
+      { ocrResult: '' },
+      { ocrResult: 'stale-parent-text' }
+    );
+    expect(r.ocrResult).to.equal('');
+  });
+
+  it('両方欠落: フィールドはundefined(捏造しない)', () => {
+    const r = resolveDetailFields(undefined, {});
+    expect(r.ocrResult).to.be.undefined;
+    expect(r.pageResults).to.be.undefined;
+  });
+
+  it('型不正(非string/非array)は採用せずフォールバック→両方不正ならundefined', () => {
+    const r = resolveDetailFields(
+      { ocrResult: 123, pageResults: 'not-array' },
+      { ocrResult: null, pageResults: { bad: true } }
+    );
+    expect(r.ocrResult).to.be.undefined;
+    expect(r.pageResults).to.be.undefined;
+  });
+
+  it('空配列のpageResultsは有効値: 親へフォールバックしない', () => {
+    const r = resolveDetailFields(
+      { pageResults: [] },
+      { pageResults: [{ pageNumber: 1 }] }
+    );
+    expect(r.pageResults).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## 概要
ADR-0018 Phase D の PR-D2。Functions の読者4箇所を親docの `ocrResult`/`pageResults` 直読みから detail/main 優先読み（親フォールバック付き dual-read）に切替える。Phase E（親からの実フィールド削除 = egress実削減）の前提。

計画: session108 承認済み /impl-plan。前工程 PR-D1 (#598) マージ済み。

## 実装
- **`documentDetail.ts` 新設**: `resolveDetailFields`（detail優先+親フォールバック、FEクリア後のフィールド不在形対応、''は有効値）+ `readDocWithDetail`（**read-only transaction の tx.getAll** による同一スナップショット paired-read）
- **getOcrText / regenerateSummary**（ADR #5/#6）: paired-read + fieldMask（重量 pageResults の転送抑止）
- **ocrProcessor pageResultsReuse**（ADR #1）: detail優先読み。**parentDocumentId ゲート**で非分割doc（大多数）への read 追加ゼロ
- **pdfOperations detectSplitPoints / splitPdf**（ADR #2/#3）: paired-read + `resolveSplitPageInputs` 共通アクセサ

## 品質ゲート（計画準拠）
- /safe-refactor: 検出0件
- /code-review high（finder 5系統）: **7クラスタ検出 → 全反映**。主要3件: ①db.getAll(2ref)のsnapshot一貫性は公式保証なし（4/5系統独立指摘）→ 全読者 readOnly transaction 統一 ②ocrProcessor の無条件 detail read（大多数docへの無駄read+新失敗点）→ ゲート化 ③ambient namespace の単独実行 TS2503（実測再現）→ import type 化
- Codex review-diff（effort=high）: **No actionable correctness issues**（1ラウンド収束、新テスト14件を独立実行PASS）

## Test plan
- [x] functions 1,663テスト PASS（resolveDetailFields 単体7件 + 配線契約7件を新設）
- [x] tsc --noEmit / eslint（変更ファイル指摘0）
- [x] 新テストの単独 ts-node 実行 PASS（順序依存 TS2503 の解消確認）
- [ ] マージ後 dev 自動デプロイで OCR/要約再生成/分割候補の実機確認（本番展開は Phase D 全PR完了後・展開ゲート経由）

## 既知の時間窓（運用ゲートで対処、documentDetail.ts に明記）
旧FE（PWAキャッシュ）の親のみクリア + OCR失敗で stale detail が残る窓 → 環境ごとに「Hosting(PR-D1)先行 → `--verify` stale=0 確認 → Functions」の展開順序で封鎖（承認済み計画のデプロイゲート）

Refs #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)