### PR TITLE
fix(ocr): OCR結果Storageの孤児オブジェクトをreprocess/supersede時に解消 (#625)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -741,6 +741,30 @@ function createDefaultOcrResultStorageAdapter(): OcrResultStorageAdapter {
 }
 
 /**
+ * 現在もこのrun(ocrRunId)がドキュメントの所有者であるかをFirestore再読みで確認する。
+ * 確認自体が失敗した場合は安全側に倒しfalse(=もはや現在のrunではない扱い)を返す。
+ */
+async function isStillCurrentOwner(
+  docRef: FirebaseFirestore.DocumentReference,
+  ocrRunId: string,
+  docId: string,
+  functionName: string
+): Promise<boolean> {
+  try {
+    const snap = await docRef.get();
+    return !shouldSkipSuccessCleanup(snap.exists, snap.data()?.ocrRunId, ocrRunId);
+  } catch (err) {
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:ocrResultCleanupVerify`,
+      documentId: docId,
+    });
+    return false;
+  }
+}
+
+/**
  * `ocr-results/{docId}/` 配下をlistingし、keepOcrRunId(あれば)に対応するオブジェクト
  * 以外をbest-effortで削除する (Issue #625)。
  *
@@ -751,12 +775,17 @@ function createDefaultOcrResultStorageAdapter(): OcrResultStorageAdapter {
  * クリア処理と競合して機能しない)。呼出しは最終transaction成功後(=確実にcommit済み)に
  * 限定すること。
  *
- * /code-review low 指摘反映: 呼出し前にドキュメントを再読みし、`ocrRunId`(このrun自身の
- * 所有権トークン)が依然最新であることを`shouldSkipSuccessCleanup`で確認してからcleanup
- * する。再読み時点で既に後続runにownershipが移っている場合はcleanup自体をスキップし、
- * 後続run自身の成功パスcleanupに委ねる(でなければ後続runが直近書き込んだ有効な
- * オブジェクトを、先行runの古い視点でのcleanupが誤削除しうる)。listing/削除いずれの
- * 失敗もOCR処理結果を巻き戻さず、safeLogErrorにのみ記録する。
+ * /code-review low 指摘反映: listing前に`isStillCurrentOwner`でドキュメントを再読みし、
+ * `ocrRunId`(このrun自身の所有権トークン)が依然最新であることを確認してからcleanupする。
+ * 再読み時点で既に後続runにownershipが移っている場合はcleanup自体をスキップし、後続run
+ * 自身の成功パスcleanupに委ねる(でなければ後続runが直近書き込んだ有効なオブジェクトを、
+ * 先行runの古い視点でのcleanupが誤削除しうる)。
+ *
+ * CodeRabbit指摘反映(PR #629): listing〜複数回delete の間にも同じレースが起こりうるため、
+ * 削除の都度`isStillCurrentOwner`で再検証し、supersedeを検知した時点で残りの削除を
+ * 中断する(レースウィンドウを「削除1件ごと」まで縮小する。完全な排除ではなくbest-effort
+ * 設計の残存リスク低減)。listing/削除いずれの失敗もOCR処理結果を巻き戻さず、
+ * safeLogErrorにのみ記録する。
  */
 async function cleanupOrphanedOcrResultObjects(
   docId: string,
@@ -767,21 +796,7 @@ async function cleanupOrphanedOcrResultObjects(
 ): Promise<void> {
   const docRef = db.doc(`documents/${docId}`);
 
-  let skip: boolean;
-  try {
-    const snap = await docRef.get();
-    skip = shouldSkipSuccessCleanup(snap.exists, snap.data()?.ocrRunId, ocrRunId);
-  } catch (err) {
-    await safeLogError({
-      error: err instanceof Error ? err : new Error(String(err)),
-      source: 'ocr',
-      functionName: `${functionName}:ocrResultCleanupVerify`,
-      documentId: docId,
-    });
-    return;
-  }
-
-  if (skip) {
+  if (!(await isStillCurrentOwner(docRef, ocrRunId, docId, functionName))) {
     console.log(
       `Skipping success-path cleanup for ${docId}: run ${ocrRunId} no longer current (superseded or document deleted)`
     );
@@ -796,6 +811,13 @@ async function cleanupOrphanedOcrResultObjects(
     const toDelete = computeOcrResultObjectsToDelete(allObjectNames, keepObjectName);
 
     for (const objectName of toDelete) {
+      if (!(await isStillCurrentOwner(docRef, ocrRunId, docId, functionName))) {
+        console.log(
+          `Aborting remaining cleanup for ${docId}: run ${ocrRunId} superseded mid-cleanup`
+        );
+        break;
+      }
+
       try {
         await adapter.deleteObject(objectName);
         console.log(`Deleted orphaned OCR result object: ${objectName}`);

--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -37,6 +37,12 @@ import { validatePageResultsForReuse } from './pageResultsReuse';
 import { resolveDetailFields } from './documentDetail';
 import { applyConfirmedFieldProtection } from './confirmedFieldMerge';
 import { buildOcrExcerpt } from './ocrExcerpt';
+import {
+  computeOcrResultObjectsToDelete,
+  shouldSkipCompensatingDelete,
+  shouldSkipSuccessCleanup,
+  type OcrResultStorageAdapter,
+} from './ocrResultCleanup';
 
 // #267: buildPageResult / 型は ./buildPageResult モジュールに移設。
 // #278: 型名 PageOcrResult → RawPageOcrResult にリネーム (shared/types.ts の post-processed
@@ -356,102 +362,119 @@ export async function processDocument(
   // stale snapshot問題が起きる(Issue #526本文の設計要件)。
   const docRef = db.doc(`documents/${docId}`);
 
-  await db.runTransaction(async (tx) => {
-    const freshSnap = await tx.get(docRef);
-    // tryStartProcessing() と同じ存在チェックパターン。
-    // ドキュメントが処理中に削除されると tx.update() は NOT_FOUND を投げるが、
-    // ここで明示的に検知することで handleProcessingError() の lastErrorMessage に
-    // 原因不明な NOT_FOUND ではなく具体的な状況が残る(silent-failure-hunter指摘)。
-    if (!freshSnap.exists) {
-      throw new Error(
-        `Document ${docId} was deleted during OCR processing, aborting confirmed-merge update`
+  try {
+    await db.runTransaction(async (tx) => {
+      const freshSnap = await tx.get(docRef);
+      // tryStartProcessing() と同じ存在チェックパターン。
+      // ドキュメントが処理中に削除されると tx.update() は NOT_FOUND を投げるが、
+      // ここで明示的に検知することで handleProcessingError() の lastErrorMessage に
+      // 原因不明な NOT_FOUND ではなく具体的な状況が残る(silent-failure-hunter指摘)。
+      if (!freshSnap.exists) {
+        throw new Error(
+          `Document ${docId} was deleted during OCR processing, aborting confirmed-merge update`
+        );
+      }
+      const freshData = freshSnap.data()!;
+
+      // Issue #540: 所有権(ocrRunId)・入力世代(fileUrl/mimeType)検証。処理開始からOCR完了
+      // までの間(最大540秒)に、reprocess等で別の実行が同一docIdに対して開始されている、
+      // またはfileUrl/mimeTypeが変化している場合、この実行の抽出結果はもはや正しい対象を
+      // 表していない。書込みを一切行わずOcrRunSupersededErrorをthrowしてabortする
+      // (呼出元processOCR.tsはこれをエラーではなく正常なsupersedeとして扱う)。
+      const ownership = evaluateOcrRunOwnership(freshData, {
+        ocrRunId,
+        fileUrl: docData.fileUrl as string,
+        mimeType: docData.mimeType as string,
+      });
+      if (!ownership.ok) {
+        throw new OcrRunSupersededError(
+          `OCR run for document ${docId} superseded (reason: ${ownership.reason}), skipping write`,
+          docId,
+          ownership.reason,
+          {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+            thinkingTokens: totalThinkingTokens,
+            pagesProcessed: totalPages,
+          }
+        );
+      }
+
+      const merged = applyConfirmedFieldProtection(extractionFields, {
+        customerConfirmed: freshData.customerConfirmed,
+        officeConfirmed: freshData.officeConfirmed,
+        documentTypeConfirmed: freshData.documentTypeConfirmed,
+        customerName: freshData.customerName,
+        customerId: freshData.customerId,
+        careManager: freshData.careManager,
+        isDuplicateCustomer: freshData.isDuplicateCustomer,
+        needsManualCustomerSelection: freshData.needsManualCustomerSelection,
+        confirmedBy: freshData.confirmedBy,
+        confirmedAt: freshData.confirmedAt,
+        officeName: freshData.officeName,
+        officeId: freshData.officeId,
+        officeConfirmedBy: freshData.officeConfirmedBy,
+        officeConfirmedAt: freshData.officeConfirmedAt,
+        documentType: freshData.documentType,
+        category: freshData.category,
+      });
+
+      // displayFileName 生成 (#178 Stage 1、Issue #526 D2でマージ後の最終メタから生成)
+      // 「未判定」「不明顧客」等のデフォルト値・日付のみでの識別不能な名前生成の抑制は
+      // generateDisplayFileName内部で行うため、ここでは merged の値をそのまま渡す。
+      const displayFileName = generateDisplayFileName({
+        documentType: merged.documentType,
+        customerName: merged.customerName,
+        officeName: merged.officeName,
+        fileDate: dateResult.formattedDate ?? undefined,
+      });
+
+      // ドキュメント更新
+      // Issue #548-B1: 要約は自動生成しない (regenerateSummary onCall 経由の手動生成のみ)。
+      // OCR再実行のたびに summary を無効化することで、documentType/customerName/officeName等が
+      // 更新されたのに古い内容の要約が残存する不整合 (429自動rescue・fix-stuck-documents.js等、
+      // getReprocessClearFields()を経由しない再処理経路でも発生しうる) を構造的に防ぐ。
+      // summary/summaryTruncated/summaryOriginalLengthの3フィールドを同時削除する。
+      // 後2者はIssue #215以前の旧フラット形式の残骸クリーンアップ(前方互換とは無関係)。
+      tx.update(docRef, {
+        ...merged,
+        ...(displayFileName ? { displayFileName } : {}),
+        summary: admin.firestore.FieldValue.delete(),
+        summaryTruncated: admin.firestore.FieldValue.delete(),
+        summaryOriginalLength: admin.firestore.FieldValue.delete(),
+        ocrExcerpt,
+        status: 'processed',
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      // ADR-0018 (Issue #547) Phase E: ocrResult/pageResultsはdetail/mainにのみ書く
+      // (本体updateの`merged`は型レベルでこれらを含まない、ocrUpdatePayloadBuilder.ts参照)。
+      // 本体updateと同一transactionでのdetail/main書込みはMUST: 原子性(2回の独立書込は禁止)。
+      tx.set(docRef.collection('detail').doc('main'), {
+        ocrResult: savedOcrResult,
+        pageResults,
+      });
+
+      console.log(
+        `Document ${docId} processed: ${merged.documentType}, ${merged.customerName}`
       );
+    });
+  } catch (err) {
+    // Issue #625: 最終transaction失敗時(supersede/ドキュメント削除/その他エラー)、
+    // 今回このrunがStorageに新規作成したオブジェクトをbest-effortで補償削除してから、
+    // 元のエラーをそのままre-throwする(呼出元processOCR.tsのsupersede/エラー処理は
+    // 一切変更しない)。
+    if (ocrResultUrl) {
+      await compensateDeleteOnFailure(docId, ocrRunId, functionName);
     }
-    const freshData = freshSnap.data()!;
+    throw err;
+  }
 
-    // Issue #540: 所有権(ocrRunId)・入力世代(fileUrl/mimeType)検証。処理開始からOCR完了
-    // までの間(最大540秒)に、reprocess等で別の実行が同一docIdに対して開始されている、
-    // またはfileUrl/mimeTypeが変化している場合、この実行の抽出結果はもはや正しい対象を
-    // 表していない。書込みを一切行わずOcrRunSupersededErrorをthrowしてabortする
-    // (呼出元processOCR.tsはこれをエラーではなく正常なsupersedeとして扱う)。
-    const ownership = evaluateOcrRunOwnership(freshData, {
-      ocrRunId,
-      fileUrl: docData.fileUrl as string,
-      mimeType: docData.mimeType as string,
-    });
-    if (!ownership.ok) {
-      throw new OcrRunSupersededError(
-        `OCR run for document ${docId} superseded (reason: ${ownership.reason}), skipping write`,
-        docId,
-        ownership.reason,
-        {
-          inputTokens: totalInputTokens,
-          outputTokens: totalOutputTokens,
-          thinkingTokens: totalThinkingTokens,
-          pagesProcessed: totalPages,
-        }
-      );
-    }
-
-    const merged = applyConfirmedFieldProtection(extractionFields, {
-      customerConfirmed: freshData.customerConfirmed,
-      officeConfirmed: freshData.officeConfirmed,
-      documentTypeConfirmed: freshData.documentTypeConfirmed,
-      customerName: freshData.customerName,
-      customerId: freshData.customerId,
-      careManager: freshData.careManager,
-      isDuplicateCustomer: freshData.isDuplicateCustomer,
-      needsManualCustomerSelection: freshData.needsManualCustomerSelection,
-      confirmedBy: freshData.confirmedBy,
-      confirmedAt: freshData.confirmedAt,
-      officeName: freshData.officeName,
-      officeId: freshData.officeId,
-      officeConfirmedBy: freshData.officeConfirmedBy,
-      officeConfirmedAt: freshData.officeConfirmedAt,
-      documentType: freshData.documentType,
-      category: freshData.category,
-    });
-
-    // displayFileName 生成 (#178 Stage 1、Issue #526 D2でマージ後の最終メタから生成)
-    // 「未判定」「不明顧客」等のデフォルト値・日付のみでの識別不能な名前生成の抑制は
-    // generateDisplayFileName内部で行うため、ここでは merged の値をそのまま渡す。
-    const displayFileName = generateDisplayFileName({
-      documentType: merged.documentType,
-      customerName: merged.customerName,
-      officeName: merged.officeName,
-      fileDate: dateResult.formattedDate ?? undefined,
-    });
-
-    // ドキュメント更新
-    // Issue #548-B1: 要約は自動生成しない (regenerateSummary onCall 経由の手動生成のみ)。
-    // OCR再実行のたびに summary を無効化することで、documentType/customerName/officeName等が
-    // 更新されたのに古い内容の要約が残存する不整合 (429自動rescue・fix-stuck-documents.js等、
-    // getReprocessClearFields()を経由しない再処理経路でも発生しうる) を構造的に防ぐ。
-    // summary/summaryTruncated/summaryOriginalLengthの3フィールドを同時削除する。
-    // 後2者はIssue #215以前の旧フラット形式の残骸クリーンアップ(前方互換とは無関係)。
-    tx.update(docRef, {
-      ...merged,
-      ...(displayFileName ? { displayFileName } : {}),
-      summary: admin.firestore.FieldValue.delete(),
-      summaryTruncated: admin.firestore.FieldValue.delete(),
-      summaryOriginalLength: admin.firestore.FieldValue.delete(),
-      ocrExcerpt,
-      status: 'processed',
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
-
-    // ADR-0018 (Issue #547) Phase E: ocrResult/pageResultsはdetail/mainにのみ書く
-    // (本体updateの`merged`は型レベルでこれらを含まない、ocrUpdatePayloadBuilder.ts参照)。
-    // 本体updateと同一transactionでのdetail/main書込みはMUST: 原子性(2回の独立書込は禁止)。
-    tx.set(docRef.collection('detail').doc('main'), {
-      ocrResult: savedOcrResult,
-      pageResults,
-    });
-
-    console.log(
-      `Document ${docId} processed: ${merged.documentType}, ${merged.customerName}`
-    );
-  });
+  // Issue #625: transaction成功後(=確実にcommit済み)、ocr-results/{docId}/配下を
+  // 正規化する。今回Storageに保存した場合はそのrunのみ残し、保存しなかった場合は
+  // (OCR結果がFirestore本体にインライン保持されている)配下の全オブジェクトを孤児と
+  // みなして削除する。
+  await cleanupOrphanedOcrResultObjects(docId, ocrRunId, ocrResultUrl ? ocrRunId : null, functionName);
 
   return {
     pagesProcessed: totalPages,
@@ -699,4 +722,147 @@ async function saveOcrResult(docId: string, ocrRunId: string, ocrResult: string)
   );
 
   return `gs://${bucket.name}/${objectPath}`;
+}
+
+function createDefaultOcrResultStorageAdapter(): OcrResultStorageAdapter {
+  const bucket = storage.bucket();
+  return {
+    async listObjectNames(prefix: string): Promise<string[]> {
+      const [files] = await bucket.getFiles({ prefix });
+      return files.map((f) => f.name);
+    },
+    async deleteObject(objectName: string): Promise<void> {
+      await withRetry(
+        () => bucket.file(objectName).delete({ ignoreNotFound: true }),
+        RETRY_CONFIGS.storage
+      );
+    },
+  };
+}
+
+/**
+ * `ocr-results/{docId}/` 配下をlistingし、keepOcrRunId(あれば)に対応するオブジェクト
+ * 以外をbest-effortで削除する (Issue #625)。
+ *
+ * FE側のreprocessクリア処理(getReprocessClearFields、reprocess開始時にocrResultUrlを
+ * 即座にdeleteFieldする)のタイミングに依存せず、Storage自体をsource of truthとして
+ * 扱うことで、通常のreprocessサイクルで生じる孤児オブジェクトを解消する(Codexセカンド
+ * オピニオンでの指摘: Firestoreのフィールド値を頼りに旧URLを特定する設計は、reprocess
+ * クリア処理と競合して機能しない)。呼出しは最終transaction成功後(=確実にcommit済み)に
+ * 限定すること。
+ *
+ * /code-review low 指摘反映: 呼出し前にドキュメントを再読みし、`ocrRunId`(このrun自身の
+ * 所有権トークン)が依然最新であることを`shouldSkipSuccessCleanup`で確認してからcleanup
+ * する。再読み時点で既に後続runにownershipが移っている場合はcleanup自体をスキップし、
+ * 後続run自身の成功パスcleanupに委ねる(でなければ後続runが直近書き込んだ有効な
+ * オブジェクトを、先行runの古い視点でのcleanupが誤削除しうる)。listing/削除いずれの
+ * 失敗もOCR処理結果を巻き戻さず、safeLogErrorにのみ記録する。
+ */
+async function cleanupOrphanedOcrResultObjects(
+  docId: string,
+  ocrRunId: string,
+  keepOcrRunId: string | null,
+  functionName: string,
+  adapter: OcrResultStorageAdapter = createDefaultOcrResultStorageAdapter()
+): Promise<void> {
+  const docRef = db.doc(`documents/${docId}`);
+
+  let skip: boolean;
+  try {
+    const snap = await docRef.get();
+    skip = shouldSkipSuccessCleanup(snap.exists, snap.data()?.ocrRunId, ocrRunId);
+  } catch (err) {
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:ocrResultCleanupVerify`,
+      documentId: docId,
+    });
+    return;
+  }
+
+  if (skip) {
+    console.log(
+      `Skipping success-path cleanup for ${docId}: run ${ocrRunId} no longer current (superseded or document deleted)`
+    );
+    return;
+  }
+
+  const prefix = `ocr-results/${docId}/`;
+  const keepObjectName = keepOcrRunId ? `${prefix}${keepOcrRunId}.txt` : null;
+
+  try {
+    const allObjectNames = await adapter.listObjectNames(prefix);
+    const toDelete = computeOcrResultObjectsToDelete(allObjectNames, keepObjectName);
+
+    for (const objectName of toDelete) {
+      try {
+        await adapter.deleteObject(objectName);
+        console.log(`Deleted orphaned OCR result object: ${objectName}`);
+      } catch (err) {
+        await safeLogError({
+          error: err instanceof Error ? err : new Error(String(err)),
+          source: 'ocr',
+          functionName: `${functionName}:ocrResultCleanup`,
+          documentId: docId,
+        });
+      }
+    }
+  } catch (err) {
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:ocrResultCleanupListing`,
+      documentId: docId,
+    });
+  }
+}
+
+/**
+ * 最終transaction失敗時、今回のrunがStorageに新規作成したオブジェクトを
+ * best-effortで補償削除する (Issue #625)。
+ *
+ * 削除前にドキュメントを再読みし `shouldSkipCompensatingDelete` で安全確認する。
+ * 確認自体が失敗した場合は安全側に倒し削除をスキップする(リーク許容)。
+ */
+async function compensateDeleteOnFailure(
+  docId: string,
+  ocrRunId: string,
+  functionName: string,
+  adapter: OcrResultStorageAdapter = createDefaultOcrResultStorageAdapter()
+): Promise<void> {
+  const docRef = db.doc(`documents/${docId}`);
+  const objectName = `ocr-results/${docId}/${ocrRunId}.txt`;
+
+  let skip: boolean;
+  try {
+    const snap = await docRef.get();
+    const data = snap.data();
+    skip = shouldSkipCompensatingDelete(snap.exists, data?.status, data?.ocrRunId, ocrRunId);
+  } catch (err) {
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:ocrResultCompensateVerify`,
+      documentId: docId,
+    });
+    return;
+  }
+
+  if (skip) {
+    console.log(`Skipping compensating delete for ${docId}: run ${ocrRunId} was actually adopted`);
+    return;
+  }
+
+  try {
+    await adapter.deleteObject(objectName);
+    console.log(`Compensating delete of orphaned OCR result object: ${objectName}`);
+  } catch (err) {
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:ocrResultCleanup`,
+      documentId: docId,
+    });
+  }
 }

