### PR TITLE
fix(pdf): splitPdfの新エラーコード(already-exists/aborted)をFE対応 (Issue #621)

### DIFF
--- a/frontend/src/components/PdfSplitModal.tsx
+++ b/frontend/src/components/PdfSplitModal.tsx
@@ -40,6 +40,7 @@ import { useDocumentMasters, useCustomerMasters, useOfficeMasters } from '@/hook
 import { PdfSplitPreview } from './PdfSplitPreview'
 import { getDisplayFileName } from '@/utils/getDisplayFileName'
 import { applySegmentFieldEdit, buildSegmentConfirmedFlags, type SegmentTextField } from '@/lib/documentUtils'
+import { getCallableErrorCode, getCallableErrorMessage } from '@/lib/callFunction'
 import type { Document, SplitSuggestion, SplitSegment } from '@shared/types'
 
 interface PdfSplitModalProps {
@@ -120,12 +121,17 @@ export function PdfSplitModal({
   const rotatePdf = useRotatePdfPages()
 
   // 分割候補から初期ポイントを設定
+  // Issue #621: already-exists/aborted失敗時にuseSplitPdfのonErrorが
+  // ['document']をinvalidateすると、確認ステップ中でもdocument.splitSuggestions
+  // の参照が変わり本エフェクトが再発火してしまう。確認ステップ以降はユーザーが
+  // 確定させたsplitPointsを保持し、自動候補による上書きをしない。
   useEffect(() => {
+    if (isConfirmStep) return
     if (document.splitSuggestions && document.splitSuggestions.length > 0) {
       const points = document.splitSuggestions.map((s) => s.afterPageNumber)
       setSplitPoints(points)
     }
-  }, [document.splitSuggestions])
+  }, [document.splitSuggestions, isConfirmStep])
 
   // gs:// URL を HTTPS ダウンロードURLに変換
   useEffect(() => {
@@ -340,7 +346,27 @@ export function PdfSplitModal({
       onClose()
     } catch (error) {
       console.error('Split error:', error)
-      const message = error instanceof Error ? error.message : '分割処理に失敗しました'
+      // Issue #621: already-exists/aborted はBE側メッセージに内部docIdや英語の
+      // 技術的説明文が含まれるため、そのまま表示せず文脈に応じた文言に翻訳する。
+      // それ以外のコード(invalid-argument/not-found/failed-precondition等)は
+      // 従来通り生メッセージを表示する(getCallableErrorMessageは未知コードを
+      // 汎用文言に丸めてしまい、splitPdf固有の具体的な原因情報が失われるため)
+      const code = getCallableErrorCode(error)
+      let message: string
+      if (code === 'already-exists') {
+        message = 'この書類は既に分割済みです。画面を更新して最新の状態をご確認ください。'
+      } else if (code === 'aborted') {
+        message = '別の操作と競合したため分割を中断しました。時間をおいて再度お試しください。'
+      } else if (
+        code === 'unauthenticated' ||
+        code === 'deadline-exceeded' ||
+        code === 'internal' ||
+        code === 'permission-denied'
+      ) {
+        message = getCallableErrorMessage(error, '分割処理に失敗しました')
+      } else {
+        message = error instanceof Error ? error.message : '分割処理に失敗しました'
+      }
       toast.error(`分割エラー: ${message}`)
     }
   }

--- a/frontend/src/components/PdfSplitModal.tsx
+++ b/frontend/src/components/PdfSplitModal.tsx
@@ -3,7 +3,7 @@
  * 分割候補の表示、手動追加、分割実行
  */
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { ref, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
 import { toast } from 'sonner'
@@ -121,17 +121,20 @@ export function PdfSplitModal({
   const rotatePdf = useRotatePdfPages()
 
   // 分割候補から初期ポイントを設定
-  // Issue #621: already-exists/aborted失敗時にuseSplitPdfのonErrorが
-  // ['document']をinvalidateすると、確認ステップ中でもdocument.splitSuggestions
-  // の参照が変わり本エフェクトが再発火してしまう。確認ステップ以降はユーザーが
-  // 確定させたsplitPointsを保持し、自動候補による上書きをしない。
+  // Issue #621 (Codexレビュー指摘反映): isConfirmStepへの依存でガードすると、
+  // 「戻る」でisConfirmStepがfalseに戻った際に本エフェクトが再発火し、結局
+  // ユーザーの手動編集がsplitSuggestionsで上書きされてしまう(往路のonError
+  // invalidateだけでなく復路の「戻る」操作でも同じ問題が起きる)。
+  // ステップ遷移に依存させず、同一document.idに対しては一度だけ初期化する。
+  const initializedDocIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (isConfirmStep) return
+    if (initializedDocIdRef.current === document.id) return
     if (document.splitSuggestions && document.splitSuggestions.length > 0) {
       const points = document.splitSuggestions.map((s) => s.afterPageNumber)
       setSplitPoints(points)
+      initializedDocIdRef.current = document.id
     }
-  }, [document.splitSuggestions, isConfirmStep])
+  }, [document.id, document.splitSuggestions])
 
   // gs:// URL を HTTPS ダウンロードURLに変換
   useEffect(() => {

--- a/frontend/src/components/__tests__/PdfSplitModal.test.tsx
+++ b/frontend/src/components/__tests__/PdfSplitModal.test.tsx
@@ -264,11 +264,21 @@ describe('PdfSplitModal - detail取得状態によるボタン制御 (Issue #547
     expect(screen.queryByText(/セグメント 3/)).toBeNull()
   })
 
-  it('確認ステップから「戻る」で分割ポイント選択に戻っても、ユーザーが手動追加したポイントは維持される（Codexレビュー指摘: isConfirmStep依存ガードの復路での再発防止）', async () => {
-    // splitSuggestionsなし(自動候補ゼロ)の書類で、ユーザーが手動でポイントを追加するケース
-    render(
+  it('確認ステップから「戻る」で分割ポイント選択に戻っても、ユーザーが確定したsplitPointsは維持される（Codexレビュー指摘: isConfirmStep依存ガードの復路での再発防止）', async () => {
+    // comment-analyzerレビュー指摘: 旧版のこのテストはsplitSuggestions=[]（常に空）を
+    // 使っていたため、isConfirmStepガード版・docId-ref版のどちらでもeffect本体が
+    // 実行されず、テストが実際には回帰を検出できていなかった。document.splitSuggestions
+    // の「参照」が変化するケースでなければ、isConfirmStepガードの有無による差が
+    // 現れないため、非空のsplitSuggestionsを用いて参照変化を発生させる。
+    const initialDoc = makeDocument({
+      totalPages: 4,
+      splitSuggestions: [
+        { afterPageNumber: 1, reason: 'manual', confidence: 100, newDocumentType: null, newCustomerName: null },
+      ],
+    })
+    const { rerender } = render(
       <PdfSplitModal
-        document={makeDocument({ totalPages: 4, splitSuggestions: [] })}
+        document={initialDoc}
         isOpen={true}
         onClose={vi.fn()}
         onSuccess={vi.fn()}
@@ -277,21 +287,41 @@ describe('PdfSplitModal - detail取得状態によるボタン制御 (Issue #547
       />
     )
 
-    // 手動でページ1の後に分割ポイントを追加(splitSuggestionsが空のため自動候補には無い)
-    fireEvent.click(screen.getByRole('button', { name: 'ページ 1 の後で分割' }))
     fireEvent.click(screen.getByRole('button', { name: '次へ: 分割内容の確認' }))
     await screen.findByRole('button', { name: /分割を実行/ })
     expect(screen.getByText(/セグメント 2/)).toBeDefined()
 
-    // 「戻る」で選択ステップに戻る(isConfirmStepがfalseに戻る)
+    // 確認ステップ中に document.splitSuggestions が新しい参照に変わる
+    // (旧isConfirmStepガード版はこの時点ではまだ再適用をブロックする)
+    const docWithMoreSuggestions = makeDocument({
+      totalPages: 4,
+      splitSuggestions: [
+        { afterPageNumber: 1, reason: 'manual', confidence: 100, newDocumentType: null, newCustomerName: null },
+        { afterPageNumber: 2, reason: 'manual', confidence: 100, newDocumentType: null, newCustomerName: null },
+      ],
+    })
+    rerender(
+      <PdfSplitModal
+        document={docWithMoreSuggestions}
+        isOpen={true}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        detailLoading={false}
+        detailError={false}
+      />
+    )
+
+    // 「戻る」でisConfirmStepがfalseに戻る。旧isConfirmStepガード版は
+    // ここで依存配列のisConfirmStep変化によりeffectが再発火し、
+    // 変化済みのsplitSuggestions([1,2])で上書きしてしまっていた
     fireEvent.click(screen.getByRole('button', { name: '戻る' }))
-    // 再度「次へ」で確認ステップに戻る
     fireEvent.click(screen.getByRole('button', { name: '次へ: 分割内容の確認' }))
     await screen.findByRole('button', { name: /分割を実行/ })
 
-    // 手動追加したsplitPointsが保持されており、splitSuggestions(空)による
-    // 上書きでセグメントが1件に戻っていないこと
+    // 元のsplitPoints=[1]（2セグメント）のまま。セグメント3が出現していれば
+    // [1,2]で上書きされた=回帰再発を意味する
     expect(screen.getByText(/セグメント 2/)).toBeDefined()
+    expect(screen.queryByText(/セグメント 3/)).toBeNull()
   })
 })
 

--- a/frontend/src/components/__tests__/PdfSplitModal.test.tsx
+++ b/frontend/src/components/__tests__/PdfSplitModal.test.tsx
@@ -263,6 +263,36 @@ describe('PdfSplitModal - detail取得状態によるボタン制御 (Issue #547
     // (旧実装ではここでeffectが再発火しsplitPoints=[1,2]→3セグメントに変化していた)
     expect(screen.queryByText(/セグメント 3/)).toBeNull()
   })
+
+  it('確認ステップから「戻る」で分割ポイント選択に戻っても、ユーザーが手動追加したポイントは維持される（Codexレビュー指摘: isConfirmStep依存ガードの復路での再発防止）', async () => {
+    // splitSuggestionsなし(自動候補ゼロ)の書類で、ユーザーが手動でポイントを追加するケース
+    render(
+      <PdfSplitModal
+        document={makeDocument({ totalPages: 4, splitSuggestions: [] })}
+        isOpen={true}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        detailLoading={false}
+        detailError={false}
+      />
+    )
+
+    // 手動でページ1の後に分割ポイントを追加(splitSuggestionsが空のため自動候補には無い)
+    fireEvent.click(screen.getByRole('button', { name: 'ページ 1 の後で分割' }))
+    fireEvent.click(screen.getByRole('button', { name: '次へ: 分割内容の確認' }))
+    await screen.findByRole('button', { name: /分割を実行/ })
+    expect(screen.getByText(/セグメント 2/)).toBeDefined()
+
+    // 「戻る」で選択ステップに戻る(isConfirmStepがfalseに戻る)
+    fireEvent.click(screen.getByRole('button', { name: '戻る' }))
+    // 再度「次へ」で確認ステップに戻る
+    fireEvent.click(screen.getByRole('button', { name: '次へ: 分割内容の確認' }))
+    await screen.findByRole('button', { name: /分割を実行/ })
+
+    // 手動追加したsplitPointsが保持されており、splitSuggestions(空)による
+    // 上書きでセグメントが1件に戻っていないこと
+    expect(screen.getByText(/セグメント 2/)).toBeDefined()
+  })
 })
 
 function makeFunctionsError(code: string, message: string): Error {

--- a/frontend/src/components/__tests__/PdfSplitModal.test.tsx
+++ b/frontend/src/components/__tests__/PdfSplitModal.test.tsx
@@ -65,6 +65,15 @@ vi.mock('@/hooks/usePdfSplit', async () => {
   }
 })
 
+const mockToastError = vi.fn()
+const mockToastSuccess = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}))
+
 import { PdfSplitModal } from '../PdfSplitModal'
 
 const makeDocument = (overrides: Partial<Document> = {}): Document => ({
@@ -205,5 +214,150 @@ describe('PdfSplitModal - detail取得状態によるボタン制御 (Issue #547
     )
 
     expect(isDisabled(screen.getByRole('button', { name: /分割を実行/ }))).toBe(true)
+  })
+
+  it('確認ステップ中に document.splitSuggestions の参照が変わっても、ユーザーが確定した splitPoints は維持される（Issue #621回帰防止: useSplitPdfのonErrorがinvalidateQueriesすると発生しうる）', async () => {
+    const initialDoc = makeDocument({
+      totalPages: 4,
+      splitSuggestions: [
+        { afterPageNumber: 1, reason: 'manual', confidence: 100, newDocumentType: null, newCustomerName: null },
+      ],
+    })
+    const { rerender } = render(
+      <PdfSplitModal
+        document={initialDoc}
+        isOpen={true}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        detailLoading={false}
+        detailError={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '次へ: 分割内容の確認' }))
+    await screen.findByRole('button', { name: /分割を実行/ })
+    // splitPoints=[1] → 2セグメント（セグメント3は存在しない）
+    expect(screen.getByText(/セグメント 2/)).toBeDefined()
+    expect(screen.queryByText(/セグメント 3/)).toBeNull()
+
+    // 確認ステップのまま document.splitSuggestions が新しい配列参照で変化する
+    // (already-exists/aborted の onError による ['document'] invalidate 相当を模擬)
+    rerender(
+      <PdfSplitModal
+        document={makeDocument({
+          totalPages: 4,
+          splitSuggestions: [
+            { afterPageNumber: 1, reason: 'manual', confidence: 100, newDocumentType: null, newCustomerName: null },
+            { afterPageNumber: 2, reason: 'manual', confidence: 100, newDocumentType: null, newCustomerName: null },
+          ],
+        })}
+        isOpen={true}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        detailLoading={false}
+        detailError={false}
+      />
+    )
+
+    // 確認ステップ中はsplitPointsが上書きされずセグメント3は出現しない
+    // (旧実装ではここでeffectが再発火しsplitPoints=[1,2]→3セグメントに変化していた)
+    expect(screen.queryByText(/セグメント 3/)).toBeNull()
+  })
+})
+
+function makeFunctionsError(code: string, message: string): Error {
+  const err = new Error(message)
+  ;(err as Error & { code: string }).code = `functions/${code}`
+  return err
+}
+
+function lastToastErrorMessage(): string {
+  const calls = mockToastError.mock.calls
+  const lastCall = calls[calls.length - 1]
+  if (!lastCall) throw new Error('toast.error was not called')
+  return lastCall[0] as string
+}
+
+async function executeSplit() {
+  render(
+    <PdfSplitModal
+      document={makeDocument()}
+      isOpen={true}
+      onClose={vi.fn()}
+      onSuccess={vi.fn()}
+      detailLoading={false}
+      detailError={false}
+    />
+  )
+  fireEvent.click(screen.getByRole('button', { name: '次へ: 分割内容の確認' }))
+  const executeButton = await screen.findByRole('button', { name: /分割を実行/ })
+  fireEvent.click(executeButton)
+}
+
+describe('PdfSplitModal - splitPdfエラーハンドリング (Issue #621)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('already-exists エラー時、内部IDを含まない日本語メッセージをtoast表示する', async () => {
+    mockSplitPdfMutateAsync.mockRejectedValueOnce(
+      makeFunctionsError('already-exists', "Document doc-001 has already been split (status='split')")
+    )
+
+    await executeSplit()
+
+    await vi.waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    const shownMessage = lastToastErrorMessage()
+    expect(shownMessage).not.toMatch(/doc-001/)
+    expect(shownMessage).not.toMatch(/already-exists|already been split/i)
+    expect(shownMessage).toContain('既に分割')
+  })
+
+  it('aborted エラー時、内部IDを含まない日本語メッセージをtoast表示する', async () => {
+    mockSplitPdfMutateAsync.mockRejectedValueOnce(
+      makeFunctionsError(
+        'aborted',
+        'splitPdf aborted: concurrent split detected (parent=doc-001 was modified since read)'
+      )
+    )
+
+    await executeSplit()
+
+    await vi.waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    const shownMessage = lastToastErrorMessage()
+    expect(shownMessage).not.toMatch(/doc-001/)
+    expect(shownMessage).not.toMatch(/splitPdf aborted|concurrent split detected/i)
+    expect(shownMessage).toContain('競合')
+  })
+
+  it('その他のエラー(internal)時は従来通りgetCallableErrorMessageのフォールバック文言を表示する', async () => {
+    mockSplitPdfMutateAsync.mockRejectedValueOnce(makeFunctionsError('internal', 'network glitch'))
+
+    await executeSplit()
+
+    await vi.waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    const shownMessage = lastToastErrorMessage()
+    expect(shownMessage).not.toMatch(/network glitch/i)
+    expect(shownMessage).toContain('通信エラー')
+  })
+
+  it('not-found エラー時は具体的な原因情報を保持するため生メッセージを表示する（回帰防止: 汎用文言に丸めない）', async () => {
+    mockSplitPdfMutateAsync.mockRejectedValueOnce(makeFunctionsError('not-found', 'Document not found'))
+
+    await executeSplit()
+
+    await vi.waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    expect(lastToastErrorMessage()).toContain('Document not found')
+  })
+
+  it('failed-precondition エラー時は具体的な原因情報を保持するため生メッセージを表示する（回帰防止）', async () => {
+    mockSplitPdfMutateAsync.mockRejectedValueOnce(
+      makeFunctionsError('failed-precondition', 'Document has no updateTime; cannot enforce optimistic locking')
+    )
+
+    await executeSplit()
+
+    await vi.waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    expect(lastToastErrorMessage()).toContain('Document has no updateTime')
   })
 })

