### PR TITLE
fix(scripts): 監査スクリプトの個別一覧を対応優先度順にソート

### DIFF
--- a/scripts/check-customer-master-integrity.js
+++ b/scripts/check-customer-master-integrity.js
@@ -246,7 +246,19 @@ async function main() {
     .map((reason) => `${reason}=${reasonCounts.get(reason) ?? 0}件`)
     .join(', ');
   console.log(`  内訳: ${reasonSummary}`);
-  for (const c of unconfirmed.slice(0, 20)) {
+  // 個別一覧は同名衝突未確定(件数が少なく最も対応優先度が高い)→customerId↔name乖離→
+  // 顧客名未設定/sentinel値(大半を占めるレガシーdebt)の順にソートする。Firestore取得順の
+  // ままだと大量のsentinel値docに埋もれ、先頭20件のプレビューに真に対応が必要な同名衝突が
+  // 一件も表示されないことがある(decision-maker指摘、2026-07-26)。
+  const REASON_PRIORITY = [
+    UNCONFIRMED_REASON.UNCONFIRMED_COLLISION,
+    UNCONFIRMED_REASON.NAME_ID_MISMATCH,
+    UNCONFIRMED_REASON.INVALID_NAME,
+  ];
+  const sortedUnconfirmed = [...unconfirmed].sort(
+    (a, b) => REASON_PRIORITY.indexOf(a.reason) - REASON_PRIORITY.indexOf(b.reason)
+  );
+  for (const c of sortedUnconfirmed.slice(0, 20)) {
     console.log(`  - ${c.doc.id.slice(0, 12)}… customerName=「${c.doc.customerName}」 理由=${c.reason}`);
   }
   if (unconfirmed.length > 20) console.log(`  …他${unconfirmed.length - 20}件`);


### PR DESCRIPTION
## Summary
- `check-customer-master-integrity.js`の`[D]`個別doc一覧はFirestore取得順のまま先頭20件をプレビュー表示していたため、kanameoneの実データ（182件中159件が顧客名未設定/sentinel値のレガシーdebt）では、真に対応が必要な「同名衝突未確定」3件が一件もプレビューに表示されない状態だった
- 同名衝突未確定（最も少なく最優先）→customerId↔name乖離→顧客名未設定/sentinel値（大半を占める低優先度debt）の順にソートしてから先頭20件を表示するよう変更

## Test plan
- [x] `node --check`でスクリプト構文確認
- [x] ソートロジックを合成データで検証（優先度順に正しく並ぶことを確認）
- [ ] マージ後: GitHub Actions `Run Operations Script`をkanameoneで再実行し、同名衝突未確定3件がプレビューに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)