### PR TITLE
docs(handoff): kanameoneコスト圧縮の追加検証結果を記録

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -59,6 +59,10 @@ updated: 2026-07-14
   - `scripts/backfill-detail-subcollection.ts`の`backfillOneDoc()`は`detail/main`書込みに加え必ず親ドキュメント(`documents/{docId}`)も`tx.update()`するため、`onDocumentWrite`/`onDocumentWriteSearchIndex`の2トリガーを毎回発火させる設計と判明（7/9 UTC実測: 18,960回/15,848回発火）
   - この時点では「無関係な変更でもトリガーが連鎖する」問題への対策(`isAggregationUnchanged`、`functions/src/utils/groupAggregation.ts`)がまだ存在せず（対策はPhase E本体と同じPR #611、2026-07-10マージ）、重フィールド(ocrResult/pageResults)が親に残った状態でbefore/afterペイロードが大量配信されたことがegress急増の直接原因と強く推定される
   - **結論**: 一過性の移行作業由来の副作用であり、対策は既に本番投入済みのため8月以降の再発は見込み低い。ただし数値の完全一致(153.99GiBぴったり)までは検証できておらず、最終確認は7月分確定請求を待つ（上記2項目と合わせて確認）
+- **【追加検証、2026-07-14 session127】Firestoreサイズ再計測+Gemini21日分実測でPhase E効果・コスト水準を直接確認**:
+  - `measure-field-byte-sizes --limit 300`をkanameoneに再実行。ドキュメント全体サイズ平均4,095B（Issue #547事前計測時点の19,831Bから79.4%削減）、`ocrResult`/`pageResults`ともにpresent=0/300（親から完全に削除済み）を確認。Phase Eの効果が完璧に機能していることを直接証明
+  - `check-gemini-cost-stats --days 21 --doc-limit 500`で6/24〜7/14の日次実測を取得。session114と同一手法（7/8 vs 7/10+7/11のOCR単体交絡排除比較）で単価倍率約5.17倍を再現確認（session114の5.068倍とほぼ一致）。移行後(7/9〜7/13)の絶対額（アプリ内推定値）は5日平均$0.82/日・月間換算約$25で、6月実績のVertex AIコスト(¥6,093)を下回る可能性がある水準
+  - **結論の更新**: 「2倍以内」達成の確度に関するdecision-makerとの対話ベースの主観評価を60-75%→80%程度に上方修正。Firestore側は実測でほぼ確証、Gemini側も独立した21日データで楽観的傾向を再現。ただし`estimatedCostUsd`はアプリ内推定値で実請求ではなく、月末までの残り期間の変動は未知数のため引き続き最終確認は7月分確定請求を待つ
 - dev環境のテストデータ`phase-e-devcheck-001`/`phase-e-devcheck-002`の後片付け（任意）
 - 前ミッション（#547/#548運用コスト圧縮2トラック）は2026-07-10技術完了・2026-07-12是正確認済み。詳細はgit history（`git log -p docs/handoff/GOAL.md`）およびdocs/handoff/LATEST.md/archive参照
 - （任意・着手指示なき限り不要）OCR突合精度向上ミッション（本ミッション、タスクIで撤退）で未解明のまま残った「kanameone confirmed-replayでbaseline自体の一致率が33.3%/41.7%と低い」原因。将来的に興味を持った場合の起点はGOAL.mdタスクH/Iの記録、および`scripts/compare-ocr-arbitration-logic-confirmed.ts`

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,8 +1,26 @@
 # ハンドオフメモ
 
-**更新日**: 2026-07-14 session126（kanameone 7月請求急増の原因調査・特定、GOAL.md監視事項へ記録。詳細は下記session126サマリ参照）
+**更新日**: 2026-07-14 session127（kanameoneコスト圧縮の追加検証、Firestoreサイズ再計測+Gemini21日分実測。詳細は下記session127サマリ参照）
 
 <!-- session115〜117・121・122はLATEST.md詳細サマリ未追記（GOAL.mdのみ更新）。#539完遂・#540完遂(OCR実行所有権ガード)・#625(OCR Storage孤児化解消)・#547 Phase E是正(Hostingデプロイ漏れ)、および候補抽出スパイク(タスクA、PR#641)・候補抽出呼出し実装(タスクB、PR#642)・arbitration実装(タスクC、PR#643)の経緯はGOAL.md/ADR-0018/該当コミットメッセージで追跡可能なため遡及記載はROI低と判断、着手せず -->
