### PR TITLE
fix: 担当CM別ファイル名バグ・事業所別100件キャップ・テーブル列幅・グループ名検索を修正

### DIFF
--- a/frontend/src/components/views/CustomerSubGroup.tsx
+++ b/frontend/src/components/views/CustomerSubGroup.tsx
@@ -18,6 +18,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
 import { getStatusConfig, formatTimestamp } from '@/lib/documentUtils';
+import { getDisplayFileName } from '@/utils/getDisplayFileName';
 import {
   buildCustomerFolderGroups,
   type FolderGroup,
@@ -124,7 +125,7 @@ function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
       <FileText className="h-4 w-4 flex-shrink-0 text-gray-400" />
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-gray-900 truncate">
-          {document.fileName}
+          {getDisplayFileName(document)}
         </p>
         <p className="text-xs text-gray-500 truncate">
           {document.documentType || '未判定'}

--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -19,12 +19,16 @@ import {
   UserCheck,
   Loader2,
   AlertCircle,
+  Search,
+  X,
 } from 'lucide-react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { Timestamp } from 'firebase/firestore';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import {
   useDocumentGroups,
   useGroupStats,
@@ -45,6 +49,7 @@ import {
   summarizeCategoryGroups,
   type CategoryHierarchy,
 } from '@/lib/buildDocumentTypeCategoryGroups';
+import { filterGroupsByName } from '@/lib/filterGroupsByName';
 import { GroupDocumentList } from './GroupDocumentList';
 import type { DateRange } from '@/components/DateRangeFilter';
 
@@ -220,12 +225,11 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [selectedKanaRow, setSelectedKanaRow] = useState<KanaRow | null>(null);
+  const [nameFilter, setNameFilter] = useState('');
 
   const isCustomerView = groupType === 'customer';
   const isDocumentTypeView = groupType === 'documentType';
   const needsFurigana = groupType === 'customer' || groupType === 'careManager';
-  // 顧客別: あいうえお順クライアントソート、書類種別: カテゴリ階層化のため全件必要
-  const useClientSort = isCustomerView || isDocumentTypeView;
 
   const {
     data: groups,
@@ -233,9 +237,12 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
     isError,
     error,
   } = useDocumentGroups({
+    // サーバー側 count 降順 + 上位100件キャップだと、書類数の少ない事業所/担当CMが
+    // 恒久的に非表示になる（バグ②）。全グループタイプで全件取得し、必要なソート・
+    // 上限は displayGroups 側でクライアント処理する。
     groupType,
-    sortBy: useClientSort ? 'none' : 'count',
-    limitCount: useClientSort ? undefined : 100,
+    sortBy: 'none',
+    limitCount: undefined,
   });
 
   const { data: stats } = useGroupStats(groupType);
@@ -268,22 +275,32 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
   // カテゴリ未運用テナントでは未分類 1 件にまとまるため、階層 UI を出さず従来のフラット表示に戻す
   const useCategoryHierarchy =
     isDocumentTypeView && categoryHierarchy.length > 0 && !isAllUncategorized(categoryHierarchy);
+  // 書類種別のカテゴリ階層表示はグループを再構成するため、フリーテキスト絞り込みの対象外
+  const showNameFilter = !(isDocumentTypeView && useCategoryHierarchy);
 
   // 顧客別: あいうえお順ソート + フィルター
   // furiganaMap未準備時はソート・フィルターをスキップ（空結果防止）
   // 書類種別タブ・階層省略時: 全件取得しているので件数降順 + 上位 100 件で従来表示と同等にする
   const displayGroups = useMemo(() => {
     if (!groups) return [];
+    let result: DocumentGroup[];
     if (isCustomerView) {
       if (!isFuriganaReady) return groups;
       const sorted = sortGroupsByFurigana(groups, furiganaMap);
-      return filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
+      result = filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
+    } else if (isDocumentTypeView && !useCategoryHierarchy) {
+      result = [...groups].sort((a, b) => b.count - a.count).slice(0, 100);
+    } else if (isDocumentTypeView) {
+      result = groups;
+    } else {
+      // 事業所別・担当CM別: サーバー側の上位100件キャップを廃止したため、
+      // 従来の表示順（件数降順）をクライアント側で維持する（全件表示、上限なし）
+      result = [...groups].sort((a, b) => b.count - a.count);
     }
-    if (isDocumentTypeView && !useCategoryHierarchy) {
-      return [...groups].sort((a, b) => b.count - a.count).slice(0, 100);
-    }
-    return groups;
-  }, [groups, isCustomerView, isDocumentTypeView, useCategoryHierarchy, isFuriganaReady, furiganaMap, selectedKanaRow]);
+    // カテゴリ階層表示は内部でグループを再構成するため、フリーテキスト絞り込みは対象外
+    if (isDocumentTypeView && useCategoryHierarchy) return result;
+    return filterGroupsByName(result, nameFilter);
+  }, [groups, isCustomerView, isDocumentTypeView, useCategoryHierarchy, isFuriganaReady, furiganaMap, selectedKanaRow, nameFilter]);
 
   const config = GROUP_TYPE_CONFIG[groupType];
 
