### PR TITLE
fix(pdf): splitPdf/rotatePdfPagesのNOT_FOUND誤診断メッセージを分離 (#620)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -869,8 +869,17 @@ export const splitPdf = onCall(
         );
         // Issue #539: precondition mismatch (二重split race) は internal ではなく aborted として
         // 区別する。判定は rotatePdfPages と共通の isFirestorePreconditionFailure ヘルパーを使う。
+        // Issue #620: NOT_FOUND (親doc削除) は FAILED_PRECONDITION (同時書込み) と原因が異なるため
+        // isFirestoreNotFound で分離し、誤って「二重split」と断定しないメッセージにする。
         const errMessage = unwrapErrorMessage(firestoreErr);
         if (isFirestorePreconditionFailure(firestoreErr)) {
+          if (isFirestoreNotFound(firestoreErr)) {
+            throw new HttpsError(
+              'aborted',
+              `splitPdf aborted: parent document (${documentId}) was deleted during processing: ${errMessage}`,
+              { stage: 'firestoreBatch', parentDocumentId: documentId }
+            );
+          }
           throw new HttpsError(
             'aborted',
             `splitPdf aborted: concurrent split detected (parent=${documentId} was modified since read, likely split by another request): ${errMessage}`,
@@ -955,6 +964,24 @@ function isFirestorePreconditionFailure(err: unknown): boolean {
     errCode === 'failed-precondition' ||
     errCode === 'not-found' ||
     /FAILED_PRECONDITION|NOT_FOUND|precondition|no document to update/i.test(errMessage)
+  );
+}
+
+/**
+ * isFirestorePreconditionFailure が true のケースのうち、NOT_FOUND (親doc削除) のみを
+ * 判定する (Issue #620)。FAILED_PRECONDITION (同時書込みによる二重split) と区別し、
+ * 呼び出し側でより正確な診断メッセージを出し分けるために使う。
+ */
+function isFirestoreNotFound(err: unknown): boolean {
+  const errCode =
+    err instanceof Error && 'code' in err
+      ? (err as { code: number | string }).code
+      : undefined;
+  const errMessage = unwrapErrorMessage(err);
+  return (
+    errCode === 5 || // NOT_FOUND
+    errCode === 'not-found' ||
+    /NOT_FOUND|no document to update/i.test(errMessage)
   );
 }
 
@@ -1228,8 +1255,17 @@ export const rotatePdfPages = onCall(
       }
       // Firestore precondition mismatch (NOT_FOUND / FAILED_PRECONDITION 等) を concurrent write として扱う。
       // 判定は splitPdf と共通の isFirestorePreconditionFailure ヘルパーを使う。
+      // Issue #620: NOT_FOUND (親doc削除) は FAILED_PRECONDITION (同時書込み) と原因が異なるため
+      // isFirestoreNotFound で分離し、誤って「concurrent write」と断定しないメッセージにする。
       const errMessage = unwrapErrorMessage(commitErr);
       if (isFirestorePreconditionFailure(commitErr)) {
+        if (isFirestoreNotFound(commitErr)) {
+          throw new HttpsError(
+            'aborted',
+            `Rotation aborted: parent document (${documentId}) was deleted during processing: ${errMessage}`,
+            rollbackDetails
+          );
+        }
         throw new HttpsError(
           'aborted',
           `Concurrent write detected during rotation (document updateTime drift): ${errMessage}`,

--- a/functions/test/rotatePdfPagesContract.test.ts
+++ b/functions/test/rotatePdfPagesContract.test.ts
@@ -154,6 +154,11 @@ describe('rotatePdfPages source code grep contract (PR-D3 AC3 拡張)', () => {
       expect(rotateBody).to.match(/Concurrent write detected/i);
     });
 
+    it('NOT_FOUND (親doc削除) は Concurrent write と区別したメッセージになる (Issue #620)', () => {
+      expect(rotateBody).to.match(/isFirestoreNotFound\(commitErr\)/);
+      expect(rotateBody).to.match(/was deleted during processing/);
+    });
+
     it('precondition mismatch 判定は splitPdf と共通の isFirestorePreconditionFailure ヘルパーを呼ぶ (Issue #539で共通化)', () => {
       // 判定ロジック自体は rotatePdfPages 関数体の外 (isFirestorePreconditionFailure) に
       // 抽出されているため、rotateBody からは呼出し箇所のみを検証する

--- a/functions/test/splitPdfConcurrencyGuardContract.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardContract.test.ts
@@ -94,6 +94,14 @@ describe('splitPdf 二重split race防止 grep contract (Issue #539)', () => {
     );
   });
 
+  it('NOT_FOUND (親doc削除) は FAILED_PRECONDITION (二重split) と区別したメッセージになる (Issue #620)', () => {
+    expect(sourceText).to.match(/function isFirestoreNotFound\(/);
+    expect(sourceText).to.match(/isFirestoreNotFound\(firestoreErr\)/);
+    expect(sourceText).to.match(
+      /HttpsError\(\s*['"]aborted['"][\s\S]{0,200}was deleted during processing/
+    );
+  });
+
   it('precondition mismatch 時も既存の Storage cleanup を経由してから aborted へ分岐する', () => {
     const catchIdx = sourceText.indexOf('} catch (firestoreErr) {');
     const cleanupCallMatch = /await cleanupAccumulatedStorageFiles\(\s*accumulated,\s*'firestoreBatch',/.exec(


### PR DESCRIPTION
## Summary
- `isFirestorePreconditionFailure` は FAILED_PRECONDITION (二重split) と NOT_FOUND (親doc削除) を同一分類しており、親doc削除時にも「二重splitの可能性」と誤診断するメッセージが返っていた
- 新規ヘルパー `isFirestoreNotFound` で NOT_FOUND のみを分離判定し、splitPdf / rotatePdfPages 双方で削除検出時により正確なメッセージ (`parent document was deleted during processing`) を返すよう分岐を追加

## Test plan
- [x] `npm run build` (tsc) 成功
- [x] `npm test` 1730 passing (既存回帰なし)
- [x] `splitPdfConcurrencyGuardContract.test.ts` / `rotatePdfPagesContract.test.ts` に新設した Issue #620 分岐の grep contract test を含め該当テスト単体実行でも全PASS

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when a document is deleted during PDF splitting or page rotation.
  * More clearly distinguishes deleted documents from concurrent processing conflicts.

* **Tests**
  * Added coverage to verify accurate handling and messaging for deleted-document scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->