--- a/frontend/src/hooks/__tests__/usePdfSplit.test.tsx
+++ b/frontend/src/hooks/__tests__/usePdfSplit.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * useSplitPdf 単体テスト (Issue #621)
+ *
+ * splitPdf は already-exists (既に分割済み) / aborted (並行split競合) で失敗する場合、
+ * いずれもサーバー側の状態が実際に変化した(または既に変化していた)ことを示すため、
+ * onSuccess と同じキャッシュキーを invalidate して画面を最新化する必要がある。
+ * それ以外のエラー(internal等)では従来通り invalidate しない。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+const mockCallFunction = vi.fn()
+vi.mock('@/lib/callFunction', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/callFunction')>('@/lib/callFunction')
+  return {
+    ...actual,
+    callFunction: (...args: unknown[]) => mockCallFunction(...args),
+  }
+})
+
+import { useSplitPdf } from '../usePdfSplit'
+
+function makeFunctionsError(code: string, message: string): Error {
+  const err = new Error(message)
+  ;(err as Error & { code: string }).code = `functions/${code}`
+  return err
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return { wrapper, invalidateSpy }
+}
+
+const request = { documentId: 'doc-001', splitPoints: [1], segments: [] }
+
+describe('useSplitPdf - Issue #621 already-exists/aborted時のキャッシュ無効化', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('already-exists で失敗した場合、documentsInfinite/document を invalidate する', async () => {
+    mockCallFunction.mockRejectedValueOnce(
+      makeFunctionsError('already-exists', "Document doc-001 has already been split (status='split')")
+    )
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useSplitPdf(), { wrapper })
+
+    result.current.mutate(request)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['document'] })
+  })
+
+  it('aborted で失敗した場合、documentsInfinite/document を invalidate する', async () => {
+    mockCallFunction.mockRejectedValueOnce(
+      makeFunctionsError('aborted', 'splitPdf aborted: concurrent split detected (parent=doc-001 was modified since read)')
+    )
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useSplitPdf(), { wrapper })
+
+    result.current.mutate(request)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['document'] })
+  })
+
+  it('internal 等の他コードで失敗した場合は invalidate しない', async () => {
+    mockCallFunction.mockRejectedValueOnce(makeFunctionsError('internal', 'unexpected server error'))
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useSplitPdf(), { wrapper })
+
+    result.current.mutate(request)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('成功時は従来通り documentsInfinite/document を invalidate する(回帰確認)', async () => {
+    mockCallFunction.mockResolvedValueOnce({ success: true, createdDocuments: ['doc-002'] })
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useSplitPdf(), { wrapper })
+
+    result.current.mutate(request)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['document'] })
+  })
+})

