### PR TITLE
feat(scripts): reprocess-master-matching.js/measure-summary-cost.tsをdetail/main優先読みに切替 (Issue #547 Phase D PR-D4)

### DIFF
--- a/scripts/lib/detailReaderCutoverContract.test.ts
+++ b/scripts/lib/detailReaderCutoverContract.test.ts
@@ -1,0 +1,104 @@
+/**
+ * scripts/ 読者の detail/main 切替 配線契約テスト (ADR-0018 Phase D PR-D4, Issue #547)
+ *
+ * functions/test/detailReadCutoverContract.test.ts (PR-D2) と同じ grep-based 契約パターン。
+ * 「reprocess-master-matching.js / measure-summary-cost.ts が detail優先+親フォールバックで
+ * ocrResult/pageResults を読む」配線をソース文字列レベルで lock-in する。
+ *
+ * AC9 (Phase E 前提ゲート): 本テストがPASSする = scripts/ 配下に、既知の許可リスト
+ * (backfill移行元データ/診断比較/fixture投入の3カテゴリ)以外で親 ocrResult/pageResults を
+ * 直接参照する「読者」が存在しないことを保証する。1読者でも切替が漏れると、Phase E
+ * (親からの実フィールド削除) 後にその読者が空データを受け取り、silent な機能停止が起きる。
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+const scriptsDir = resolve(__dirname, '..');
+
+const reprocessMasterMatchingSrc = readFileSync(
+  resolve(scriptsDir, 'reprocess-master-matching.js'),
+  'utf-8'
+);
+const measureSummaryCostSrc = readFileSync(resolve(scriptsDir, 'measure-summary-cost.ts'), 'utf-8');
+
+/**
+ * 許可リスト: 親 ocrResult/pageResults への直接参照が意図的に必要なファイル
+ * (scripts/ からの相対パス)。新規スクリプトが未許可のまま直接参照した場合、
+ * 下記 AC9 テストが検出する。安易な追記は禁止 — 追記時は理由をコメントで明記すること。
+ */
+const ALLOWLIST = new Set([
+  // dual-write fixture投入 (既存Firestore状態からの解決ではなく、投入するfixtureデータそのもの)
+  'seed-dev-data.ts',
+  // Phase C backfill本体: 親の既存ocrResult/pageResultsがdetail/mainへの移行元データ
+  'backfill-detail-subcollection.ts',
+  // 上記のヘルパー
+  'lib/backfillDetailHelpers.ts',
+  // #548 一時的診断スクリプト: 親/detailの値を意図的に比較するのが目的(実行済み、再利用予定なし)
+  'diagnose-confirmed-replay-sampling.ts',
+  // PR-D4で detail優先+親フォールバックに切替済み(下記テストで個別に配線確認する対象そのもの)
+  'reprocess-master-matching.js',
+  'measure-summary-cost.ts',
+]);
+
+const EXCLUDED_DIR_NAMES = new Set(['node_modules', '.git']);
+
+function walkSourceFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDED_DIR_NAMES.has(entry)) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkSourceFiles(full, files);
+    } else if (/\.(ts|js)$/.test(entry) && !/\.test\.(ts|js)$/.test(entry)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+test('reprocess-master-matching.js: detail優先 + 親フォールバックでocrResult/pageResultsを解決する (ADR-0018 Phase D PR-D4)', () => {
+  assert.match(
+    reprocessMasterMatchingSrc,
+    /docSnap\.ref\.collection\('detail'\)\.doc\('main'\)\.get\(\)/
+  );
+  assert.match(
+    reprocessMasterMatchingSrc,
+    /typeof detailData\?\.ocrResult === 'string' \? detailData\.ocrResult : \(doc\.ocrResult \|\| ''\)/
+  );
+  assert.match(
+    reprocessMasterMatchingSrc,
+    /Array\.isArray\(detailData\?\.pageResults\) \? detailData\.pageResults : \(doc\.pageResults \|\| \[\]\)/
+  );
+  // 旧経路 (detail解決なしの直接ocrResult参照によるスキップ判定) が残っていないこと
+  assert.doesNotMatch(reprocessMasterMatchingSrc, /if \(!doc\.ocrResult\) \{/);
+});
+
+test('measure-summary-cost.ts: detail優先 + 親フォールバックでocrResultを解決する (ADR-0018 Phase D PR-D4)', () => {
+  assert.match(measureSummaryCostSrc, /db\.doc\(`documents\/\$\{docId\}\/detail\/main`\)\.get\(\)/);
+  assert.match(
+    measureSummaryCostSrc,
+    /typeof detailData\?\.ocrResult === 'string' \? detailData\.ocrResult : \(data\.ocrResult \|\| ''\)/
+  );
+});
+
+test('AC9 (Phase E前提ゲート): scripts/ 配下に許可リスト外で親ocrResult/pageResultsを直接参照するファイルが存在しない', () => {
+  const allFiles = walkSourceFiles(scriptsDir);
+  const violations: string[] = [];
+  for (const file of allFiles) {
+    const rel = relative(scriptsDir, file).split('\\').join('/');
+    if (ALLOWLIST.has(rel)) continue;
+    const src = readFileSync(file, 'utf-8');
+    if (/\.ocrResult\b/.test(src) || /\.pageResults\b/.test(src)) {
+      violations.push(rel);
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `許可リスト外で親ocrResult/pageResultsを直接参照するファイルが見つかりました: ${JSON.stringify(violations)}。` +
+      'detail優先+親フォールバックへの切替が必要、または正当な理由があれば本テストのALLOWLISTに理由付きで追記してください。'
+  );
+});

--- a/scripts/lib/detailReaderCutoverContract.test.ts
+++ b/scripts/lib/detailReaderCutoverContract.test.ts
@@ -6,9 +6,15 @@
  * ocrResult/pageResults を読む」配線をソース文字列レベルで lock-in する。
  *
  * AC9 (Phase E 前提ゲート): 本テストがPASSする = scripts/ 配下に、既知の許可リスト
- * (backfill移行元データ/診断比較/fixture投入の3カテゴリ)以外で親 ocrResult/pageResults を
+ * (backfill移行元データ/診断比較/計測/fixture投入の4カテゴリ)以外で親 ocrResult/pageResults を
  * 直接参照する「読者」が存在しないことを保証する。1読者でも切替が漏れると、Phase E
  * (親からの実フィールド削除) 後にその読者が空データを受け取り、silent な機能停止が起きる。
+ *
+ * 検出パターンは `.ocrResult`/`.pageResults` のドット参照だけでなく、`'ocrResult'`/
+ * `'pageResults'` の文字列リテラル参照(ブラケット記法 `d[field]` や配列経由の動的
+ * アクセス)も対象に含める(Codexレビュー指摘: measure-field-byte-sizes.js が
+ * `HEAVY_FIELDS` 配列経由の `d[field]` でこれらのフィールドを読んでおり、ドット
+ * 参照のみの検出だと見逃す)。
  */
 
 import assert from 'node:assert/strict';
@@ -38,6 +44,10 @@ const ALLOWLIST = new Set([
   'lib/backfillDetailHelpers.ts',
   // #548 一時的診断スクリプト: 親/detailの値を意図的に比較するのが目的(実行済み、再利用予定なし)
   'diagnose-confirmed-replay-sampling.ts',
+  // Issue #547着手前の事前計測スクリプト(ADR-0018 Context節に実測値の出典として記載、PR #555)。
+  // 移行前の親docの重フィールドのバイトサイズ分布を測るのが目的そのもののため、
+  // detail優先化すると計測対象(移行前の親doc実態)を失い本来の目的と矛盾する。read-only。
+  'measure-field-byte-sizes.js',
   // PR-D4で detail優先+親フォールバックに切替済み(下記テストで個別に配線確認する対象そのもの)
   'reprocess-master-matching.js',
   'measure-summary-cost.ts',
@@ -66,11 +76,11 @@ test('reprocess-master-matching.js: detail優先 + 親フォールバックでoc
   );
   assert.match(
     reprocessMasterMatchingSrc,
-    /typeof detailData\?\.ocrResult === 'string' \? detailData\.ocrResult : \(doc\.ocrResult \|\| ''\)/
+    /typeof detailData\?\.ocrResult === 'string'\s*\n\s*\? detailData\.ocrResult\s*\n\s*: \(typeof doc\.ocrResult === 'string' \? doc\.ocrResult : ''\)/
   );
   assert.match(
     reprocessMasterMatchingSrc,
-    /Array\.isArray\(detailData\?\.pageResults\) \? detailData\.pageResults : \(doc\.pageResults \|\| \[\]\)/
+    /Array\.isArray\(detailData\?\.pageResults\)\s*\n\s*\? detailData\.pageResults\s*\n\s*: \(Array\.isArray\(doc\.pageResults\) \? doc\.pageResults : \[\]\)/
   );
   // 旧経路 (detail解決なしの直接ocrResult参照によるスキップ判定) が残っていないこと
   assert.doesNotMatch(reprocessMasterMatchingSrc, /if \(!doc\.ocrResult\) \{/);
@@ -80,18 +90,19 @@ test('measure-summary-cost.ts: detail優先 + 親フォールバックでocrResu
   assert.match(measureSummaryCostSrc, /db\.doc\(`documents\/\$\{docId\}\/detail\/main`\)\.get\(\)/);
   assert.match(
     measureSummaryCostSrc,
-    /typeof detailData\?\.ocrResult === 'string' \? detailData\.ocrResult : \(data\.ocrResult \|\| ''\)/
+    /typeof detailData\?\.ocrResult === 'string'\s*\n\s*\? detailData\.ocrResult\s*\n\s*: \(typeof data\.ocrResult === 'string' \? data\.ocrResult : ''\)/
   );
 });
 
 test('AC9 (Phase E前提ゲート): scripts/ 配下に許可リスト外で親ocrResult/pageResultsを直接参照するファイルが存在しない', () => {
   const allFiles = walkSourceFiles(scriptsDir);
   const violations: string[] = [];
+  const detectionPattern = /\.ocrResult\b|\.pageResults\b|'ocrResult'|"ocrResult"|'pageResults'|"pageResults"/;
   for (const file of allFiles) {
     const rel = relative(scriptsDir, file).split('\\').join('/');
     if (ALLOWLIST.has(rel)) continue;
     const src = readFileSync(file, 'utf-8');
-    if (/\.ocrResult\b/.test(src) || /\.pageResults\b/.test(src)) {
+    if (detectionPattern.test(src)) {
       violations.push(rel);
     }
   }

--- a/scripts/measure-summary-cost.ts
+++ b/scripts/measure-summary-cost.ts
@@ -63,7 +63,9 @@ async function main(): Promise<void> {
   // functions/src/ocr/documentDetail.ts と同じフィールド単位フォールバック規則。
   const detailSnap = await db.doc(`documents/${docId}/detail/main`).get();
   const detailData = detailSnap.exists ? detailSnap.data() : undefined;
-  const ocrResult: string = typeof detailData?.ocrResult === 'string' ? detailData.ocrResult : (data.ocrResult || '');
+  const ocrResult: string = typeof detailData?.ocrResult === 'string'
+    ? detailData.ocrResult
+    : (typeof data.ocrResult === 'string' ? data.ocrResult : '');
   const documentType: string = data.documentType || '';
 
   console.log(`対象文書: ${docId}`);

--- a/scripts/measure-summary-cost.ts
+++ b/scripts/measure-summary-cost.ts
@@ -58,7 +58,12 @@ async function main(): Promise<void> {
   }
 
   const data = snap.data()!;
-  const ocrResult: string = data.ocrResult || '';
+  // ADR-0018 Phase D PR-D4 (Issue #547): detail/main優先 + 親フォールバックで
+  // ocrResultを解決する。frontend/src/hooks/useDocuments.ts の resolveDetailFields、
+  // functions/src/ocr/documentDetail.ts と同じフィールド単位フォールバック規則。
+  const detailSnap = await db.doc(`documents/${docId}/detail/main`).get();
+  const detailData = detailSnap.exists ? detailSnap.data() : undefined;
+  const ocrResult: string = typeof detailData?.ocrResult === 'string' ? detailData.ocrResult : (data.ocrResult || '');
   const documentType: string = data.documentType || '';
 
   console.log(`対象文書: ${docId}`);

--- a/scripts/reprocess-master-matching.js
+++ b/scripts/reprocess-master-matching.js
@@ -481,8 +481,12 @@ async function main() {
     // FEクリア後のフィールド不在はundefinedとして扱う)。
     const detailSnap = await docSnap.ref.collection('detail').doc('main').get();
     const detailData = detailSnap.exists ? detailSnap.data() : undefined;
-    const ocrText = typeof detailData?.ocrResult === 'string' ? detailData.ocrResult : (doc.ocrResult || '');
-    const pageResults = Array.isArray(detailData?.pageResults) ? detailData.pageResults : (doc.pageResults || []);
+    const ocrText = typeof detailData?.ocrResult === 'string'
+      ? detailData.ocrResult
+      : (typeof doc.ocrResult === 'string' ? doc.ocrResult : '');
+    const pageResults = Array.isArray(detailData?.pageResults)
+      ? detailData.pageResults
+      : (Array.isArray(doc.pageResults) ? doc.pageResults : []);
 
     // OCR結果がない場合はスキップ
     if (!ocrText) {

--- a/scripts/reprocess-master-matching.js
+++ b/scripts/reprocess-master-matching.js
@@ -474,14 +474,22 @@ async function main() {
     const doc = docSnap.data();
     const docId = docSnap.id;
 
+    // ADR-0018 Phase D PR-D4 (Issue #547): detail/main優先 + 親フォールバックで
+    // ocrResult/pageResultsを解決する。frontend/src/hooks/useDocuments.ts の
+    // resolveDetailFields、functions/src/ocr/documentDetail.ts と同じフィールド単位
+    // フォールバック規則(''/[]は有効値として親へフォールバックしない、
+    // FEクリア後のフィールド不在はundefinedとして扱う)。
+    const detailSnap = await docSnap.ref.collection('detail').doc('main').get();
+    const detailData = detailSnap.exists ? detailSnap.data() : undefined;
+    const ocrText = typeof detailData?.ocrResult === 'string' ? detailData.ocrResult : (doc.ocrResult || '');
+    const pageResults = Array.isArray(detailData?.pageResults) ? detailData.pageResults : (doc.pageResults || []);
+
     // OCR結果がない場合はスキップ
-    if (!doc.ocrResult) {
+    if (!ocrText) {
       console.log(`⏭️  ${docId}: OCR結果なし - スキップ`);
       skipped++;
       continue;
     }
-
-    const ocrText = doc.ocrResult;
 
     // マスター照合を再実行
     const customerResult = extractCustomerCandidates(ocrText, customerMasters);
@@ -489,7 +497,6 @@ async function main() {
     const docTypeResult = extractDocumentTypeCandidates(ocrText, documentTypeMasters);
 
     // 日付抽出を再実行（1ページ目優先）
-    const pageResults = doc.pageResults || [];
     const firstPageText = pageResults.length > 0 ? pageResults[0]?.text : undefined;
     const dateResult = extractDateEnhanced(ocrText, firstPageText);
 


### PR DESCRIPTION
## Summary
- ADR-0018 Phase D の scripts 読者切替(PR-D3の続き)。`reprocess-master-matching.js`(マスター照合・日付抽出の全書類再実行)と `measure-summary-cost.ts`(#562 summary生成コスト測定)を、`documents/{id}/detail/main` 優先+親docフォールバックの読み取りに切替
- フォールバック規則は `functions/src/ocr/documentDetail.ts`・`frontend/src/hooks/useDocuments.ts` の `resolveDetailFields` と同一(`typeof === 'string'`/`Array.isArray` によるフィールド単位判定)
- `scripts/lib/detailReaderCutoverContract.test.ts` 新設: 両スクリプトの配線をgrep契約で固定 + **AC9(Phase E前提ゲート)**として `scripts/` 配下に許可リスト外で親`ocrResult`/`pageResults`を直接参照するファイルが存在しないことを検証
- Codexセカンドオピニオンで2件の指摘を反映: ①AC9の検出パターンがドット記法のみで、`measure-field-byte-sizes.js`(Issue #547着手前の事前計測スクリプト、`HEAVY_FIELDS`配列経由の`d[field]`ブラケット記法)を見逃していた漏れを解消(検出パターンを引用符付き文字列リテラルまで拡張+許可リストに追加) ②親フォールバックの真偽値判定を`typeof === 'string'`の厳密チェックに統一

## Test plan
- [x] `node --check scripts/reprocess-master-matching.js` 構文OK
- [x] `cd scripts && npm test` 45 passing (新規3件: reprocess-master-matching.js配線確認/measure-summary-cost.ts配線確認/AC9読者ゼロゲート)
- [x] AC9検出ロジックの動作確認: 未許可ファイルに`.ocrResult`直接参照を意図的に追加してテストがFAILすることを確認(検出漏れがないことの実証)
- [x] `cd scripts && npx tsc --noEmit -p .` 実行、対象2ファイルにエラーなし(pre-existing無関係エラー2件は`pr-d4-backfill/`配下の別Issue #445由来、本PR差分に含まれずmainでも再現確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCR and page result data now prefer the latest detail view, with automatic fallback to the parent record when needed.
  * Summary cost calculations now use the same priority logic, improving consistency across processing.

* **Bug Fixes**
  * Reprocessing now handles missing or partial OCR/page data more reliably.
  * Added checks to prevent outdated direct-parent data access from slipping back in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->