### PR TITLE
fix(documents): 書類一覧テーブルのページ数/ステータス列の縦折り返しを修正

### DIFF
--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -86,7 +86,7 @@ function SortableHeader({
 
   return (
     <th
-      className={`px-2 py-2 text-left text-xs font-medium text-gray-700 cursor-pointer hover:bg-gray-100 select-none sm:px-4 sm:py-3 sm:text-sm ${hideOnMobile ? 'hidden lg:table-cell' : ''}`}
+      className={`px-2 py-2 text-left text-xs font-medium text-gray-700 cursor-pointer hover:bg-gray-100 select-none whitespace-nowrap sm:px-4 sm:py-3 sm:text-sm ${hideOnMobile ? 'hidden lg:table-cell' : ''}`}
       onClick={() => onClick(field)}
     >
       <div className="flex items-center gap-1">
@@ -271,16 +271,16 @@ function DocumentRow({
       <td className="px-2 py-2 text-xs text-gray-700 sm:px-4 sm:py-3 sm:text-sm">{formatDateTime(document.processedAt)}</td>
       <td className="hidden px-4 py-3 text-gray-700 lg:table-cell">{formatTimestamp(document.fileDate)}</td>
       {/* ページ数 (#525): 0 は旧形式 doc (OCR 前の初期値) のため「-」表示 */}
-      <td className="hidden px-4 py-3 text-gray-700 xl:table-cell">
+      <td className="hidden whitespace-nowrap px-4 py-3 text-gray-700 xl:table-cell">
         {document.totalPages > 0 ? `${document.totalPages}` : '-'}
       </td>
-      <td className="px-2 py-2 sm:px-4 sm:py-3">
+      <td className="whitespace-nowrap px-2 py-2 sm:px-4 sm:py-3">
         {needsReview ? (
-          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
+          <Badge variant="outline" className="whitespace-nowrap bg-orange-100 text-orange-800 border-orange-300 text-xs">
             選択待ち
           </Badge>
         ) : (
-          <Badge variant={statusConfig.variant} className="text-xs sm:text-sm">{statusConfig.label}</Badge>
+          <Badge variant={statusConfig.variant} className="whitespace-nowrap text-xs sm:text-sm">{statusConfig.label}</Badge>
         )}
       </td>
       <td className="px-2 py-2 sm:px-3 sm:py-3 text-center">
@@ -918,7 +918,7 @@ export function DocumentsPage() {
                       <SortableHeader label="登録日" field="processedAt" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} />
                       <SortableHeader label="書類日付" field="fileDate" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} hideOnMobile />
                       {/* ページ数 (#525): xl 未満は非表示 (#424 教訓 — lg 帯 1024px は 7 列 940px + スクロールバーで限界のため列を増やさない) */}
-                      <th className="hidden px-4 py-3 text-left text-sm font-medium text-gray-700 xl:table-cell">ページ数</th>
+                      <th className="hidden whitespace-nowrap px-4 py-3 text-left text-sm font-medium text-gray-700 xl:table-cell">ページ数</th>
                       <SortableHeader label="ステータス" field="status" currentField={sortField} currentOrder={sortOrder} onClick={handleSort} />
                       <th className="px-2 py-2 text-center text-xs font-medium text-gray-700 sm:px-3 sm:py-3 sm:text-sm w-12">
                         <CheckCircle2 className="h-4 w-4 text-gray-400 inline-block" />


### PR DESCRIPTION
## 概要

kanameone本番の書類一覧タブで、「ステータス」ヘッダー・「選択待ち」等のバッジ、「ページ数」ヘッダーが1文字ずつ縦に折り返され判読不能になる表示崩れが報告された。原因を特定し修正した。

## 原因

- 「ページ数」列(Issue #525で追加)のヘッダー/データセルには `white-space` 指定が一切なく、通常のテキストとして折り返し可能だった
- 「ステータス」列(`SortableHeader`)は `truncate`(nowrap + ellipsis)のみで、`<th>` 自体・親の `flex` コンテナに幅指定がなかった
- テーブルは `table-layout: auto` かつ `w-full` のため、列数が多い状態(xl=1280px境界でページ数列が出現し計8列)でビューポート幅が窮屈になると、ブラウザが短いテキストの列を極端に圧縮し、縦折り返しが発生していた
- PR #531(#525実装)の実機検証は768/1024/1280pxの3点で行われていたが、xl境界(1280px)ちょうど付近での列圧縮は当時見逃されていた

## 修正内容

`frontend/src/pages/DocumentsPage.tsx` の該当セルに `whitespace-nowrap` を追加(7箇所)。収まらない場合は既存の `overflow-x-auto` による横スクロールに委ねる。

- `SortableHeader` の `<th>`(全ヘッダー列に一括適用)
- 「ページ数」列のヘッダー・データセル
- 「ステータス」バッジ2種(「選択待ち」固定文言・`statusConfig.label`)

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint src/pages/DocumentsPage.tsx` — エラーなし
- [x] `npx vitest run` — 20 files / 333 tests 全PASS(既存回帰なし)
- [x] 実機確認(Playwright): 本番と同一のTailwindクラス構成・実データ相当のテキスト長を静的HTMLで再現し、修正前後を比較
  - 修正前 1280px: 「ページ数」「ステータス」ヘッダーが縦折り返し、バッジも欠落表示を再現確認
  - 修正後 1280px: 全列ヘッダー・バッジが1行で正常表示
  - 修正後 1024px: ページ数列は仕様通り非表示、ステータス列は崩れず正常表示(事業所列の複数行折り返しは既存仕様で対象外)
  - 注記: kanameoneは実データが本番にしかなく、devはGoogle認証がブロックされ実機ログイン確認は不可のため、上記は同一マークアップ構成の静的再現による検証。本番デプロイ後、実画面での最終確認を推奨

## 関連

- Issue #525(ページ数列追加)がこの表示崩れの誘因

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved document table column spacing and alignment.
  * Prevented headers and status badges from wrapping unexpectedly.
  * Refined the display of page counts on larger screens.
  * Updated the visual styling of documents awaiting selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->