### PR TITLE
docs(handoff): GOAL.md更新 — Phase D cocoro/kanameone本番展開完遂を反映 (Issue #547)

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -1,7 +1,7 @@
 ---
 updated: 2026-07-09
 ---
-<!-- session109: Phase D PR-D3(#601)/PR-D4(#602)実装+マージ完遂を反映 -->
+<!-- session110: Phase D cocoro/kanameone本番展開完遂を反映 -->
 
 ## 現在のミッション
 運用コスト圧縮2トラック — #547 Firestore読取egress削減（ADR-0018 detail/main分離）と #548 Gemini 3.5 Flash移行 — を、本番2環境（kanameone / cocoro）で安全に完遂する。
@@ -28,11 +28,11 @@ updated: 2026-07-09
 - [x] #547 Phase D **PR-D2**: Functions 読者切替（**PR #599 マージ済み** 2026-07-09。readDocWithDetail=readOnly transaction統一、parentDocumentIdゲート、fieldMask。dev実機確認済み）
 - [x] #547 Phase D **PR-D3**: FE 読者切替（**PR #601 マージ済み** 2026-07-09。fetchDocumentDetail/resolveDetailFields/useDocumentDetail新設、DocumentDetailModal/PdfSplitModalオンデマンドdetail取得、getOcrExcerpt→ocrExcerpt参照化、searchText dead code除去。code-review high 5エージェント+Codexで検出2件〔documentDetailキャッシュ無効化漏れ/独立ポーリングレース〕修正済み、ui-verified確認済み）
 - [x] #547 Phase D **PR-D4**: scripts 読者切替（**PR #602 マージ済み** 2026-07-09。reprocess-master-matching.js/measure-summary-cost.tsをdetail優先+親フォールバックに切替、AC9読者ゼロgrep契約テスト新設〔scripts/lib/detailReaderCutoverContract.test.ts〕。Codexで検出2件〔measure-field-byte-sizes.js検出漏れ/フォールバック順序〕修正済み）
-- [ ] #547 Phase D 展開（trigger: 全PR merge済み(D1〜D4完了) + dev AC確認 + 環境ごと番号単位認可。**環境内は Hosting先行 → stale/pending検証ゲート → Functions の順**（旧PWA由来stale再利用の封鎖）→ 展開先: cocoro→kanameone の順で番号認可を仰ぐ）
-- [ ] #547 Phase E impl-plan 起票 → 実行 → Issue #547 close（trigger: Phase D 展開完了 + AC9ゲートPASS。destructive につき番号認可+devリハーサル必須。ADR-0018 Phase E行にCodex P2/P3所見〔PdfSplitModalのdetail loading中ブロック欠如/useDocumentDetailのisError未サーフェス〕を確認事項として記録済み）
+- [x] #547 Phase D 展開（2026-07-09 session110完遂。dev: E2E確認PASS〔OCR結果アコーディオン/PDF分割モーダル/処理履歴OCR抜粋、コンソールエラー0件〕。cocoro: Hosting→verify PASS〔新規処理1件のbackfill漏れを検出・--execute再実行で解消→再verify全件parity一致〕→Functions全関数update成功。kanameone: Hosting→verify一発PASS〔9,435件全件parity一致〕→Functions全関数update成功。副産物: kanameone Hosting用GitHub Actions workflow新設〔PR #606、Firebase CLIブラウザ認証不要化〕）
+- [ ] #547 Phase E impl-plan 起票 → 実行 → Issue #547 close（trigger: AC9ゲートPASS確認。destructive につき番号認可+devリハーサル必須。ADR-0018 Phase E行にCodex P2/P3所見〔PdfSplitModalのdetail loading中ブロック欠如/useDocumentDetailのisError未サーフェス〕を確認事項として記録済み）
 
 ## 🔄 中断点（in-flight）
-- 対象タスク: #547 Phase D 展開（cocoro/kanameone への Hosting→Functions→scripts 展開）
-- 直前の状態: PR-D1(#598)/PR-D2(#599)/PR-D3(#601)/PR-D4(#602) 全マージ済み。dev環境はmain push時のCI自動デプロイ対象のため、次回dev push時に全PR分が反映される見込み(要確認)。本番2環境(cocoro/kanameone)はまだ旧FE/旧Functions/旧scriptsのまま
-- 次の一手: ① dev環境で全PR反映後のE2E動作確認(念のため) ② cocoro環境への展開可否をdecision-makerに確認(番号単位認可) → Hosting(D1+D3)先行デプロイ→verify --stale=0確認→Functions(D2)→scripts(D4)の順 ③ kanameone環境も同順序で展開 ④ 両環境展開完了後、AC9ゲートPASS確認→Phase E impl-plan起票
+- 対象タスク: #547 Phase E 着手前のAC9ゲート確認
+- 直前の状態: Phase D展開が cocoro/kanameone 両本番環境で完遂（2026-07-09 session110）。両環境ともverify stale=0・in-pipeline=0・parity一致を確認済み
+- 次の一手: ① AC9ゲート内容の確認（ADR-0018参照、Phase D展開完了が満たすべき条件の特定）② PASSであれば Phase E（親docの大容量フィールド削除、egress削減本体）の `/impl-plan` フル起票 → dev リハーサル必須 → 番号単位認可
 - 検証コマンド: `cd functions && npm test`（1,664 passing）/ `cd frontend && npm test`（304 passing）/ `cd scripts && npm test`（45 passing）


### PR DESCRIPTION
## Summary
- Issue #547 Phase D（Firestore detail/main分離のdual-read cutover）本番展開が cocoro/kanameone 両環境で完遂したことをGOAL.mdに反映
- 完了項目チェック、中断点をPhase E着手前のAC9ゲート確認待ちに更新

## Context
session110: dev環境E2E確認PASS → cocoro展開（Hosting→verify→Functions、backfill漏れ1件検出・解消）→ kanameone展開（Hosting→verify→Functions、9,435件一発PASS）を完遂。副産物としてkanameone Hosting用GitHub Actions workflow（PR #606）を新設。

## Test plan
- [x] docs-onlyの変更のため構文確認のみ（Markdown）

🤖 Generated with [Claude Code](https://claude.com/claude-code)