### PR TITLE
fix(ocr): thinkingLevel LOW→MINIMALでGemini 3.5 Flashコスト削減

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -943,10 +943,14 @@ ${pageNumber ? `\nこれは${pageNumber}ページ目です。` : ''}
           // thinkingを最小化しコストを削減する。gemini-2.5-flashはthinkingBudget方式
           // (既定0、GEMINI_OCR_THINKING_BUDGET環境変数でfeature flag化、GEMINI_CONFIG参照)。
           // Issue #548: gemini-3.5-flashはthinkingBudget非対応でthinkingLevel方式のみサポートのため、
-          // A/Bテストharness(PR #559、実機3回PASS・精度劣化なし)で実証済みのthinkingLevel.LOWを使用する。
+          // thinkingLevel.MINIMALを使用する(2026-07-24、LOWから変更)。2.5-flash時代の
+          // thinkingBudget=0という運用方針との一貫性を優先し、devフィクスチャ(14件)+
+          // kanameone/cocoro本番confirmed実データ(計18件)の計32件で精度検証(全件LOWと
+          // 完全一致、劣化ゼロ)、thinkingトークンは全件0でコスト16〜32%減を確認済み。
+          // 詳細はIssue #714コメント参照。
           // ロールバックは`GEMINI_MODEL_ID=gemini-2.5-flash`設定+functions再deployのみ(コード変更不要)。
           thinkingConfig: IS_35_MODEL
-            ? { thinkingLevel: ThinkingLevel.LOW }
+            ? { thinkingLevel: ThinkingLevel.MINIMAL }
             : { thinkingBudget: GEMINI_CONFIG.ocrThinkingBudget },
         },
       });
@@ -1092,7 +1096,7 @@ export async function extractOcrCandidates(
           config: {
             maxOutputTokens: GEMINI_MAX_OUTPUT_TOKENS,
             thinkingConfig: IS_35_MODEL
-              ? { thinkingLevel: ThinkingLevel.LOW }
+              ? { thinkingLevel: ThinkingLevel.MINIMAL }
               : { thinkingBudget: GEMINI_CONFIG.ocrThinkingBudget },
             responseMimeType: 'application/json',
             responseSchema: candidateSchema,


### PR DESCRIPTION
## Summary
- `ocrProcessor.ts`のthinkingConfigを`ThinkingLevel.LOW`→`ThinkingLevel.MINIMAL`に変更(2箇所)
- 2.5-flash時代の`thinkingBudget=0`(OCR転記は推論不要という運用方針)との一貫性を優先

## 検証
- dev環境デプロイ済み・実機E2E確認済み(GitHub Actions経由でpending文書作成→dev実運用の1分間隔ポーリングで処理、status:processed・thinkingTokens:0を実データで確認)
- 精度検証: devフィクスチャ(14件)+kanameone/cocoro本番confirmed実データ(計18件)の**計32件**でLOWとの精度比較を実施、**全件で一致率が完全に同一(劣化ゼロ)**
- コスト検証: thinkingトークンは全件0に減少、実データで**16〜32%のコスト削減**を確認
- 詳細はIssue #714コメント参照

## Test plan
- [x] `tsc --noEmit` エラーなし
- [x] `npm test` 1909件全PASS
- [x] `npm run lint` 0 errors
- [x] dev Cloud Functionsへの実デプロイ・実機E2E確認
- [x] devフィクスチャ + kanameone/cocoro本番confirmed実データでの精度A/Bテスト(計32件、劣化ゼロ確認)

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR processing for the Gemini 3.5 model by using a more streamlined reasoning configuration.
  * Applied the same optimization to structured OCR candidate extraction for more consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->