### PR TITLE
feat(fax-duplication): PR-C FE表示実装 (task 6, GOAL.md)

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -30,7 +30,7 @@ import { PdfViewer } from '@/components/PdfViewer'
 import { PdfSplitModal } from '@/components/PdfSplitModal'
 import { MasterSelectField } from '@/components/MasterSelectField'
 import { ExtractionInfoPopover } from '@/components/ExtractionInfoPopover'
-import { useDocument, useDocumentDetail, useReprocessDocument, resolveDetailFields } from '@/hooks/useDocuments'
+import { useDocument, useDocumentDetail, useReprocessDocument, useDistributionSiblingCount, resolveDetailFields } from '@/hooks/useDocuments'
 import { useDocumentEdit } from '@/hooks/useDocumentEdit'
 import { useCustomers, useOffices, useDocumentTypes, useCareManagers } from '@/hooks/useMasters'
 import { useMasterAlias } from '@/hooks/useMasterAlias'
@@ -392,6 +392,11 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
   const [showReprocessDialog, setShowReprocessDialog] = useState(false)
   const { reprocess, reprocessingId } = useReprocessDocument()
   const isReprocessing = reprocessingId !== null && reprocessingId === documentId
+  // 複数顧客FAX複製機能 (GOAL.md D4): 「自動配信・要整理」の識別は distributionId && !verified
+  const isUnorganizedDistribution = !!document?.distributionId && !document?.verified
+  const { data: distributionSiblingCount } = useDistributionSiblingCount(
+    isUnorganizedDistribution ? document?.distributionId : undefined
+  )
   // 削除確認ダイアログ
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -1346,6 +1351,15 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                   <div className="mt-4 rounded-lg bg-yellow-50 p-3">
                     <p className="text-xs font-medium text-yellow-800">同姓同名の顧客が存在します</p>
                     <p className="mt-1 text-xs text-yellow-700">{document.allCustomerCandidates}</p>
+                  </div>
+                )}
+
+                {/* 複数顧客FAX複製 (GOAL.md task 6-3): 自動配信・要整理の識別表示 */}
+                {isUnorganizedDistribution && (
+                  <div className="mt-4 rounded-lg bg-blue-50 p-3">
+                    <p className="text-xs font-medium text-blue-800">
+                      同一FAXを{distributionSiblingCount ?? '…'}名に配信・要整理
+                    </p>
                   </div>
                 )}
 

