### PR TITLE
fix(search): fax由来ファイル名の-L\d+-判定に14桁タイムスタンプ検証を追加(#686)

### DIFF
--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -192,8 +192,11 @@ export function extractFilenameInfo(filename: string): FilenameInfo {
   // 拡張子を除去
   const baseName = filename.replace(/\.[^.]+$/, '');
 
-  // -L1-, -L2- などのパターンを検出してプレフィックスを抽出
-  const match = baseName.match(/^(.+?)-L\d+-/);
+  // -L1-, -L2- などのパターンを検出してプレフィックスを抽出。
+  // fax gateway由来ファイル名は`{prefix}-L{レーン番号}-{YYYYMMDDHHMMSS}`形式(14桁タイムスタンプ
+  // 必須、tokenizer.ts参照)のため、直後が14桁タイムスタンプでない場合は非fax由来の偶然一致と
+  // みなしprefixを切り詰めない(Issue #686: 「見積書-L1000-final.pdf」等の誤マッチ防止)
+  const match = baseName.match(/^(.+?)-L\d+-(\d{14})$/);
   let prefix = match ? match[1] : baseName;
 
   // 半角カナを全角に、全角数字を半角に正規化

--- a/functions/test/extractors.test.ts
+++ b/functions/test/extractors.test.ts
@@ -97,6 +97,19 @@ describe('extractFilenameInfo', () => {
     expect(info.prefix).to.equal('');
     expect(info.prefixType).to.equal('unknown');
   });
+
+  // Issue #686: fax gateway由来ファイル名は`{prefix}-L{レーン番号}-{YYYYMMDDHHMMSS}`形式
+  // (14桁タイムスタンプ必須)。非fax由来ファイル名が偶然`-L\d+-`様の部分文字列を含む場合、
+  // 後続が14桁タイムスタンプでなければfax由来と誤判定してはならない
+  it('-L\\d+-の直後が14桁タイムスタンプでない場合は誤判定せずbaseName全体をprefixとする', () => {
+    const info = extractFilenameInfo('見積書-L1000-final.pdf');
+    expect(info.prefix).to.equal('見積書-L1000-final');
+  });
+
+  it('-L\\d+-の直後の数字が14桁に満たない場合も誤判定せずbaseName全体をprefixとする', () => {
+    const info = extractFilenameInfo('資料-L5-2026.pdf');
+    expect(info.prefix).to.equal('資料-L5-2026');
+  });
 });
 
 describe('extractDocumentTypeEnhanced', () => {


### PR DESCRIPTION
## Summary
- `extractFilenameInfo()`(`functions/src/utils/extractors.ts`)の`-L\d+-`パターンマッチが、fax由来でない任意のファイル名に偶然`-L<数字>-`様の部分文字列が含まれる場合、prefixが誤って切り詰められ、tokenizer.tsの検索インデックスから内容の一部が脱落する問題を修正
- fax gateway由来ファイル名の正式命名規則`{prefix}-L{レーン番号}-{YYYYMMDDHHMMSS}`(tokenizer.tsに既存コメントあり)に基づき、`-L\d+-`の直後が14桁タイムスタンプであることを必須条件化。非fax由来ファイル名(例: `見積書-L1000-final.pdf`)は正しくbaseName全体をprefixとして扱うようになる

## Test plan
- [x] TDD Red→Green: 再現テスト2件追加(`functions/test/extractors.test.ts`)、修正前に失敗・修正後にPASSを確認
- [x] 既存回帰テスト`functions/test/extractors.test.ts`全PASS(9件)
- [x] `functions/test/tokenizer*.test.ts`全PASS(45件、Issue #680由来のfileNameトークン化ケース含む)
- [x] `npm test`(functions全体) 1857 passing / 0 failing
- [x] `npm run lint` 0 errors(既存warningのみ、変更ファイル外)
- [x] `npx tsc --noEmit` 0 errors
- [x] `/code-review low` 指摘0件

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)