### PR TITLE
fix: 書類種別カテゴリ階層表示でもグループ名フリーテキスト検索を有効化

### DIFF
--- a/frontend/src/components/views/GroupList.tsx
+++ b/frontend/src/components/views/GroupList.tsx
@@ -49,7 +49,7 @@ import {
   summarizeCategoryGroups,
   type CategoryHierarchy,
 } from '@/lib/buildDocumentTypeCategoryGroups';
-import { filterGroupsByName } from '@/lib/filterGroupsByName';
+import { filterGroupsByName, filterCategoryHierarchyByName } from '@/lib/filterGroupsByName';
 import { GroupDocumentList } from './GroupDocumentList';
 import type { DateRange } from '@/components/DateRangeFilter';
 
@@ -275,15 +275,22 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
   // カテゴリ未運用テナントでは未分類 1 件にまとまるため、階層 UI を出さず従来のフラット表示に戻す
   const useCategoryHierarchy =
     isDocumentTypeView && categoryHierarchy.length > 0 && !isAllUncategorized(categoryHierarchy);
-  // 書類種別のカテゴリ階層表示はグループを再構成するため、フリーテキスト絞り込みの対象外
-  const showNameFilter = !(isDocumentTypeView && useCategoryHierarchy);
+
+  // カテゴリ階層表示時のフリーテキスト絞り込み: カテゴリ内のグループをそれぞれ絞り込み、
+  // 一致するグループが0件になったカテゴリは表示から除外する
+  // (/codex review-diff指摘: kanameone 126/126・cocoro 27/27件でcategory運用済みのため
+  //  「カテゴリ階層表示時は検索欄非表示」のままだと両クライアントで検索機能が実質使えなかった)
+  const filteredCategoryHierarchy = useMemo(() => {
+    if (!useCategoryHierarchy) return categoryHierarchy;
+    return filterCategoryHierarchyByName(categoryHierarchy, nameFilter);
+  }, [categoryHierarchy, useCategoryHierarchy, nameFilter]);
 
   // 顧客別: あいうえお順ソート + フィルター
   // furiganaMap未準備時はソート・フィルターをスキップ（空結果防止）
   // 書類種別タブ・階層省略時: 全件取得しているので件数降順 + 上位 100 件で従来表示と同等にする
   const displayGroups = useMemo(() => {
     if (!groups) return [];
-    // カテゴリ階層表示は内部でグループを再構成するため、フリーテキスト絞り込みは対象外
+    // カテゴリ階層表示は filteredCategoryHierarchy 側で絞り込むため、ここでは元のgroupsをそのまま返す
     if (isDocumentTypeView && useCategoryHierarchy) return groups;
 
     // フリーテキスト絞り込みは、書類種別フラット表示の上位100件キャップより先に適用する。
@@ -371,6 +378,13 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
     );
   }
 
+  // カテゴリ階層表示・フラット表示のどちらでも同じ基準で「絞り込み後の件数」「絞り込み結果0件」を扱う
+  const matchedGroupCount = useCategoryHierarchy
+    ? filteredCategoryHierarchy.reduce((sum, category) => sum + category.groups.length, 0)
+    : displayGroups.length;
+  const isNameFilterActive = nameFilter.trim().length > 0;
+  const isNameFilterEmptyResult = isNameFilterActive && matchedGroupCount === 0;
+
   return (
     <div className="space-y-4">
       {/* 統計情報 */}
@@ -388,29 +402,27 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
         </div>
       )}
 