--- a/frontend/src/hooks/usePdfSplit.ts
+++ b/frontend/src/hooks/usePdfSplit.ts
@@ -3,8 +3,8 @@
  * Cloud Functionsと連携してPDF分割を実行
  */
 
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { callFunction } from '@/lib/callFunction'
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { callFunction, getCallableErrorCode } from '@/lib/callFunction'
 import type { SplitSuggestion, SplitSegment } from '@shared/types'
 
 // ============================================
@@ -119,14 +119,25 @@ async function splitPdf(request: SplitPdfRequest): Promise<SplitPdfResponse> {
   )
 }
 
+function invalidateSplitQueries(queryClient: QueryClient): void {
+  queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
+  queryClient.invalidateQueries({ queryKey: ['document'] })
+}
+
 export function useSplitPdf() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: splitPdf,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      queryClient.invalidateQueries({ queryKey: ['document'] })
+    onSuccess: () => invalidateSplitQueries(queryClient),
+    onError: (err) => {
+      // Issue #621: already-exists(既に分割済み)/aborted(並行split競合)は
+      // いずれもサーバー側の状態が実際に変化した(または既に変化していた)ことを示すため、
+      // 失敗時も画面を最新化する必要がある
+      const code = getCallableErrorCode(err)
+      if (code === 'already-exists' || code === 'aborted') {
+        invalidateSplitQueries(queryClient)
+      }
     },
   })
 }

