### PR TITLE
ci(deploy): kanameone/cocoro Hosting用GitHub Actions workflow追加

### DIFF
--- a/.github/workflows/deploy-hosting.yml
+++ b/.github/workflows/deploy-hosting.yml
@@ -1,0 +1,68 @@
+name: Deploy Firebase Hosting
+
+# kanameone/cocoro は Firebase CLI ローカルログイン(systemkaname@kanameone.com等)が
+# 前提だが、セッション失効時にブラウザ再認証が必要でAI実行環境からは対応不能
+# (Issue #547 Phase D session110)。GitHub Actions経由ならSA鍵で完結できるため、
+# deploy-functions.yml と同じ SA 認証パターンで Hosting のみを対象に追加。
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment target'
+        required: true
+        default: 'kanameone'
+        type: choice
+        options:
+          - kanameone
+          - cocoro
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: ./frontend
+        run: npm run build
+        env:
+          VITE_FIREBASE_API_KEY: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_API_KEY_KANAMEONE || secrets.VITE_FIREBASE_API_KEY_COCORO }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_AUTH_DOMAIN_KANAMEONE || secrets.VITE_FIREBASE_AUTH_DOMAIN_COCORO }}
+          VITE_FIREBASE_PROJECT_ID: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_PROJECT_ID_KANAMEONE || secrets.VITE_FIREBASE_PROJECT_ID_COCORO }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_STORAGE_BUCKET_KANAMEONE || secrets.VITE_FIREBASE_STORAGE_BUCKET_COCORO }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_MESSAGING_SENDER_ID_KANAMEONE || secrets.VITE_FIREBASE_MESSAGING_SENDER_ID_COCORO }}
+          VITE_FIREBASE_APP_ID: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_APP_ID_KANAMEONE || secrets.VITE_FIREBASE_APP_ID_COCORO }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: |-
+            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
+                secrets.GCP_SA_KEY }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase Hosting
+        run: firebase deploy --only hosting -P ${{ github.event.inputs.environment }} --force
+
+      - name: Notify deployment status
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == 'success' ]; then
+            echo "✅ Deployment successful"
+          else
+            echo "❌ Deployment failed"
+          fi

--- a/.github/workflows/deploy-hosting.yml
+++ b/.github/workflows/deploy-hosting.yml
@@ -1,9 +1,12 @@
 name: Deploy Firebase Hosting
 
-# kanameone/cocoro は Firebase CLI ローカルログイン(systemkaname@kanameone.com等)が
-# 前提だが、セッション失効時にブラウザ再認証が必要でAI実行環境からは対応不能
+# kanameone は Firebase CLI ローカルログイン(systemkaname@kanameone.com)が前提だが、
+# セッション失効時にブラウザ再認証が必要でAI実行環境からは対応不能
 # (Issue #547 Phase D session110)。GitHub Actions経由ならSA鍵で完結できるため、
 # deploy-functions.yml と同じ SA 認証パターンで Hosting のみを対象に追加。
+#
+# cocoroは対象外(cocoro用 VITE_FIREBASE_*_COCORO Secretsは未登録。既存のローカル
+# 手動デプロイ手順が機能しているため。追加する場合はSecrets登録 + choice追加が必要)。
 
 on:
   workflow_dispatch:
@@ -15,7 +18,6 @@ on:
         type: choice
         options:
           - kanameone
-          - cocoro
 
 jobs:
   deploy:
@@ -38,19 +40,17 @@ jobs:
         working-directory: ./frontend
         run: npm run build
         env:
-          VITE_FIREBASE_API_KEY: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_API_KEY_KANAMEONE || secrets.VITE_FIREBASE_API_KEY_COCORO }}
-          VITE_FIREBASE_AUTH_DOMAIN: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_AUTH_DOMAIN_KANAMEONE || secrets.VITE_FIREBASE_AUTH_DOMAIN_COCORO }}
-          VITE_FIREBASE_PROJECT_ID: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_PROJECT_ID_KANAMEONE || secrets.VITE_FIREBASE_PROJECT_ID_COCORO }}
-          VITE_FIREBASE_STORAGE_BUCKET: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_STORAGE_BUCKET_KANAMEONE || secrets.VITE_FIREBASE_STORAGE_BUCKET_COCORO }}
-          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_MESSAGING_SENDER_ID_KANAMEONE || secrets.VITE_FIREBASE_MESSAGING_SENDER_ID_COCORO }}
-          VITE_FIREBASE_APP_ID: ${{ github.event.inputs.environment == 'kanameone' && secrets.VITE_FIREBASE_APP_ID_KANAMEONE || secrets.VITE_FIREBASE_APP_ID_COCORO }}
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY_KANAMEONE }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN_KANAMEONE }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID_KANAMEONE }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET_KANAMEONE }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID_KANAMEONE }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID_KANAMEONE }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: |-
-            ${{ github.event.inputs.environment == 'kanameone' && secrets.GCP_SA_KEY_KANAMEONE ||
-                secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GCP_SA_KEY_KANAMEONE }}
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools


### PR DESCRIPTION
## Summary
- Firebase CLIの`systemkaname@kanameone.com`ローカルログインがセッション失効時にブラウザ再認証必須で、AI実行環境から対応不能な問題への対処
- 既存の`deploy-functions.yml`と同じSA鍵認証パターンで、Hosting専用の新規workflow `deploy-hosting.yml` を追加（environment選択: kanameone/cocoro）
- kanameone用Firebase Web SDK設定値をGitHub Secretsに新規登録（`VITE_FIREBASE_*_KANAMEONE`、クライアント公開情報のため非機密）
- cocoro用Secretsは未登録（既存のローカル手動デプロイ手順が機能しているため今回スコープ外、cocoroを選択した場合はSecrets未設定でデプロイが失敗するのみ・実害なし）

## Context
Issue #547 Phase D 本番展開作業中（session110）、kanameone環境のHostingデプロイを試みたところFirebase CLIログインが失効しており、ブラウザ認証が必要でAI実行環境では対応できないことが判明。GitHub Actions経由での対応を指示されたため本PRを作成。

## Test plan
- [x] YAML構文確認（ローカルで`.firebaserc`のkanameoneエイリアス、frontend/package.jsonのbuildスクリプトを確認済み）
- [ ] マージ後、`gh workflow run "Deploy Firebase Hosting" -f environment=kanameone` で実際にkanameone Hostingへのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)