### PR TITLE
fix(pdf): splitPdfに二重split race防止の排他制御を追加 (#539)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "type-check:test": "tsc --noEmit -p tsconfig.test.json",
     "test": "npm run type-check:test && mocha --require ts-node/register --timeout 10000 'test/**/*.test.ts' --ignore 'test/firestore.rules.test.ts' --ignore 'test/*Integration.test.ts'",
     "test:rules": "mocha --require ts-node/register --timeout 10000 'test/firestore.rules.test.ts'",
-    "test:integration": "mocha --require ts-node/register --timeout 15000 test/ocrRetryIntegration.test.ts test/rescueStuckProcessingIntegration.test.ts test/rescueErroredIntegration.test.ts test/gmailAttachmentIntegration.test.ts test/splitPdfIntegration.test.ts test/searchDocumentsIntegration.test.ts test/rateLimiterIntegration.test.ts"
+    "test:integration": "mocha --require ts-node/register --timeout 15000 test/ocrRetryIntegration.test.ts test/rescueStuckProcessingIntegration.test.ts test/rescueErroredIntegration.test.ts test/gmailAttachmentIntegration.test.ts test/splitPdfIntegration.test.ts test/splitPdfConcurrencyGuardIntegration.test.ts test/searchDocumentsIntegration.test.ts test/rateLimiterIntegration.test.ts"
   },
   "engines": {
     "node": "20"

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -336,12 +336,20 @@ async function cleanupAccumulatedStorageFiles(
  * retry loop は startUpdateTime を最初の読取り時点のまま固定して使い回していたため、
  * retry の backoff window 中に他プロセスが正当な操作(reprocess等、二重splitに限らない)で
  * 親 doc を更新すると、T4 の precondition が「二重split」と誤診断して正当な処理を abort していた。
- * retry直前にこの関数で状態を再取得し startUpdateTime を更新することで、stale precondition の
- * 窓を「初回読取り〜最終commit」から「直近のretry再読取り〜最終commit」に縮小する。
+ *
+ * Codex review (PR #623) P1 反映: updateTime だけを rebase して retry を継続すると、
+ * retry が使い続ける docData/sourcePageResults/sourceObjectName 等は初回読取り時点のまま
+ * stale なので、その間に status(reprocessでpendingへ) や fileUrl が変化していた場合、
+ * stale データから作った子docを新しい parent revision に紐付けて split 完了させてしまう
+ * (precondition だけ通って実データは古い、という別種のバグ)。
+ * status/fileUrl が初回読取りから変化していないかも検証し、変化があれば rebase せず
+ * 安全側に abort する。変化がなければ updateTime のみ最新化して retry を継続する。
  */
 async function recheckParentBeforeRetry(
   docRef: FirebaseFirestore.DocumentReference,
-  documentId: string
+  documentId: string,
+  expectedStatus: unknown,
+  expectedFileUrl: string
 ): Promise<FirebaseFirestore.Timestamp> {
   const snap = await docRef.get();
   if (!snap.exists) {
@@ -355,6 +363,12 @@ async function recheckParentBeforeRetry(
     throw new HttpsError(
       'already-exists',
       `Document ${documentId} has already been split (status='split') (detected during retry)`
+    );
+  }
+  if (data.status !== expectedStatus || data.fileUrl !== expectedFileUrl) {
+    throw new HttpsError(
+      'aborted',
+      `splitPdf aborted: parent document was modified during retry (documentId=${documentId}, status or fileUrl changed since initial read) — please retry the split operation`
     );
   }
   const updateTime = snap.updateTime;
@@ -506,7 +520,7 @@ export const splitPdf = onCall(
             await backoffSleep(attempt);
             // Issue #539 fix: retry前に親docを再チェックし、stale startUpdateTimeによる
             // 誤ったprecondition失敗(二重splitの誤検知)を防ぐ
-            startUpdateTime = await recheckParentBeforeRetry(docRef, documentId);
+            startUpdateTime = await recheckParentBeforeRetry(docRef, documentId, docData.status, fileUrl);
             continue;
           }
           throw new HttpsError(
@@ -780,7 +794,7 @@ export const splitPdf = onCall(
             await backoffSleep(attempt);
             // Issue #539 fix: retry前に親docを再チェックし、stale startUpdateTimeによる
             // 誤ったprecondition失敗(二重splitの誤検知)を防ぐ
-            startUpdateTime = await recheckParentBeforeRetry(docRef, documentId);
+            startUpdateTime = await recheckParentBeforeRetry(docRef, documentId, docData.status, fileUrl);
             continue;
           }
           throw new HttpsError(

--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -331,6 +331,42 @@ async function cleanupAccumulatedStorageFiles(
   }
 }
 
+/**
+ * source-drift retry (MAX_RETRIES) の backoff 直後に親 doc の現在状態を再チェックする (Issue #539 fix)。
+ * retry loop は startUpdateTime を最初の読取り時点のまま固定して使い回していたため、
+ * retry の backoff window 中に他プロセスが正当な操作(reprocess等、二重splitに限らない)で
+ * 親 doc を更新すると、T4 の precondition が「二重split」と誤診断して正当な処理を abort していた。
+ * retry直前にこの関数で状態を再取得し startUpdateTime を更新することで、stale precondition の
+ * 窓を「初回読取り〜最終commit」から「直近のretry再読取り〜最終commit」に縮小する。
+ */
+async function recheckParentBeforeRetry(
+  docRef: FirebaseFirestore.DocumentReference,
+  documentId: string
+): Promise<FirebaseFirestore.Timestamp> {
+  const snap = await docRef.get();
+  if (!snap.exists) {
+    throw new HttpsError(
+      'not-found',
+      `Document ${documentId} was deleted during splitPdf retry`
+    );
+  }
+  const data = snap.data()!;
+  if (data.status === 'split') {
+    throw new HttpsError(
+      'already-exists',
+      `Document ${documentId} has already been split (status='split') (detected during retry)`
+    );
+  }
+  const updateTime = snap.updateTime;
+  if (!updateTime) {
+    throw new HttpsError(
+      'failed-precondition',
+      'Document has no updateTime; cannot enforce optimistic locking'
+    );
+  }
+  return updateTime;
+}
+
 export const splitPdf = onCall(
   {
     region: 'asia-northeast1',
@@ -396,6 +432,23 @@ export const splitPdf = onCall(
     }
 
     const docData = docSnapshot.data()!;
+
+    // Issue #539: 二重split race防止。既にsplit済みのdocへの再実行を重い処理前に拒否する
+    // (完全な同時実行のrace windowはT4のbatch.update precondition側でカバー、rotatePdfPagesと同一パターン)
+    if (docData.status === 'split') {
+      throw new HttpsError(
+        'already-exists',
+        `Document ${documentId} has already been split (status='split')`
+      );
+    }
+    let startUpdateTime = docSnapshot.updateTime;
+    if (!startUpdateTime) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Document has no updateTime; cannot enforce optimistic locking'
+      );
+    }
+
     // 分割元の pageResults は detail 優先で解決し、以降の全用途(セグメント抽出/子doc用
     // ocrResult 生成)で同一ソースを使う
     const sourcePageResults = resolveSplitPageInputs(detailSnapshot.data(), docData);
@@ -451,6 +504,9 @@ export const splitPdf = onCall(
           lastDriftError = err;
           if (attempt < MAX_RETRIES) {
             await backoffSleep(attempt);
+            // Issue #539 fix: retry前に親docを再チェックし、stale startUpdateTimeによる
+            // 誤ったprecondition失敗(二重splitの誤検知)を防ぐ
+            startUpdateTime = await recheckParentBeforeRetry(docRef, documentId);
             continue;
           }
           throw new HttpsError(
@@ -722,6 +778,9 @@ export const splitPdf = onCall(
           lastDriftError = err;
           if (attempt < MAX_RETRIES) {
             await backoffSleep(attempt);
+            // Issue #539 fix: retry前に親docを再チェックし、stale startUpdateTimeによる
+            // 誤ったprecondition失敗(二重splitの誤検知)を防ぐ
+            startUpdateTime = await recheckParentBeforeRetry(docRef, documentId);
             continue;
           }
           throw new HttpsError(
@@ -761,11 +820,17 @@ export const splitPdf = onCall(
         });
       }
       // 元ドキュメントのステータスを更新 (分割済みフラグ) — child set と同一 batch
-      batch.update(docRef, {
-        splitInto: createdDocIds,
-        status: 'split',
-        isSplitSource: true,
-      });
+      // Issue #539: lastUpdateTime precondition で二重split raceを防止 (rotatePdfPagesと同一パターン)。
+      // 読取り時点(startUpdateTime)から親docが変更されていれば FAILED_PRECONDITION で commit 拒否される。
+      batch.update(
+        docRef,
+        {
+          splitInto: createdDocIds,
+          status: 'split',
+          isSplitSource: true,
+        },
+        { lastUpdateTime: startUpdateTime }
+      );
       try {
         await batch.commit();
       } catch (firestoreErr) {
@@ -788,16 +853,22 @@ export const splitPdf = onCall(
           'firestoreBatch',
           documentId
         );
+        // Issue #539: precondition mismatch (二重split race) は internal ではなく aborted として
+        // 区別する。判定は rotatePdfPages と共通の isFirestorePreconditionFailure ヘルパーを使う。
+        const errMessage = unwrapErrorMessage(firestoreErr);
+        if (isFirestorePreconditionFailure(firestoreErr)) {
+          throw new HttpsError(
+            'aborted',
+            `splitPdf aborted: concurrent split detected (parent=${documentId} was modified since read, likely split by another request): ${errMessage}`,
+            { stage: 'firestoreBatch', parentDocumentId: documentId }
+          );
+        }
         // /review-pr silent-failure-hunter C1: Firebase Functions v2 は非 HttpsError を
         // INTERNAL (message: "INTERNAL") に潰す。明示的に internal でラップして
         // 原因 message + structured details を client / 監視ログへ surface する。
         throw new HttpsError(
           'internal',
-          `splitPdf Firestore batch commit failed (parent=${documentId}, segments=${accumulated.length}): ${
-            firestoreErr instanceof Error
-              ? firestoreErr.message
-              : String(firestoreErr)
-          }`,
+          `splitPdf Firestore batch commit failed (parent=${documentId}, segments=${accumulated.length}): ${errMessage}`,
           {
             stage: 'firestoreBatch',
             parentDocumentId: documentId,
@@ -849,6 +920,28 @@ export const splitPdf = onCall(
  */
 function unwrapErrorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Firestore commit/update の失敗が optimistic locking の precondition mismatch
+ * (lastUpdateTime drift 等) によるものかを判定する。rotatePdfPages / splitPdf 共通。
+ * Evaluator CRITICAL Q1: Firestore admin SDK の Error.code は @grpc/grpc-js 内部実装で
+ * 公式 API 約束ではない (SDK バージョンアップで number → string 変動リスクあり)。
+ * 堅牢化のため 3 系統 OR 判定: (a) gRPC 数値 code (b) Cloud Functions 文字列 code (c) message fallback
+ */
+function isFirestorePreconditionFailure(err: unknown): boolean {
+  const errCode =
+    err instanceof Error && 'code' in err
+      ? (err as { code: number | string }).code
+      : undefined;
+  const errMessage = unwrapErrorMessage(err);
+  return (
+    errCode === 9 || // FAILED_PRECONDITION
+    errCode === 5 || // NOT_FOUND
+    errCode === 'failed-precondition' ||
+    errCode === 'not-found' ||
+    /FAILED_PRECONDITION|NOT_FOUND|precondition|no document to update/i.test(errMessage)
+  );
 }
 
 interface RotateRequest {
@@ -1120,24 +1213,9 @@ export const rotatePdfPages = onCall(
         throw commitErr;
       }
       // Firestore precondition mismatch (NOT_FOUND / FAILED_PRECONDITION 等) を concurrent write として扱う。
-      // Evaluator CRITICAL Q1: Firestore admin SDK の Error.code は @grpc/grpc-js 内部実装で
-      // 公式 API 約束ではない (SDK バージョンアップで number → string 変動リスクあり)。
-      // 堅牢化のため 3 系統 OR 判定: (a) gRPC 数値 code (b) Cloud Functions 文字列 code (c) error.message string fallback
-      const errCode =
-        commitErr instanceof Error && 'code' in commitErr
-          ? (commitErr as { code: number | string }).code
-          : undefined;
+      // 判定は splitPdf と共通の isFirestorePreconditionFailure ヘルパーを使う。
       const errMessage = unwrapErrorMessage(commitErr);
-      const isPreconditionFailure =
-        // (a) gRPC 数値 code
-        errCode === 9 || // FAILED_PRECONDITION
-        errCode === 5 || // NOT_FOUND
-        // (b) Cloud Functions 文字列 code
-        errCode === 'failed-precondition' ||
-        errCode === 'not-found' ||
-        // (c) error.message string fallback (SDK 型変動への防御)
-        /FAILED_PRECONDITION|NOT_FOUND|precondition|no document to update/i.test(errMessage);
-      if (isPreconditionFailure) {
+      if (isFirestorePreconditionFailure(commitErr)) {
         throw new HttpsError(
           'aborted',
           `Concurrent write detected during rotation (document updateTime drift): ${errMessage}`,

--- a/functions/test/rotatePdfPagesContract.test.ts
+++ b/functions/test/rotatePdfPagesContract.test.ts
@@ -74,9 +74,11 @@ function extractRollbackOrphanRotationFunctionBody(): string {
 
 describe('rotatePdfPages source code grep contract (PR-D3 AC3 拡張)', () => {
   let rotateBody: string;
+  let fileContent: string;
 
   before(() => {
     rotateBody = extractRotatePdfPagesFunctionBody();
+    fileContent = fs.readFileSync(SOURCE_PATH, 'utf-8');
   });
 
   describe('AC3: 旧 path 削除パターンの全面禁止 (rotatePdfPages 関数体内)', () => {
@@ -152,20 +154,26 @@ describe('rotatePdfPages source code grep contract (PR-D3 AC3 拡張)', () => {
       expect(rotateBody).to.match(/Concurrent write detected/i);
     });
 
-    it('gRPC FAILED_PRECONDITION (code 9) / NOT_FOUND (code 5) を concurrent write として扱う', () => {
+    it('precondition mismatch 判定は splitPdf と共通の isFirestorePreconditionFailure ヘルパーを呼ぶ (Issue #539で共通化)', () => {
+      // 判定ロジック自体は rotatePdfPages 関数体の外 (isFirestorePreconditionFailure) に
+      // 抽出されているため、rotateBody からは呼出し箇所のみを検証する
+      expect(rotateBody).to.match(/isFirestorePreconditionFailure\(commitErr\)/);
+    });
+
+    it('isFirestorePreconditionFailure: gRPC FAILED_PRECONDITION (code 9) / NOT_FOUND (code 5) を concurrent write として扱う', () => {
       // Firestore backend が precondition mismatch で発する gRPC code を catch して aborted に wrap
-      expect(rotateBody).to.match(/errCode === 9/);
-      expect(rotateBody).to.match(/errCode === 5/);
+      expect(fileContent).to.match(/errCode === 9/);
+      expect(fileContent).to.match(/errCode === 5/);
     });
 
-    it('Cloud Functions 文字列 code (failed-precondition / not-found) も OR 判定対象 (Evaluator CRITICAL Q1 SDK 型変動防御)', () => {
-      expect(rotateBody).to.match(/errCode === ['"]failed-precondition['"]/);
-      expect(rotateBody).to.match(/errCode === ['"]not-found['"]/);
+    it('isFirestorePreconditionFailure: Cloud Functions 文字列 code (failed-precondition / not-found) も OR 判定対象 (Evaluator CRITICAL Q1 SDK 型変動防御)', () => {
+      expect(fileContent).to.match(/errCode === ['"]failed-precondition['"]/);
+      expect(fileContent).to.match(/errCode === ['"]not-found['"]/);
     });
 
-    it('error.message regex fallback も OR 判定 (SDK 型変動の最終防御線)', () => {
+    it('isFirestorePreconditionFailure: error.message regex fallback も OR 判定 (SDK 型変動の最終防御線)', () => {
       // FAILED_PRECONDITION / NOT_FOUND / precondition / no document to update のいずれか string match
-      expect(rotateBody).to.match(
+      expect(fileContent).to.match(
         /FAILED_PRECONDITION\|NOT_FOUND\|precondition\|no document to update/
       );
     });

--- a/functions/test/splitPdfConcurrencyGuardContract.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardContract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * splitPdf 二重split race防止の grep contract テスト (Issue #539)
+ *
+ * splitPdf は同一documentIdへの並行呼出しに対する排他制御を持たない設計だったため、
+ * 二重クリック/クライアント再送等でstatus='split'書込みが競合すると、片方が生成した
+ * 子ドキュメントが親のsplitIntoから参照されない孤児になるリスクがあった
+ * (Issue #432と同種の「気づかれない重複・孤児データ」リスク)。
+ *
+ * 対策は2層 (rotatePdfPagesの既存パターンを踏襲):
+ *   1. 早期拒否: 読取り時点でstatus==='split'なら重い処理(PDF分割/Storage書込み)前に
+ *      already-existsで拒否する
+ *   2. 楽観的並行性制御: batch.update(docRef, ..., {lastUpdateTime})で、読取り〜書込みの
+ *      間に他プロセスが親docを更新していたら FAILED_PRECONDITION で commit 自体が拒否される
+ *
+ * ソース文字列レベルで配線の退行を防ぐ (splitPdfDocIdNamespace.test.ts と同形式)。
+ * precondition自体の実際のFirestore挙動は splitPdfConcurrencyGuardIntegration.test.ts
+ * (emulator) で検証する。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+// 削除すると Mocha esm-utils がこのファイルを ESM として load し、
+// `ReferenceError: __dirname is not defined in ES module scope` で test 全体が
+// load 失敗する (NodeNext + ローカル import なし時の挙動、splitPdfDocIdNamespace.test.ts と同型)。
+// 副作用ゼロの local import を 1 つ追加することで CJS loader に推論させる workaround。
+import '../src/storage/storageDeletionGuard';
+
+const SOURCE_PATH = resolve(__dirname, '..', 'src/pdf/pdfOperations.ts');
+const sourceText = readFileSync(SOURCE_PATH, 'utf-8');
+
+describe('splitPdf 二重split race防止 grep contract (Issue #539)', () => {
+  it("早期拒否: docData.status === 'split' なら already-exists で拒否する", () => {
+    expect(sourceText).to.match(/docData\.status === 'split'/);
+    expect(sourceText).to.match(/'already-exists'/);
+  });
+
+  it('早期拒否チェックは readDocWithDetail の直後、PDF download より前にある', () => {
+    const readIdx = sourceText.indexOf('await readDocWithDetail(db, docRef)');
+    const statusCheckIdx = sourceText.indexOf("docData.status === 'split'");
+    const downloadIdx = sourceText.indexOf('acquireSourceSnapshot(file)');
+    expect(readIdx).to.be.greaterThan(-1);
+    expect(statusCheckIdx, 'status check must be found').to.be.greaterThan(readIdx);
+    expect(downloadIdx).to.be.greaterThan(statusCheckIdx);
+  });
+
+  it('startUpdateTime を読取り時点のsnapshotから保持しnullガードする (retry時再代入のためlet)', () => {
+    expect(sourceText).to.match(/let startUpdateTime = docSnapshot\.updateTime;/);
+    expect(sourceText).to.match(/if \(!startUpdateTime\) \{/);
+  });
+
+  it('drift retry前に recheckParentBeforeRetry で親docを再チェックし startUpdateTime を更新する (Issue #539 fix: stale precondition誤検知防止)', () => {
+    expect(sourceText).to.match(/async function recheckParentBeforeRetry\(/);
+    // T1 (sourceSnapshot取得時drift) と T3 (final drift) の両方の retry 直前で呼ばれる
+    const callSites = sourceText.match(
+      /startUpdateTime = await recheckParentBeforeRetry\(docRef, documentId\);/g
+    );
+    expect(callSites, 'recheckParentBeforeRetry call sites must be found').to.not.be.null;
+    expect(callSites!.length, 'must be called at both T1 and T3 retry points').to.equal(2);
+  });
+
+  it('recheckParentBeforeRetry は already-exists / not-found / failed-precondition の3系統を判定する', () => {
+    const fnMatch = /async function recheckParentBeforeRetry\([\s\S]{0,900}?\n}/.exec(sourceText);
+    expect(fnMatch, 'recheckParentBeforeRetry function body must be found').to.not.be.null;
+    const fnBody = fnMatch![0];
+    expect(fnBody).to.match(/if \(!snap\.exists\) \{/);
+    expect(fnBody).to.match(/'not-found'/);
+    expect(fnBody).to.match(/data\.status === 'split'/);
+    expect(fnBody).to.match(/'already-exists'/);
+    expect(fnBody).to.match(/if \(!updateTime\) \{/);
+    expect(fnBody).to.match(/'failed-precondition'/);
+  });
+
+  it('親doc更新は lastUpdateTime precondition 付きの batch.update である', () => {
+    const updateMatch = /batch\.update\(\s*docRef,/.exec(sourceText);
+    const preconditionMatch = /\{\s*lastUpdateTime:\s*startUpdateTime\s*\}/.exec(sourceText);
+    expect(updateMatch, 'batch.update(docRef, ...) call site must be found').to.not.be.null;
+    expect(preconditionMatch, 'lastUpdateTime precondition must be found').to.not.be.null;
+    expect(preconditionMatch!.index).to.be.greaterThan(updateMatch!.index);
+  });
+
+  it('precondition mismatch は internal ではなく aborted で区別される (rotatePdfPagesと共通の isFirestorePreconditionFailure ヘルパー)', () => {
+    expect(sourceText).to.match(/function isFirestorePreconditionFailure\(/);
+    expect(sourceText).to.match(/isFirestorePreconditionFailure\(firestoreErr\)/);
+    expect(sourceText).to.match(/errCode === 9/); // FAILED_PRECONDITION (ヘルパー定義内)
+    expect(sourceText).to.match(/errCode === 'failed-precondition'/);
+    expect(sourceText).to.match(
+      /HttpsError\(\s*['"]aborted['"][\s\S]{0,200}concurrent split detected/
+    );
+  });
+
+  it('precondition mismatch 時も既存の Storage cleanup を経由してから aborted へ分岐する', () => {
+    const catchIdx = sourceText.indexOf('} catch (firestoreErr) {');
+    const cleanupCallMatch = /await cleanupAccumulatedStorageFiles\(\s*accumulated,\s*'firestoreBatch',/.exec(
+      sourceText
+    );
+    const preconditionCheckIdx = sourceText.indexOf(
+      'isFirestorePreconditionFailure(firestoreErr)'
+    );
+    expect(catchIdx).to.be.greaterThan(-1);
+    expect(cleanupCallMatch, 'cleanup call site must be found').to.not.be.null;
+    expect(cleanupCallMatch!.index).to.be.greaterThan(catchIdx);
+    expect(preconditionCheckIdx).to.be.greaterThan(cleanupCallMatch!.index);
+  });
+});

--- a/functions/test/splitPdfConcurrencyGuardContract.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardContract.test.ts
@@ -53,20 +53,25 @@ describe('splitPdf 二重split race防止 grep contract (Issue #539)', () => {
     expect(sourceText).to.match(/async function recheckParentBeforeRetry\(/);
     // T1 (sourceSnapshot取得時drift) と T3 (final drift) の両方の retry 直前で呼ばれる
     const callSites = sourceText.match(
-      /startUpdateTime = await recheckParentBeforeRetry\(docRef, documentId\);/g
+      /startUpdateTime = await recheckParentBeforeRetry\(docRef, documentId, docData\.status, fileUrl\);/g
     );
     expect(callSites, 'recheckParentBeforeRetry call sites must be found').to.not.be.null;
     expect(callSites!.length, 'must be called at both T1 and T3 retry points').to.equal(2);
   });
 
-  it('recheckParentBeforeRetry は already-exists / not-found / failed-precondition の3系統を判定する', () => {
-    const fnMatch = /async function recheckParentBeforeRetry\([\s\S]{0,900}?\n}/.exec(sourceText);
+  it('recheckParentBeforeRetry は already-exists / not-found / failed-precondition の3系統に加え status/fileUrl drift も判定する (Codex PR #623 P1 fix)', () => {
+    const fnMatch = /async function recheckParentBeforeRetry\([\s\S]{0,1400}?\n}/.exec(sourceText);
     expect(fnMatch, 'recheckParentBeforeRetry function body must be found').to.not.be.null;
     const fnBody = fnMatch![0];
     expect(fnBody).to.match(/if \(!snap\.exists\) \{/);
     expect(fnBody).to.match(/'not-found'/);
     expect(fnBody).to.match(/data\.status === 'split'/);
     expect(fnBody).to.match(/'already-exists'/);
+    // Codex P1: statusまたはfileUrlが初回読取りから変化していたら、docData/sourcePageResults等の
+    // 実処理データがstaleなままrebaseされてしまうため、updateTimeのみのrebaseは行わずabortする
+    expect(fnBody).to.match(
+      /data\.status !== expectedStatus \|\| data\.fileUrl !== expectedFileUrl/
+    );
     expect(fnBody).to.match(/if \(!updateTime\) \{/);
     expect(fnBody).to.match(/'failed-precondition'/);
   });

--- a/functions/test/splitPdfConcurrencyGuardIntegration.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardIntegration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * splitPdf 二重split race防止 integration テスト (Issue #539, Firestore emulator)
+ *
+ * pdfOperations.ts の splitPdf T4 (Firestore atomic batch write) に追加した
+ * lastUpdateTime precondition が、実際の Firestore emulator 上で意図通り機能するかを検証する。
+ * splitPdf 自体は pdf-lib / Storage 副作用が大きく直接呼べないため
+ * (splitPdfIntegration.test.ts と同方針)、T4 の書込み形 (batch.update(docRef, payload,
+ * { lastUpdateTime })) を再現して検証する。grep contract は
+ * splitPdfConcurrencyGuardContract.test.ts 側で実装配線を保護する。
+ *
+ * 実行: firebase emulators:exec --only firestore --project split-pdf-integration-test \
+ *         'npm run test:integration'
+ */
+
+import './helpers/initFirestoreEmulator';
+
+import { expect } from 'chai';
+import * as admin from 'firebase-admin';
+import { cleanupCollections } from './helpers/cleanupEmulator';
+
+const db = admin.firestore();
+const COLLECTIONS_TO_CLEAN: readonly string[] = ['documents'];
+
+// splitPdf T4 の親doc更新 (pdfOperations.ts: batch.update(docRef, payload, { lastUpdateTime }))
+// と同等の書き込みを再現する。
+async function commitSplitLikeParentUpdate(
+  docRef: admin.firestore.DocumentReference,
+  createdDocIds: string[],
+  lastUpdateTime: admin.firestore.Timestamp
+): Promise<void> {
+  const batch = db.batch();
+  batch.update(
+    docRef,
+    { splitInto: createdDocIds, status: 'split', isSplitSource: true },
+    { lastUpdateTime }
+  );
+  await batch.commit();
+}
+
+describe('splitPdf 二重split race防止 integration (#539)', () => {
+  beforeEach(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  it('drift無し(読取り後に親docが変更されていない)場合、precondition付きbatch.commitは成功する', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+
+    const snap = await docRef.get();
+    await commitSplitLikeParentUpdate(docRef, ['child-A'], snap.updateTime!);
+
+    const after = await docRef.get();
+    expect(after.data()!.status).to.equal('split');
+    expect(after.data()!.splitInto).to.deep.equal(['child-A']);
+  });
+
+  it('drift有り(読取り後に他プロセスが親docを更新済み)の場合、precondition付きbatch.commitはFAILED_PRECONDITIONで失敗する', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+
+    // 2並行呼出しを模す: 両方とも同じ古いsnapshotのupdateTimeを保持
+    const staleSnap = await docRef.get();
+    const staleUpdateTime = staleSnap.updateTime!;
+
+    // 1つ目のリクエストが先にsplitを完了させる (親docのupdateTimeが進む)
+    await commitSplitLikeParentUpdate(docRef, ['child-A'], staleUpdateTime);
+
+    // 2つ目のリクエストは古いupdateTimeのままcommitしようとして失敗するべき
+    let thrown: unknown;
+    try {
+      await commitSplitLikeParentUpdate(docRef, ['child-B'], staleUpdateTime);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown, 'second concurrent commit must throw').to.not.be.undefined;
+
+    // pdfOperations.ts の isPreconditionFailure 判定ロジックと同一条件で検証
+    // (実装と同じ3系統OR: gRPC数値code / Cloud Functions文字列code / message fallback)
+    const errCode =
+      thrown instanceof Error && 'code' in thrown
+        ? (thrown as { code: number | string }).code
+        : undefined;
+    const errMessage = thrown instanceof Error ? thrown.message : String(thrown);
+    const isPreconditionFailure =
+      errCode === 9 ||
+      errCode === 5 ||
+      errCode === 'failed-precondition' ||
+      errCode === 'not-found' ||
+      /FAILED_PRECONDITION|NOT_FOUND|precondition|no document to update/i.test(errMessage);
+    expect(
+      isPreconditionFailure,
+      `expected precondition failure, got code=${errCode} message=${errMessage}`
+    ).to.equal(true);
+
+    // 親docは1つ目のリクエストの結果のまま (2つ目の上書きが発生していないこと)
+    const after = await docRef.get();
+    expect(after.data()!.splitInto).to.deep.equal(['child-A']);
+  });
+
+  it('早期拒否をすり抜けたrace windowでも、T4のprecondition側で最終的に守られる', async () => {
+    // 早期拒否(docData.status==='split'チェック)はrace window(両方が旧statusを読む場合)を
+    // すり抜けうる。その場合でもT4のprecondition側で片方は必ず拒否されることを検証する。
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+    const staleSnap = await docRef.get();
+
+    await commitSplitLikeParentUpdate(docRef, ['child-A'], staleSnap.updateTime!);
+
+    let thrown = false;
+    try {
+      await commitSplitLikeParentUpdate(docRef, ['child-B'], staleSnap.updateTime!);
+    } catch {
+      thrown = true;
+    }
+    expect(thrown).to.equal(true);
+  });
+});
+
+// pdfOperations.ts の recheckParentBeforeRetry (Issue #539 fix) と同等のロジックを再現する。
+// source-drift retry の backoff 直後にこれを呼び、startUpdateTime を最新化することで
+// 「retry中に発生した二重split以外の正当な同時更新」を誤ってabortしなくなることを検証する。
+async function recheckParentLikeSplitPdf(
+  docRef: admin.firestore.DocumentReference,
+  documentId: string
+): Promise<admin.firestore.Timestamp> {
+  const snap = await docRef.get();
+  if (!snap.exists) {
+    throw Object.assign(new Error(`Document ${documentId} was deleted during splitPdf retry`), {
+      code: 'not-found',
+    });
+  }
+  const data = snap.data()!;
+  if (data.status === 'split') {
+    throw Object.assign(
+      new Error(`Document ${documentId} has already been split (status='split') (detected during retry)`),
+      { code: 'already-exists' }
+    );
+  }
+  const updateTime = snap.updateTime;
+  if (!updateTime) {
+    throw Object.assign(new Error('Document has no updateTime'), {
+      code: 'failed-precondition',
+    });
+  }
+  return updateTime;
+}
+
+describe('splitPdf drift-retry前の親doc再チェック (Issue #539 fix: stale startUpdateTime誤検知防止)', () => {
+  beforeEach(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  it('retry中に二重splitとは無関係な正当な更新(reprocess等)が入っても、再チェック後のupdateTimeでbatch.commitは成功する', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+    const staleUpdateTime = (await docRef.get()).updateTime!;
+
+    // source-drift retryのbackoff window中に、reprocess等の無関係な正当な操作が親docを更新する想定
+    await docRef.update({ status: 'processed', reprocessedAt: 'dummy' });
+
+    // 修正前: staleUpdateTimeのままcommitしようとしてFAILED_PRECONDITIONで誤ってabortしていた
+    let thrownWithStale = false;
+    try {
+      await commitSplitLikeParentUpdate(docRef, ['child-A'], staleUpdateTime);
+    } catch {
+      thrownWithStale = true;
+    }
+    expect(thrownWithStale, 'stale updateTimeでは誤ってprecondition失敗するはず(修正前の再現)').to.equal(
+      true
+    );
+
+    // 修正後: retry前にrecheckParentBeforeRetry相当で再取得したupdateTimeを使えば成功する
+    const refreshedUpdateTime = await recheckParentLikeSplitPdf(docRef, docRef.id);
+    await commitSplitLikeParentUpdate(docRef, ['child-A'], refreshedUpdateTime);
+
+    const after = await docRef.get();
+    expect(after.data()!.status).to.equal('split');
+    expect(after.data()!.splitInto).to.deep.equal(['child-A']);
+  });
+
+  it('retry前の再チェック時に既にstatus=split済みなら already-exists で即座に拒否する(無駄な再試行を避ける)', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+
+    // 他プロセスが既に本物のsplitを完了させた状態
+    await docRef.update({ status: 'split', splitInto: ['child-X'], isSplitSource: true });
+
+    let thrownCode: unknown;
+    try {
+      await recheckParentLikeSplitPdf(docRef, docRef.id);
+    } catch (err) {
+      thrownCode = (err as { code?: unknown }).code;
+    }
+    expect(thrownCode).to.equal('already-exists');
+  });
+
+  it('retry前の再チェック時に親docが削除されていたら not-found で拒否する', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+    await docRef.delete();
+
+    let thrownCode: unknown;
+    try {
+      await recheckParentLikeSplitPdf(docRef, docRef.id);
+    } catch (err) {
+      thrownCode = (err as { code?: unknown }).code;
+    }
+    expect(thrownCode).to.equal('not-found');
+  });
+});

--- a/functions/test/splitPdfConcurrencyGuardIntegration.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardIntegration.test.ts
@@ -116,12 +116,15 @@ describe('splitPdf 二重split race防止 integration (#539)', () => {
   });
 });
 
-// pdfOperations.ts の recheckParentBeforeRetry (Issue #539 fix) と同等のロジックを再現する。
-// source-drift retry の backoff 直後にこれを呼び、startUpdateTime を最新化することで
-// 「retry中に発生した二重split以外の正当な同時更新」を誤ってabortしなくなることを検証する。
+// pdfOperations.ts の recheckParentBeforeRetry (Issue #539 fix, Codex PR #623 P1 fix) と
+// 同等のロジックを再現する。source-drift retry の backoff 直後にこれを呼び、
+// status/fileUrlが初回読取りから変化していなければ startUpdateTime を最新化して継続、
+// 変化していれば(処理中のdocData等がstaleになるため)rebaseせず安全側にabortする。
 async function recheckParentLikeSplitPdf(
   docRef: admin.firestore.DocumentReference,
-  documentId: string
+  documentId: string,
+  expectedStatus: unknown,
+  expectedFileUrl: string
 ): Promise<admin.firestore.Timestamp> {
   const snap = await docRef.get();
   if (!snap.exists) {
@@ -134,6 +137,14 @@ async function recheckParentLikeSplitPdf(
     throw Object.assign(
       new Error(`Document ${documentId} has already been split (status='split') (detected during retry)`),
       { code: 'already-exists' }
+    );
+  }
+  if (data.status !== expectedStatus || data.fileUrl !== expectedFileUrl) {
+    throw Object.assign(
+      new Error(
+        `splitPdf aborted: parent document was modified during retry (documentId=${documentId}, status or fileUrl changed since initial read)`
+      ),
+      { code: 'aborted' }
     );
   }
   const updateTime = snap.updateTime;
@@ -150,13 +161,13 @@ describe('splitPdf drift-retry前の親doc再チェック (Issue #539 fix: stale
     await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
   });
 
-  it('retry中に二重splitとは無関係な正当な更新(reprocess等)が入っても、再チェック後のupdateTimeでbatch.commitは成功する', async () => {
+  it('retry中にstatus/fileUrlを変えない無関係な更新が入っても、再チェック後のupdateTimeでbatch.commitは成功する', async () => {
     const docRef = db.collection('documents').doc();
-    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+    await docRef.set({ fileName: 'a.pdf', status: 'processed', fileUrl: 'gs://bucket/a.pdf' });
     const staleUpdateTime = (await docRef.get()).updateTime!;
 
-    // source-drift retryのbackoff window中に、reprocess等の無関係な正当な操作が親docを更新する想定
-    await docRef.update({ status: 'processed', reprocessedAt: 'dummy' });
+    // source-drift retryのbackoff window中に、statusもfileUrlも変えない無関係な更新が入る想定
+    await docRef.update({ status: 'processed', someUnrelatedFlag: 'dummy' });
 
     // 修正前: staleUpdateTimeのままcommitしようとしてFAILED_PRECONDITIONで誤ってabortしていた
     let thrownWithStale = false;
@@ -169,8 +180,13 @@ describe('splitPdf drift-retry前の親doc再チェック (Issue #539 fix: stale
       true
     );
 
-    // 修正後: retry前にrecheckParentBeforeRetry相当で再取得したupdateTimeを使えば成功する
-    const refreshedUpdateTime = await recheckParentLikeSplitPdf(docRef, docRef.id);
+    // 修正後: status/fileUrlが不変なのでrebaseして継続、再取得したupdateTimeを使えば成功する
+    const refreshedUpdateTime = await recheckParentLikeSplitPdf(
+      docRef,
+      docRef.id,
+      'processed',
+      'gs://bucket/a.pdf'
+    );
     await commitSplitLikeParentUpdate(docRef, ['child-A'], refreshedUpdateTime);
 
     const after = await docRef.get();
@@ -180,14 +196,14 @@ describe('splitPdf drift-retry前の親doc再チェック (Issue #539 fix: stale
 
   it('retry前の再チェック時に既にstatus=split済みなら already-exists で即座に拒否する(無駄な再試行を避ける)', async () => {
     const docRef = db.collection('documents').doc();
-    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+    await docRef.set({ fileName: 'a.pdf', status: 'processed', fileUrl: 'gs://bucket/a.pdf' });
 
     // 他プロセスが既に本物のsplitを完了させた状態
     await docRef.update({ status: 'split', splitInto: ['child-X'], isSplitSource: true });
 
     let thrownCode: unknown;
     try {
-      await recheckParentLikeSplitPdf(docRef, docRef.id);
+      await recheckParentLikeSplitPdf(docRef, docRef.id, 'processed', 'gs://bucket/a.pdf');
     } catch (err) {
       thrownCode = (err as { code?: unknown }).code;
     }
@@ -196,15 +212,53 @@ describe('splitPdf drift-retry前の親doc再チェック (Issue #539 fix: stale
 
   it('retry前の再チェック時に親docが削除されていたら not-found で拒否する', async () => {
     const docRef = db.collection('documents').doc();
-    await docRef.set({ fileName: 'a.pdf', status: 'processed' });
+    await docRef.set({ fileName: 'a.pdf', status: 'processed', fileUrl: 'gs://bucket/a.pdf' });
     await docRef.delete();
 
     let thrownCode: unknown;
     try {
-      await recheckParentLikeSplitPdf(docRef, docRef.id);
+      await recheckParentLikeSplitPdf(docRef, docRef.id, 'processed', 'gs://bucket/a.pdf');
     } catch (err) {
       thrownCode = (err as { code?: unknown }).code;
     }
     expect(thrownCode).to.equal('not-found');
+  });
+
+  it('retry中にstatusが変化(reprocess等でpendingへ)していたら、docData/pageResults等がstaleなためrebaseせずabortする (Codex PR #623 P1 fix)', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed', fileUrl: 'gs://bucket/a.pdf' });
+
+    // reprocessは親docのstatusをpendingに変える(かつpageResults等の処理対象データもクリアする)
+    await docRef.update({ status: 'pending' });
+
+    let thrownCode: unknown;
+    try {
+      await recheckParentLikeSplitPdf(docRef, docRef.id, 'processed', 'gs://bucket/a.pdf');
+    } catch (err) {
+      thrownCode = (err as { code?: unknown }).code;
+    }
+    expect(
+      thrownCode,
+      'status変化時はstaleなdocData/pageResultsからのsplit完了を防ぐためabortedになるべき'
+    ).to.equal('aborted');
+  });
+
+  it('retry中にfileUrlが変化していたら、sourceObjectName等がstaleなためrebaseせずabortする (Codex PR #623 P1 fix)', async () => {
+    const docRef = db.collection('documents').doc();
+    await docRef.set({ fileName: 'a.pdf', status: 'processed', fileUrl: 'gs://bucket/a.pdf' });
+
+    // fileUrlだけが変化するケース(statusは変わらない)
+    await docRef.update({ fileUrl: 'gs://bucket/a-replaced.pdf' });
+
+    let thrownCode: unknown;
+    try {
+      await recheckParentLikeSplitPdf(docRef, docRef.id, 'processed', 'gs://bucket/a.pdf');
+    } catch (err) {
+      thrownCode = (err as { code?: unknown }).code;
+    }
+    expect(
+      thrownCode,
+      'fileUrl変化時はstaleなsourceObjectNameからのsplit完了を防ぐためabortedになるべき'
+    ).to.equal('aborted');
   });
 });

--- a/functions/test/splitPdfDetailDualWriteContract.test.ts
+++ b/functions/test/splitPdfDetailDualWriteContract.test.ts
@@ -74,12 +74,16 @@ describe('splitPdf detail/main dual-write contract (ADR-0018 Phase B)', () => {
     const detailSetIdx = sourceText.indexOf(
       "batch.set(item.newDocRef.collection('detail').doc('main'),"
     );
-    const parentUpdateIdx = sourceText.indexOf('batch.update(docRef, {');
+    // Issue #539: lastUpdateTime precondition 追加で batch.update(docRef, { が
+    // 複数行 (batch.update(\n docRef,\n {) に変わったため正規表現で検索する
+    const parentUpdateMatch = /batch\.update\(\s*docRef,/.exec(sourceText);
+    const parentUpdateIdx = parentUpdateMatch ? parentUpdateMatch.index : -1;
     const commitIdx = sourceText.indexOf('await batch.commit();');
     expect(loopIdx).to.be.greaterThan(-1);
     expect(detailSetIdx, 'detail/main batch.set call site must be found').to
       .be.greaterThan(loopIdx);
-    expect(parentUpdateIdx).to.be.greaterThan(detailSetIdx);
+    expect(parentUpdateIdx, 'parent batch.update(docRef, ...) call site must be found').to
+      .be.greaterThan(detailSetIdx);
     expect(commitIdx).to.be.greaterThan(parentUpdateIdx);
   });
 });

--- a/functions/test/splitPdfDocIdNamespace.test.ts
+++ b/functions/test/splitPdfDocIdNamespace.test.ts
@@ -101,8 +101,18 @@ describe('splitPdf cleanup / atomic write 設計 (Issue #445 PR-D2 atomic batch)
   it('Firestore batch 失敗時は HttpsError(internal) で原因 message を client へ surface する (/review-pr silent-failure-hunter C1)', () => {
     // 旧: throw wrapped (Error.cause) → INTERNAL に潰れる
     // 新: throw new HttpsError('internal', ...message + originalErr.message..., { stage: 'firestoreBatch', ... })
-    expect(content).to.match(/HttpsError\(\s*['"]internal['"][\s\S]{0,400}firestoreErr/);
+    // Issue #539: errMessage = unwrapErrorMessage(firestoreErr) の中間変数経由になったため
+    // firestoreErr直接参照ではなく errMessage を検索する (値の由来は unwrapErrorMessage(firestoreErr) 呼出で保証)
+    expect(content).to.match(/const errMessage = unwrapErrorMessage\(firestoreErr\)/);
+    expect(content).to.match(/HttpsError\(\s*['"]internal['"][\s\S]{0,400}errMessage/);
     expect(content).to.match(/stage:\s*['"]firestoreBatch['"]/);
+  });
+
+  it('Firestore batch commit の precondition mismatch (二重split race) は HttpsError(aborted) で区別される (Issue #539)', () => {
+    expect(content).to.match(/isFirestorePreconditionFailure\(firestoreErr\)/);
+    expect(content).to.match(
+      /HttpsError\(\s*['"]aborted['"][\s\S]{0,200}concurrent split detected/
+    );
   });
 
   it('drift 検出時は HttpsError aborted で投げ retry max 後に最終 fail する', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18316,6 +18316,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/logging": "^11.2.1",
+        "@google/genai": "^2.10.0",
         "@pdf-lib/fontkit": "^1.1.1",
         "firebase-admin": "^12.7.0",
         "pdf-lib": "1.17.1"


### PR DESCRIPTION
## Summary
- splitPdf(`functions/src/pdf/pdfOperations.ts`)に同一documentIdへの並行呼出しを防ぐ排他制御を追加。Issue #432と同種の「気づかれない孤児データ」リスクの再発防止。
  - 早期拒否: 読取り時点で`status==='split'`なら重い処理(PDF分割/Storage書込み)前に`already-exists`で拒否
  - 楽観的並行性制御: `batch.update`に`lastUpdateTime`preconditionを追加し、読取り〜書込み間の親doc変更を`FAILED_PRECONDITION`で検出、`aborted`として分類(既存の`rotatePdfPages`と共通の`isFirestorePreconditionFailure`ヘルパーに判定ロジックを統合、DRY違反を解消)
- `/code-review high`(8 finders → 1-vote verify)で実装直後に新たな正確性バグを検出・修正: source-drift retry(最大2回)のbackoff window中に`startUpdateTime`が再読込されず、二重splitとは無関係な正当な同時操作(reprocess等)まで誤って「二重split」と誤診断してabortしていた。retry直前に親docを再チェックする`recheckParentBeforeRetry`を追加してstale precondition窓を縮小。
- 同じcode-reviewで検出したその他7件の指摘(NOT_FOUND誤診断メッセージ/FE未対応/テストのvacuous risk)は、ユーザー判断によりスコープ外として別Issue化: #620, #621, #622

## Test plan
- [x] `npx tsc --noEmit` (src/test 両方) パス
- [x] `npm test` (unit, 1690 passing / 0 failing)
- [x] `firebase emulators:exec --only firestore -- npm run test:integration` (83 passing / 0 failing、新規6件のconcurrency guard integration testを含む)
- [x] `eslint` 変更ファイル エラー0件・警告0件
- [x] `/safe-refactor` でDRY違反(isFirestorePreconditionFailure重複)を検出・修正
- [x] `/code-review high` で8件検出、全件1-vote verifyでCONFIRMED。指摘1(stale startUpdateTime false-positive abort)を本PRで修正、残り7件は#620/#621/#622へ

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF splitting safeguards to prevent duplicate processing during concurrent updates.
  * Retries now recheck the parent document, detecting deletions or completed splits sooner.
  * Improved error handling for concurrent operations and other processing failures.

* **Tests**
  * Added integration coverage for concurrency, retries, stale updates, and parent document changes.
  * Expanded contract tests for concurrency protection and batch update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->