### PR TITLE
perf(ocr): OCR実行の所有権チェックをPDFページループ内に前倒し (#626)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -15,7 +15,12 @@ import {
   calculateRetryDelay429Ms,
 } from '../utils/retry';
 import { safeLogError } from '../utils/errorLogger';
-import { evaluateOcrRunOwnership, OcrRunSupersededError } from './ocrRunGuard';
+import {
+  evaluateOcrRunOwnership,
+  OcrRunSupersededError,
+  type OcrRunExpectation,
+  type OcrRunOwnershipResult,
+} from './ocrRunGuard';
 import { getRateLimiter } from '../utils/rateLimiter';
 import { GCP_CONFIG, GEMINI_CONFIG, isThreePointFiveModel } from '../utils/config';
 import {
@@ -141,6 +146,16 @@ export async function processDocument(
 ): Promise<OcrProcessingResult> {
   console.log(`Processing document: ${docId}`);
 
+  // Issue #626: PDFページOCRループ内で早期所有権チェックに使うため、最終transaction用
+  // (元は363行目付近で定義)より前方に移動。db.doc()自体はFirestore read副作用を持たない
+  // 参照生成のみなので、早期に定義しても安全。
+  const docRef = db.doc(`documents/${docId}`);
+  const ownershipExpectation: OcrRunExpectation = {
+    ocrRunId,
+    fileUrl: docData.fileUrl as string,
+    mimeType: docData.mimeType as string,
+  };
+
   // Issue #526 D3: 分割子ドキュメント(#445で確立済みのparentDocumentIdを持つ)が
   // 親から継承した有効なpageResultsを持つ場合、ページOCRを再実行せず再利用する(コスト削減)。
   // ADR-0018 Phase D (#1): 再利用元は detail/main を優先読み(親フォールバック付き)。
@@ -198,6 +213,32 @@ export async function processDocument(
 
       for (let i = 0; i < totalPages; i++) {
         const pageNumber = i + 1;
+
+        // Issue #626: 各ページのGemini呼出し前に軽量な所有権チェックを行う。最終transaction
+        // (evaluateOcrRunOwnershipによる検証)と同じ判定基準だが、ここで先に検知することで
+        // supersededされたrunが残りページ分のGemini APIコストを消費し切ってから最終
+        // transactionで結果を破棄する無駄を防ぐ。最終transactionのガードは
+        // defense-in-depthとして引き続き必要 (このチェックはbest-effort最適化)。
+        const ownership = await checkOcrRunStillOwned(
+          docRef,
+          ownershipExpectation,
+          docId,
+          functionName
+        );
+        if (!ownership.ok) {
+          throw new OcrRunSupersededError(
+            `OCR run for document ${docId} superseded during page OCR loop (page ${pageNumber}/${totalPages}, reason: ${ownership.reason}), aborting remaining pages`,
+            docId,
+            ownership.reason,
+            {
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+              thinkingTokens: totalThinkingTokens,
+              pagesProcessed: i,
+            }
+          );
+        }
+
         console.log(`Processing page ${pageNumber}/${totalPages}`);
 
         const pageBuffer = await extractPdfPage(buffer, i);
@@ -359,8 +400,8 @@ export async function processDocument(
   // Issue #526 D2: confirmed保護マージはFirestore transaction内で最新ドキュメントを
   // 読み直してから行う。OCR/抽出処理は数秒〜数十秒かかるため、docData(呼出時点の
   // スナップショット)をそのまま使うと、処理中にユーザーが編集した内容と競合する
-  // stale snapshot問題が起きる(Issue #526本文の設計要件)。
-  const docRef = db.doc(`documents/${docId}`);
+  // stale snapshot問題が起きる(Issue #526本文の設計要件)。docRef自体は関数冒頭
+  // (Issue #626)で早期定義済みのためここでは再定義しない。
 
   try {
     await db.runTransaction(async (tx) => {
@@ -381,11 +422,7 @@ export async function processDocument(
       // またはfileUrl/mimeTypeが変化している場合、この実行の抽出結果はもはや正しい対象を
       // 表していない。書込みを一切行わずOcrRunSupersededErrorをthrowしてabortする
       // (呼出元processOCR.tsはこれをエラーではなく正常なsupersedeとして扱う)。
-      const ownership = evaluateOcrRunOwnership(freshData, {
-        ocrRunId,
-        fileUrl: docData.fileUrl as string,
-        mimeType: docData.mimeType as string,
-      });
+      const ownership = evaluateOcrRunOwnership(freshData, ownershipExpectation);
       if (!ownership.ok) {
         throw new OcrRunSupersededError(
           `OCR run for document ${docId} superseded (reason: ${ownership.reason}), skipping write`,
@@ -738,6 +775,37 @@ function createDefaultOcrResultStorageAdapter(): OcrResultStorageAdapter {
       );
     },
   };
+}
+
+/**
+ * PDFページOCRループの各イテレーション開始前に呼ぶ、軽量な所有権チェック (Issue #626)。
+ * 最終transactionと同じ evaluateOcrRunOwnership の判定基準(ocrRunId→status→fileUrl→
+ * mimeType)をそのまま使い、Firestore再読みの結果を渡すだけの薄いラッパー。
+ *
+ * Firestore read自体が失敗した場合は `{ ok: true }` (継続) を返す。cleanup用の
+ * isStillCurrentOwner (失敗時false=安全側でスキップ、実害はorphan object残存のみ)とは
+ * 判断基準が異なる意図的な選択: 本チェックはbest-effort最適化でありdata整合性は最終
+ * transactionが最終的に担保するため、read失敗で誤って正当な処理を中断するfalse positiveの
+ * コストの方が高いと判断した。
+ */
+export async function checkOcrRunStillOwned(
+  docRef: FirebaseFirestore.DocumentReference,
+  expected: OcrRunExpectation,
+  docId: string,
+  functionName: string
+): Promise<OcrRunOwnershipResult> {
+  try {
+    const snap = await docRef.get();
+    return evaluateOcrRunOwnership(snap.data() ?? {}, expected);
+  } catch (err) {
+    await safeLogError({
+      error: err instanceof Error ? err : new Error(String(err)),
+      source: 'ocr',
+      functionName: `${functionName}:ocrRunOwnershipEarlyCheck`,
+      documentId: docId,
+    });
+    return { ok: true };
+  }
 }
 
 /**

--- a/functions/test/ocrProcessorEarlyOwnershipCheckWiringContract.test.ts
+++ b/functions/test/ocrProcessorEarlyOwnershipCheckWiringContract.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ocrProcessor.ts の PDFページOCRループ早期所有権チェック配線契約テスト (Issue #626)
+ *
+ * supersededされたOCR runが、残りページのGemini API呼出しを消費し切ってから最終
+ * transactionで初めて破棄される無駄を防ぐため、PDFページOCRループの各イテレーション
+ * 開始時(Gemini呼出し前)に checkOcrRunStillOwned を挟んでいる。
+ * processDocument自体はStorage/Gemini副作用が大きく直接呼び出せないため
+ * (ocrRunGuardIntegration.test.ts / ocrProcessorOcrResultCleanupWiringContract.test.ts と
+ * 同方針)、配線自体はソース文字列レベルでlock-inし、判定ロジック(checkOcrRunStillOwned
+ * 自体)の実際の動作は ocrRunGuardIntegration.test.ts (emulator) で検証する。
+ *
+ * Issue #622 教訓: grep anchor をファイル全体に対して緩く書くと vacuous になりうるため、
+ * PDFページループのブロックのみを extractBraceBlock で抽出してからマッチさせる。
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { extractBraceBlock } from './helpers/extractBraceBlock';
+
+const OCR_PROCESSOR_PATH = 'src/ocr/ocrProcessor.ts';
+const PROCESS_DOCUMENT_ANCHOR = /export\s+async\s+function\s+processDocument\s*\(/;
+const PDF_PAGE_LOOP_ANCHOR = /for\s*\(\s*let\s+i\s*=\s*0\s*;\s*i\s*<\s*totalPages\s*;\s*i\+\+\s*\)/;
+const CHECK_FN_ANCHOR = /export\s+async\s+function\s+checkOcrRunStillOwned\s*\(/;
+
+function expectSingleDefinition(source: string, pattern: RegExp, label: string): void {
+  const count = (source.match(pattern) ?? []).length;
+  expect(count, `${label} の定義が複数存在する場合は anchor の narrow が必要`).to.equal(1);
+}
+
+describe('ocrProcessor PDFページOCRループ早期所有権チェック配線契約 (Issue #626)', () => {
+  let pdfPageLoopBody = '';
+  let checkFunctionBody = '';
+
+  before(() => {
+    const absPath = resolve(process.cwd(), OCR_PROCESSOR_PATH);
+    const source = readFileSync(absPath, 'utf-8');
+
+    expectSingleDefinition(
+      source,
+      /export\s+async\s+function\s+processDocument\s*\(/g,
+      'processDocument'
+    );
+    const processDocumentBody = extractBraceBlock(source, PROCESS_DOCUMENT_ANCHOR);
+    expect(processDocumentBody, 'processDocument 関数本体の抽出に失敗した').to.not.be.null;
+
+    expectSingleDefinition(processDocumentBody!, /for\s*\(\s*let\s+i\s*=\s*0/g, 'PDFページループ');
+    const loopBody = extractBraceBlock(processDocumentBody, PDF_PAGE_LOOP_ANCHOR, {
+      anchorMode: 'after-match',
+    });
+    expect(loopBody, 'PDFページループ本体の抽出に失敗した').to.not.be.null;
+    pdfPageLoopBody = loopBody!;
+
+    expectSingleDefinition(
+      source,
+      /export\s+async\s+function\s+checkOcrRunStillOwned\s*\(/g,
+      'checkOcrRunStillOwned'
+    );
+    const checkBody = extractBraceBlock(source, CHECK_FN_ANCHOR);
+    expect(checkBody, 'checkOcrRunStillOwned 関数本体の抽出に失敗した').to.not.be.null;
+    checkFunctionBody = checkBody!;
+  });
+
+  it('checkOcrRunStillOwned の呼出しが extractPdfPage / ocrWithGemini より前にある', () => {
+    const checkCallIdx = pdfPageLoopBody.indexOf('await checkOcrRunStillOwned(');
+    const extractPdfPageIdx = pdfPageLoopBody.indexOf('await extractPdfPage(buffer, i)');
+    const ocrWithGeminiIdx = pdfPageLoopBody.indexOf("await ocrWithGemini(pageBuffer, 'application/pdf'");
+    expect(checkCallIdx, 'checkOcrRunStillOwned呼出しが見つからない').to.be.greaterThan(-1);
+    expect(extractPdfPageIdx, 'extractPdfPage呼出しが見つからない').to.be.greaterThan(checkCallIdx);
+    expect(ocrWithGeminiIdx, 'ocrWithGemini呼出しが見つからない').to.be.greaterThan(extractPdfPageIdx);
+  });
+
+  it('ownership.ok が false の場合 OcrRunSupersededError を throw し、以降のGemini呼出しをスキップする', () => {
+    const checkCallIdx = pdfPageLoopBody.indexOf('await checkOcrRunStillOwned(');
+    const throwMatch = /if\s*\(\s*!ownership\.ok\s*\)\s*\{[\s\S]{0,400}?throw new OcrRunSupersededError\(/.exec(
+      pdfPageLoopBody
+    );
+    expect(throwMatch, 'ownership.ok===false時のOcrRunSupersededError throwが見つからない').to.not.be.null;
+    expect(throwMatch!.index).to.be.greaterThan(checkCallIdx);
+
+    const ocrWithGeminiIdx = pdfPageLoopBody.indexOf("await ocrWithGemini(pageBuffer, 'application/pdf'");
+    expect(throwMatch!.index, 'throwはGemini呼出しより前になければ早期中断の意味がない').to.be.lessThan(
+      ocrWithGeminiIdx
+    );
+  });
+
+  it('OcrRunSupersededError の tokenUsage は中断時点までの累積値(pagesProcessed: i)を渡す', () => {
+    expect(pdfPageLoopBody).to.match(
+      /throw new OcrRunSupersededError\([\s\S]{0,400}?pagesProcessed:\s*i,?\s*\}/
+    );
+    expect(pdfPageLoopBody).to.match(/inputTokens:\s*totalInputTokens/);
+    expect(pdfPageLoopBody).to.match(/outputTokens:\s*totalOutputTokens/);
+    expect(pdfPageLoopBody).to.match(/thinkingTokens:\s*totalThinkingTokens/);
+  });
+
+  it('checkOcrRunStillOwned はFirestore read失敗時に { ok: true } (継続) を返す (false positive回避)', () => {
+    expect(checkFunctionBody).to.match(/\}\s*catch\s*\(\s*err\s*\)\s*\{[\s\S]{0,300}?return\s*\{\s*ok:\s*true\s*\};/);
+  });
+
+  it('checkOcrRunStillOwned は evaluateOcrRunOwnership を再利用し、独自の判定ロジックを複製しない', () => {
+    expect(checkFunctionBody).to.match(/return evaluateOcrRunOwnership\(/);
+  });
+});

--- a/functions/test/ocrRunGuardIntegration.test.ts
+++ b/functions/test/ocrRunGuardIntegration.test.ts
@@ -17,7 +17,11 @@ import './helpers/initFirestoreEmulator';
 
 import { expect } from 'chai';
 import * as admin from 'firebase-admin';
-import { tryStartProcessing, handleProcessingError } from '../src/ocr/ocrProcessor';
+import {
+  tryStartProcessing,
+  handleProcessingError,
+  checkOcrRunStillOwned,
+} from '../src/ocr/ocrProcessor';
 import { evaluateOcrRunOwnership, OcrRunSupersededError } from '../src/ocr/ocrRunGuard';
 import { cleanupCollections } from './helpers/cleanupEmulator';
 
@@ -290,5 +294,102 @@ describe('OCR実行所有権ガード integration (#540)', () => {
     // 削除エラー自体はsupersededと違いerrors/に記録される(観測性の回帰防止)
     const errors = await db.collection('errors').get();
     expect(errors.empty, 'ドキュメント削除エラーはerrors/に記録されるべき').to.equal(false);
+  });
+});
+
+describe('checkOcrRunStillOwned: PDFページOCRループの早期所有権チェック (Issue #626)', () => {
+  beforeEach(async () => {
+    await cleanupCollections(db, COLLECTIONS_TO_CLEAN);
+  });
+
+  it('所有権が維持されている場合 { ok: true } を返す', async () => {
+    const docId = 'doc-early-check-ok';
+    const docRef = db.collection('documents').doc(docId);
+    await docRef.set({
+      status: 'pending',
+      fileUrl: 'gs://bucket/a.pdf',
+      mimeType: 'application/pdf',
+    });
+    const claim = await tryStartProcessing(docId);
+    const { ocrRunId, docData } = claim!;
+
+    const result = await checkOcrRunStillOwned(
+      docRef,
+      { ocrRunId, fileUrl: docData.fileUrl as string, mimeType: docData.mimeType as string },
+      docId,
+      'test'
+    );
+
+    expect(result).to.deep.equal({ ok: true });
+  });
+
+  it('reprocess等で別runにclaimし直された場合 run-id-mismatch を返す', async () => {
+    const docId = 'doc-early-check-superseded';
+    const docRef = db.collection('documents').doc(docId);
+    await docRef.set({
+      status: 'pending',
+      fileUrl: 'gs://bucket/a.pdf',
+      mimeType: 'application/pdf',
+    });
+    const claimA = await tryStartProcessing(docId);
+    const { ocrRunId: ocrRunIdA, docData: docDataA } = claimA!;
+
+    // run Aのページループ処理中に、reprocess相当でrun Bがclaimする
+    await docRef.update({ status: 'pending' });
+    await tryStartProcessing(docId);
+
+    const result = await checkOcrRunStillOwned(
+      docRef,
+      {
+        ocrRunId: ocrRunIdA,
+        fileUrl: docDataA.fileUrl as string,
+        mimeType: docDataA.mimeType as string,
+      },
+      docId,
+      'test'
+    );
+
+    expect(result).to.deep.equal({ ok: false, reason: 'run-id-mismatch' });
+  });
+
+  it('ドキュメントが処理中に削除された場合 run-id-mismatch を返す(ocrRunIdがundefinedになるため)', async () => {
+    const docId = 'doc-early-check-deleted';
+    const docRef = db.collection('documents').doc(docId);
+    await docRef.set({
+      status: 'pending',
+      fileUrl: 'gs://bucket/a.pdf',
+      mimeType: 'application/pdf',
+    });
+    const claim = await tryStartProcessing(docId);
+    const { ocrRunId, docData } = claim!;
+
+    await docRef.delete();
+
+    const result = await checkOcrRunStillOwned(
+      docRef,
+      { ocrRunId, fileUrl: docData.fileUrl as string, mimeType: docData.mimeType as string },
+      docId,
+      'test'
+    );
+
+    expect(result).to.deep.equal({ ok: false, reason: 'run-id-mismatch' });
+  });
+
+  it('Firestore read自体が失敗した場合、false positiveを避けるため { ok: true } (継続) を返す', async () => {
+    const docId = 'doc-early-check-read-failure';
+    // docRef.get()自体がrejectするモック(admin appの初期化に依存しない純粋な差し替え)。
+    // 実運用のdocRefと同じshapeを満たせばよいため、テスト目的でキャストする。
+    const failingDocRef = {
+      get: () => Promise.reject(new Error('simulated transient Firestore read failure')),
+    } as unknown as FirebaseFirestore.DocumentReference;
+
+    const result = await checkOcrRunStillOwned(
+      failingDocRef,
+      { ocrRunId: 'run-x', fileUrl: 'gs://bucket/a.pdf', mimeType: 'application/pdf' },
+      docId,
+      'test'
+    );
+
+    expect(result).to.deep.equal({ ok: true });
   });
 });


### PR DESCRIPTION
## Summary
- `processDocument()`のPDFページOCRループが、reprocess等で`ocrRunId`が変わった(superseded)ことを全ページ完了後の最終transactionでしか検知できず、残りページ分のGemini API呼出しコストを消費し切ってから結果を破棄していた
- `checkOcrRunStillOwned()`ヘルパーを追加し、各ページのGemini呼出し前に`evaluateOcrRunOwnership`と同じ判定基準(ocrRunId→status→fileUrl→mimeType)で軽量チェックを行う。所有権喪失を検知した時点で`OcrRunSupersededError`をthrowし、以降のページ処理をスキップする
- Firestore read自体が失敗した場合は false positive(正当な処理の誤中断)を避けるため継続扱い(`{ ok: true }`)とする(cleanup用の`isStillCurrentOwner`とは判断基準が異なる意図的な選択、PR body/コード内コメントに理由を明記)
- 最終transactionのガードは変更せずdefense-in-depthとして維持

## Test plan
- [x] `npm run build` (tsc) 成功
- [x] `npm test` 1735 passing (既存回帰なし、新規5件追加)
- [x] `firebase emulators:exec --only firestore ... npm run test:integration` 96 passing (`checkOcrRunStillOwned`の4ケース: 所有権維持/superseded/ドキュメント削除/read失敗 全PASS)
- [x] `ocrProcessorEarlyOwnershipCheckWiringContract.test.ts` でPDFループ内の配線(Gemini呼出し前チェック・tokenUsage集計・read失敗時継続)をgrep contractでlock-in

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF OCR processing to stop promptly when a run is superseded, avoiding unnecessary processing of remaining pages.
  * Added safeguards for ownership changes, deleted records, and temporary data-read failures.

* **Tests**
  * Added coverage for early processing cancellation, ownership changes, deleted records, and read failures.
  * Verified that processing metrics remain accurate when OCR is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->