--- a/frontend/src/hooks/__tests__/appendReprocessClearToBatch.test.ts
+++ b/frontend/src/hooks/__tests__/appendReprocessClearToBatch.test.ts
@@ -1,0 +1,97 @@
+/**
+ * appendReprocessClearToBatch 単体テスト (GOAL.md task 6-2, PR-C)
+ *
+ * distributionId保持doc(複製元・複製コピー)の再処理時、customerId/customerName/
+ * customerConfirmed/careManagerがクリア対象から除外されることを検証する。
+ * BE側(functions/src/ocr/confirmedFieldMerge.ts)の既存confirmed保護マージが
+ * customerConfirmed:trueのまま機能する前提を崩さないための分岐。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { WriteBatch } from 'firebase/firestore'
+
+const mockGetDoc = vi.fn()
+const mockDoc = vi.fn((...args: unknown[]) => ({ __ref: args }))
+const mockBatchUpdate = vi.fn()
+
+vi.mock('firebase/firestore', async () => {
+  const actual = await vi.importActual('firebase/firestore')
+  return {
+    ...actual,
+    doc: (...args: unknown[]) => mockDoc(...args),
+    getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  }
+})
+
+vi.mock('../../lib/firebase', () => ({
+  db: { type: 'firestore' },
+}))
+
+import { appendReprocessClearToBatch } from '../useDocuments'
+
+describe('appendReprocessClearToBatch', () => {
+  const batch = { update: mockBatchUpdate } as unknown as WriteBatch
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('distributionId保持docは customerId/customerName/customerConfirmed/careManager をクリア対象から除外し、true を返す', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({ distributionId: 'orig-doc-1' }) }) // 親doc
+      .mockResolvedValueOnce({ exists: () => false }) // detail/main
+    const hasDistributionId = await appendReprocessClearToBatch(batch, 'doc-1')
+
+    expect(hasDistributionId).toBe(true)
+    const [, updatePayload] = mockBatchUpdate.mock.calls[0]!
+    expect(updatePayload).not.toHaveProperty('customerId')
+    expect(updatePayload).not.toHaveProperty('customerName')
+    expect(updatePayload).not.toHaveProperty('careManager')
+    expect(updatePayload).not.toHaveProperty('customerConfirmed')
+    // 顧客系以外は通常どおりクリア対象に含む
+    expect(updatePayload).toHaveProperty('officeId')
+    expect(updatePayload.officeConfirmed).toBe(false)
+    expect(updatePayload.status).toBe('pending')
+  })
+
+  it('distributionId未保持docは通常どおり全顧客フィールドをクリア対象に含め、false を返す', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({}) })
+      .mockResolvedValueOnce({ exists: () => false })
+    const hasDistributionId = await appendReprocessClearToBatch(batch, 'doc-2')
+
+    expect(hasDistributionId).toBe(false)
+    const [, updatePayload] = mockBatchUpdate.mock.calls[0]!
+    expect(updatePayload).toHaveProperty('customerId')
+    expect(updatePayload).toHaveProperty('customerName')
+    expect(updatePayload).toHaveProperty('careManager')
+    expect(updatePayload.customerConfirmed).toBe(false)
+  })
+
+  it('distributionIdが空文字の場合は保持doc扱いしない(異常系)', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({ distributionId: '' }) })
+      .mockResolvedValueOnce({ exists: () => false })
+    const hasDistributionId = await appendReprocessClearToBatch(batch, 'doc-3')
+
+    expect(hasDistributionId).toBe(false)
+  })
+
+  it('detail/mainが存在する場合、detailクリアもbatchに積む', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({}) })
+      .mockResolvedValueOnce({ exists: () => true })
+    await appendReprocessClearToBatch(batch, 'doc-4')
+
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('detail/mainが不在の場合、detailクリアはbatchに積まない', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({}) })
+      .mockResolvedValueOnce({ exists: () => false })
+    await appendReprocessClearToBatch(batch, 'doc-5')
+
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
+++ b/frontend/src/hooks/__tests__/reprocessDetailClearContract.test.ts
@@ -28,7 +28,7 @@ describe('reprocess-clear detail/main 配線契約 (ADR-0018 PR4b)', () => {
       /export async function appendReprocessClearToBatch[\s\S]*?\n\}/
     )
     expect(helper, 'appendReprocessClearToBatch が定義されていること').not.toBeNull()
-    expect(helper![0]).toMatch(/status: 'pending',\s*\.\.\.getReprocessClearFields\(\)/)
+    expect(helper![0]).toMatch(/status: 'pending',\s*\.\.\.getReprocessClearFields\(hasDistributionId\)/)
   })
 
   it('ヘルパー: detail/main は存在確認(getDoc)の上、存在時のみ getReprocessDetailClearFields でクリアする', () => {

--- a/frontend/src/hooks/__tests__/useDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useDocuments.test.ts
@@ -303,6 +303,23 @@ describe('firestoreToDocument', () => {
 
       expect(result.documentTypeConfirmed).toBeUndefined()
     })
+
+    it('distributionId を正しく変換する (GOAL.md task 6-1, PR-C)', () => {
+      const data = {
+        ...baseFirestoreData,
+        distributionId: 'orig-doc-1',
+      }
+
+      const result = firestoreToDocument('doc-001', data)
+
+      expect(result.distributionId).toBe('orig-doc-1')
+    })
+
+    it('distributionId が undefined の場合も正しく処理する (GOAL.md task 6-1, PR-C)', () => {
+      const result = firestoreToDocument('doc-001', baseFirestoreData)
+
+      expect(result.distributionId).toBeUndefined()
+    })
   })
 
   describe('summary フィールド (Issue #215 discriminated union + 後方互換読込)', () => {
@@ -484,6 +501,42 @@ describe('getReprocessClearFields (Issue #215: 旧3キー + 新summary 全て de
   it('documentTypeConfirmed を false にリセットする (Issue #526)', () => {
     const fields = getReprocessClearFields()
     expect(fields.documentTypeConfirmed).toBe(false)
+  })
+
+  // GOAL.md task 6-2 (PR-C): distributionId保持docは顧客系フィールドを再処理で
+  // 上書きしてはならない(BE側confirmedFieldMerge保護が機能する前提を崩さないため)
+  describe('preserveDistributionFields (GOAL.md task 6-2, PR-C)', () => {
+    it('デフォルト(引数省略)では customerId/customerName/customerConfirmed/careManager をクリア対象に含む', () => {
+      const fields = getReprocessClearFields()
+      expect(fields).toHaveProperty('customerId')
+      expect(fields).toHaveProperty('customerName')
+      expect(fields).toHaveProperty('careManager')
+      expect(fields.customerConfirmed).toBe(false)
+    })
+
+    it('preserveDistributionFields=false では通常どおりクリア対象に含む', () => {
+      const fields = getReprocessClearFields(false)
+      expect(fields).toHaveProperty('customerId')
+      expect(fields).toHaveProperty('customerName')
+      expect(fields).toHaveProperty('careManager')
+      expect(fields.customerConfirmed).toBe(false)
+    })
+
+    it('preserveDistributionFields=true では customerId/customerName/customerConfirmed/careManager をクリア対象から除外する', () => {
+      const fields = getReprocessClearFields(true)
+      expect(fields).not.toHaveProperty('customerId')
+      expect(fields).not.toHaveProperty('customerName')
+      expect(fields).not.toHaveProperty('careManager')
+      expect(fields).not.toHaveProperty('customerConfirmed')
+    })
+
+    it('preserveDistributionFields=true でも他の顧客系フィールド(officeId等)は通常どおりクリア対象に含む', () => {
+      const fields = getReprocessClearFields(true)
+      expect(fields).toHaveProperty('officeId')
+      expect(fields).toHaveProperty('officeName')
+      expect(fields.officeConfirmed).toBe(false)
+      expect(fields.verified).toBe(false)
+    })
   })
 })
 

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -21,6 +21,7 @@ import {
   QueryConstraint,
   startAfter,
   DocumentSnapshot,
+  getCountFromServer,
 } from 'firebase/firestore'
 import { useState } from 'react'
 import { toast } from 'sonner'
@@ -209,7 +210,28 @@ export function firestoreToDocument(id: string, data: Record<string, unknown>): 
     needsManualCustomerSelection: data.needsManualCustomerSelection as boolean | undefined,
     // 書類種別確定フィールド（Issue #526）
     documentTypeConfirmed: data.documentTypeConfirmed as boolean | undefined,
+    // 複数顧客FAX複製機能 (GOAL.md D4): 元doc・全コピーに同一値を付与
+    distributionId: data.distributionId as string | undefined,
   }
+}
+
+/**
+ * distributionId兄弟doc(元doc+全コピー)の件数を取得するフック
+ * (GOAL.md task 6-3, PR-C)。詳細画面の「同一FAXをN名に配信・要整理」表示用。
+ * 件数のみ必要なため getCountFromServer の集計クエリを使い、ドキュメント本体の
+ * ダウンロードコストを避ける。
+ */
+export function useDistributionSiblingCount(distributionId: string | undefined) {
+  return useQuery({
+    queryKey: ['distributionSiblingCount', distributionId],
+    queryFn: async () => {
+      const q = query(collection(db, 'documents'), where('distributionId', '==', distributionId))
+      const snapshot = await getCountFromServer(q)
+      return snapshot.data().count
+    },
+    enabled: !!distributionId,
+    staleTime: 30 * 1000,
+  })
 }
 
 // ============================================
