### PR TITLE
test(pdf): splitPdfConcurrencyGuardContract.test.tsのvacuous test riskを解消 (#622)

### DIFF
--- a/functions/src/pdf/pdfOperations.ts
+++ b/functions/src/pdf/pdfOperations.ts
@@ -952,7 +952,7 @@ function unwrapErrorMessage(e: unknown): string {
  * 公式 API 約束ではない (SDK バージョンアップで number → string 変動リスクあり)。
  * 堅牢化のため 3 系統 OR 判定: (a) gRPC 数値 code (b) Cloud Functions 文字列 code (c) message fallback
  */
-function isFirestorePreconditionFailure(err: unknown): boolean {
+export function isFirestorePreconditionFailure(err: unknown): boolean {
   const errCode =
     err instanceof Error && 'code' in err
       ? (err as { code: number | string }).code

--- a/functions/test/splitPdfConcurrencyGuardContract.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardContract.test.ts
@@ -15,6 +15,13 @@
  * ソース文字列レベルで配線の退行を防ぐ (splitPdfDocIdNamespace.test.ts と同形式)。
  * precondition自体の実際のFirestore挙動は splitPdfConcurrencyGuardIntegration.test.ts
  * (emulator) で検証する。
+ *
+ * Issue #622: splitPdf 関数体スコープに閉じた検索に統一する。
+ * ファイル全体 (sourceText) を対象にした indexOf/exec は、detectSplitPoints (readDocWithDetail
+ * を splitPdf より前に呼ぶ) や rotatePdfPages (同一の `{ lastUpdateTime: startUpdateTime }`
+ * literal を持つ) 側の記述に偶然救われて pass する vacuous test になりうる。
+ * splitPdf 本体の外にあるヘルパー (isFirestorePreconditionFailure / isFirestoreNotFound /
+ * recheckParentBeforeRetry の定義自体) の検証のみ sourceText を使う。
  */
 
 import { expect } from 'chai';
@@ -29,30 +36,60 @@ import '../src/storage/storageDeletionGuard';
 const SOURCE_PATH = resolve(__dirname, '..', 'src/pdf/pdfOperations.ts');
 const sourceText = readFileSync(SOURCE_PATH, 'utf-8');
 
+/**
+ * splitPdf 関数の export 行から、対応する `);` までを括弧バランスで抽出する
+ * (rotatePdfPagesContract.test.ts の extractRotatePdfPagesFunctionBody と同形式)。
+ * detectSplitPoints 等の他関数にある同名 literal (readDocWithDetail 等) への
+ * 誤マッチを避けるため、grep contract は本関数の戻り値のみを対象にする。
+ */
+function extractSplitPdfFunctionBody(): string {
+  const startMarker = 'export const splitPdf = onCall(';
+  const startIdx = sourceText.indexOf(startMarker);
+  expect(startIdx, 'splitPdf 関数が見つからない').to.be.greaterThan(-1);
+
+  let depth = 0;
+  let i = startIdx + startMarker.length - 1; // `(` 位置
+  for (; i < sourceText.length; i++) {
+    if (sourceText[i] === '(') depth++;
+    else if (sourceText[i] === ')') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  const endIdx = sourceText.indexOf(';', i) + 1;
+  return sourceText.slice(startIdx, endIdx);
+}
+
 describe('splitPdf 二重split race防止 grep contract (Issue #539)', () => {
-  it("早期拒否: docData.status === 'split' なら already-exists で拒否する", () => {
-    expect(sourceText).to.match(/docData\.status === 'split'/);
-    expect(sourceText).to.match(/'already-exists'/);
+  let splitPdfBody: string;
+
+  before(() => {
+    splitPdfBody = extractSplitPdfFunctionBody();
   });
 
-  it('早期拒否チェックは readDocWithDetail の直後、PDF download より前にある', () => {
-    const readIdx = sourceText.indexOf('await readDocWithDetail(db, docRef)');
-    const statusCheckIdx = sourceText.indexOf("docData.status === 'split'");
-    const downloadIdx = sourceText.indexOf('acquireSourceSnapshot(file)');
+  it("早期拒否: docData.status === 'split' なら already-exists で拒否する", () => {
+    expect(splitPdfBody).to.match(/docData\.status === 'split'/);
+    expect(splitPdfBody).to.match(/'already-exists'/);
+  });
+
+  it('早期拒否チェックは readDocWithDetail の直後、PDF download より前にある (splitPdf 本体スコープ限定, Issue #622)', () => {
+    const readIdx = splitPdfBody.indexOf('await readDocWithDetail(db, docRef)');
+    const statusCheckIdx = splitPdfBody.indexOf("docData.status === 'split'");
+    const downloadIdx = splitPdfBody.indexOf('acquireSourceSnapshot(file)');
     expect(readIdx).to.be.greaterThan(-1);
     expect(statusCheckIdx, 'status check must be found').to.be.greaterThan(readIdx);
     expect(downloadIdx).to.be.greaterThan(statusCheckIdx);
   });
 
   it('startUpdateTime を読取り時点のsnapshotから保持しnullガードする (retry時再代入のためlet)', () => {
-    expect(sourceText).to.match(/let startUpdateTime = docSnapshot\.updateTime;/);
-    expect(sourceText).to.match(/if \(!startUpdateTime\) \{/);
+    expect(splitPdfBody).to.match(/let startUpdateTime = docSnapshot\.updateTime;/);
+    expect(splitPdfBody).to.match(/if \(!startUpdateTime\) \{/);
   });
 
   it('drift retry前に recheckParentBeforeRetry で親docを再チェックし startUpdateTime を更新する (Issue #539 fix: stale precondition誤検知防止)', () => {
     expect(sourceText).to.match(/async function recheckParentBeforeRetry\(/);
     // T1 (sourceSnapshot取得時drift) と T3 (final drift) の両方の retry 直前で呼ばれる
-    const callSites = sourceText.match(
+    const callSites = splitPdfBody.match(
       /startUpdateTime = await recheckParentBeforeRetry\(docRef, documentId, docData\.status, fileUrl\);/g
     );
     expect(callSites, 'recheckParentBeforeRetry call sites must be found').to.not.be.null;
@@ -60,6 +97,7 @@ describe('splitPdf 二重split race防止 grep contract (Issue #539)', () => {
   });
 
   it('recheckParentBeforeRetry は already-exists / not-found / failed-precondition の3系統に加え status/fileUrl drift も判定する (Codex PR #623 P1 fix)', () => {
+    // recheckParentBeforeRetry は splitPdf 関数体の外で定義されたヘルパーのため sourceText 全体から抽出する
     const fnMatch = /async function recheckParentBeforeRetry\([\s\S]{0,1400}?\n}/.exec(sourceText);
     expect(fnMatch, 'recheckParentBeforeRetry function body must be found').to.not.be.null;
     const fnBody = fnMatch![0];
@@ -76,38 +114,40 @@ describe('splitPdf 二重split race防止 grep contract (Issue #539)', () => {
     expect(fnBody).to.match(/'failed-precondition'/);
   });
 
-  it('親doc更新は lastUpdateTime precondition 付きの batch.update である', () => {
-    const updateMatch = /batch\.update\(\s*docRef,/.exec(sourceText);
-    const preconditionMatch = /\{\s*lastUpdateTime:\s*startUpdateTime\s*\}/.exec(sourceText);
+  it('親doc更新は lastUpdateTime precondition 付きの batch.update である (splitPdf 本体スコープ限定, Issue #622)', () => {
+    const updateMatch = /batch\.update\(\s*docRef,/.exec(splitPdfBody);
+    const preconditionMatch = /\{\s*lastUpdateTime:\s*startUpdateTime\s*\}/.exec(splitPdfBody);
     expect(updateMatch, 'batch.update(docRef, ...) call site must be found').to.not.be.null;
     expect(preconditionMatch, 'lastUpdateTime precondition must be found').to.not.be.null;
     expect(preconditionMatch!.index).to.be.greaterThan(updateMatch!.index);
   });
 
   it('precondition mismatch は internal ではなく aborted で区別される (rotatePdfPagesと共通の isFirestorePreconditionFailure ヘルパー)', () => {
-    expect(sourceText).to.match(/function isFirestorePreconditionFailure\(/);
-    expect(sourceText).to.match(/isFirestorePreconditionFailure\(firestoreErr\)/);
+    // isFirestorePreconditionFailure 自体は splitPdf 関数体の外で定義されたヘルパーのため sourceText で確認
+    expect(sourceText).to.match(/export function isFirestorePreconditionFailure\(/);
     expect(sourceText).to.match(/errCode === 9/); // FAILED_PRECONDITION (ヘルパー定義内)
     expect(sourceText).to.match(/errCode === 'failed-precondition'/);
-    expect(sourceText).to.match(
+    // 呼び出し箇所・分岐メッセージは splitPdf 本体スコープで検証
+    expect(splitPdfBody).to.match(/isFirestorePreconditionFailure\(firestoreErr\)/);
+    expect(splitPdfBody).to.match(
       /HttpsError\(\s*['"]aborted['"][\s\S]{0,200}concurrent split detected/
     );
   });
 
-  it('NOT_FOUND (親doc削除) は FAILED_PRECONDITION (二重split) と区別したメッセージになる (Issue #620)', () => {
+  it('NOT_FOUND (親doc削除) は FAILED_PRECONDITION (二重split) と区別したメッセージになる (Issue #620, #622)', () => {
     expect(sourceText).to.match(/function isFirestoreNotFound\(/);
-    expect(sourceText).to.match(/isFirestoreNotFound\(firestoreErr\)/);
-    expect(sourceText).to.match(
+    expect(splitPdfBody).to.match(/isFirestoreNotFound\(firestoreErr\)/);
+    expect(splitPdfBody).to.match(
       /HttpsError\(\s*['"]aborted['"][\s\S]{0,200}was deleted during processing/
     );
   });
 
-  it('precondition mismatch 時も既存の Storage cleanup を経由してから aborted へ分岐する', () => {
-    const catchIdx = sourceText.indexOf('} catch (firestoreErr) {');
+  it('precondition mismatch 時も既存の Storage cleanup を経由してから aborted へ分岐する (splitPdf 本体スコープ限定, Issue #622)', () => {
+    const catchIdx = splitPdfBody.indexOf('} catch (firestoreErr) {');
     const cleanupCallMatch = /await cleanupAccumulatedStorageFiles\(\s*accumulated,\s*'firestoreBatch',/.exec(
-      sourceText
+      splitPdfBody
     );
-    const preconditionCheckIdx = sourceText.indexOf(
+    const preconditionCheckIdx = splitPdfBody.indexOf(
       'isFirestorePreconditionFailure(firestoreErr)'
     );
     expect(catchIdx).to.be.greaterThan(-1);

--- a/functions/test/splitPdfConcurrencyGuardIntegration.test.ts
+++ b/functions/test/splitPdfConcurrencyGuardIntegration.test.ts
@@ -17,6 +17,7 @@ import './helpers/initFirestoreEmulator';
 import { expect } from 'chai';
 import * as admin from 'firebase-admin';
 import { cleanupCollections } from './helpers/cleanupEmulator';
+import { isFirestorePreconditionFailure } from '../src/pdf/pdfOperations';
 
 const db = admin.firestore();
 const COLLECTIONS_TO_CLEAN: readonly string[] = ['documents'];
@@ -74,22 +75,13 @@ describe('splitPdf 二重split race防止 integration (#539)', () => {
     }
     expect(thrown, 'second concurrent commit must throw').to.not.be.undefined;
 
-    // pdfOperations.ts の isPreconditionFailure 判定ロジックと同一条件で検証
-    // (実装と同じ3系統OR: gRPC数値code / Cloud Functions文字列code / message fallback)
-    const errCode =
-      thrown instanceof Error && 'code' in thrown
-        ? (thrown as { code: number | string }).code
-        : undefined;
-    const errMessage = thrown instanceof Error ? thrown.message : String(thrown);
-    const isPreconditionFailure =
-      errCode === 9 ||
-      errCode === 5 ||
-      errCode === 'failed-precondition' ||
-      errCode === 'not-found' ||
-      /FAILED_PRECONDITION|NOT_FOUND|precondition|no document to update/i.test(errMessage);
+    // pdfOperations.ts の isFirestorePreconditionFailure を直接importして検証する
+    // (Issue #622: ロジックの手動複製によるドリフトリスクを解消)
     expect(
-      isPreconditionFailure,
-      `expected precondition failure, got code=${errCode} message=${errMessage}`
+      isFirestorePreconditionFailure(thrown),
+      `expected precondition failure, got ${
+        thrown instanceof Error ? thrown.message : String(thrown)
+      }`
     ).to.equal(true);
 
     // 親docは1つ目のリクエストの結果のまま (2つ目の上書きが発生していないこと)


### PR DESCRIPTION
## Summary
- `splitPdfConcurrencyGuardContract.test.ts` の一部テストが sourceText 全体を検索しており、退行を実際には検知できない (vacuous test) 状態だった
  - `readIdx` が `splitPdf` より前に定義された `detectSplitPoints` 内の同一literal (`readDocWithDetail(db, docRef)`) にマッチしていた
  - `lastUpdateTime` precondition検索が `rotatePdfPages` 側の同一literalに偶然救われていた
- `extractSplitPdfFunctionBody()` で `splitPdf` 関数本体のみを抽出し、該当テストの検索スコープを限定 (`rotatePdfPagesContract.test.ts` の既存パターンを踏襲)
- `isFirestorePreconditionFailure` を `export` し、`splitPdfConcurrencyGuardIntegration.test.ts` が手動複製していた判定ロジックを直接importに置換 (ドリフトリスク解消)

## Test plan
- [x] `npm run build` (tsc) 成功
- [x] `npm test` 1730 passing (既存回帰なし)
- [x] `splitPdfConcurrencyGuardContract.test.ts` / `rotatePdfPagesContract.test.ts` 単体実行で全PASS
- [x] `firebase emulators:exec --only firestore ... splitPdfConcurrencyGuardIntegration.test.ts` で8件全PASS(export化したヘルパーの直接import経由での動作確認)

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)