+
+## session127 サマリ（2026-07-14、kanameoneコスト圧縮の追加検証）
+
+session126の調査結果（トリガーストーム特定）を踏まえ、decision-makerから「これ以上できること・ROIが良いこと」を問われ、read-only検証2件をGitHub Actions経由で実行。
+
+### 実行内容と結果
+- `measure-field-byte-sizes --limit 300`（kanameone）: ドキュメント全体サイズ平均4,095B（Issue #547事前計測時点の平均19,831Bから79.4%削減）。`ocrResult`/`pageResults`ともにpresent=0/300で親から完全削除済みを確認。Phase Eの効果が完璧に機能していることを直接証明する決定的な実測
+- `check-gemini-cost-stats --days 21 --doc-limit 500`（kanameone）: `stats/gemini/daily`の6/24〜7/14の日次実測を取得。session114と同一手法（7/8 vs 7/10+7/11のOCR単体交絡排除比較）で単価倍率約5.17倍を再現確認（session114の5.068倍とほぼ一致、独立データでの再現性を確認）。移行後(7/9〜7/13)の絶対額（アプリ内推定値`estimatedCostUsd`）は5日平均$0.82/日・月間換算約$25で、6月実績のVertex AIコスト(¥6,093)を下回る可能性がある水準
+
+### 結論
+「2倍以内」達成の確度に関する主観評価を60-75%→80%程度に上方修正。Firestore側は実測でほぼ確証、Gemini側も独立した21日データで楽観的傾向を再現した。ただし`estimatedCostUsd`はアプリ内推定値で実請求そのものではなく、月末までの残り期間の変動は未知数のため、最終確認は引き続き8月上旬の7月分確定請求を待つ（GOAL.md監視・確認事項に記録済み）。
+
+### Issue Net
+Net 0（GitHub Issue非経由、read-only調査のみ）
+
+### 引き継ぎ教訓
+- `check-gemini-cost-stats.js`は集計サマリーを計算する設計ではなく、`stats/gemini/daily`の生データと直近documentsの生データをそのまま出力する設計（72行の薄いスクリプト）。GitHub Actionsログを`tail`や末尾grepだけで見ると生データ（documents一覧）に隠れて日次統計セクションを見落とすため、`grep -n "=== "`等でセクション区切りを先に特定してから読むこと
+- Bashツールの実行間で環境変数`CLOUDSDK_ACTIVE_CONFIG_NAME`が想定外に持続するケースがあった（`switch-client.sh`が`export`する値が後続コマンドに残存）。gcloud named config切替が反映されない場合は、まず`unset CLOUDSDK_ACTIVE_CONFIG_NAME`してから`gcloud config configurations list`で確認するとよい
 
 ## session126 サマリ（2026-07-14、kanameone 7月請求急増の原因調査・特定）
 


### PR DESCRIPTION
## Summary
- session126（トリガーストーム特定）に続く追加検証結果をGOAL.md/LATEST.mdに記録
- Firestoreサイズ再計測（kanameone、n=300）: ドキュメント全体サイズ平均4,095B（Issue #547事前計測時点の19,831Bから79.4%削減）、`ocrResult`/`pageResults`ともにpresent=0/300で親から完全削除済みを確認。Phase Eの効果が完璧に機能していることを直接証明
- Gemini21日分実測（kanameone、6/24〜7/14）: session114と同一手法で単価倍率約5.17倍を再現確認（session114の5.068倍とほぼ一致）。絶対額（アプリ内推定値）は6月実績を下回る可能性がある水準
- 「2倍以内」達成の確度評価を60-75%→80%程度に上方修正

## Test plan
- doc-onlyの変更のため構文検証のみ（`/code-review low`実施、findings 0件）
- GOAL.md/LATEST.md間の数値整合性（4,095B、79.4%、5.17倍等）を目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)