### PR TITLE
docs(handoff): GOAL.mdのupdated日付を陳腐化解消

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-07-22
+updated: 2026-07-23
 ---
 <!-- 前ミッション(dev/kanameone/cocoro環境監査・保守検証)は2026-07-20完遂。全文はdocs/handoff/LATEST.md参照。 -->
 


### PR DESCRIPTION
## Summary
- handoffチェック中に発見。frontmatterの`updated: 2026-07-22`が本日(2026-07-23)の複数回の編集を反映していなかったため修正

## Test plan
- docs-onlyのため構文確認のみ