### PR TITLE
docs(handoff): OCR突合精度向上ミッションをGOAL.mdへ登録

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -1,40 +1,45 @@
 ---
 updated: 2026-07-13
 ---
-<!-- session121: 全タスク完了・監視事項2件のみ残存の状態でdecision-maker合意のうえGOAL.mdを圧縮。旧本文（session95〜120の詳細tasksチェックリスト・session別HTMLコメント）はgit historyおよびdocs/handoff/LATEST.md（session113〜120の詳細サマリ）・docs/handoff/archive/2026-07-history.md（session100〜110）に保持済みのため情報欠落なし。詳細を辿る場合は `git log -p docs/handoff/GOAL.md` または上記アーカイブを参照 -->
+<!-- session121: 新ミッション着手。前ミッション(#547/#548運用コスト圧縮2トラック)は達成済みのためgit historyへ圧縮済み(git log -p docs/handoff/GOAL.md参照)。本ミッションはIssue #548「保留カード」(OCR全文転記→エンティティリスト化)の技術検証から派生。当初コスト削減目的だったが、保守的スコープではコスト削減効果がほぼ見込めないと判明したため「突合精度向上」に目的を再定義(decision-maker合意)。Codexセカンドオピニオン(plan mode)で2点の設計修正(呼出し分離+保守的arbitration)を反映済み -->
 
 ## 現在のミッション
-運用コスト圧縮2トラック — #547 Firestore読取egress削減（ADR-0018 detail/main分離）と #548 Gemini 3.5 Flash移行 — を、本番2環境（kanameone / cocoro）で安全に完遂する。
-
-**🎉 ミッション達成**（2026-07-10 session113 技術完了 → 2026-07-12 session117 で本番デプロイ漏れの是正確認済み）。下記「完了の定義」2点をいずれも充足。ただし「完了」は#547/#548の実装・展開が完了したことを意味し、**運用コストが以前より安くなったことは意味しない**（下記「重要な注記」参照）。
+OCR突合（documentType/customerName/officeName/date）の精度向上のため、Geminiに文書内の候補テキストを独立呼出しで抽出させ、既存のマスター突合ロジック（`extractors.ts`）と保守的arbitrationで統合する。dev環境でA/B検証を固め、精度が現行を下回らないことを確認できた場合のみkanameone→cocoro本番展開する。
 
 ## 背景・why
-- 運用コストが収益を圧迫しており「もはや待ったなしの状態」（decision-maker 明言、session106-107）
-- #548 は Gemini 2.5 Flash retirement 期限 **2026-10-16** が外部制約
-- #547 の egress 実削減は Phase E（親docの大容量フィールド削除）で初めて発生する
+- 前身のIssue #548「保留カード」（OCR全文転記→エンティティリスト化、コスト削減目的、−¥11,000/月級と試算）を技術検証した結果、保守的スコープ（PDF分割検出・全文表示・要約生成を維持）ではコスト削減効果はほぼ見込めないと判明し、目的を「突合精度向上」に再定義（decision-maker合意、session121）
+- Codexセカンドオピニオン（plan mode、session121）で2点の重大な指摘を受け計画に反映済み:
+  1. 全文転記とエンティティ抽出を同一Gemini呼出しにすると、PDF分割検出・全文表示・要約生成への「影響ゼロ」という前提が崩れる → **候補抽出を別呼出しに分離**（既存`ocrWithGemini()`は無改修、pageText結合テキストを入力とする新規呼出しを追加）
+  2. best-of選択（スコアが高い方を無条件採用）は、誤った候補が偶然マスターと完全一致した場合に正しい既存結果を上書きするリスクがある → **保守的arbitration**（同点は全文系優先、候補はpageText内への逐語的存在確認=grounding必須、日付は種別・根拠込みで特別扱い）
+- 不変条件（絶対）: 突合の精度劣化は一切禁止。候補抽出呼出しが失敗しても既存の全文ベース突合にフォールバックし、本体OCR処理は絶対にブロックしない
 
-## 完了の定義（達成済み）
-- Issue #548 が close される（達成済み、2026-07-09）
-- #547 Phase E が完了し、egress実削減効果が発生する（達成済み、2026-07-10 session113 技術完了 → 2026-07-12 session117 是正: Phase E本番実行時にdual-write停止コードが未デプロイのまま削除が実施されていた不整合を検出・修正し実効化。詳細: ADR-0018「是正: 2026-07-12」）
-- 不変条件: 本番 documents の既存フィールドを破壊しない — 維持確認済み（両環境とも detail/main不在0件）
-
-## 重要な注記（コスト実態）
-- **#548はコスト削減策ではない**: Gemini 2.5 Flash廃止＋日本データレジデンシー要件による強制移行。単価は2.5比で高く、全対策後も試算約¥23,000/月（3.5移行前の現状¥12,714/月より高い）
-- **実効値上がり倍率は4手法が収束**: 理論値3.88倍／A-Bテスト事前実測3.7〜4倍／confirmed-replay実測5.53倍／本番実測クリーン版5.07倍（session120で「未解明の残差」も比較対象選択ミスと判明し解消済み）
-- **真の黒字化には保留中の「OCR出力エンティティリスト化」（−¥11,000/月級）の着手判断が別途必要**。本ミッションのスコープ外、decision-maker判断待ちの保留カードとして下記に記録
-- 実請求書での最終実測確認は8月上旬（7月分請求書確定）待ち
+## 完了の定義
+- 候補抽出呼出しの追加が既存`ocrWithGemini()`/pageResults保存処理を一切変更しない（証明: git diffで`functions/src/ocr/ocrProcessor.ts`の既存OCR部分が無改修であることを確認）
+- 新ロジックが既存`extractDocumentTypeEnhanced`等のシグネチャを破壊しない（証明: `cd functions && npm test`で既存テスト全PASS）
+- 候補抽出呼出しが失敗/タイムアウト/スキーマ逸脱しても既存の全文ベース突合で処理継続する（証明: 単体テストで候補抽出例外ケースを追加しPASS）
+- arbitrationが「同点は全文系優先」「grounding必須」「日付は種別・根拠込みで判定」を満たす（証明: 単体テストで誤マスター一致による上書きシナリオを再現し防止できることを確認）
+- dev環境A/Bテストで書類種別/顧客/事業所/日付の4項目とも精度が現行を下回らない（証明: 拡張版`compare-gemini-ocr-models-confirmed.ts`相当のdev実行結果）
+- kanameone confirmed-replay検証（顧客/事業所は既存実データ、書類種別/日付は新規人手ラベル評価セット）で4項目とも精度が現行同等以上（証明: GitHub Actions実行ログ、read-only）
+- 出力トークン増分・コスト増が実測・可視化されている（証明: A/Bハーネスのトークン計測ログ）
+- 本番展開後、kanameone/cocoro双方でエラー率が展開前と同水準（証明: `fix-stuck-documents --include-errors --dry-run`でエラー0件）
+- 不変条件: 上記いずれかのACが未達の場合、無理に本番展開しない（dev検証止まりで完了とする撤退基準）
 
 ## 進行中のtasks
-- [x] #548 Gemini 3.5 Flash移行（kanameone/cocoro本番展開、confirmed-replay統計検証含む） — 全完了
-- [x] #547 Phase C（backfill）〜Phase E（dual-write停止+削除実行、両環境本番実行）— 全完了・是正確認済み
-- [x] 副産物Issue #539/#540/#625/#620/#621/#622（splitPdf/OCR周辺のP1/P2バグ）— 全完了・本番2環境展開済み
+- [ ] A. 候補抽出用・第2Gemini呼出しのスパイク（pageText入力でのresponseSchema実現性・grounding検証手法・プロンプトインジェクション対策の検証、出力トークン実測）
+- [ ] B. 候補抽出呼出し実装（`ocrProcessor.ts`に新規関数追加、既存`ocrWithGemini()`は無改修、ドキュメント単位で1回呼出し、Aに依存）
+- [ ] C. `extractors.ts`拡張 + 保守的arbitration実装（同点全文優先・grounding必須・日付特別扱い・強根拠昇格ルール、Bと並列可能）
+- [ ] D. `processDocument()`統合（候補抽出+arbitration組込み、失敗時は既存動作へフォールバック、B,Cに依存）
+- [ ] E. 単体テスト追加（extractors.ts新関数・arbitrationロジック・フォールバックケース、C,Dに依存）
+- [ ] F. A/Bテストハーネス拡張 + 4項目gate化 + 日付/書類種別用の人手ラベル付き固定評価セット新規整備（層化抽出: 複数人名/複数日付/FAX/手書き/複数ページ、B,Cと並列着手可）
+- [ ] G. dev環境A/Bテスト実行（4項目の精度・トークン増分・grounding失敗率確認、D,E,Fに依存）
+- [ ] H. kanameone confirmed-replay検証（read-only、Gが良好な場合のみ実施、番号単位認可）
+- [ ] I. prod展開判断+実施（Hが基準を満たす場合のみ、kanameone→cocoro順、番号単位認可）
 
 ## 🔄 中断点（in-flight）
 なし
 
-## 監視・確認事項（トリガー待ち）
+## 監視・確認事項（トリガー待ち、前ミッション#547/#548から継続）
 - egress実削減効果の翌月請求での実測確認（未実施。8月上旬の7月分請求書で確認）
 - #548試算（全対策後¥23,000/月）の実額最終確認（実額は7月分請求書確定後）
-- dev環境のテストデータ`phase-e-devcheck-001`(意図的に壊れた不一致状態、実害なし)/`phase-e-devcheck-002`(正常)の後片付け（任意）
-- 保留カード「OCR出力エンティティリスト化」着手要否のdecision-maker判断（本ミッションのスコープ外）
-- 検証コマンド: `cd functions && npm test`（1,680 passing）/ `cd frontend && npm test`（310 passing）/ `cd scripts && npm test`（72 passing）
+- dev環境のテストデータ`phase-e-devcheck-001`/`phase-e-devcheck-002`の後片付け（任意）
+- 前ミッション（#547/#548運用コスト圧縮2トラック）は2026-07-10技術完了・2026-07-12是正確認済み。詳細はgit history（`git log -p docs/handoff/GOAL.md`）およびdocs/handoff/LATEST.md/archive参照


### PR DESCRIPTION
## Summary
- Issue #548「保留カード」(OCR全文転記→エンティティリスト化)から派生した新ミッションを`docs/handoff/GOAL.md`へ登録
- `/impl-plan`フルモードで計画策定 → Codexセカンドオピニオン(plan mode)で2点の設計修正を反映 → Phase 5.1承認済み
- 前ミッション(#547/#548運用コスト圧縮2トラック)はgit historyへ圧縮済み、本PRで新ミッションに更新

## Test plan
- ドキュメントのみの変更のため、構文（Markdown）目視確認のみ実施
- hookとの契約である `## 現在のミッション` / `## 🔄 中断点` 見出し文字列を変更していないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project mission to focus on improving OCR matching accuracy for document type, customer name, office name, and date.
  - Documented a conservative candidate-selection approach with grounding checks and special handling for dates.
  - Added fallback requirements to preserve existing OCR processing when candidate extraction fails or times out.
  - Revised completion criteria, testing plans, monitoring guidance, and rollout checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->