@@ -258,18 +280,15 @@ export function updateDocumentInListCache(
  * 直接の呼出元は appendReprocessClearToBatch のみ（再処理3経路は
  * ヘルパー経由で間接利用）。deleteField() はファクトリ関数内で毎回生成（安全性）
  *
- * TODO(GOAL.md task 6-2, PR-C): 複数顧客FAX複製機能(kanameone現場要件)により、
- * distributionIdを持つdoc(複製元・複製コピー)はcustomerId/customerName/careManagerが
- * 「OCRが自動抽出した提案値」ではなく「配信によって確定した顧客の識別子」である。
- * 現状この関数は無条件でcustomerConfirmed:false + customerId等をdeleteFieldするため、
- * distributionId保持docを本関数経由で再処理すると、BE側(functions/src/ocr/faxDuplication.ts
- * のalreadyConfirmedOrVerifiedガード・confirmedFieldMerge保護)が機能する前提
- * (=customerConfirmedがtrueのまま)が崩れ、次回OCR完了時にcustomerIdが上書きされてしまう
- * (Codexセカンドオピニオンで指摘済みの既知ギャップ、evaluator指摘で再確認)。
- * task 6-2でこの関数(または呼出元)にdistributionId分岐を追加し、複製メンバーのdocは
- * 顧客系フィールドをクリア対象から除外すること。flag ON展開(task 8)より前に完了必須。
+ * GOAL.md task 6-2 (PR-C): distributionIdを持つdoc(複製元・複製コピー)の
+ * customerId/customerName/customerConfirmed/careManagerは「OCRが自動抽出した提案値」
+ * ではなく「配信によって確定した顧客の識別子」のため、`preserveDistributionFields`
+ * がtrueの場合はこの4フィールドをクリア対象から除外する。customerConfirmedが
+ * trueのまま残ることで、BE側(functions/src/ocr/confirmedFieldMerge.ts)の既存
+ * confirmed保護マージがそのまま働き、次回OCR完了時にcustomerIdが上書きされるのを防ぐ
+ * (Codexセカンドオピニオンで指摘済みのギャップへの対応)。
  */
-export function getReprocessClearFields() {
+export function getReprocessClearFields(preserveDistributionFields: boolean = false) {
   const df = deleteField()
   return {
     // OCR結果
@@ -291,14 +310,13 @@ export function getReprocessClearFields() {
     // derivedObjectPath と実 Storage state が不整合になるため必ずクリアする
     provenance: df,
     // メタ情報
-    customerName: df,
-    customerId: df,
+    ...(preserveDistributionFields ? {} : { customerName: df, customerId: df }),
     officeName: df,
     officeId: df,
     documentType: df,
     fileDate: df,
     fileDateFormatted: df,
-    careManager: df,
+    ...(preserveDistributionFields ? {} : { careManager: df }),
     category: df,
     // 候補・スコア
     customerCandidates: df,
@@ -311,7 +329,7 @@ export function getReprocessClearFields() {
     allCustomerCandidates: df,
     suggestedNewOffice: df,
     // 確認ステータス
-    customerConfirmed: false,
+    ...(preserveDistributionFields ? {} : { customerConfirmed: false }),
     confirmedBy: null,
     confirmedAt: null,
     officeConfirmed: false,
@@ -375,20 +393,30 @@ export function getReprocessDetailClearFields() {
  * 確認と commit の間に detail が作成されるレース(並行OCR完了)はあり得るが、その場合も
  * 親クリアで status:'pending' になった doc を次の OCR パイプラインが dual-write で
  * 上書きするため自己修復する。
+ *
+ * distributionId (GOAL.md task 6-2, PR-C) の有無を判定するため親docを事前読込する。
+ * detail存在確認と同様に、読込と commit の間のレース(並行OCR完了によるdistributionId
+ * 付与)は次のOCRパイプラインが再度dual-writeで上書きするため自己修復する。
+ * 戻り値のhasDistributionIdは呼出元の楽観的更新(customerName等をブランクにしない)に使う。
  */
 export async function appendReprocessClearToBatch(
   batch: WriteBatch,
   documentId: string
-): Promise<void> {
-  batch.update(doc(db, 'documents', documentId), {
+): Promise<boolean> {
+  const docRef = doc(db, 'documents', documentId)
+  const docSnap = await getDoc(docRef)
+  const distributionId = docSnap.data()?.distributionId
+  const hasDistributionId = typeof distributionId === 'string' && distributionId.length > 0
+  batch.update(docRef, {
     status: 'pending',
-    ...getReprocessClearFields(),
+    ...getReprocessClearFields(hasDistributionId),
   })
   const detailRef = doc(db, 'documents', documentId, 'detail', 'main')
   const detailSnap = await getDoc(detailRef)
   if (detailSnap.exists()) {
     batch.update(detailRef, getReprocessDetailClearFields())
   }
+  return hasDistributionId
 }
 
 // ============================================
@@ -414,18 +442,18 @@ export function useReprocessDocument() {
       // ADR-0018 Phase D PR4b (Issue #547): 親docクリアと detail/main クリアを
       // 単一batchで原子的にコミット(他2箇所 useErrors/DocumentsPage と同一ヘルパー)
       const batch = writeBatch(db)
-      await appendReprocessClearToBatch(batch, documentId)
+      const hasDistributionId = await appendReprocessClearToBatch(batch, documentId)
       await batch.commit()
-      // 楽観的更新（即時UI反映）
+      // 楽観的更新（即時UI反映）。distributionId保持docはcustomerName/customerConfirmedを
+      // 実際にはクリアしない(GOAL.md task 6-2)ため、楽観的更新でも空表示にしない。
       updateDocumentInListCache(queryClient, documentId, {
         status: 'pending',
         ocrResult: '',
-        customerName: '',
         officeName: '',
         documentType: '',
-        customerConfirmed: false,
         officeConfirmed: false,
         verified: false,
+        ...(hasDistributionId ? {} : { customerName: '', customerConfirmed: false }),
       })
       queryClient.invalidateQueries({ queryKey: ['document', documentId] })
       // detail/main もクリア対象 (appendReprocessClearToBatch) のため、キャッシュ済み

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -287,6 +287,10 @@ export function updateDocumentInListCache(
  * trueのまま残ることで、BE側(functions/src/ocr/confirmedFieldMerge.ts)の既存
  * confirmed保護マージがそのまま働き、次回OCR完了時にcustomerIdが上書きされるのを防ぐ
  * (Codexセカンドオピニオンで指摘済みのギャップへの対応)。
+ *
+ * distributionId自体はこの関数の戻り値に一切含めない(deleteField()もしない/常に
+ * 保持もしない)。update()にキーとして含まれないフィールドはFirestore側の既存値が
+ * そのまま残るため、意図的な省略により再処理を跨いで自然に保持される。
  */
 export function getReprocessClearFields(preserveDistributionFields: boolean = false) {
   const df = deleteField()

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -486,7 +486,24 @@ export function DocumentsPage() {
 
     setIsBulkOperating(true)
     try {
-      const ids = Array.from(selectedIds)
+      // codex review指摘(PR #677): pending/processing中のdocを再処理すると、
+      // appendReprocessClearToBatchのdistributionId読込とOCR完了トランザクションの
+      // 競合(TOCTOU)でdistributionId保護が外れうる。既定の一覧フィルタは'processed'
+      // だが、フィルタを変更すればpending/processing中docも選択可能なため、実行時に
+      // 明示的に除外する(単体doc再処理ボタンは元々error/processedのみ表示のため対象外)。
+      const allDocsForStatusCheck = documentsData?.pages.flatMap(page => page.documents) ?? []
+      const inProgressIds = new Set(
+        allDocsForStatusCheck
+          .filter((d) => d.status === 'pending' || d.status === 'processing')
+          .map((d) => d.id)
+      )
+      const ids = Array.from(selectedIds).filter((id) => !inProgressIds.has(id))
+      const skippedCount = selectedIds.size - ids.length
+      if (ids.length === 0) {
+        toast.error(`選択した${skippedCount}件は処理中のため再処理をスキップしました`)
+        setIsBulkOperating(false)
+        return
+      }
       const CHUNK_SIZE = 250
       let succeededCount = 0
       let chunkFailed = false
@@ -532,7 +549,11 @@ export function DocumentsPage() {
         toast.error(`一括再処理が途中で失敗しました（${succeededCount}/${ids.length}件完了）`)
       } else {
         clearSelection()
-        toast.success(`${succeededCount}件を再処理キューに追加しました`)
+        toast.success(
+          skippedCount > 0
+            ? `${succeededCount}件を再処理キューに追加しました（処理中のため${skippedCount}件はスキップ）`
+            : `${succeededCount}件を再処理キューに追加しました`
+        )
       }
     } catch (error) {
       console.error('Bulk reprocess error:', error)
@@ -540,7 +561,7 @@ export function DocumentsPage() {
     } finally {
       setIsBulkOperating(false)
     }
-  }, [selectedIds, queryClient, clearSelection])
+  }, [selectedIds, queryClient, clearSelection, documentsData])
 
   // 一括削除
   const handleBulkDelete = useCallback(async () => {


### PR DESCRIPTION
## Summary
- GOAL.md task 6 (PR-C: FE表示) を実装。複数顧客FAX複製機能(kanameone現場要件)のdistributionIdフィールドをFE側で正しく扱う
- 6-1: `firestoreToDocument()` に `distributionId` マッピング追加
- 6-2: `getReprocessClearFields()` に `preserveDistributionFields` 分岐追加。distributionId保持docの再処理時、customerId/customerName/customerConfirmed/careManagerをクリア対象から除外し、BE側confirmedFieldMerge保護が機能する前提を維持
- 6-3: 詳細画面に「同一FAXをN名に配信・要整理」バッジを表示 (`distributionId && !verified` から導出、`useDistributionSiblingCount`で兄弟doc件数を集計クエリ取得)

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npx vitest run` 356 tests PASS (新規: appendReprocessClearToBatch.test.ts 5件 + firestoreToDocument/getReprocessClearFields拡張テスト)
- [x] ブラウザ確認 (Firebase Emulator + Playwright MCP): distributionId保持docで配信バッジ表示、verified:true時にバッジ非表示を確認 (#193教訓)
- [x] `/code-review medium` 実施 (8角度finder + verify)。CONFIRMED 1件(bulk reprocess時の非効率な追加read、フォローアップ課題として記録)+ PLAUSIBLE 2件(hasDistributionId判定条件のBE側との差異=既存設計レビュー済みの許容範囲、distributionId不保持の意図をコメント明記済み)

Closes: GOAL.md task 6 (PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational banner showing when a document is distributed to multiple recipients and needs organization.
  * Preserved relevant recipient details when reprocessing distributed documents.
  * Bulk reprocessing now skips documents already pending or processing and reports skipped items in notifications.

* **Bug Fixes**
  * Prevented conflicting reprocessing operations and improved handling of distributed document data.

* **Tests**
  * Expanded coverage for distribution tracking, reprocessing behavior, and conditional detail clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->