--- a/frontend/src/lib/__tests__/callFunction.test.ts
+++ b/frontend/src/lib/__tests__/callFunction.test.ts
@@ -8,8 +8,7 @@
  * message.includes() 方式では検知できず、FirebaseError.code による判定が必須。
  */
 
-import { describe, it, expect } from 'vitest'
-import { getCallableErrorMessage } from '../callFunction'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // firebase/functions の FunctionsError は FirebaseError を継承し
 // code: `functions/${FunctionsErrorCodeCore}` を持つ。テストでは最小限のシェイプで模擬する。
@@ -18,6 +17,19 @@ function makeFunctionsError(code: string, message: string): Error {
   ;(err as Error & { code: string }).code = `functions/${code}`
   return err
 }
+
+const mockCallableImpl = vi.fn()
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => mockCallableImpl,
+}))
+
+const mockGetIdToken = vi.fn().mockResolvedValue('new-token')
+vi.mock('../firebase', () => ({
+  functions: {},
+  auth: { currentUser: { getIdToken: (...args: unknown[]) => mockGetIdToken(...args) } },
+}))
+
+import { getCallableErrorMessage, callFunction } from '../callFunction'
 
 describe('getCallableErrorMessage - Issue #621 already-exists/aborted', () => {
   it('code=already-exists のとき、内部IDを含まない汎用日本語メッセージを返す', () => {
@@ -54,5 +66,44 @@ describe('getCallableErrorMessage - Issue #621 already-exists/aborted', () => {
   it('未知のcode/messageはdefaultMessageにフォールバックする', () => {
     const err = makeFunctionsError('unknown', 'something went wrong')
     expect(getCallableErrorMessage(err, 'デフォルトエラー')).toBe('デフォルトエラー')
+  })
+})
+
+describe('callFunction - リトライ動作 (silent-failure-hunterレビュー指摘)', () => {
+  beforeEach(() => {
+    mockCallableImpl.mockReset()
+    mockGetIdToken.mockClear()
+    mockGetIdToken.mockResolvedValue('new-token')
+  })
+
+  it('リトライ対象コード(unauthenticated)で失敗後、リトライも別コードで失敗した場合はリトライ後の実際のエラーをthrowする（旧実装は元のerrを握りつぶしていた）', async () => {
+    const firstErr = makeFunctionsError('unauthenticated', 'token expired')
+    const retryErr = makeFunctionsError('already-exists', 'Document abc123 has already been split')
+    mockCallableImpl
+      .mockRejectedValueOnce(firstErr)
+      .mockRejectedValueOnce(retryErr)
+
+    await expect(callFunction('splitPdf', {})).rejects.toBe(retryErr)
+    expect(mockGetIdToken).toHaveBeenCalledWith(true)
+    expect(mockCallableImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('リトライ対象でないコード(invalid-argument)はトークンリフレッシュせず即座に元のエラーをthrowする', async () => {
+    const err = makeFunctionsError('invalid-argument', 'bad input')
+    mockCallableImpl.mockRejectedValueOnce(err)
+
+    await expect(callFunction('splitPdf', {})).rejects.toBe(err)
+    expect(mockGetIdToken).not.toHaveBeenCalled()
+    expect(mockCallableImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('リトライが成功した場合は成功データを返す', async () => {
+    const err = makeFunctionsError('deadline-exceeded', 'timeout')
+    mockCallableImpl
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({ data: { success: true } })
+
+    await expect(callFunction('splitPdf', {})).resolves.toEqual({ success: true })
+    expect(mockCallableImpl).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/src/lib/__tests__/callFunction.test.ts
+++ b/frontend/src/lib/__tests__/callFunction.test.ts
@@ -1,0 +1,58 @@
+/**
+ * getCallableErrorMessage 単体テスト
+ *
+ * Issue #621: splitPdfの新エラーコード(already-exists/aborted)がFE未対応で
+ * 生の英語メッセージ+内部ドキュメントIDがそのままユーザーに露出する問題の修正。
+ * BE側のエラーメッセージは 'already-exists' という文字列を含まないため
+ * (例: "Document abc123 has already been split (status='split')")、
+ * message.includes() 方式では検知できず、FirebaseError.code による判定が必須。
+ */
+
+import { describe, it, expect } from 'vitest'
+import { getCallableErrorMessage } from '../callFunction'
+
+// firebase/functions の FunctionsError は FirebaseError を継承し
+// code: `functions/${FunctionsErrorCodeCore}` を持つ。テストでは最小限のシェイプで模擬する。
+function makeFunctionsError(code: string, message: string): Error {
+  const err = new Error(message)
+  ;(err as Error & { code: string }).code = `functions/${code}`
+  return err
+}
+
+describe('getCallableErrorMessage - Issue #621 already-exists/aborted', () => {
+  it('code=already-exists のとき、内部IDを含まない汎用日本語メッセージを返す', () => {
+    const err = makeFunctionsError(
+      'already-exists',
+      "Document abc123 has already been split (status='split')"
+    )
+
+    const message = getCallableErrorMessage(err)
+
+    expect(message).not.toMatch(/abc123/)
+    expect(message).not.toMatch(/already-exists|already been split/i)
+    expect(message).toContain('既に完了')
+  })
+
+  it('code=aborted のとき、内部ドキュメントIDを含まない汎用日本語メッセージを返す', () => {
+    const err = makeFunctionsError(
+      'aborted',
+      'splitPdf aborted: concurrent split detected (parent=abc123 was modified since read, likely split by another request): precondition failed'
+    )
+
+    const message = getCallableErrorMessage(err)
+
+    expect(message).not.toMatch(/abc123/)
+    expect(message).not.toMatch(/splitPdf aborted|concurrent split detected/i)
+    expect(message).toContain('競合')
+  })
+
+  it('code情報がなくメッセージ文字列に already-exists/aborted の語が含まれない従来ケースは既存のフォールバックのまま', () => {
+    const err = new Error('permission-denied: not in whitelist')
+    expect(getCallableErrorMessage(err)).toBe('権限がありません。')
+  })
+
+  it('未知のcode/messageはdefaultMessageにフォールバックする', () => {
+    const err = makeFunctionsError('unknown', 'something went wrong')
+    expect(getCallableErrorMessage(err, 'デフォルトエラー')).toBe('デフォルトエラー')
+  })
+})

--- a/frontend/src/lib/callFunction.ts
+++ b/frontend/src/lib/callFunction.ts
@@ -13,13 +13,24 @@
 import { httpsCallable } from 'firebase/functions'
 import { functions, auth } from './firebase'
 
+/**
+ * Cloud Functions callable のエラーコードを取得する（`functions/${code}` prefixを除去）。
+ * BE側のエラーメッセージ文字列自体にコード名が含まれるとは限らないため
+ * (例: splitPdfのalready-exists/abortedは内部docId混じりの説明文のみ)、
+ * メッセージのパターンマッチではなく FirebaseError.code を正としてハンドリングする。
+ */
+export function getCallableErrorCode(err: unknown): string | undefined {
+  if (!(err instanceof Error)) return undefined
+  const code = (err as Error & { code?: unknown }).code
+  return typeof code === 'string' ? code.replace(/^functions\//, '') : undefined
+}
+
 /** リトライ対象のエラーかどうか判定 */
 function isRetryableError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false
-  const msg = err.message
-  return msg.includes('unauthenticated') ||
-    msg.includes('deadline-exceeded') ||
-    msg.includes('internal')
+  const code = getCallableErrorCode(err)
+  return code === 'unauthenticated' ||
+    code === 'deadline-exceeded' ||
+    code === 'internal'
 }
 
 /**
@@ -45,28 +56,17 @@ export async function callFunction<TReq, TRes>(
     return result.data
   } catch (err) {
     if (isRetryableError(err) && auth.currentUser) {
-      try {
-        await auth.currentUser.getIdToken(true)
-        const result = await callable(data)
-        return result.data
-      } catch {
-        // リトライも失敗 → 元のエラーをthrow
-      }
+      // silent-failure-hunterレビュー指摘: リトライ後の呼び出しをtry/catchで
+      // 包んで元のerrをthrowすると、getCallableErrorCode/onErrorベースの
+      // 分岐(Issue #621)がリトライ後の真のコード(例: already-exists)を
+      // 見られなくなる。リトライ後に失敗した場合はここでcatchせず、
+      // その例外をそのまま呼び出し元へ伝播させる(リトライの結果を正とする)。
+      await auth.currentUser.getIdToken(true)
+      const result = await callable(data)
+      return result.data
     }
     throw err
   }
-}
-
-/**
- * Cloud Functions callable のエラーコードを取得する（`functions/${code}` prefixを除去）。
- * BE側のエラーメッセージ文字列自体にコード名が含まれるとは限らないため
- * (例: splitPdfのalready-exists/abortedは内部docId混じりの説明文のみ)、
- * メッセージのパターンマッチではなく FirebaseError.code を正としてハンドリングする。
- */
-export function getCallableErrorCode(err: unknown): string | undefined {
-  if (!(err instanceof Error)) return undefined
-  const code = (err as Error & { code?: unknown }).code
-  return typeof code === 'string' ? code.replace(/^functions\//, '') : undefined
 }
 
 /** よくあるエラーをユーザー向けメッセージに変換 */

--- a/frontend/src/lib/callFunction.ts
+++ b/frontend/src/lib/callFunction.ts
@@ -57,12 +57,27 @@ export async function callFunction<TReq, TRes>(
   }
 }
 
+/**
+ * Cloud Functions callable のエラーコードを取得する（`functions/${code}` prefixを除去）。
+ * BE側のエラーメッセージ文字列自体にコード名が含まれるとは限らないため
+ * (例: splitPdfのalready-exists/abortedは内部docId混じりの説明文のみ)、
+ * メッセージのパターンマッチではなく FirebaseError.code を正としてハンドリングする。
+ */
+export function getCallableErrorCode(err: unknown): string | undefined {
+  if (!(err instanceof Error)) return undefined
+  const code = (err as Error & { code?: unknown }).code
+  return typeof code === 'string' ? code.replace(/^functions\//, '') : undefined
+}
+
 /** よくあるエラーをユーザー向けメッセージに変換 */
 export function getCallableErrorMessage(err: unknown, defaultMessage = '処理に失敗しました'): string {
   if (!(err instanceof Error)) return defaultMessage
+  const code = getCallableErrorCode(err)
+  if (code === 'already-exists') return 'この操作は既に完了しています。画面を更新して最新の状態をご確認ください。'
+  if (code === 'aborted') return '別の操作と競合したため処理を中断しました。時間をおいて再度お試しください。'
   const msg = err.message
-  if (msg.includes('unauthenticated')) return 'ログインセッションが切れました。ページを再読み込みしてください。'
-  if (msg.includes('deadline-exceeded') || msg.includes('internal')) return '通信エラーが発生しました。電波状況を確認して再度お試しください。'
-  if (msg.includes('permission-denied') || msg.includes('not in whitelist')) return '権限がありません。'
+  if (code === 'unauthenticated' || msg.includes('unauthenticated')) return 'ログインセッションが切れました。ページを再読み込みしてください。'
+  if (code === 'deadline-exceeded' || code === 'internal' || msg.includes('deadline-exceeded') || msg.includes('internal')) return '通信エラーが発生しました。電波状況を確認して再度お試しください。'
+  if (code === 'permission-denied' || msg.includes('permission-denied') || msg.includes('not in whitelist')) return '権限がありません。'
   return defaultMessage
 }


### PR DESCRIPTION
## Summary
- Issue #539で追加された`splitPdf`の`already-exists`/`aborted`エラーコードがFE未対応で、内部ドキュメントIDを含む生の英語エラーがそのままトースト表示され、失敗時に一覧・詳細のクエリキャッシュも無効化されていなかった問題を修正
- `callFunction.ts`に`getCallableErrorCode()`を新設し、`FirebaseError.code`を正としてエラー種別を判定（BE側メッセージ文字列にコード名が含まれるとは限らないため）
- `PdfSplitModal.tsx`のcatch節でalready-exists/aborted向けの日本語文言を表示。未知コードは従来通り生メッセージを表示し原因情報の欠落を防ぐ
- `usePdfSplit.ts`の`useSplitPdf`に`onError`を追加し、already-exists/aborted時に`documentsInfinite`/`document`クエリを無効化

## 品質ゲート
- `/safe-refactor`: DRY違反1件（invalidateQueries重複）を修正
- `/code-review medium`: 8角度並列レビュー→2件CONFIRMEDの回帰を検出・修正
  1. onErrorのキャッシュ無効化が確認ステップ中の`useEffect`を再発火させ、ユーザーが確定した`splitPoints`を無言で上書きしうる問題（`isConfirmStep`中は自動候補による上書きを停止するガードを追加）
  2. 未知エラーコード（`not-found`/`failed-precondition`等）で有用な生メッセージが汎用文言に丸められ原因情報が失われる問題（既知の翻訳対象コード以外は生メッセージへフォールバック）

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npm run lint` PASS（警告0件）
- [x] `npx vitest run` 324件全PASS（新規13件含む）
- [x] `npm run build` PASS
- [x] **本PR自身で実機検証**: dev環境（doc-split-dev、seed_generic_12p.pdf）でPlaywright MCPにより分割モーダルの正常系を確認（分割実行→バッジ「分割済」に変化→モーダル自動クローズ、コンソールエラー0件）。already-exists/aborted翻訳ロジックとsplitPoints上書き防止ガードは、Firebase SDK公式型契約（`FunctionsError.code = functions/${code}`）に基づく合成エラーを用いた11件のコンポーネントテスト（実React描画）で担保

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when PDF splitting fails, including clearer handling of conflicts and completed operations.
  * Prevented confirmed split points from being reset during confirmation.
  * Ensured document lists and details refresh when a split conflict occurs, keeping the interface up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->