--- a/functions/src/ocr/ocrResultCleanup.ts
+++ b/functions/src/ocr/ocrResultCleanup.ts
@@ -1,0 +1,77 @@
+/**
+ * OCR結果Storageオブジェクト孤児化クリーンアップの純粋ロジック (Issue #625)
+ *
+ * `ocr-results/{docId}/{ocrRunId}.txt` はrun毎に分離されているため、reprocessの度に
+ * 新しいrunが新しいパスへオブジェクトを作成し、旧オブジェクトは誰にも削除されず孤児化する。
+ * FE側のreprocessクリア処理(getReprocessClearFields、frontend/src/hooks/useDocuments.ts)は
+ * `ocrResultUrl`フィールドをreprocess開始時に即座にdeleteFieldするため、Firestoreの
+ * フィールド値を頼りに旧URLを特定する設計は機能しない(Codexセカンドオピニオンで指摘)。
+ * 本モジュールの純粋関数は、Cloud Storage自体をsource of truthとして扱う設計を支える。
+ *
+ * firebase-admin初期化なしで検証できるよう、ocrProcessor.tsとは独立したモジュールに
+ * 分離する(summaryPromptBuilder.ts等、このディレクトリの既存パターンを踏襲)。
+ */
+
+/**
+ * OCR結果Storageオブジェクトのlist/delete操作を抽象化するアダプタ。
+ * テスト時にfake実装へ差し替えることで、実Storageに触れずcleanup/補償削除の
+ * 呼出し配線を検証できる。
+ */
+export interface OcrResultStorageAdapter {
+  listObjectNames(prefix: string): Promise<string[]>;
+  deleteObject(objectName: string): Promise<void>;
+}
+
+/**
+ * OCR結果Storageオブジェクトのクリーンアップ対象を計算する。
+ *
+ * `ocr-results/{docId}/` 配下の全オブジェクト名から、残すべき1件(keepObjectName)を
+ * 除いた削除対象を返す。keepObjectNameがnullの場合は全件削除対象とする(今回の実行で
+ * Storage保存が発生しなかった=OCR結果がFirestore本体にインライン保持されている場合)。
+ */
+export function computeOcrResultObjectsToDelete(
+  allObjectNames: string[],
+  keepObjectName: string | null
+): string[] {
+  return allObjectNames.filter((name) => name !== keepObjectName);
+}
+
+/**
+ * 補償削除の安全確認 (Codexセカンドオピニオン指摘反映)。
+ *
+ * 最終transactionのthrowは「未commitの確証」にはならない(ローカルにはエラーが
+ * 返っても実際にはサーバー側でcommit済みの場合がありうる)。再読みしたドキュメントが
+ * `status: 'processed'` かつ `ocrRunId` が今回のrunと一致する場合、このrunは実際には
+ * 採用されていた(transactionは実は成功していた)と判断し、削除をスキップする。
+ */
+export function shouldSkipCompensatingDelete(
+  docExists: boolean,
+  docStatus: string | undefined,
+  docOcrRunId: string | undefined,
+  ocrRunId: string
+): boolean {
+  return docExists && docStatus === 'processed' && docOcrRunId === ocrRunId;
+}
+
+/**
+ * 成功パスcleanupの安全確認 (/code-review low 指摘反映)。
+ *
+ * 「このrunの最終transactionが成功した」ことは、cleanup実行**時点**でこのrunが依然
+ * 最新であることを保証しない。reprocess等で後続run(次のocrRunId)が既にclaimしている
+ * 場合、後続runは自分自身の成功時にownの成功パスcleanupを実行し「後続run自身のオブジェクト
+ * のみkeep・他は削除」する。この状態でさらに先行runのcleanupが「先行run自身のオブジェクト
+ * のみkeep」で実行されると、後続runが直近書き込んだ有効なオブジェクトを誤削除し、
+ * Firestoreの`ocrResultUrl`が指す実体が消失する(孤児化より深刻な退行)。
+ *
+ * cleanup実行直前にドキュメントを再読みし、`ocrRunId`が既に別の値に変わっている
+ * (=後続runにより上書きされた)場合はcleanup自体をスキップする(後続run自身の
+ * cleanup呼出しに委ねる)。ドキュメントが削除されている場合もスキップする(削除時の
+ * 孤児化はdeleteDocument.ts側の別経路、本Issueのスコープ外)。
+ */
+export function shouldSkipSuccessCleanup(
+  docExists: boolean,
+  docOcrRunId: string | undefined,
+  ocrRunId: string
+): boolean {
+  return !docExists || docOcrRunId !== ocrRunId;
+}

