### PR TITLE
docs(help): Googleドライブ連携ヘルプの手順記載を実装に合わせて修正

### DIFF
--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -406,12 +406,12 @@ function AdminGuide() {
 
         <div className="info-box">
           <h4>この機能を使うには</h4>
-          <p>設定画面の「Google Drive連携」カードから、以下の3ステップで設定します。</p>
+          <p>「設定」画面上部のタブから「Google Drive」を選ぶと表示される「Google Drive連携」カードで、以下の3ステップで設定します。</p>
         </div>
 
         <h3>1. Drive接続</h3>
         <ol className="steps-list">
-          <li>設定画面の「Google Drive連携」カードを開く</li>
+          <li>「設定」画面を開き、上部のタブから「Google Drive」を選ぶ</li>
           <li>「Google Driveと連携する」ボタンをクリック</li>
           <li>表示されたGoogleアカウントの選択画面で、エクスポート先として使うアカウントを選び、アクセスを許可する</li>
           <li>連携が完了すると「連携済み」バッジと連携したアカウントのメールアドレスが表示される</li>
@@ -441,7 +441,7 @@ function AdminGuide() {
         </p>
         <ol className="steps-list">
           <li>プリセットボタンをクリックしてテンプレートを初期化する（または個別に階層を組み立てる）</li>
-          <li>内容を確認し「保存」をクリック</li>
+          <li>内容を確認し「設定を保存」をクリック</li>
         </ol>
 
         <div className="info-box">


### PR DESCRIPTION
## Summary
kanameone/cocoro（本番クライアント）へGoogle Drive接続の案内を送る前の事前確認として、ヘルプページ（`/help` 管理者ガイド）のGoogle Drive連携セクションが実装と一致しているかをコード照合 + 実機（Playwright MCP, dev環境）で確認した。以下2点の不一致を修正。

1. 「設定画面の『Google Drive連携』カードから」という記載は、あたかも設定画面を開けば直接カードが見えるかのように読めるが、実際は上部タブから「Google Drive」を選ぶ操作が必要（デフォルトタブは「Gmail設定」）。この手順への言及がなかったため追記
2. フォルダ階層テンプレートの保存ボタンの実ラベルは「設定を保存」だが、ヘルプは「保存」と記載していた

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npm run lint` PASS
- [x] Firebase Emulator + Playwright MCPで実機確認（`/help` 管理者ガイド→Google Drive連携セクション、`/settings` → Google Driveタブ、実際のボタンラベルをスクリーンショットで直接照合）
- [x] テキストのみの変更のためロジック影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the administrator guide for Google Drive integration with clearer setup instructions.
  * Clarified the first setup step, including tab selection and navigation to the settings screen.
  * Updated the button label in the folder hierarchy setup instructions from “Save” to “Save Settings.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->