### PR TITLE
docs(handoff): GOAL.md完了の定義を実態に合わせて修正 (Issue #547)

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -13,8 +13,8 @@ updated: 2026-07-09
 - #547 の egress 実削減は Phase E（親docの大容量フィールド削除）で初めて発生する。Phase C（backfill）/ Phase D（dual-read cutover）はその前提工程
 
 ## 完了の定義
-- Issue #548 が close される（証明: `gh issue view 548 --json state --jq .state` が `CLOSED`）
-- Issue #547 が close される（証明: `gh issue view 547 --json state --jq .state` が `CLOSED`）
+- Issue #548 が close される（証明: `gh issue view 548 --json state --jq .state` が `CLOSED`。**達成済み、2026-07-09**）
+- **#547 Phase E が完了し、egress実削減効果が発生する**（証明: 本体 `documents/{docId}` から `ocrResult`/`pageResults` が `FieldValue.delete()` で削除され、一覧クエリの転送量が実測で減少）。**注: Issue #547自体は2026-07-07 Phase B完遂時点で既にclose済み**（ADR-0018記載の意図的運用: 「Phase C以降は別途decision-maker起点指示+`/impl-plan`で着手」）。Phase C/D/Eの進捗はIssue再オープンではなく本GOAL.md + ADR-0018で追跡する
 - 不変条件: 本番 documents の既存フィールドを破壊しない（backfill の親doc更新は ocrExcerpt 1フィールドのみ・detail/main は create 経由のみ。契約テスト `scripts/lib/backfillScriptContract.test.ts` の PASS を維持）
 
 ## 進行中のtasks


### PR DESCRIPTION
## Summary
- GOAL.mdの完了の定義「Issue #547 が close される」を「Phase E完了(egress実削減効果発生)」に差し替え
- Issue #547は2026-07-07 Phase B完遂時点で既にcloseされている(ADR-0018記載の意図的運用)ことを注記

## Context
handoff §7 GitHub Issues同期チェックで、GOAL.mdの完了条件（Issue #547がCLOSED）が既に満たされているにも関わらずミッション自体は未完了（Phase C/D/Eが残っている）という整合性の乖離を検出。Issue #547はADR-0018の運用方針により意図的にPhase B完遂時点でcloseされ、以降はIssue再オープンではなくGOAL.md/ADR-0018で追跡する設計だったため、完了条件をその実態に合わせた。

## Test plan
- [x] docs-onlyの変更のため構文確認のみ（Markdown）

🤖 Generated with [Claude Code](https://claude.com/claude-code)