--- a/functions/test/ocrProcessorOcrResultCleanupWiringContract.test.ts
+++ b/functions/test/ocrProcessorOcrResultCleanupWiringContract.test.ts
@@ -20,37 +20,53 @@ const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
 const PROCESS_DOCUMENT_ANCHOR = /export\s+async\s+function\s+processDocument\s*\(/;
 
 const CLEANUP_FN_ANCHOR = /async\s+function\s+cleanupOrphanedOcrResultObjects\s*\(/;
+const IS_CURRENT_OWNER_FN_ANCHOR = /async\s+function\s+isStillCurrentOwner\s*\(/;
+
+/**
+ * ファイル内で anchor が単一マッチであることを表明するヘルパー。
+ * 2つ目の定義が追加された場合、extractBraceBlock の anchor は最初の定義に
+ * マッチし続けるため、narrow 漏れによる vacuous test (#622 同種) を防ぐ。
+ */
+function expectSingleDefinition(source: string, pattern: RegExp, label: string): void {
+  const count = (source.match(pattern) ?? []).length;
+  expect(count, `${label} の定義が複数存在する場合は anchor の narrow が必要`).to.equal(1);
+}
 
 describe('ocrProcessor OCR結果クリーンアップ配線契約 (Issue #625)', () => {
   let processDocumentBody = '';
   let cleanupFunctionBody = '';
+  let isStillCurrentOwnerBody = '';
 
   before(() => {
     const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
     const source = readFileSync(absPath, 'utf-8');
 
-    // processDocument はファイル内で1つのみ定義されている前提。2つ目が追加された場合、
-    // 本 anchor は最初の定義にマッチし続けるため、その時点で narrow が必要になる。
-    const defCount = (source.match(/export\s+async\s+function\s+processDocument\s*\(/g) ?? [])
-      .length;
-    expect(defCount, 'processDocument の定義が複数存在する場合は anchor の narrow が必要').to.equal(
-      1
+    expectSingleDefinition(
+      source,
+      /export\s+async\s+function\s+processDocument\s*\(/g,
+      'processDocument'
     );
-
     const body = extractBraceBlock(source, PROCESS_DOCUMENT_ANCHOR);
     expect(body, 'processDocument 関数本体の抽出に失敗した').to.not.be.null;
     processDocumentBody = body!;
 
-    const cleanupDefCount = (
-      source.match(/async\s+function\s+cleanupOrphanedOcrResultObjects\s*\(/g) ?? []
-    ).length;
-    expect(
-      cleanupDefCount,
-      'cleanupOrphanedOcrResultObjects の定義が複数存在する場合は anchor の narrow が必要'
-    ).to.equal(1);
+    expectSingleDefinition(
+      source,
+      /async\s+function\s+cleanupOrphanedOcrResultObjects\s*\(/g,
+      'cleanupOrphanedOcrResultObjects'
+    );
     const cleanupBody = extractBraceBlock(source, CLEANUP_FN_ANCHOR);
     expect(cleanupBody, 'cleanupOrphanedOcrResultObjects 関数本体の抽出に失敗した').to.not.be.null;
     cleanupFunctionBody = cleanupBody!;
+
+    expectSingleDefinition(
+      source,
+      /async\s+function\s+isStillCurrentOwner\s*\(/g,
+      'isStillCurrentOwner'
+    );
+    const ownerCheckBody = extractBraceBlock(source, IS_CURRENT_OWNER_FN_ANCHOR);
+    expect(ownerCheckBody, 'isStillCurrentOwner 関数本体の抽出に失敗した').to.not.be.null;
+    isStillCurrentOwnerBody = ownerCheckBody!;
   });
 
   /**
@@ -134,26 +150,65 @@ describe('ocrProcessor OCR結果クリーンアップ配線契約 (Issue #625)',
     expect(cleanupIdx).to.be.lessThan(returnIdx);
   });
 
-  it('cleanupOrphanedOcrResultObjectsはlisting/削除前にshouldSkipSuccessCleanupで所有権を再確認する (/code-review low 指摘反映)', () => {
-    // 先行run自身の古い視点でのcleanupが、後続runが直近書き込んだ有効なオブジェクトを
-    // 誤削除するレースを防ぐための安全確認。listing呼出しより前に配線されていること、
-    // skip時はlisting自体を実行せずreturnすることを検証する。
-    expect(cleanupFunctionBody).to.match(
+  it('isStillCurrentOwnerはshouldSkipSuccessCleanupを正しい引数で呼ぶ', () => {
+    expect(isStillCurrentOwnerBody).to.match(
       /shouldSkipSuccessCleanup\s*\(\s*snap\.exists\s*,\s*snap\.data\(\)\?\.\s*ocrRunId\s*,\s*ocrRunId\s*\)/,
       'shouldSkipSuccessCleanupが正しい引数で呼ばれていない'
     );
+  });
 
-    const skipCheckIdx = cleanupFunctionBody.indexOf('shouldSkipSuccessCleanup(');
+  it('cleanupOrphanedOcrResultObjectsはlisting前にisStillCurrentOwnerで所有権を再確認する', () => {
+    // 先行run自身の古い視点でのcleanupが、後続runが直近書き込んだ有効なオブジェクトを
+    // 誤削除するレースを防ぐための安全確認。listing呼出しより前に配線されていること、
+    // skip時はlisting自体を実行せずreturnすることを検証する(#622同種のvacuous test防止のため、
+    // isStillCurrentOwner自体はisStillCurrentOwnerBodyで別途配線確認済み)。
+    const preCheckIdx = cleanupFunctionBody.indexOf('isStillCurrentOwner(');
     const listingIdx = cleanupFunctionBody.indexOf('adapter.listObjectNames(');
-    expect(skipCheckIdx, 'shouldSkipSuccessCleanup呼出が見つからない').to.be.greaterThan(-1);
+    expect(preCheckIdx, 'listing前のisStillCurrentOwner呼出が見つからない').to.be.greaterThan(-1);
     expect(listingIdx, 'adapter.listObjectNames呼出が見つからない').to.be.greaterThan(-1);
-    expect(skipCheckIdx, 'shouldSkipSuccessCleanupがlistingより後に配線されている').to.be.lessThan(
+    expect(preCheckIdx, 'isStillCurrentOwnerがlistingより後に配線されている').to.be.lessThan(
       listingIdx
     );
 
     expect(cleanupFunctionBody).to.match(
-      /if\s*\(\s*skip\s*\)\s*\{[\s\S]*?return\s*;[\s\S]*?\}/,
-      'skip=trueの場合にreturnしていない — listing/削除が実行されてしまう'
+      /if\s*\(\s*!\s*\(\s*await\s+isStillCurrentOwner\s*\([\s\S]*?\)\s*\)\s*\)\s*\{[\s\S]*?return\s*;/,
+      'isStillCurrentOwnerがfalseの場合にreturnしていない — listing/削除が実行されてしまう'
     );
+  });
+
+  it('cleanupOrphanedOcrResultObjectsは削除ループ内でも都度isStillCurrentOwnerを再検証しbreakする (CodeRabbit指摘反映 PR #629)', () => {
+    // listing〜複数回deleteの間にも同じレースが起こりうるため、削除の都度所有権を
+    // 再検証し、supersedeを検知した時点で残りの削除を中断してレースウィンドウを
+    // 「削除1件ごと」まで縮小する。
+    const forLoopIdx = cleanupFunctionBody.indexOf('for (const objectName of toDelete)');
+    expect(forLoopIdx, 'for (const objectName of toDelete) ループが見つからない').to.be.greaterThan(
+      -1
+    );
+    const ownerCheckCallCount = (cleanupFunctionBody.match(/isStillCurrentOwner\s*\(/g) ?? [])
+      .length;
+    expect(
+      ownerCheckCallCount,
+      'isStillCurrentOwner呼出がlisting前+ループ内の2箇所存在しない — 削除毎の再検証が配線されていない'
+    ).to.equal(2);
+
+    const loopBody = extractBraceBlock(
+      cleanupFunctionBody.slice(forLoopIdx),
+      'for (const objectName of toDelete)',
+      { anchorMode: 'after-match' }
+    );
+    expect(loopBody, 'for ループ本体の抽出に失敗した').to.not.be.null;
+    expect(loopBody).to.match(
+      /if\s*\(\s*!\s*\(\s*await\s+isStillCurrentOwner\s*\([\s\S]*?\)\s*\)\s*\)\s*\{[\s\S]*?break\s*;/,
+      'ループ内でisStillCurrentOwnerがfalseの場合にbreakしていない — supersede後も削除を継続してしまう'
+    );
+
+    const loopOwnerCheckIdx = loopBody!.indexOf('isStillCurrentOwner(');
+    const loopDeleteIdx = loopBody!.indexOf('adapter.deleteObject(');
+    expect(loopOwnerCheckIdx, 'ループ内のisStillCurrentOwner呼出が見つからない').to.be.greaterThan(
+      -1
+    );
+    expect(loopDeleteIdx, 'ループ内のadapter.deleteObject呼出が見つからない').to.be.greaterThan(-1);
+    expect(loopOwnerCheckIdx, 'ループ内でisStillCurrentOwnerがdeleteより後に配線されている').to.be
+      .lessThan(loopDeleteIdx);
   });
 });

--- a/functions/test/ocrProcessorOcrResultCleanupWiringContract.test.ts
+++ b/functions/test/ocrProcessorOcrResultCleanupWiringContract.test.ts
@@ -1,0 +1,159 @@
+/**
+ * ocrProcessor.ts の OCR結果Storageクリーンアップ配線契約テスト (Issue #625)
+ *
+ * `cleanupOrphanedOcrResultObjects` / `compensateDeleteOnFailure` は Storage/Firestore
+ * 副作用が大きく processDocument を直接呼び出しては検証できない(既存 ocrRunGuardIntegration
+ * 等と同方針)。本テストは呼出し配置をソース文字列レベルで lock-in する
+ * (docs/context/test-strategy.md §2.1 のgrep-based契約パターン踏襲)。
+ *
+ * Issue #622 教訓: grep anchor をファイル全体に対して緩く書くと、無関係な箇所に
+ * マッチして vacuous になりうる。本テストは processDocument 関数本体のみを
+ * extractBraceBlock で抽出してからマッチさせ、スコープを限定する。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
+const PROCESS_DOCUMENT_ANCHOR = /export\s+async\s+function\s+processDocument\s*\(/;
+
+const CLEANUP_FN_ANCHOR = /async\s+function\s+cleanupOrphanedOcrResultObjects\s*\(/;
+
+describe('ocrProcessor OCR結果クリーンアップ配線契約 (Issue #625)', () => {
+  let processDocumentBody = '';
+  let cleanupFunctionBody = '';
+
+  before(() => {
+    const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
+    const source = readFileSync(absPath, 'utf-8');
+
+    // processDocument はファイル内で1つのみ定義されている前提。2つ目が追加された場合、
+    // 本 anchor は最初の定義にマッチし続けるため、その時点で narrow が必要になる。
+    const defCount = (source.match(/export\s+async\s+function\s+processDocument\s*\(/g) ?? [])
+      .length;
+    expect(defCount, 'processDocument の定義が複数存在する場合は anchor の narrow が必要').to.equal(
+      1
+    );
+
+    const body = extractBraceBlock(source, PROCESS_DOCUMENT_ANCHOR);
+    expect(body, 'processDocument 関数本体の抽出に失敗した').to.not.be.null;
+    processDocumentBody = body!;
+
+    const cleanupDefCount = (
+      source.match(/async\s+function\s+cleanupOrphanedOcrResultObjects\s*\(/g) ?? []
+    ).length;
+    expect(
+      cleanupDefCount,
+      'cleanupOrphanedOcrResultObjects の定義が複数存在する場合は anchor の narrow が必要'
+    ).to.equal(1);
+    const cleanupBody = extractBraceBlock(source, CLEANUP_FN_ANCHOR);
+    expect(cleanupBody, 'cleanupOrphanedOcrResultObjects 関数本体の抽出に失敗した').to.not.be.null;
+    cleanupFunctionBody = cleanupBody!;
+  });
+
+  /**
+   * processDocument内には capPageResultsAggregate 用の try/catch (Issue #293/#297) が
+   * 先行して存在するため、`}\s*catch\s*\(\s*err\s*\)` を processDocumentBody 全体に対して
+   * 素朴にマッチさせると先行 catch を誤って拾う(#622 と同種の vacuous risk)。
+   * `await db.runTransaction(` 以降にスコープを絞り、その直後のcatchのみを抽出する。
+   */
+  function extractRunTransactionCatchBlock(): string {
+    const runTransactionIdx = processDocumentBody.indexOf('await db.runTransaction(');
+    expect(runTransactionIdx, 'await db.runTransaction( が見つからない').to.be.greaterThan(-1);
+    const fromTransaction = processDocumentBody.slice(runTransactionIdx);
+
+    const transactionCallbackBlock = extractBraceBlock(
+      fromTransaction,
+      'await db.runTransaction(',
+      { anchorMode: 'after-match' }
+    );
+    expect(transactionCallbackBlock, 'db.runTransactionコールバック本体の抽出に失敗した').to.not.be
+      .null;
+
+    const afterCallbackIdx = fromTransaction.indexOf(transactionCallbackBlock!) +
+      transactionCallbackBlock!.length;
+    const afterCallback = fromTransaction.slice(afterCallbackIdx);
+
+    const catchBlock = extractBraceBlock(afterCallback, /\}\s*catch\s*\(\s*err\s*\)\s*/, {
+      anchorMode: 'after-match',
+    });
+    expect(catchBlock, 'db.runTransaction直後のcatchブロックが抽出できない').to.not.be.null;
+    return catchBlock!;
+  }
+
+  it('最終transactionはtry/catchで包まれている', () => {
+    expect(processDocumentBody).to.match(
+      /try\s*\{\s*await\s+db\.runTransaction\(/,
+      'db.runTransaction呼出がtry/catchで包まれていない — 失敗時の補償削除が配線されていない'
+    );
+  });
+
+  it('catchブロックはocrResultUrlがある場合のみcompensateDeleteOnFailureを呼ぶ', () => {
+    const catchBlock = extractRunTransactionCatchBlock();
+
+    expect(catchBlock).to.match(
+      /if\s*\(\s*ocrResultUrl\s*\)\s*\{/,
+      'catchブロック内でocrResultUrlの有無を確認していない'
+    );
+    expect(catchBlock).to.match(
+      /compensateDeleteOnFailure\s*\(\s*docId\s*,\s*ocrRunId\s*,\s*functionName\s*\)/,
+      'catchブロック内でcompensateDeleteOnFailureが正しい引数で呼ばれていない'
+    );
+    expect(catchBlock).to.match(
+      /throw\s+err\s*;/,
+      'catchブロックが元のエラーをre-throwしていない — 呼出元processOCR.tsのsupersede/エラー処理を壊す'
+    );
+  });
+
+  it('catchブロック内でcompensateDeleteOnFailureはthrow errより前に呼ばれる', () => {
+    const catchBlock = extractRunTransactionCatchBlock();
+    const compensateIdx = catchBlock.indexOf('compensateDeleteOnFailure(');
+    const throwIdx = catchBlock.indexOf('throw err;');
+    expect(compensateIdx, 'compensateDeleteOnFailure呼出が見つからない').to.be.greaterThan(-1);
+    expect(throwIdx, 'throw err; が見つからない').to.be.greaterThan(-1);
+    expect(compensateIdx).to.be.lessThan(throwIdx);
+  });
+
+  it('transaction成功後(catchブロックの外)でcleanupOrphanedOcrResultObjectsを呼ぶ', () => {
+    // catchブロック終端以降、return文より前に呼ばれていることを確認する。
+    const catchBlock = extractRunTransactionCatchBlock();
+    const afterCatchIdx = processDocumentBody.indexOf(catchBlock) + catchBlock.length;
+    const afterCatchSource = processDocumentBody.slice(afterCatchIdx);
+
+    expect(afterCatchSource).to.match(
+      /cleanupOrphanedOcrResultObjects\s*\(\s*docId\s*,\s*ocrRunId\s*,\s*ocrResultUrl\s*\?\s*ocrRunId\s*:\s*null\s*,\s*functionName\s*\)/,
+      'transaction成功後にcleanupOrphanedOcrResultObjectsが正しい引数(検証用ocrRunId含む)で呼ばれていない'
+    );
+
+    const cleanupIdx = afterCatchSource.indexOf('cleanupOrphanedOcrResultObjects(');
+    const returnIdx = afterCatchSource.indexOf('return {');
+    expect(cleanupIdx, 'cleanupOrphanedOcrResultObjects呼出が見つからない').to.be.greaterThan(-1);
+    expect(returnIdx, 'return文が見つからない').to.be.greaterThan(-1);
+    expect(cleanupIdx).to.be.lessThan(returnIdx);
+  });
+
+  it('cleanupOrphanedOcrResultObjectsはlisting/削除前にshouldSkipSuccessCleanupで所有権を再確認する (/code-review low 指摘反映)', () => {
+    // 先行run自身の古い視点でのcleanupが、後続runが直近書き込んだ有効なオブジェクトを
+    // 誤削除するレースを防ぐための安全確認。listing呼出しより前に配線されていること、
+    // skip時はlisting自体を実行せずreturnすることを検証する。
+    expect(cleanupFunctionBody).to.match(
+      /shouldSkipSuccessCleanup\s*\(\s*snap\.exists\s*,\s*snap\.data\(\)\?\.\s*ocrRunId\s*,\s*ocrRunId\s*\)/,
+      'shouldSkipSuccessCleanupが正しい引数で呼ばれていない'
+    );
+
+    const skipCheckIdx = cleanupFunctionBody.indexOf('shouldSkipSuccessCleanup(');
+    const listingIdx = cleanupFunctionBody.indexOf('adapter.listObjectNames(');
+    expect(skipCheckIdx, 'shouldSkipSuccessCleanup呼出が見つからない').to.be.greaterThan(-1);
+    expect(listingIdx, 'adapter.listObjectNames呼出が見つからない').to.be.greaterThan(-1);
+    expect(skipCheckIdx, 'shouldSkipSuccessCleanupがlistingより後に配線されている').to.be.lessThan(
+      listingIdx
+    );
+
+    expect(cleanupFunctionBody).to.match(
+      /if\s*\(\s*skip\s*\)\s*\{[\s\S]*?return\s*;[\s\S]*?\}/,
+      'skip=trueの場合にreturnしていない — listing/削除が実行されてしまう'
+    );
+  });
+});

--- a/functions/test/ocrResultCleanup.test.ts
+++ b/functions/test/ocrResultCleanup.test.ts
@@ -1,0 +1,81 @@
+/**
+ * OCR結果Storageクリーンアップ純粋関数のunit test (Issue #625)
+ *
+ * firebase-admin初期化なしで検証する (summaryPromptBuilder.test.ts等と同方針)。
+ */
+
+import { expect } from 'chai';
+import {
+  computeOcrResultObjectsToDelete,
+  shouldSkipCompensatingDelete,
+  shouldSkipSuccessCleanup,
+} from '../src/ocr/ocrResultCleanup';
+
+describe('computeOcrResultObjectsToDelete (Issue #625)', () => {
+  it('keepObjectNameと異なる全オブジェクトを削除対象として返す', () => {
+    const all = [
+      'ocr-results/doc1/run-a.txt',
+      'ocr-results/doc1/run-b.txt',
+      'ocr-results/doc1/run-c.txt',
+    ];
+    expect(computeOcrResultObjectsToDelete(all, 'ocr-results/doc1/run-b.txt')).to.deep.equal([
+      'ocr-results/doc1/run-a.txt',
+      'ocr-results/doc1/run-c.txt',
+    ]);
+  });
+
+  it('keepObjectNameがnullの場合は全件を削除対象とする(今回Storage保存が発生しなかった場合)', () => {
+    const all = ['ocr-results/doc1/run-a.txt', 'ocr-results/doc1/run-b.txt'];
+    expect(computeOcrResultObjectsToDelete(all, null)).to.deep.equal(all);
+  });
+
+  it('空配列を渡した場合は空配列を返す', () => {
+    expect(computeOcrResultObjectsToDelete([], 'ocr-results/doc1/run-a.txt')).to.deep.equal([]);
+  });
+
+  it('keepObjectNameがlisting結果に存在しない場合は全件を削除対象とする', () => {
+    const all = ['ocr-results/doc1/run-a.txt'];
+    expect(computeOcrResultObjectsToDelete(all, 'ocr-results/doc1/run-zzz.txt')).to.deep.equal(all);
+  });
+
+  it('keepObjectName以外にオブジェクトが存在しない場合は空配列を返す', () => {
+    const all = ['ocr-results/doc1/run-a.txt'];
+    expect(computeOcrResultObjectsToDelete(all, 'ocr-results/doc1/run-a.txt')).to.deep.equal([]);
+  });
+});
+
+describe('shouldSkipCompensatingDelete (Issue #625)', () => {
+  it('ドキュメントがprocessedかつocrRunId一致 → スキップする(実は採用されていた)', () => {
+    expect(shouldSkipCompensatingDelete(true, 'processed', 'run-a', 'run-a')).to.be.true;
+  });
+
+  it('ドキュメントが存在しない(削除済み) → スキップしない(補償削除してよい)', () => {
+    expect(shouldSkipCompensatingDelete(false, undefined, undefined, 'run-a')).to.be.false;
+  });
+
+  it('ocrRunIdが別の値(所有権を失った) → スキップしない', () => {
+    expect(shouldSkipCompensatingDelete(true, 'processing', 'run-b', 'run-a')).to.be.false;
+  });
+
+  it('statusがprocessedでない(まだprocessing等) → スキップしない', () => {
+    expect(shouldSkipCompensatingDelete(true, 'processing', 'run-a', 'run-a')).to.be.false;
+  });
+
+  it('statusがprocessedだがocrRunIdが異なる(別runが既に上書き) → スキップしない', () => {
+    expect(shouldSkipCompensatingDelete(true, 'processed', 'run-b', 'run-a')).to.be.false;
+  });
+});
+
+describe('shouldSkipSuccessCleanup (Issue #625、/code-review low 指摘反映)', () => {
+  it('ocrRunIdが依然一致 → スキップしない(cleanupしてよい)', () => {
+    expect(shouldSkipSuccessCleanup(true, 'run-a', 'run-a')).to.be.false;
+  });
+
+  it('後続runにより既にocrRunIdが上書きされている → スキップする(誤削除防止)', () => {
+    expect(shouldSkipSuccessCleanup(true, 'run-b', 'run-a')).to.be.true;
+  });
+
+  it('ドキュメントが削除されている → スキップする', () => {
+    expect(shouldSkipSuccessCleanup(false, undefined, 'run-a')).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #540でOCR結果Storageの保存先をrun毎パス(`ocr-results/{docId}/{ocrRunId}.txt`)に分離した結果、reprocess/supersede発生の度に旧オブジェクトが孤児化・無制限蓄積する問題を修正
- 当初はFirestoreの`ocrResultUrl`フィールド値を頼りに旧URLを特定する設計を検討したが、Codexセカンドオピニオンで「FE側のreprocessクリア処理(`getReprocessClearFields`)が`ocrResultUrl`を事前削除するため通常reprocessでは機能しない」というCritical指摘を受け、Cloud Storage自体をsource of truthとしてprefix listingする設計に変更
- `/code-review low`で「成功パスが後続runの有効なオブジェクトを誤削除しうるレースコンディション」を追加検出、`shouldSkipSuccessCleanup`によるFirestore再検証を追加して修正済み

## 変更内容
- `functions/src/ocr/ocrProcessor.ts`: 最終transactionをtry/catchで包み、成功時は`ocr-results/{docId}/`配下をlistingして現在有効なrun以外を正規化、失敗時(supersede/削除等)は今回作成した新規オブジェクトを安全確認付きで補償削除
- `functions/src/ocr/ocrResultCleanup.ts`(新規): 純粋関数群(`computeOcrResultObjectsToDelete`, `shouldSkipCompensatingDelete`, `shouldSkipSuccessCleanup`)
- テスト: 純粋関数unit test + 配線契約test(source-grepベース、Issue #622の「vacuous test」教訓を踏まえ`extractBraceBlock`で関数本体スコープに限定、実際に配線を壊すと失敗することを検証済み)

## Test plan
- [x] `npm run type-check:test` PASS
- [x] `npm test` 全PASS (1726 passing, 6 pending / 既存分含む回帰なし)
- [x] `/code-review low` 実施、レースコンディション指摘→修正→再レビューでfindings 0件を確認
- [x] `/safe-refactor` 実施(MEDIUM指摘1件はユーザー判断で見送り)
- [x] 配線契約testが実際に配線崩れを検知することを一時的にコードを壊して確認済み(vacuous test防止)

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR processing reliability when documents are deleted or superseded during processing.
  * Prevented valid OCR results from being removed during overlapping or newer processing runs.
  * Added cleanup of orphaned OCR result files and rollback of files created when processing fails.

* **Tests**
  * Added coverage for OCR result cleanup, failure recovery, and concurrent processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->