-      {/* グループ名フリーテキスト絞り込み（書類種別のカテゴリ階層表示時は対象外） */}
-      {showNameFilter && (
-        <div className="relative max-w-sm">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            placeholder={`${config.label}の名前で絞り込み...`}
-            value={nameFilter}
-            onChange={(e) => setNameFilter(e.target.value)}
-            className="pl-9 pr-9"
-          />
-          {nameFilter && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 p-0"
-              onClick={() => setNameFilter('')}
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          )}
-        </div>
-      )}
+      {/* グループ名フリーテキスト絞り込み（書類種別のカテゴリ階層表示時も対象） */}
+      <div className="relative max-w-sm">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder={`${config.label}の名前で絞り込み...`}
+          value={nameFilter}
+          onChange={(e) => setNameFilter(e.target.value)}
+          className="pl-9 pr-9"
+        />
+        {nameFilter && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 p-0"
+            onClick={() => setNameFilter('')}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
 
       {/* あかさたなフィルター（顧客別のみ） */}
       {isCustomerView && (
@@ -430,12 +442,12 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
       {/* グループ一覧 */}
       <Card>
         {/* フィルター適用時の件数表示 */}
-        {((isCustomerView && selectedKanaRow) || (showNameFilter && nameFilter)) && (
+        {((isCustomerView && selectedKanaRow) || isNameFilterActive) && (
           <div className="px-4 py-2 text-xs text-gray-500 border-b border-gray-100">
-            {displayGroups.length}件 / {groups.length}件
+            {matchedGroupCount}件 / {groups.length}件
           </div>
         )}
-        {showNameFilter && nameFilter && displayGroups.length === 0 ? (
+        {isNameFilterEmptyResult ? (
           <div className="flex flex-col items-center justify-center py-16 text-gray-500">
             <Search className="mb-4 h-12 w-12 text-gray-300" />
             <p className="text-lg font-medium">該当する{config.label}が見つかりません</p>
@@ -444,7 +456,7 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
         ) : (
         <div className="divide-y divide-gray-100">
           {useCategoryHierarchy
-            ? categoryHierarchy.map((category) => (
+            ? filteredCategoryHierarchy.map((category) => (
                 <CategoryItem
                   key={category.categoryName}
                   category={category}
@@ -477,7 +489,7 @@ export function GroupList({ groupType, dateFilter, onDocumentSelect }: GroupList
         </div>
         )}
         {/* あかさたなフィルターで結果0件の場合（名前絞り込みが0件表示を出している間は重複表示しない） */}
-        {isCustomerView && selectedKanaRow && displayGroups.length === 0 && !nameFilter && (
+        {isCustomerView && selectedKanaRow && displayGroups.length === 0 && !isNameFilterActive && (
           <div className="py-8 text-center text-sm text-gray-500">
             「{selectedKanaRow}」行の顧客はいません
           </div>

--- a/frontend/src/lib/__tests__/filterGroupsByName.test.ts
+++ b/frontend/src/lib/__tests__/filterGroupsByName.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { filterGroupsByName, normalizeForNameFilter } from '../filterGroupsByName';
+import { filterGroupsByName, filterCategoryHierarchyByName, normalizeForNameFilter } from '../filterGroupsByName';
 import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+import type { CategoryHierarchy } from '../buildDocumentTypeCategoryGroups';
 import { Timestamp } from 'firebase/firestore';
 
 function makeGroup(displayName: string): DocumentGroup {
@@ -72,5 +73,40 @@ describe('filterGroupsByName', () => {
     expect(() => filterGroupsByName(withMissingName, 'ダチョウ')).not.toThrow();
     const result = filterGroupsByName(withMissingName, 'ダチョウ');
     expect(result.map((g) => g.displayName)).toEqual(['ヘルパーステーションダチョウ']);
+  });
+});
+
+describe('filterCategoryHierarchyByName', () => {
+  const hierarchy: CategoryHierarchy[] = [
+    {
+      categoryName: '報告書',
+      groups: [makeGroup('FAX送り状'), makeGroup('FAX送信確認')],
+    },
+    {
+      categoryName: 'アセスメント',
+      groups: [makeGroup('アセスメントシート')],
+    },
+  ];
+
+  it('カテゴリ内のグループを絞り込み、一致するグループがないカテゴリは除外する', () => {
+    const result = filterCategoryHierarchyByName(hierarchy, 'FAX送り状');
+    expect(result).toHaveLength(1);
+    expect(result.at(0)?.categoryName).toBe('報告書');
+    expect(result.at(0)?.groups.map((g) => g.displayName)).toEqual(['FAX送り状']);
+  });
+
+  it('カテゴリをまたいで一致する場合は両カテゴリとも残る', () => {
+    const result = filterCategoryHierarchyByName(hierarchy, 'FAX');
+    expect(result).toHaveLength(1);
+    expect(result.at(0)?.groups).toHaveLength(2);
+  });
+
+  it('空文字の場合は元の階層をそのまま返す', () => {
+    const result = filterCategoryHierarchyByName(hierarchy, '');
+    expect(result).toEqual(hierarchy);
+  });
+
+  it('一致しない場合は空配列を返す（全カテゴリが除外される）', () => {
+    expect(filterCategoryHierarchyByName(hierarchy, '存在しない書類種別')).toEqual([]);
   });
 });

--- a/frontend/src/lib/filterGroupsByName.ts
+++ b/frontend/src/lib/filterGroupsByName.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DocumentGroup } from '@/hooks/useDocumentGroups';
+import type { CategoryHierarchy } from '@/lib/buildDocumentTypeCategoryGroups';
 import { normalizeName } from '@/lib/textNormalizer';
 
 /**
@@ -17,8 +18,26 @@ export function normalizeForNameFilter(value: string): string {
   return normalizeName(value).toLowerCase();
 }
 
-export function filterGroupsByName(groups: DocumentGroup[], filterText: string): DocumentGroup[] {
+export function filterGroupsByName(groups: readonly DocumentGroup[], filterText: string): DocumentGroup[] {
   const normalized = normalizeForNameFilter(filterText.trim());
-  if (!normalized) return groups;
+  if (!normalized) return [...groups];
   return groups.filter((g) => normalizeForNameFilter(g.displayName).includes(normalized));
+}
+
+/**
+ * カテゴリ階層表示（書類種別タブでカテゴリマスターが運用されているテナント）向けの
+ * フリーテキスト絞り込み。各カテゴリ内のグループを絞り込み、一致するグループが
+ * 0件になったカテゴリは結果から除外する。
+ */
+export function filterCategoryHierarchyByName(
+  hierarchy: readonly CategoryHierarchy[],
+  filterText: string,
+): CategoryHierarchy[] {
+  if (!filterText.trim()) return [...hierarchy];
+  return hierarchy
+    .map((category) => ({
+      ...category,
+      groups: filterGroupsByName(category.groups, filterText),
+    }))
+    .filter((category) => category.groups.length > 0);
 }


### PR DESCRIPTION
## Summary
PR #717（担当CM別ファイル名バグ・事業所別100件キャップ・テーブル列幅・グループ名検索の修正）マージ後、`/codex review-diff`でのセカンドオピニオンにより1件のP2指摘を受けたための追加修正。

**指摘内容**: 書類種別ビューでカテゴリ階層表示(`useCategoryHierarchy=true`)が有効な場合、新規追加したグループ名フリーテキスト検索欄が非表示になり機能しない。Codexはこれを「通常の設定済みケース」と評価。

**事実確認**: kanameone・cocoro本番環境の`masters/documents/items`を確認したところ、両クライアントとも書類種別マスターの`category`フィールドが100%運用されていた(kanameone 126/126件、cocoro 27/27件)。つまり両クライアントの書類種別ビューでは常にカテゴリ階層表示となり、新機能の検索が実質常に使えない状態だった。

## Changes
- `filterGroupsByName.ts`: `filterCategoryHierarchyByName()`を追加。カテゴリごとに内包するグループを絞り込み、一致するグループが0件になったカテゴリは結果から除外する
- `GroupList.tsx`: 検索欄の表示条件(`showNameFilter`)を廃止し全ビュー共通で表示。`filteredCategoryHierarchy`でカテゴリ階層の絞り込み結果を保持し、件数表示・空状態メッセージもフラット表示と共通ロジックに統一
- `filterGroupsByName()`の引数型を`readonly DocumentGroup[]`に緩和(`CategoryHierarchy.groups`が`readonly`のため)

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npm run lint` PASS(warning 0件)
- [x] `npm test -- --run` 32ファイル/479件 全PASS(カテゴリ横断絞り込み・空カテゴリ除外・空文字時の全件返却の新規テスト含む)
- [x] Firebase Emulator + Playwright MCPで実機確認
  - 書類種別マスターにcategory付きデータ(報告書/アセスメント)を投入し、カテゴリ階層表示を再現
  - 検索欄が表示され、「FAX」検索で「報告書」カテゴリ(2種別/3件)のみに絞り込まれることを確認
  - 一致しない検索語で「該当する書類種別が見つかりません」の空状態メッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added name filtering for groups in both standard lists and document-category views.
  * Category views now show only matching categories and groups.
  * Improved empty-state messaging and result counts for name searches.
  * Name matching supports case, width, character variations, and surrounding spaces.

* **Bug Fixes**
  * Enabled name search in document-category views.
  * Improved handling of empty or non-matching searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->