@@ -368,6 +385,30 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
         </div>
       )}
 
+      {/* グループ名フリーテキスト絞り込み（書類種別のカテゴリ階層表示時は対象外） */}
+      {showNameFilter && (
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder={`${config.label}の名前で絞り込み...`}
+            value={nameFilter}
+            onChange={(e) => setNameFilter(e.target.value)}
+            className="pl-9 pr-9"
+          />
+          {nameFilter && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 p-0"
+              onClick={() => setNameFilter('')}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      )}
+
       {/* あかさたなフィルター（顧客別のみ） */}
       {isCustomerView && (
         <KanaFilterBar
@@ -386,11 +427,18 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
       {/* グループ一覧 */}
       <Card>
         {/* フィルター適用時の件数表示 */}
-        {isCustomerView && selectedKanaRow && (
+        {((isCustomerView && selectedKanaRow) || (showNameFilter && nameFilter)) && (
           <div className="px-4 py-2 text-xs text-gray-500 border-b border-gray-100">
             {displayGroups.length}件 / {groups.length}件
           </div>
         )}
+        {showNameFilter && nameFilter && displayGroups.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-500">
+            <Search className="mb-4 h-12 w-12 text-gray-300" />
+            <p className="text-lg font-medium">該当する{config.label}が見つかりません</p>
+            <p className="mt-1 text-sm">絞り込みキーワードを変更してお試しください</p>
+          </div>
+        ) : (
         <div className="divide-y divide-gray-100">
           {useCategoryHierarchy
             ? categoryHierarchy.map((category) => (
@@ -424,8 +472,9 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
                 />
               ))}
         </div>
-        {/* フィルターで結果0件の場合 */}
-        {isCustomerView && selectedKanaRow && displayGroups.length === 0 && (
+        )}
+        {/* あかさたなフィルターで結果0件の場合（名前絞り込みが0件表示を出している間は重複表示しない） */}
+        {isCustomerView && selectedKanaRow && displayGroups.length === 0 && !nameFilter && (
           <div className="py-8 text-center text-sm text-gray-500">
             「{selectedKanaRow}」行の顧客はいません
           </div>

--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -283,23 +283,26 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
   // 書類種別タブ・階層省略時: 全件取得しているので件数降順 + 上位 100 件で従来表示と同等にする
   const displayGroups = useMemo(() => {
     if (!groups) return [];
-    let result: DocumentGroup[];
-    if (isCustomerView) {
-      if (!isFuriganaReady) return groups;
-      const sorted = sortGroupsByFurigana(groups, furiganaMap);
-      result = filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
-    } else if (isDocumentTypeView && !useCategoryHierarchy) {
-      result = [...groups].sort((a, b) => b.count - a.count).slice(0, 100);
-    } else if (isDocumentTypeView) {
-      result = groups;
-    } else {
-      // 事業所別・担当CM別: サーバー側の上位100件キャップを廃止したため、
-      // 従来の表示順（件数降順）をクライアント側で維持する（全件表示、上限なし）
-      result = [...groups].sort((a, b) => b.count - a.count);
-    }
     // カテゴリ階層表示は内部でグループを再構成するため、フリーテキスト絞り込みは対象外
-    if (isDocumentTypeView && useCategoryHierarchy) return result;
-    return filterGroupsByName(result, nameFilter);
+    if (isDocumentTypeView && useCategoryHierarchy) return groups;
+
+    // フリーテキスト絞り込みは、書類種別フラット表示の上位100件キャップより先に適用する。
+    // 先に上位100件へ切り詰めてしまうと、101件目以降にしか存在しない書類種別を検索しても
+    // 常に0件になる不具合が起きるため（/code-review指摘）。
+    const nameFiltered = filterGroupsByName(groups, nameFilter);
+
+    if (isCustomerView) {
+      if (!isFuriganaReady) return nameFiltered;
+      const sorted = sortGroupsByFurigana(nameFiltered, furiganaMap);
+      return filterGroupsByKanaRow(sorted, selectedKanaRow, furiganaMap);
+    }
+    if (isDocumentTypeView) {
+      // 書類種別タブ・階層省略時: 件数降順 + 上位100件で従来表示と同等にする
+      return [...nameFiltered].sort((a, b) => b.count - a.count).slice(0, 100);
+    }
+    // 事業所別・担当CM別: サーバー側の上位100件キャップを廃止したため、
+    // 従来の表示順（件数降順）をクライアント側で維持する（全件表示、上限なし）
+    return [...nameFiltered].sort((a, b) => b.count - a.count);
   }, [groups, isCustomerView, isDocumentTypeView, useCategoryHierarchy, isFuriganaReady, furiganaMap, selectedKanaRow, nameFilter]);
 
   const config = GROUP_TYPE_CONFIG[groupType];

--- a/frontend/src/lib/__tests__/filterGroupsByName.test.ts
+++ b/frontend/src/lib/__tests__/filterGroupsByName.test.ts
@@ -1,0 +1,60 @@
+/**
+ * filterGroupsByName / normalizeForNameFilter 単体テスト
+ *
+ * グループビュー（事業所別・書類種別・担当CM別）でグループ名をフリーテキストで
+ * 絞り込む機能（#⑤要望対応）。全角/半角・大文字小文字の差異を吸収する。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { filterGroupsByName, normalizeForNameFilter } from '../filterGroupsByName';
+import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+import { Timestamp } from 'firebase/firestore';
+
+function makeGroup(displayName: string): DocumentGroup {
+  return {
+    id: displayName,
+    groupType: 'office',
+    groupKey: displayName,
+    displayName,
+    count: 1,
+    latestAt: Timestamp.now(),
+    latestDocs: [],
+    updatedAt: Timestamp.now(),
+  };
+}
+
+describe('normalizeForNameFilter', () => {
+  it('全角英数字を半角に正規化する', () => {
+    expect(normalizeForNameFilter('ＤＡＣＨＯ')).toBe('dacho');
+  });
+
+  it('大文字小文字を区別しない', () => {
+    expect(normalizeForNameFilter('Helper')).toBe('helper');
+  });
+});
+
+describe('filterGroupsByName', () => {
+  const groups = [
+    makeGroup('ヘルパーステーションダチョウ'),
+    makeGroup('テスト第一事業所'),
+    makeGroup('テスト事業所'),
+  ];
+
+  it('部分一致するグループのみ返す', () => {
+    const result = filterGroupsByName(groups, 'ダチョウ');
+    expect(result.map((g) => g.displayName)).toEqual(['ヘルパーステーションダチョウ']);
+  });
+
+  it('空文字の場合は全件返す（絞り込み未適用）', () => {
+    expect(filterGroupsByName(groups, '')).toHaveLength(3);
+  });
+
+  it('前後の空白は無視される', () => {
+    const result = filterGroupsByName(groups, '  ダチョウ  ');
+    expect(result).toHaveLength(1);
+  });
+
+  it('一致しない場合は空配列を返す', () => {
+    expect(filterGroupsByName(groups, '存在しない事業所')).toEqual([]);
+  });
+});

--- a/frontend/src/lib/__tests__/filterGroupsByName.test.ts
+++ b/frontend/src/lib/__tests__/filterGroupsByName.test.ts
@@ -31,6 +31,15 @@ describe('normalizeForNameFilter', () => {
   it('大文字小文字を区別しない', () => {
     expect(normalizeForNameFilter('Helper')).toBe('helper');
   });
+
+  it('旧字体(外字)を新字体に正規化する', () => {
+    expect(normalizeForNameFilter('髙橋')).toBe('高橋');
+  });
+
+  it('undefined/nullを渡してもクラッシュせず空文字を返す', () => {
+    expect(normalizeForNameFilter(undefined as unknown as string)).toBe('');
+    expect(normalizeForNameFilter(null as unknown as string)).toBe('');
+  });
 });
 
 describe('filterGroupsByName', () => {
@@ -56,5 +65,12 @@ describe('filterGroupsByName', () => {
 
   it('一致しない場合は空配列を返す', () => {
     expect(filterGroupsByName(groups, '存在しない事業所')).toEqual([]);
+  });
+
+  it('displayNameがundefinedのグループが混在していてもクラッシュしない（異常系）', () => {
+    const withMissingName = [...groups, makeGroup(undefined as unknown as string)];
+    expect(() => filterGroupsByName(withMissingName, 'ダチョウ')).not.toThrow();
+    const result = filterGroupsByName(withMissingName, 'ダチョウ');
+    expect(result.map((g) => g.displayName)).toEqual(['ヘルパーステーションダチョウ']);
   });
 });

--- a/frontend/src/lib/filterGroupsByName.ts
+++ b/frontend/src/lib/filterGroupsByName.ts
@@ -1,0 +1,19 @@
+/**
+ * グループ名フリーテキスト絞り込み
+ *
+ * 事業所別・書類種別・担当CM別・顧客別ビューで、グループ名（displayName）を
+ * フリーテキストで絞り込むための純粋関数。
+ */
+
+import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+
+/** 全角/半角・大文字小文字の差異を吸収して比較するための正規化 */
+export function normalizeForNameFilter(value: string): string {
+  return value.normalize('NFKC').toLowerCase();
+}
+
+export function filterGroupsByName(groups: DocumentGroup[], filterText: string): DocumentGroup[] {
+  const normalized = normalizeForNameFilter(filterText.trim());
+  if (!normalized) return groups;
+  return groups.filter((g) => normalizeForNameFilter(g.displayName).includes(normalized));
+}

--- a/frontend/src/lib/filterGroupsByName.ts
+++ b/frontend/src/lib/filterGroupsByName.ts
@@ -6,10 +6,15 @@
  */
 
 import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+import { normalizeName } from '@/lib/textNormalizer';
 
-/** 全角/半角・大文字小文字の差異を吸収して比較するための正規化 */
+/**
+ * 全角/半角・大文字小文字・旧字体(外字)の差異を吸収して比較するための正規化。
+ * normalizeName内部が `text || ''` で null/undefined を安全に空文字化するため、
+ * displayName が欠損したドキュメントを渡してもクラッシュしない。
+ */
 export function normalizeForNameFilter(value: string): string {
-  return value.normalize('NFKC').toLowerCase();
+  return normalizeName(value).toLowerCase();
 }
 
 export function filterGroupsByName(groups: DocumentGroup[], filterText: string): DocumentGroup[] {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -258,10 +258,10 @@ function DocumentRow({
         </td>
       )}
       <td className="px-2 py-2 sm:px-4 sm:py-3">
-        <div className="flex items-center gap-2 sm:gap-3">
+        <div className="flex items-start gap-2 sm:gap-3">
           <FileText className="h-4 w-4 flex-shrink-0 text-gray-400 sm:h-5 sm:w-5" />
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-gray-900 sm:text-base">{getDisplayFileName(document)}</p>
+          <div className="min-w-0 max-w-[160px] sm:max-w-[240px]">
+            <p className="break-words text-sm font-medium text-gray-900 sm:text-base">{getDisplayFileName(document)}</p>
             <p className="truncate text-xs text-gray-500 sm:text-sm">{document.documentType || '未判定'}</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
kanameoneからの実機フィードバック(①②③⑤)への対応。

- **①** 担当CM別ビューで`displayFileName`ではなく生の`fileName`(内部ID風文字列)が表示される不具合を修正。`CustomerSubGroup.tsx`内の`DocumentRow`が`getDisplayFileName()`を呼んでいなかったのが原因
- **②** 事業所別・担当CM別ビューでサーバー側`count`降順+上位100件キャップにより、書類数の少ない事業所/CM(例: 「ヘルパーステーションダチョウ」)が恒久的に非表示になる不具合を修正。顧客別・書類種別ビューと同様に全件取得+クライアント側ソートに変更
- **③** 書類一覧テーブルでファイル名列に幅制約がなく、区切り文字のない長いファイル名(内部ID風)で列が肥大化しステータス列が画面外に押し出される不具合を修正。`max-width`+`break-words`で折り返し表示に変更
- **⑤** 事業所別・書類種別・担当CM別・顧客別ビューにグループ名のフリーテキスト絞り込みを追加(全角/半角・大小文字を吸収)。「あかさたな順ソート」の代替として要望されたニーズに対応(元の④要望は⑤で代替可能と判断され対応不要)

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npm run lint` PASS(warning 0件)
- [x] `npm test -- --run` 32ファイル/472件 全PASS(新規テスト`filterGroupsByName.test.ts` 6件含む)
- [x] Firebase Emulator + Playwright MCPで実機確認
  - 担当CM別ビューで`displayFileName`が正しく表示されることを確認(①)
  - 事業所別ビューで105件の検証用事業所+「ヘルパーステーションダチョウ」が全件表示されることを確認(②、108グループ全表示)
  - 書類一覧テーブルで区切り文字のない長いファイル名が折り返し表示され、ステータス列が画面内に収まることを確認(③)
  - 事業所別・担当CM別ビューでフリーテキスト絞り込み(部分一致・0件時のメッセージ)が機能することを確認(⑤)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a free-text filter for finding groups by name.
  * Group filtering now supports partial matches, whitespace trimming, and consistent matching across letter formats.

* **Improvements**
  * Updated group results, counts, sorting, and empty states to reflect active filters.
  * Improved document filename display by using the appropriate displayed name.
  * File names now wrap across multiple lines instead of being cut off in narrower layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->