### PR TITLE
feat: 同姓同名(別人)候補の書類を現場管理者へ能動的に知らせるUIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,24 @@ jobs:
         # 解決済み。node --test ランナーで軽量実行(外部依存なし、数秒)。
         run: cd scripts && npm test
 
+      - name: Run frontend unit tests
+        # frontend/src/**/__tests__/*.test.tsx (vitest) はこれまでCIで未実行だった
+        # (同姓同名プロアクティブ通知UI追加、2026-07-26、Codex plan review指摘)。
+        # 依存は上のnpm ciで解決済み、emulator不要で数秒。
+        run: cd frontend && npm test
+
+      - name: Run customer identity gate integration tests (Firestore emulator)
+        # functions/test/exportDocumentIntegration.test.tsの顧客未確定ゲート13ケースは
+        # test/*Integration.test.tsがnpm run test:functionsの対象外(functions/package.json)
+        # のためこれまでCIで未実行だった(同姓同名プロアクティブ通知UI追加、2026-07-26、
+        # Codex plan review指摘)。customerAmbiguityGate.tsをshared/customerIdentity.tsへ
+        # 委譲するリファクタの回帰をCIで守るために追加。
+        run: |
+          cd functions && firebase emulators:exec --only firestore \
+            'npx mocha --require ts-node/register --timeout 15000 test/exportDocumentIntegration.test.ts'
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
       - name: Run Drive export backfill integration tests (Firestore emulator)
         # scripts/backfill-drive-export.ts はkanameone/cocoro本番展開で使うPartial
         # Update スクリプト(CLAUDE.md MUST: 更新対象外フィールド不変テスト必須、

--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -32,7 +32,8 @@ import { MasterSelectField } from '@/components/MasterSelectField'
 import { ExtractionInfoPopover } from '@/components/ExtractionInfoPopover'
 import { useDocument, useDocumentDetail, useReprocessDocument, useDistributionSiblingCount, resolveDetailFields } from '@/hooks/useDocuments'
 import { useDocumentEdit } from '@/hooks/useDocumentEdit'
-import { useCustomers, useOffices, useDocumentTypes, useCareManagers } from '@/hooks/useMasters'
+import { useCustomers, useOffices, useDocumentTypes, useCareManagers, useCustomerIdentityLookup } from '@/hooks/useMasters'
+import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity'
 import { useMasterAlias } from '@/hooks/useMasterAlias'
 import { useAliasLearningHistory, useInvalidateAliasLearningHistory } from '@/hooks/useAliasLearningHistory'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
@@ -505,7 +506,14 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
     if (rememberCustomerNotation && document && editedFields.customerName) {
       const originalCustomer = document.customerName || ''
       const newCustomerName = editedFields.customerName
-      const selectedCustomer = customers?.find(c => c.name === newCustomerName)
+      // MasterSelectFieldの選択時にeditedFields.customerIdが常に同期される(:1141参照)ため、
+      // それを優先してcustomerIdで特定する。名前一致のみ(customers?.find(c => c.name === ...))
+      // だと同姓同名の別人が存在する場合に先頭の1件へ誤ってエイリアス登録しうる
+      // (Codex plan review指摘、2026-07-26。フリーテキスト入力等でcustomerIdが空の場合のみ
+      // 名前一致にフォールバックする)。
+      const selectedCustomer = editedFields.customerId
+        ? customers?.find(c => c.id === editedFields.customerId)
+        : customers?.find(c => c.name === newCustomerName)
       if (selectedCustomer && originalCustomer !== newCustomerName) {
         try {
           await addAlias('customer', selectedCustomer.id, originalCustomer)
@@ -582,6 +590,22 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
   const needsOfficeConfirmation = document
     ? document.officeConfirmed === false && document.officeCandidates && document.officeCandidates.length > 0
     : false
+
+  // 同姓同名判定(2026-07-26追加)。useCustomers()のキャッシュ共有により追加フェッチなし
+  const identityLookup = useCustomerIdentityLookup()
+  const unconfirmedReason = document
+    ? resolveCustomerUnconfirmedReason(document, {
+        customerMasterName: document.customerId
+          ? (identityLookup.customerMasterNameById.get(document.customerId) ?? null)
+          : null,
+        sameNameCollisionNames: identityLookup.sameNameCollisionNames,
+      })
+    : null
+  const isSameNameCollision = unconfirmedReason === 'same-name-collision'
+  // 同名衝突の候補一覧(フリガナ・担当ケアマネ併記、staleな`allCustomerCandidates`より情報量が多い)
+  const collidingMasters = isSameNameCollision && document
+    ? (customers ?? []).filter(c => c.name.trim() === (document.customerName ?? '').trim())
+    : []
 
   // ドキュメントが変わったらdownloadUrlをリセット
   useEffect(() => {
@@ -1188,9 +1212,15 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                         <div className="flex items-center gap-2">
                           <span className="truncate text-sm text-gray-900">{document.customerName || '未判定'}</span>
                           <ExtractionInfoPopover fieldType="customer" document={document} />
-                          {needsCustomerConfirmation && (
-                            <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
-                              選択待ち
+                          {(needsCustomerConfirmation || isSameNameCollision) && (
+                            <Badge
+                              variant="outline"
+                              className="bg-orange-100 text-orange-800 border-orange-300 text-xs"
+                              title={isSameNameCollision
+                                ? '同姓同名の顧客マスターが複数あります。正しい顧客を選び直してください'
+                                : undefined}
+                            >
+                              {isSameNameCollision ? '同姓同名' : '選択待ち'}
                             </Badge>
                           )}
                         </div>
@@ -1359,11 +1389,22 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
                   <MetaRow icon={FileText} label="ページ数" value={`${document.totalPages} ページ`} />
                 </div>
 
-                {/* 重複警告 */}
-                {document.isDuplicateCustomer && document.allCustomerCandidates && (
+                {/* 重複警告(2026-07-26: staleなisDuplicateCustomer依存からライブ判定へ置換。
+                    OCR処理時点のスナップショットは後からマスターが追加された衝突に追従しないため、
+                    isSameNameCollision(useCustomerIdentityLookup経由の常に最新の判定)に統一する) */}
+                {isSameNameCollision && (
                   <div className="mt-4 rounded-lg bg-yellow-50 p-3">
                     <p className="text-xs font-medium text-yellow-800">同姓同名の顧客が存在します</p>
-                    <p className="mt-1 text-xs text-yellow-700">{document.allCustomerCandidates}</p>
+                    <p className="mt-1 text-xs text-yellow-700">
+                      正しい顧客を選び直して保存してください（この書類はGoogle Driveへエクスポートされません）
+                    </p>
+                    <ul className="mt-1 space-y-0.5 text-xs text-yellow-700">
+                      {collidingMasters.map((c) => (
+                        <li key={c.id}>
+                          {c.name}（{c.furigana || 'フリガナ未登録'} / 担当: {c.careManagerName || '未設定'}）
+                        </li>
+                      ))}
+                    </ul>
                   </div>
                 )}
 

--- a/frontend/src/components/__tests__/CustomerSubGroup.test.tsx
+++ b/frontend/src/components/__tests__/CustomerSubGroup.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * CustomerSubGroup 単体テスト(同姓同名プロアクティブ通知UI、2026-07-26追加)
+ *
+ * CustomerSubGroupは5箇所のバッジ実装のうち唯一Firestore hookを持たず
+ * documents/identityLookup propだけでレンダリングできるため、これを代表として
+ * resolveCustomerUnconfirmedReason経由の「同姓同名」バッジ配線をコンポーネントテストする。
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Timestamp } from 'firebase/firestore'
+import type { Document } from '@shared/types'
+import type { CustomerIdentityLookup } from '@/hooks/useMasters'
+import { CustomerSubGroup } from '../views/CustomerSubGroup'
+
+const makeDocument = (overrides: Partial<Document> = {}): Document => ({
+  id: 'doc-001',
+  processedAt: Timestamp.now(),
+  fileId: 'file-001',
+  fileName: 'test.pdf',
+  mimeType: 'application/pdf',
+  ocrResult: '',
+  documentType: 'ケアプラン',
+  customerName: '松本 実',
+  officeName: 'テスト事業所',
+  fileUrl: 'https://example.com/test.pdf',
+  fileDate: Timestamp.now(),
+  isDuplicateCustomer: false,
+  totalPages: 1,
+  targetPageNumber: 1,
+  status: 'processed',
+  verified: true,
+  ...overrides,
+})
+
+const makeLookup = (sameNameCollisionNames: string[]): CustomerIdentityLookup => ({
+  sameNameCollisionNames: new Set(sameNameCollisionNames),
+  customerMasterNameById: new Map(),
+})
+
+/** 顧客グループ→フォルダグループの2段展開をクリックしてDocumentRowを可視化する */
+function expandToDocumentRow(customerName: string, documentType: string) {
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(customerName) }))
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(documentType) }))
+}
+
+describe('CustomerSubGroup - 同姓同名バッジ', () => {
+  it('両方未設定(レガシーdoc) + 同名衝突ありは「同姓同名」バッジを表示する(本件の中核)', () => {
+    const doc = makeDocument()
+    render(
+      <CustomerSubGroup
+        documents={[doc]}
+        identityLookup={makeLookup(['松本 実'])}
+      />
+    )
+    expandToDocumentRow('松本 実', 'ケアプラン')
+    expect(screen.getByText('同姓同名')).toBeDefined()
+  })
+
+  it('両方未設定 + 同名衝突なし(同名1件)は「同姓同名」バッジを表示しない(後方互換)', () => {
+    const doc = makeDocument()
+    render(
+      <CustomerSubGroup
+        documents={[doc]}
+        identityLookup={makeLookup([])}
+      />
+    )
+    expandToDocumentRow('松本 実', 'ケアプラン')
+    expect(screen.queryByText('同姓同名')).toBeNull()
+  })
+
+  it('customerConfirmed:true + 同名衝突ありは「同姓同名」バッジを表示しない(人間確定優先)', () => {
+    const doc = makeDocument({ customerConfirmed: true })
+    render(
+      <CustomerSubGroup
+        documents={[doc]}
+        identityLookup={makeLookup(['松本 実'])}
+      />
+    )
+    expandToDocumentRow('松本 実', 'ケアプラン')
+    expect(screen.queryByText('同姓同名')).toBeNull()
+  })
+
+  it('customerConfirmed:false + 同名衝突なしは既存の「選択待ち」バッジを表示する(既存挙動の回帰固定)', () => {
+    const doc = makeDocument({ customerConfirmed: false })
+    render(
+      <CustomerSubGroup
+        documents={[doc]}
+        identityLookup={makeLookup([])}
+      />
+    )
+    expandToDocumentRow('松本 実', 'ケアプラン')
+    expect(screen.getByText('選択待ち')).toBeDefined()
+    expect(screen.queryByText('同姓同名')).toBeNull()
+  })
+
+  it('前後空白付きcustomerNameでもtrim後に衝突集合と一致すれば「同姓同名」バッジを表示する(trim整合)', () => {
+    const doc = makeDocument({ customerName: ' 松本 実 ' })
+    render(
+      <CustomerSubGroup
+        documents={[doc]}
+        identityLookup={makeLookup(['松本 実'])}
+      />
+    )
+    expandToDocumentRow('松本 実', 'ケアプラン')
+    expect(screen.getByText('同姓同名')).toBeDefined()
+  })
+})

--- a/frontend/src/components/views/CustomerSubGroup.tsx
+++ b/frontend/src/components/views/CustomerSubGroup.tsx
@@ -17,12 +17,14 @@ import { Timestamp } from 'firebase/firestore';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
+import type { CustomerIdentityLookup } from '@/hooks/useMasters';
 import { getStatusConfig, formatTimestamp } from '@/lib/documentUtils';
 import { getDisplayFileName } from '@/utils/getDisplayFileName';
 import {
   buildCustomerFolderGroups,
   type FolderGroup,
 } from '@/lib/buildCustomerFolderGroups';
+import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity';
 import type { Document, DocumentMaster } from '@shared/types';
 
 // ============================================
@@ -37,6 +39,8 @@ interface CustomerSubGroupProps {
   onDocumentSelect?: (documentId: string) => void;
   /** error 書類の「再試行」(#524)。未指定時はボタン非表示 */
   onRetry?: (document: Document) => void;
+  /** 同姓同名バッジ判定用(未指定時は「選択待ち」のみ、同姓同名バッジは出さない) */
+  identityLookup?: CustomerIdentityLookup;
 }
 
 interface CustomerGroup {
@@ -101,9 +105,10 @@ interface DocumentRowProps {
   document: Document;
   onClick: () => void;
   onRetry?: (document: Document) => void;
+  identityLookup?: CustomerIdentityLookup;
 }
 
-function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
+function DocumentRow({ document, onClick, onRetry, identityLookup }: DocumentRowProps) {
   const statusConfig = getStatusConfig(document.status);
 
   // 選択待ち判定
@@ -112,7 +117,30 @@ function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
     document.officeConfirmed === false &&
     document.officeCandidates &&
     document.officeCandidates.length > 0;
-  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation;
+
+  // 同姓同名判定(2026-07-26追加)。identityLookup未指定時はDrive未接続テナント等を想定しnull扱い。
+  const unconfirmedReason = identityLookup
+    ? resolveCustomerUnconfirmedReason(document, {
+        customerMasterName: document.customerId
+          ? (identityLookup.customerMasterNameById.get(document.customerId) ?? null)
+          : null,
+        sameNameCollisionNames: identityLookup.sameNameCollisionNames,
+      })
+    : null;
+  const isSameNameCollision = unconfirmedReason === 'same-name-collision';
+  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation || isSameNameCollision;
+
+  // バッジ文言優先順位: 同姓同名(実害が大きい) > 選択待ち。title は該当する全理由を列挙し、
+  // needsReview合成による「事業所要対応が同姓同名バッジの裏で隠れる」ことを防ぐ
+  // (Codex plan review指摘、2026-07-26)。
+  const reviewReasons: string[] = [];
+  if (isSameNameCollision) {
+    reviewReasons.push('同姓同名の顧客マスターが複数あります。書類詳細で正しい顧客を選び直してください');
+  }
+  if (needsOfficeConfirmation) {
+    reviewReasons.push('事業所が未選択です');
+  }
+  const reviewTitle = reviewReasons.length > 0 ? reviewReasons.join('。') : undefined;
 
   // OCR未確認
   const isUnverified = !document.verified;
@@ -142,8 +170,13 @@ function DocumentRow({ document, onClick, onRetry }: DocumentRowProps) {
           {formatTimestamp(document.fileDate)}
         </span>
         {needsReview ? (
-          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
-            選択待ち
+          <Badge
+            variant="outline"
+            className="bg-orange-100 text-orange-800 border-orange-300 text-xs"
+            title={reviewTitle}
+          >
+            {isSameNameCollision && <Users className="mr-1 h-3 w-3 inline" />}
+            {isSameNameCollision ? '同姓同名' : '選択待ち'}
           </Badge>
         ) : (
           <Badge variant={statusConfig.variant} className="text-xs">
@@ -189,6 +222,7 @@ interface FolderGroupItemProps {
   onToggle: () => void;
   onDocumentSelect?: (documentId: string) => void;
   onRetry?: (document: Document) => void;
+  identityLookup?: CustomerIdentityLookup;
 }
 
 function FolderGroupItem({
@@ -197,6 +231,7 @@ function FolderGroupItem({
   onToggle,
   onDocumentSelect,
   onRetry,
+  identityLookup,
 }: FolderGroupItemProps) {
   return (
     <div className="border-b border-gray-50 last:border-0">
@@ -226,6 +261,7 @@ function FolderGroupItem({
               document={doc}
               onClick={() => onDocumentSelect?.(doc.id)}
               onRetry={onRetry}
+              identityLookup={identityLookup}
             />
           ))}
         </div>
@@ -245,6 +281,7 @@ interface CustomerGroupItemProps {
   onToggle: () => void;
   onDocumentSelect?: (documentId: string) => void;
   onRetry?: (document: Document) => void;
+  identityLookup?: CustomerIdentityLookup;
 }
 
 function CustomerGroupItem({
@@ -254,6 +291,7 @@ function CustomerGroupItem({
   onToggle,
   onDocumentSelect,
   onRetry,
+  identityLookup,
 }: CustomerGroupItemProps) {
   // フォルダサブグループの展開状態 (#527)。顧客を閉じると状態ごと破棄される
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
@@ -313,6 +351,7 @@ function CustomerGroupItem({
               onToggle={() => toggleFolder(folder.label)}
               onDocumentSelect={onDocumentSelect}
               onRetry={onRetry}
+              identityLookup={identityLookup}
             />
           ))}
         </div>
@@ -331,6 +370,7 @@ export function CustomerSubGroup({
   documentMasters,
   onDocumentSelect,
   onRetry,
+  identityLookup,
 }: CustomerSubGroupProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
@@ -371,6 +411,7 @@ export function CustomerSubGroup({
           onToggle={() => toggleGroup(group.customerKey)}
           onDocumentSelect={onDocumentSelect}
           onRetry={onRetry}
+          identityLookup={identityLookup}
         />
       ))}
     </div>

--- a/frontend/src/components/views/GroupDocumentList.tsx
+++ b/frontend/src/components/views/GroupDocumentList.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useMemo, useState } from 'react';
-import { FileText, Loader2, RefreshCw } from 'lucide-react';
+import { FileText, Loader2, RefreshCw, Users } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -21,7 +21,7 @@ import {
 import { LoadMoreIndicator } from '@/components/LoadMoreIndicator';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { useReprocessDocument } from '@/hooks/useDocuments';
-import { useDocumentTypes } from '@/hooks/useMasters';
+import { useDocumentTypes, useCustomerIdentityLookup, type CustomerIdentityLookup } from '@/hooks/useMasters';
 import {
   useGroupDocuments,
   type GroupType,
@@ -30,6 +30,7 @@ import { isCustomerConfirmed } from '@/hooks/useProcessingHistory';
 import { CustomerSubGroup } from './CustomerSubGroup';
 import { getStatusConfig, formatTimestamp } from '@/lib/documentUtils';
 import { getDisplayFileName } from '@/utils/getDisplayFileName';
+import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity';
 import type { Document } from '@shared/types';
 import type { DateRange } from '@/components/DateRangeFilter';
 
@@ -56,9 +57,10 @@ interface DocumentRowProps {
   onClick: () => void;
   /** error 書類の「再試行」(#524)。未指定時はボタン非表示 */
   onRetry?: (document: Document) => void;
+  identityLookup?: CustomerIdentityLookup;
 }
 
-function DocumentRow({ document, groupType, onClick, onRetry }: DocumentRowProps) {
+function DocumentRow({ document, groupType, onClick, onRetry, identityLookup }: DocumentRowProps) {
   const statusConfig = getStatusConfig(document.status);
 
   // 選択待ち判定（顧客・事業所）
@@ -67,7 +69,29 @@ function DocumentRow({ document, groupType, onClick, onRetry }: DocumentRowProps
     document.officeConfirmed === false &&
     document.officeCandidates &&
     document.officeCandidates.length > 0;
-  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation;
+
+  // 同姓同名判定(2026-07-26追加)
+  const unconfirmedReason = identityLookup
+    ? resolveCustomerUnconfirmedReason(document, {
+        customerMasterName: document.customerId
+          ? (identityLookup.customerMasterNameById.get(document.customerId) ?? null)
+          : null,
+        sameNameCollisionNames: identityLookup.sameNameCollisionNames,
+      })
+    : null;
+  const isSameNameCollision = unconfirmedReason === 'same-name-collision';
+  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation || isSameNameCollision;
+
+  // バッジ文言優先順位: 同姓同名 > 選択待ち。title は該当する全理由を列挙し、needsReview合成
+  // による「事業所要対応が同姓同名バッジの裏で隠れる」ことを防ぐ(Codex plan review指摘)。
+  const reviewReasons: string[] = [];
+  if (isSameNameCollision) {
+    reviewReasons.push('同姓同名の顧客マスターが複数あります。書類詳細で正しい顧客を選び直してください');
+  }
+  if (needsOfficeConfirmation) {
+    reviewReasons.push('事業所が未選択です');
+  }
+  const reviewTitle = reviewReasons.length > 0 ? reviewReasons.join('。') : undefined;
 
   // OCR未確認
   const isUnverified = !document.verified;
@@ -111,8 +135,13 @@ function DocumentRow({ document, groupType, onClick, onRetry }: DocumentRowProps
           {formatTimestamp(document.fileDate)}
         </span>
         {needsReview ? (
-          <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300 text-xs">
-            選択待ち
+          <Badge
+            variant="outline"
+            className="bg-orange-100 text-orange-800 border-orange-300 text-xs"
+            title={reviewTitle}
+          >
+            {isSameNameCollision && <Users className="mr-1 h-3 w-3 inline" />}
+            {isSameNameCollision ? '同姓同名' : '選択待ち'}
           </Badge>
         ) : (
           <Badge variant={statusConfig.variant} className="text-xs">
@@ -195,6 +224,9 @@ export function GroupDocumentList({
     isError: isMasterError,
     error: masterError,
   } = useDocumentTypes();
+
+  // 同姓同名バッジ判定用(2026-07-26追加)。useCustomers()のキャッシュ共有により追加フェッチなし
+  const identityLookup = useCustomerIdentityLookup();
   if (groupType === 'careManager' && isMasterError) {
     // 書類種別タブ (GroupList) と同じ診断ログ。サイレントに種別表示へ縮退させない
     console.warn(
@@ -291,6 +323,7 @@ export function GroupDocumentList({
           documentMasters={documentMasters}
           onDocumentSelect={onDocumentSelect}
           onRetry={setRetryTarget}
+          identityLookup={identityLookup}
         />
 
         <LoadMoreIndicator
@@ -316,6 +349,7 @@ export function GroupDocumentList({
             groupType={groupType}
             onClick={() => onDocumentSelect?.(doc.id)}
             onRetry={setRetryTarget}
+            identityLookup={identityLookup}
           />
         ))}
       </div>

--- a/frontend/src/hooks/__tests__/useProcessingHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useProcessingHistory.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../useProcessingHistory';
 import { firestoreToDocument } from '../useDocuments';
 import type { Document } from '@shared/types';
+import type { CustomerIdentityLookup } from '../useMasters';
 
 // Document 最小 fixture factory。必要フィールドのみ上書きする。
 function makeDoc(overrides: Partial<Document> = {}): Document {
@@ -165,6 +166,39 @@ describe('applyConfirmedFilter (#273)', () => {
     expect(applyConfirmedFilter([], 'all')).to.deep.equal([]);
     expect(applyConfirmedFilter([], 'confirmed')).to.deep.equal([]);
     expect(applyConfirmedFilter([], 'unconfirmed')).to.deep.equal([]);
+  });
+});
+
+// applyConfirmedFilterのJSDocが実装と矛盾していた(/code-review high候補で発覚、2026-07-26)。
+// identityLookup付きの挙動が単体テストで一切カバーされていなかったため追加。
+describe('applyConfirmedFilter with identityLookup (2026-07-26追加)', () => {
+  function makeLookup(sameNameCollisionNames: string[]): CustomerIdentityLookup {
+    return {
+      sameNameCollisionNames: new Set(sameNameCollisionNames),
+      customerMasterNameById: new Map(),
+    };
+  }
+
+  it('レガシーdoc(customerConfirmed/needsManualCustomerSelectionとも未設定) + 同名衝突ありはunconfirmed側に残る', () => {
+    const legacyCollisionDoc = makeDoc({ id: 'legacy-collision', customerName: '田中太郎' });
+    const result = applyConfirmedFilter([legacyCollisionDoc], 'confirmed', makeLookup(['田中太郎']));
+    expect(result).to.deep.equal([]);
+  });
+
+  it('customerConfirmed:true + 同名衝突ありは、人間確定優先のためconfirmed側に残る(precheckCustomerIdentityの設計通り。JSDoc訂正の対象だった挙動をlock-inする)', () => {
+    const confirmedCollisionDoc = makeDoc({
+      id: 'confirmed-collision',
+      customerName: '田中太郎',
+      customerConfirmed: true,
+    });
+    const result = applyConfirmedFilter([confirmedCollisionDoc], 'confirmed', makeLookup(['田中太郎']));
+    expect(result.map(d => d.id)).to.deep.equal(['confirmed-collision']);
+  });
+
+  it('identityLookup省略時は従来通りisCustomerConfirmed()のみで判定する(後方互換)', () => {
+    const legacyCollisionDoc = makeDoc({ id: 'legacy-collision', customerName: '田中太郎' });
+    const result = applyConfirmedFilter([legacyCollisionDoc], 'confirmed');
+    expect(result.map(d => d.id)).to.deep.equal(['legacy-collision']);
   });
 });
 

--- a/frontend/src/hooks/useMasters.ts
+++ b/frontend/src/hooks/useMasters.ts
@@ -3,6 +3,7 @@
  * 顧客・書類・事業所・ケアマネのCRUD操作
  */
 
+import { useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   collection,
@@ -23,6 +24,7 @@ import type {
   CareManagerMaster,
 } from '@shared/types'
 import { validateOfficeMasterImport } from '@shared/officeMasterValidation'
+import { findSameNameCollisionNames } from '@shared/customerIdentity'
 
 // 重複エラークラス
 export class DuplicateError extends Error {
@@ -80,6 +82,36 @@ export function useCustomers() {
     queryFn: fetchCustomers,
     staleTime: 5 * 60 * 1000,
   })
+}
+
+/**
+ * 現場管理者への「同姓同名」プロアクティブ通知UI用の共通lookup(2026-07-26)。
+ * useCustomers()のキャッシュ(queryKey: ['masters','customers'])をそのまま利用するため
+ * 追加フェッチは発生しない。TanStack Queryのstaletime(5分)内はマスター追加が即時反映
+ * されない点に注意(BE customerAmbiguityGate.tsはFirestoreへライブクエリのため常に最新)。
+ *
+ * コンテナ層のみで呼び出し、行コンポーネントへはpropで結果を渡すこと(単体テスト容易性のため)。
+ */
+export interface CustomerIdentityLookup {
+  /** 完全一致で2件以上あるマスター名の集合(shared/customerIdentity.tsのfindSameNameCollisionNames)。 */
+  sameNameCollisionNames: ReadonlySet<string>
+  /**
+   * customerId → マスターのname。フィールド欠損・非文字列はnull(functions/src/drive/
+   * customerAmbiguityGate.tsの`customerMaster?.name ?? null`と同一のnull集合)。
+   * Map miss(id不明)はundefinedになり、customerId↔name乖離チェックをスキップする
+   * (呼出元がresolveCustomerUnconfirmedReasonへ渡す際は`?? null`で吸収する)。
+   */
+  customerMasterNameById: ReadonlyMap<string, string | null>
+}
+
+export function useCustomerIdentityLookup(): CustomerIdentityLookup {
+  const { data: customers } = useCustomers()
+  return useMemo(() => ({
+    sameNameCollisionNames: findSameNameCollisionNames(customers ?? []),
+    customerMasterNameById: new Map(
+      (customers ?? []).map((c) => [c.id, typeof c.name === 'string' ? c.name : null])
+    ),
+  }), [customers])
 }
 
 interface AddCustomerParams {

--- a/frontend/src/hooks/useProcessingHistory.ts
+++ b/frontend/src/hooks/useProcessingHistory.ts
@@ -23,7 +23,9 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import type { Document, DocumentStatus, CustomerCandidateInfo } from '@shared/types';
+import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity';
 import { firestoreToDocument } from './useDocuments';
+import type { CustomerIdentityLookup } from './useMasters';
 
 // ============================================
 // 定数
@@ -124,14 +126,38 @@ function getPeriodDate(period: PeriodFilter): Date | null {
 }
 
 /**
+ * docが「同姓同名の可能性があるため要確認」かどうかを判定する。`identityLookup`未指定時は
+ * 常にfalse(呼出元がuseCustomerIdentityLookup()を持たない場合の後方互換)。
+ */
+function isSameNameCollisionDoc(doc: Document, identityLookup: CustomerIdentityLookup): boolean {
+  const reason = resolveCustomerUnconfirmedReason(doc, {
+    customerMasterName: doc.customerId
+      ? (identityLookup.customerMasterNameById.get(doc.customerId) ?? null)
+      : null,
+    sameNameCollisionNames: identityLookup.sameNameCollisionNames,
+  });
+  return reason === 'same-name-collision';
+}
+
+/**
  * 顧客確定フィルターを適用（クライアント側）
  *
  * #273: unit test 可能化のため export。hook 内部でのみ使用される helper。
+ *
+ * `identityLookup`を渡すと、`customerConfirmed:true`（人間確定済み）でも同姓同名の
+ * 衝突が実在する書類は「未確定」側に残す(2026-07-26追加、Codex plan review指摘)。
+ * 一覧画面の「同姓同名」バッジと表示の一貫性を保つため。省略時は従来通り
+ * `isCustomerConfirmed()`のみで判定する。
  */
-export function applyConfirmedFilter(docs: Document[], filter: ConfirmedFilter): Document[] {
+export function applyConfirmedFilter(
+  docs: Document[],
+  filter: ConfirmedFilter,
+  identityLookup?: CustomerIdentityLookup
+): Document[] {
   if (filter === 'all') return docs;
   return docs.filter(doc => {
-    const confirmed = isCustomerConfirmed(doc);
+    const confirmed = isCustomerConfirmed(doc)
+      && !(identityLookup && isSameNameCollisionDoc(doc, identityLookup));
     return filter === 'confirmed' ? confirmed : !confirmed;
   });
 }
@@ -140,7 +166,16 @@ export function applyConfirmedFilter(docs: Document[], filter: ConfirmedFilter):
 // メインフック
 // ============================================
 
-export function useProcessingHistory(filters: ProcessingHistoryFilters): ProcessingHistoryResult {
+/**
+ * `identityLookup`は「同姓同名」確定フィルター判定(applyConfirmedFilter参照)に使う。
+ * `queryKey`には含めていないため、`useCustomers()`の初回ロードが本フックの初回queryより
+ * 遅れて完了した場合、その回のフィルター結果には反映されない(次のフィルター変更・
+ * 更新ボタン・staleTime経過後の再取得で解消)。既存の5分キャッシュ許容方針と同じ判断。
+ */
+export function useProcessingHistory(
+  filters: ProcessingHistoryFilters,
+  identityLookup?: CustomerIdentityLookup
+): ProcessingHistoryResult {
   const queryClient = useQueryClient();
 
   // 内部状態
@@ -185,7 +220,7 @@ export function useProcessingHistory(filters: ProcessingHistoryFilters): Process
     setNoMoreFirestoreDocs(snapshot.docs.length < FETCH_SIZE);
 
     // クライアント側フィルター適用
-    const filteredDocs = applyConfirmedFilter(docs, filters.confirmed);
+    const filteredDocs = applyConfirmedFilter(docs, filters.confirmed, identityLookup);
 
     // 表示用とバッファに分割
     const displayDocs = filteredDocs.slice(0, PAGE_SIZE);
@@ -195,7 +230,7 @@ export function useProcessingHistory(filters: ProcessingHistoryFilters): Process
     setBuffer(remainingDocs);
 
     return displayDocs;
-  }, [filters.period, filters.status, filters.confirmed, filters.sortOrder]);
+  }, [filters.period, filters.status, filters.confirmed, filters.sortOrder, identityLookup]);
 
   // React Query
   const { data: queryData, isLoading, error } = useQuery({
@@ -283,7 +318,7 @@ export function useProcessingHistory(filters: ProcessingHistoryFilters): Process
         );
 
         // クライアント側フィルター適用
-        const filteredDocs = applyConfirmedFilter(fetchedDocs, filters.confirmed);
+        const filteredDocs = applyConfirmedFilter(fetchedDocs, filters.confirmed, identityLookup);
         currentBuffer.push(...filteredDocs);
       }
 
@@ -300,7 +335,7 @@ export function useProcessingHistory(filters: ProcessingHistoryFilters): Process
     } finally {
       setIsFetchingMore(false);
     }
-  }, [buffer, lastFirestoreDoc, noMoreFirestoreDocs, isFetchingMore, filters]);
+  }, [buffer, lastFirestoreDoc, noMoreFirestoreDocs, isFetchingMore, filters, identityLookup]);
 
   // hasMore 判定
   const hasMore = useMemo(() => {

--- a/frontend/src/hooks/useProcessingHistory.ts
+++ b/frontend/src/hooks/useProcessingHistory.ts
@@ -144,10 +144,15 @@ function isSameNameCollisionDoc(doc: Document, identityLookup: CustomerIdentityL
  *
  * #273: unit test 可能化のため export。hook 内部でのみ使用される helper。
  *
- * `identityLookup`を渡すと、`customerConfirmed:true`（人間確定済み）でも同姓同名の
- * 衝突が実在する書類は「未確定」側に残す(2026-07-26追加、Codex plan review指摘)。
- * 一覧画面の「同姓同名」バッジと表示の一貫性を保つため。省略時は従来通り
- * `isCustomerConfirmed()`のみで判定する。
+ * `identityLookup`を渡すと、レガシーdoc（`customerConfirmed`/`needsManualCustomerSelection`
+ * とも未設定）で同姓同名の衝突が実在する書類は「未確定」側に残す(2026-07-26追加、
+ * Codex plan review指摘)。`customerConfirmed:true`（人間確定済み）の書類は、同名衝突が
+ * 実在しても`resolveCustomerUnconfirmedReason()`(shared/customerIdentity.ts)が人間確定を
+ * 優先し衝突チェックへ到達しないため対象外のまま「確定」側に残る — 一覧画面の「同姓同名」
+ * バッジ(同一関数を使用)が同じ理由で表示されないため、表示との一貫性は保たれる
+ * (2026-07-26、/code-review high候補で当初のJSDocが「customerConfirmed:trueでも未確定に
+ * 残す」と誤記していたため実装に合わせて訂正)。省略時は従来通り`isCustomerConfirmed()`
+ * のみで判定する。
  */
 export function applyConfirmedFilter(
   docs: Document[],

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -52,9 +52,10 @@ import { db } from '@/lib/firebase'
 import { callFunction } from '@/lib/callFunction'
 import { Checkbox } from '@/components/ui/checkbox'
 import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, appendReprocessClearToBatch, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
-import { useCareManagers } from '@/hooks/useMasters'
+import { useCareManagers, useCustomerIdentityLookup, type CustomerIdentityLookup } from '@/hooks/useMasters'
 import { DateRangeFilter, type DateRange } from '@/components/DateRangeFilter'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
+import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity'
 import { DocumentDetailModal } from '@/components/DocumentDetailModal'
 import { AliasLearningHistoryModal } from '@/components/AliasLearningHistoryModal'
 import { PdfUploadModal } from '@/components/PdfUploadModal'
@@ -210,6 +211,7 @@ function DocumentRow({
   onSelectChange,
   showCheckbox,
   isProcessing,
+  identityLookup,
 }: {
   document: Document
   onClick: () => void
@@ -217,6 +219,7 @@ function DocumentRow({
   onSelectChange: (checked: boolean) => void
   showCheckbox: boolean
   isProcessing: boolean
+  identityLookup?: CustomerIdentityLookup
 }) {
   const statusConfig = STATUS_CONFIG[document.status] || { label: '不明', variant: 'secondary' as const }
 
@@ -226,7 +229,29 @@ function DocumentRow({
     document.officeConfirmed === false &&
     document.officeCandidates &&
     document.officeCandidates.length > 0
-  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation
+
+  // 同姓同名判定(2026-07-26追加)
+  const unconfirmedReason = identityLookup
+    ? resolveCustomerUnconfirmedReason(document, {
+        customerMasterName: document.customerId
+          ? (identityLookup.customerMasterNameById.get(document.customerId) ?? null)
+          : null,
+        sameNameCollisionNames: identityLookup.sameNameCollisionNames,
+      })
+    : null
+  const isSameNameCollision = unconfirmedReason === 'same-name-collision'
+  const needsReview = needsCustomerConfirmation || needsOfficeConfirmation || isSameNameCollision
+
+  // バッジ文言優先順位: 同姓同名 > 選択待ち。title は該当する全理由を列挙し、needsReview合成
+  // による「事業所要対応が同姓同名バッジの裏で隠れる」ことを防ぐ(Codex plan review指摘)。
+  const reviewReasons: string[] = []
+  if (isSameNameCollision) {
+    reviewReasons.push('同姓同名の顧客マスターが複数あります。書類詳細で正しい顧客を選び直してください')
+  }
+  if (needsOfficeConfirmation) {
+    reviewReasons.push('事業所が未選択です')
+  }
+  const reviewTitle = reviewReasons.length > 0 ? reviewReasons.join('。') : undefined
 
   // OCR未確認
   const isUnverified = !document.verified
@@ -276,8 +301,13 @@ function DocumentRow({
       </td>
       <td className="whitespace-nowrap px-2 py-2 sm:px-4 sm:py-3">
         {needsReview ? (
-          <Badge variant="outline" className="whitespace-nowrap bg-orange-100 text-orange-800 border-orange-300 text-xs">
-            選択待ち
+          <Badge
+            variant="outline"
+            className="whitespace-nowrap bg-orange-100 text-orange-800 border-orange-300 text-xs"
+            title={reviewTitle}
+          >
+            {isSameNameCollision && <Users className="mr-1 h-3 w-3 inline" />}
+            {isSameNameCollision ? '同姓同名' : '選択待ち'}
           </Badge>
         ) : (
           <Badge variant={statusConfig.variant} className="whitespace-nowrap text-xs sm:text-sm">{statusConfig.label}</Badge>
@@ -401,6 +431,10 @@ export function DocumentsPage() {
   const { data: stats } = useDocumentStats()
   const { data: documentMasters } = useDocumentMasters()
   const { data: careManagers } = useCareManagers()
+
+  // 同姓同名バッジ判定用(2026-07-26追加)。書類一覧(テーブルビュー)は5箇所のうち唯一
+  // useCustomers()の新規読込が増える画面(kanameone 1355件、staleTime5分キャッシュ共有)
+  const identityLookup = useCustomerIdentityLookup()
 
   // ソートハンドラ
   const handleSort = useCallback((field: SortField) => {
@@ -956,6 +990,7 @@ export function DocumentsPage() {
                         onSelectChange={(checked) => handleSelectToggle(doc.id, checked)}
                         showCheckbox={!!selectionMode}
                         isProcessing={isBulkOperating}
+                        identityLookup={identityLookup}
                       />
                     ))}
                   </tbody>

--- a/frontend/src/pages/ProcessingHistoryPage.tsx
+++ b/frontend/src/pages/ProcessingHistoryPage.tsx
@@ -37,11 +37,13 @@ import {
   type ConfirmedFilter,
   type ProcessingHistoryFilters,
 } from '@/hooks/useProcessingHistory';
+import { useCustomerIdentityLookup, type CustomerIdentityLookup } from '@/hooks/useMasters';
+import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity';
 import { DocumentDetailModal } from '@/components/DocumentDetailModal';
 import { LoadMoreIndicator } from '@/components/LoadMoreIndicator';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import type { Document as DocType, DocumentStatus } from '@shared/types';
-import { Loader2, RefreshCw, ChevronDown, ChevronUp, AlertCircle } from 'lucide-react';
+import { Loader2, RefreshCw, ChevronDown, ChevronUp, AlertCircle, Users } from 'lucide-react';
 
 // ============================================
 // ステータスバッジコンポーネント
@@ -64,8 +66,31 @@ function StatusBadge({ status }: { status: DocumentStatus }) {
 // 選択待ちバッジコンポーネント
 // ============================================
 
-function UnconfirmedBadge({ doc }: { doc: DocType }) {
-  if (isCustomerConfirmed(doc)) return null;
+function UnconfirmedBadge({ doc, identityLookup }: { doc: DocType; identityLookup?: CustomerIdentityLookup }) {
+  const unconfirmedReason = identityLookup
+    ? resolveCustomerUnconfirmedReason(doc, {
+        customerMasterName: doc.customerId
+          ? (identityLookup.customerMasterNameById.get(doc.customerId) ?? null)
+          : null,
+        sameNameCollisionNames: identityLookup.sameNameCollisionNames,
+      })
+    : null;
+  const isSameNameCollision = unconfirmedReason === 'same-name-collision';
+
+  if (!isSameNameCollision && isCustomerConfirmed(doc)) return null;
+
+  if (isSameNameCollision) {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-orange-100 text-orange-800 border-orange-300"
+        title="同姓同名の顧客マスターが複数あります。書類詳細で正しい顧客を選び直してください"
+      >
+        <Users className="mr-1 h-3 w-3 inline" />
+        同姓同名
+      </Badge>
+    );
+  }
   return (
     <Badge variant="outline" className="bg-orange-100 text-orange-800 border-orange-300">
       選択待ち
@@ -89,6 +114,9 @@ export function ProcessingHistoryPage() {
   // 選択中のドキュメントID（詳細モーダル用）
   const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(null);
 
+  // 同姓同名バッジ判定用(2026-07-26追加)
+  const identityLookup = useCustomerIdentityLookup();
+
   // データ取得
   const {
     documents,
@@ -98,7 +126,7 @@ export function ProcessingHistoryPage() {
     error,
     fetchNextPage,
     refetch,
-  } = useProcessingHistory(filters);
+  } = useProcessingHistory(filters, identityLookup);
   const { loadMoreRef } = useInfiniteScroll({ hasNextPage: hasMore, isFetchingNextPage: isFetchingMore, fetchNextPage });
 
   // 日付グルーピング
@@ -266,7 +294,7 @@ export function ProcessingHistoryPage() {
                           <TableCell>
                             <div className="flex items-center gap-2">
                               <span className="truncate max-w-[100px]">{doc.customerName}</span>
-                              <UnconfirmedBadge doc={doc} />
+                              <UnconfirmedBadge doc={doc} identityLookup={identityLookup} />
                             </div>
                           </TableCell>
                           <TableCell className="text-sm">{doc.documentType}</TableCell>

--- a/functions/src/drive/customerAmbiguityGate.ts
+++ b/functions/src/drive/customerAmbiguityGate.ts
@@ -34,10 +34,16 @@
  * FAX複製フロー(`functions/src/ocr/faxDuplication.ts`)はこのゲートを経由しない別の書込
  * 経路であり、本モジュールとは独立に同名衝突の除外が必要(`planFaxDuplication`の
  * `sameNameCollisionNames`引数を参照)。
+ *
+ * 上記1-4の判定順序(sentinel→name↔id乖離→customerConfirmed優先のdual-read)は
+ * `shared/customerIdentity.ts`の`precheckCustomerIdentity()`へ移設した(現場管理者への
+ * 「同姓同名」プロアクティブ通知UI追加、2026-07-26。FEバッジと同一実装を共有するため)。
+ * 本関数はその判定に「衝突確認が必要」と判定された場合のみFirestoreへライブクエリを撃つ
+ * BE固有の短絡ロジックを残す。挙動・外部契約(戻り値boolean)は不変。
  */
 
 import type * as admin from 'firebase-admin';
-import { isValidCustomerSelection } from '../../../shared/customerIdentity';
+import { precheckCustomerIdentity } from '../../../shared/customerIdentity';
 import { MASTER_PATHS } from '../utils/masterPaths';
 import type { Document } from '../../../shared/types';
 
@@ -58,24 +64,11 @@ export async function isCustomerUnconfirmed(
   doc: Document,
   deps: IsCustomerUnconfirmedDeps
 ): Promise<boolean> {
-  const name = (doc.customerName ?? '').trim();
-  if (!isValidCustomerSelection(name)) {
-    return true; // sentinel値(「不明顧客」「未判定」)・空文字は常に未確定扱い
+  const pre = precheckCustomerIdentity(doc, { customerMasterName: deps.customerMasterName });
+  if (pre.outcome === 'unconfirmed') {
+    return true; // sentinel値・空文字、またはcustomerId↔name乖離
   }
-
-  // trim済みnameと比較する(doc.customerNameの生値と比較すると、マスター名は
-  // normalizeName()でtrim済みのため、前後空白が付いただけの正常docまで誤って
-  // 乖離扱いになってしまう)。
-  if (deps.customerMasterName !== null && deps.customerMasterName !== name) {
-    return true; // customerIdの指すマスター名とdoc.customerNameが乖離(マスター改名の取り残し等)
-  }
-
-  const humanConfirmed = doc.customerConfirmed !== undefined
-    ? doc.customerConfirmed
-    : doc.needsManualCustomerSelection !== undefined
-      ? !doc.needsManualCustomerSelection
-      : false; // 両方未設定(レガシーdoc)は「未確定」として扱い、曖昧性チェックに委ねる
-  if (humanConfirmed) {
+  if (pre.outcome === 'confirmed') {
     return false;
   }
 
@@ -84,7 +77,7 @@ export async function isCustomerUnconfirmed(
   // 複合インデックス不要。
   const collisionSnap = await deps.firestore
     .collection(MASTER_PATHS.customers)
-    .where('name', '==', name)
+    .where('name', '==', pre.trimmedName)
     .limit(2)
     .get();
   return collisionSnap.size > 1;

--- a/functions/src/drive/customerAmbiguityGate.ts
+++ b/functions/src/drive/customerAmbiguityGate.ts
@@ -75,6 +75,15 @@ export async function isCustomerUnconfirmed(
   // 未確定と判定された場合のみ、実際に同名マスターが2件以上存在するかをライブ確認する
   // (曖昧なものだけ止める、decision-maker承認済み方針)。単一フィールド等価検索のため
   // 複合インデックス不要。
+  //
+  // trim不整合の残存リスク(Codex review-diff P2指摘、2026-07-26): このクエリは
+  // Firestore上のマスター`name`の生値との完全一致検索のため、マスター名に前後空白が
+  // 付与されている場合(FE`findSameNameCollisionNames()`はtrim済みで衝突検出するのに
+  // このクエリは0件ヒットで通過する)、FE通知とBEブロックの挙動が食い違いうる。全件
+  // フェッチしてJS側でtrim比較する案は複合インデックス不要という本設計のメリットを
+  // 失うため採用せず、`check-customer-master-integrity.js`のwhitespaceIssues検出
+  // (PR #732、本番マスターデータで前後空白付きnameは0件と実測済み)による継続監視で
+  // 許容する判断とした。
   const collisionSnap = await deps.firestore
     .collection(MASTER_PATHS.customers)
     .where('name', '==', pre.trimmedName)

--- a/functions/src/ocr/faxDuplication.ts
+++ b/functions/src/ocr/faxDuplication.ts
@@ -104,8 +104,11 @@ export function planFaxDuplication(input: PlanFaxDuplicationInput): FaxDuplicati
   // CodeRabbit指摘: score降順の保証を呼出元(extractors.tsのsort)の暗黙の前提だけに
   // 委ねず、本関数自身でも明示的にソートしてから重複排除する(「先勝ち」dedupが
   // 最高スコア以外を拾ってしまう回帰を、モジュール境界をまたいだ暗黙契約に頼らず防ぐ)。
+  // c.name.trim(): sameNameCollisionNamesはfindSameNameCollisionNames()がtrim済みキーで
+  // 返す集合のため、c.name側もtrimしてから照合しないと前後空白付きマスター名の同名衝突を
+  // 見逃す(Codex review-diff P2指摘、2026-07-26)。インメモリ処理のため追加コストなし。
   const exactNonDuplicate = input.candidates
-    .filter((c) => c.matchType === 'exact' && !c.isDuplicate && !input.sameNameCollisionNames.has(c.name))
+    .filter((c) => c.matchType === 'exact' && !c.isDuplicate && !input.sameNameCollisionNames.has(c.name.trim()))
     .sort((a, b) => b.score - a.score);
 
   const deduped = new Map<string, CustomerCandidate>();

--- a/functions/test/customerIdentity.test.ts
+++ b/functions/test/customerIdentity.test.ts
@@ -95,6 +95,17 @@ describe('findSameNameCollisionNames', () => {
     ]);
     expect([...result]).to.deep.equal(['田中太郎']);
   });
+
+  it('nameフィールドが実行時にstringでない(欠損等)マスターがあってもクラッシュせずスキップする(2026-07-26追加、/code-review high候補で発覚したcrash risk回帰テスト)', () => {
+    const malformed = [
+      { name: '田中太郎' },
+      { name: undefined },
+      { name: '田中太郎' },
+      { name: null },
+    ] as unknown as Array<{ name: string }>;
+    expect(() => findSameNameCollisionNames(malformed)).to.not.throw();
+    expect([...findSameNameCollisionNames(malformed)]).to.deep.equal(['田中太郎']);
+  });
 });
 
 describe('precheckCustomerIdentity', () => {

--- a/functions/test/customerIdentity.test.ts
+++ b/functions/test/customerIdentity.test.ts
@@ -4,12 +4,19 @@
  * isValidCustomerSelection/findSameNameCollisionNamesはFirestore/Admin SDK非依存の
  * 純粋関数のため、displayFileName.test.ts等と同じ規約でユニットテストする(emulator不要)。
  * frontend/functions双方から参照される契約をここで固定する。
+ *
+ * precheckCustomerIdentity/resolveCustomerUnconfirmedReasonは「同姓同名」プロアクティブ
+ * 通知UI追加(2026-07-26)で新設。判定順序はfunctions/src/drive/customerAmbiguityGate.tsの
+ * isCustomerUnconfirmed()から移設したもので、既存のexportDocumentIntegration.test.ts
+ * (顧客未確定ゲート13ケース)と挙動が一致することがAC1(証明コマンド)で担保される。
  */
 
 import { expect } from 'chai';
 import {
   isValidCustomerSelection,
   findSameNameCollisionNames,
+  precheckCustomerIdentity,
+  resolveCustomerUnconfirmedReason,
 } from '../../shared/customerIdentity';
 
 describe('isValidCustomerSelection', () => {
@@ -79,5 +86,164 @@ describe('findSameNameCollisionNames', () => {
       { name: '佐藤花子' },
     ]);
     expect([...result].sort()).to.deep.equal(['田中太郎', '鈴木一郎']);
+  });
+
+  it('前後空白付きの名前もtrim後に同名として集約する(2026-07-26追加)', () => {
+    const result = findSameNameCollisionNames([
+      { name: ' 田中太郎 ' },
+      { name: '田中太郎' },
+    ]);
+    expect([...result]).to.deep.equal(['田中太郎']);
+  });
+});
+
+describe('precheckCustomerIdentity', () => {
+  it('空文字はinvalid-nameで未確定', () => {
+    const result = precheckCustomerIdentity({ customerName: '' }, { customerMasterName: null });
+    expect(result).to.deep.equal({ outcome: 'unconfirmed', reason: 'invalid-name' });
+  });
+
+  it('空白のみはinvalid-nameで未確定', () => {
+    const result = precheckCustomerIdentity({ customerName: '   ' }, { customerMasterName: null });
+    expect(result).to.deep.equal({ outcome: 'unconfirmed', reason: 'invalid-name' });
+  });
+
+  it('null customerNameはinvalid-nameで未確定', () => {
+    const result = precheckCustomerIdentity({ customerName: null }, { customerMasterName: null });
+    expect(result).to.deep.equal({ outcome: 'unconfirmed', reason: 'invalid-name' });
+  });
+
+  it('sentinel値(「未判定」「不明顧客」)はinvalid-nameで未確定', () => {
+    expect(precheckCustomerIdentity({ customerName: '未判定' }, { customerMasterName: null }))
+      .to.deep.equal({ outcome: 'unconfirmed', reason: 'invalid-name' });
+    expect(precheckCustomerIdentity({ customerName: '不明顧客' }, { customerMasterName: null }))
+      .to.deep.equal({ outcome: 'unconfirmed', reason: 'invalid-name' });
+  });
+
+  it('前後空白付きsentinel値もinvalid-nameで未確定', () => {
+    const result = precheckCustomerIdentity({ customerName: ' 不明顧客 ' }, { customerMasterName: null });
+    expect(result).to.deep.equal({ outcome: 'unconfirmed', reason: 'invalid-name' });
+  });
+
+  it('customerMasterNameが別名の場合、customerConfirmed:trueでも乖離が優先されname-id-mismatchで未確定', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: '田中太郎', customerConfirmed: true },
+      { customerMasterName: '田中次郎' }
+    );
+    expect(result).to.deep.equal({ outcome: 'unconfirmed', reason: 'name-id-mismatch' });
+  });
+
+  it('customerMasterName:nullの場合は乖離チェックをスキップする', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: '田中太郎', customerConfirmed: true },
+      { customerMasterName: null }
+    );
+    expect(result).to.deep.equal({ outcome: 'confirmed' });
+  });
+
+  it('customerConfirmed:trueは確定済み扱い', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: '田中太郎', customerConfirmed: true },
+      { customerMasterName: '田中太郎' }
+    );
+    expect(result).to.deep.equal({ outcome: 'confirmed' });
+  });
+
+  it('customerConfirmed:trueはneedsManualCustomerSelection:trueより優先される(customerConfirmed優先のdual-read)', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: '田中太郎', customerConfirmed: true, needsManualCustomerSelection: true },
+      { customerMasterName: '田中太郎' }
+    );
+    expect(result).to.deep.equal({ outcome: 'confirmed' });
+  });
+
+  it('customerConfirmed未設定・needsManualCustomerSelection:trueは未確定として衝突チェックへ進む', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: '田中太郎', needsManualCustomerSelection: true },
+      { customerMasterName: '田中太郎' }
+    );
+    expect(result).to.deep.equal({ outcome: 'needs-collision-check', trimmedName: '田中太郎' });
+  });
+
+  it('両方未設定(レガシーdoc)は未確定として衝突チェックへ進む(本件の中核)', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: '田中太郎' },
+      { customerMasterName: '田中太郎' }
+    );
+    expect(result).to.deep.equal({ outcome: 'needs-collision-check', trimmedName: '田中太郎' });
+  });
+
+  it('needs-collision-checkのtrimmedNameは前後空白を除去した値になる', () => {
+    const result = precheckCustomerIdentity(
+      { customerName: ' 松本 実 ' },
+      { customerMasterName: null }
+    );
+    expect(result).to.deep.equal({ outcome: 'needs-collision-check', trimmedName: '松本 実' });
+  });
+});
+
+describe('resolveCustomerUnconfirmedReason', () => {
+  it('両方未設定(レガシーdoc) + 同名衝突ありはsame-name-collisionを返す(本件の中核)', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '松本 実' },
+      { customerMasterName: null, sameNameCollisionNames: new Set(['松本 実']) }
+    );
+    expect(reason).to.equal('same-name-collision');
+  });
+
+  it('両方未設定 + 同名衝突なし(同名1件)はnullを返す(後方互換の砦)', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '松本 実' },
+      { customerMasterName: null, sameNameCollisionNames: new Set() }
+    );
+    expect(reason).to.be.null;
+  });
+
+  it('customerConfirmed:true + 同名衝突ありはnullを返す(人間確定優先)', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '松本 実', customerConfirmed: true },
+      { customerMasterName: '松本 実', sameNameCollisionNames: new Set(['松本 実']) }
+    );
+    expect(reason).to.be.null;
+  });
+
+  it('customerConfirmed:true + needsManualCustomerSelection:true + 同名衝突ありはnullを返す(customerConfirmed優先)', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '松本 実', customerConfirmed: true, needsManualCustomerSelection: true },
+      { customerMasterName: '松本 実', sameNameCollisionNames: new Set(['松本 実']) }
+    );
+    expect(reason).to.be.null;
+  });
+
+  it('同名3件でもsame-name-collisionを返す', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '田中太郎' },
+      { customerMasterName: null, sameNameCollisionNames: new Set(['田中太郎']) }
+    );
+    expect(reason).to.equal('same-name-collision');
+  });
+
+  it('前後空白付きcustomerNameでもtrim後に衝突集合と一致すればsame-name-collisionを返す(trim整合)', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: ' 松本 実 ' },
+      { customerMasterName: null, sameNameCollisionNames: new Set(['松本 実']) }
+    );
+    expect(reason).to.equal('same-name-collision');
+  });
+
+  it('sentinel値はinvalid-nameを返す(same-name-collisionではない)', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '未判定' },
+      { customerMasterName: null, sameNameCollisionNames: new Set() }
+    );
+    expect(reason).to.equal('invalid-name');
+  });
+
+  it('customerId↔name乖離はname-id-mismatchを返す', () => {
+    const reason = resolveCustomerUnconfirmedReason(
+      { customerName: '田中太郎' },
+      { customerMasterName: '田中次郎', sameNameCollisionNames: new Set(['田中太郎']) }
+    );
+    expect(reason).to.equal('name-id-mismatch');
   });
 });

--- a/functions/test/faxDuplication.test.ts
+++ b/functions/test/faxDuplication.test.ts
@@ -169,6 +169,21 @@ describe('planFaxDuplication (D3: 複製トリガー条件)', () => {
     expect(result.reason).to.equal('insufficientExactCandidates');
   });
 
+  it('候補名に前後空白が付いていても、trimしたうえでsameNameCollisionNamesと照合し除外する(Codex review-diff P2指摘の回帰防止、2026-07-26)', () => {
+    const result = planFaxDuplication({
+      flagEnabled: true,
+      alreadyDistributed: false,
+      alreadyConfirmedOrVerified: false,
+      sameNameCollisionNames: new Set(['田中太郎']), // findSameNameCollisionNames()はtrim済みキーを返す
+      candidates: [
+        candidate({ id: 'c1', name: ' 田中太郎 ', isDuplicate: false }), // マスター側の生値がuntrimmedのケース
+        candidate({ id: 'c2', name: '田中花子', isDuplicate: false }),
+      ],
+    });
+    expect(result.shouldDuplicate).to.equal(false);
+    expect(result.reason).to.equal('insufficientExactCandidates');
+  });
+
   it('sameNameCollisionNamesに含まれない名前の候補は、従来通り複製対象に含める(除外は衝突している名前のみに限定されること)', () => {
     const result = planFaxDuplication({
       flagEnabled: true,

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -89,6 +89,15 @@ export const CUSTOMERS = [
 ];
 
 /**
+ * 同姓同名バッジ通知UI検証用(2026-07-26追加、承認済み計画 noble-booping-leaf.md)。
+ * seed-cust-08(黒田実)と完全同名だがフリガナ・担当CMが異なる別人としてseed-cust-13を追加し、
+ * 実際に同名衝突が発生する状態を再現する。CUSTOMERS配列には含めない
+ * (buildBulkDocs()のCM別件数はコメントに明記の固定件数を前提にしており、
+ * 顧客追加は無関係なページング境界検証を壊しうるため)。
+ */
+export const COLLISION_CUSTOMER = { id: 'seed-cust-13', name: '黒田実', furigana: 'くろだまこと', cm: 2 };
+
+/**
  * totalPages のバリエーション。各値に対応する実ページ数の generic PDF を用意し、
  * Firestore の totalPages と fileUrl の実体ページ数を常に一致させる
  * (不一致だと詳細モーダル/分割プレビューのページ遷移が実 PDF と矛盾し、偽の不具合を生む)。
@@ -416,6 +425,73 @@ function buildBulkDocs(storageBucket: string): SeedDoc[] {
   return docs;
 }
 
+/**
+ * 同姓同名バッジ通知UI検証用の2件(2026-07-26追加)。COLLISION_CUSTOMER(seed-cust-13)と
+ * seed-cust-08(黒田実)の完全同名衝突を再現する。
+ * - collision-legacy-01: customerConfirmed/needsManualCustomerSelectionとも未設定
+ *   (Phase 6以前のレガシーdoc相当)。BEゲート・FEバッジとも「未確定」として同名衝突を検知し、
+ *   一覧に「同姓同名」バッジが点灯することを検証する対象(本件の中核ギャップ)
+ * - collision-confirmed-01: customerConfirmed:true(人間確定済み)。同名衝突が実在しても
+ *   人間確定が優先されバッジが出ないこと(customerAmbiguityGate.tsの設計判断と同一)を検証する対象
+ */
+function buildCollisionDocs(storageBucket: string, index: number): SeedDoc[] {
+  const { Timestamp } = admin.firestore;
+  const office = OFFICES[0];
+  const docType = DOC_TYPES[0];
+  const fileDate = spreadDate(index);
+  const createdAt = spreadDate(index + 2);
+
+  const base = {
+    processedAt: Timestamp.fromDate(createdAt),
+    mimeType: 'application/pdf',
+    documentType: docType.name,
+    customerName: '黒田実',
+    officeName: office.name,
+    fileUrl: `gs://${storageBucket}/${genericPdfFor(1)}`,
+    fileDate: Timestamp.fromDate(fileDate),
+    isDuplicateCustomer: false,
+    totalPages: 1,
+    targetPageNumber: 1,
+    status: 'processed' as const,
+    sourceType: 'upload',
+    careManager: CARE_MANAGERS[COLLISION_CUSTOMER.cm].name,
+    officeId: office.id,
+    officeConfirmed: true,
+    verified: true,
+    createdAt: Timestamp.fromDate(createdAt),
+  };
+
+  const legacyId = 'seed-doc-collision-legacy-01';
+  const confirmedId = 'seed-doc-collision-confirmed-01';
+
+  return [
+    {
+      id: legacyId,
+      data: {
+        ...base,
+        id: legacyId,
+        fileId: legacyId,
+        fileName: 'seed_同姓同名レガシー_01.pdf',
+        ocrResult: `${docType.name}\n利用者: 黒田実 様\n事業所: ${office.name}\n(seed データ・同姓同名検証用)`,
+        customerId: 'seed-cust-08',
+        // customerConfirmed/needsManualCustomerSelectionとも意図的に未設定
+      },
+    },
+    {
+      id: confirmedId,
+      data: {
+        ...base,
+        id: confirmedId,
+        fileId: confirmedId,
+        fileName: 'seed_同姓同名確定済み_01.pdf',
+        ocrResult: `${docType.name}\n利用者: 黒田実 様\n事業所: ${office.name}\n(seed データ・人間確定済み検証用)`,
+        customerId: COLLISION_CUSTOMER.id,
+        customerConfirmed: true,
+      },
+    },
+  ];
+}
+
 /** E 用 pending 書類 (uploadPdf.ts の payload 形状を踏襲。実 OCR パイプラインが処理する) */
 function buildPendingDoc(mixed: (typeof MIXED_FAX_PDFS)[number], storageBucket: string): SeedDoc {
   const { Timestamp } = admin.firestore;
@@ -489,14 +565,20 @@ async function seed(): Promise<void> {
   console.log(`モード: ${dryRun ? 'DRY RUN (書込なし)' : '実行'}${forcePending ? ' + force-pending' : ''}`);
   console.log('---');
 
-  const bulkDocs = buildBulkDocs(storageBucket);
+  // collisionDocsをbulkDocs自体に統合する(下のbulkDocs.flatMap呼出しは
+  // seedDevDataDetailDualWriteContract.test.tsがソース文字列レベルでlock-inしているため、
+  // 呼出し箇所を`[...bulkDocs, ...collisionDocs].flatMap`等に変更すると契約テストが壊れる)。
+  const baseBulkDocs = buildBulkDocs(storageBucket);
+  const collisionDocs = buildCollisionDocs(storageBucket, baseBulkDocs.length);
+  const bulkDocs = [...baseBulkDocs, ...collisionDocs];
   const pendingDocs = MIXED_FAX_PDFS.map((m) => buildPendingDoc(m, storageBucket));
   const zeroPageCount = bulkDocs.filter((d) => d.data.totalPages === 0).length;
   const errorCount = bulkDocs.filter((d) => d.data.status === 'error').length;
   const cm1Count = bulkDocs.filter((d) => d.data.careManager === CARE_MANAGERS[0].name).length;
 
   console.log('投入プラン:');
-  console.log(`  マスター: ケアマネ ${CARE_MANAGERS.length} / 顧客 ${CUSTOMERS.length} / 事業所 ${OFFICES.length} / 書類種別 ${DOC_TYPES.length}`);
+  console.log(`  マスター: ケアマネ ${CARE_MANAGERS.length} / 顧客 ${CUSTOMERS.length + 1}(同姓同名検証用+1) / 事業所 ${OFFICES.length} / 書類種別 ${DOC_TYPES.length}`);
+  console.log(`  書類: 同姓同名バッジ検証用 ${collisionDocs.length} 件 (レガシーdoc相当1 + 人間確定済み1)`);
   console.log(`  Storage PDF: 汎用 ${GENERIC_PDFS.length} + 混在FAX ${MIXED_FAX_PDFS.length} (fixtures/seed/ から)`);
   console.log(`  書類: processed/error ${bulkDocs.length} 件 (うち totalPages:0 ${zeroPageCount} / error ${errorCount} / ${CARE_MANAGERS[0].name} 配下 ${cm1Count})`);
   console.log(`  書類: pending ${pendingDocs.length} 件 (既存はスキップ。--force-pending で再投入 = 再 OCR 課金)`);
@@ -524,13 +606,16 @@ async function seed(): Promise<void> {
       ref: db.collection('masters').doc('caremanagers').collection('items').doc(cm.id),
       data: { name: cm.name, aliases: [] as string[] },
     })),
-    ...CUSTOMERS.map((c) => ({
+    ...[...CUSTOMERS, COLLISION_CUSTOMER].map((c) => ({
       ref: db.collection('masters').doc('customers').collection('items').doc(c.id),
       data: {
         name: c.name,
         furigana: c.furigana,
         careManagerName: CARE_MANAGERS[c.cm].name,
-        isDuplicate: false,
+        // seed-cust-08と完全同名の別人であることをisDuplicateで明示(2026-07-26追加)。
+        // customerAmbiguityGate.tsはisDuplicateフラグを信用せずライブクエリで衝突判定するため
+        // 動作には影響しないが、実データの慣習(MastersPage.tsx handleForceAdd)に合わせる。
+        isDuplicate: c.id === COLLISION_CUSTOMER.id || c.id === 'seed-cust-08',
         aliases: [] as string[],
         notes: 'seed データ',
       },

--- a/shared/customerIdentity.ts
+++ b/shared/customerIdentity.ts
@@ -144,6 +144,12 @@ export function isValidCustomerSelection(name: string | null | undefined): boole
 export function findSameNameCollisionNames(customers: Array<{ name: string }>): Set<string> {
   const counts = new Map<string, number>();
   for (const c of customers) {
+    // 呼出元の型`Array<{ name: string }>`は実行時保証がない。Firestoreの生データを
+    // `as string`でキャストして渡す呼出元(useMasters.tsのfetchCustomers等)があるため、
+    // nameフィールド欠損マスター(過去に本番で実在確認済み、check-customer-master-integrity.js
+    // のidToRawName導入経緯参照)が1件でもあると、型ガードなしでは`.trim()`がTypeErrorで
+    // クラッシュする(2026-07-26、/code-review high候補で発覚)。
+    if (typeof c.name !== 'string') continue;
     // BE(customerAmbiguityGate.ts)はtrim済みのdoc.customerNameで完全一致クエリするため、
     // マスター名もtrimしてから集計しないと判定が食い違いうる(2026-07-26、本番マスターデータ
     // (kanameone/cocoro双方)で前後空白付きnameが実在しないことは確認済み。addCustomer()の

--- a/shared/customerIdentity.ts
+++ b/shared/customerIdentity.ts
@@ -19,12 +19,109 @@
  * このリスト処理版はインメモリで全件を保持済みの呼出元(FE・OCR取り込み)専用。
  * exportDocument.ts 側は全件フェッチを避けるため独自の限定クエリを実装する
  * (functions/src/drive/customerAmbiguityGate.ts 参照、同一契約は双方のテストで固定する)。
+ *
+ * `precheckCustomerIdentity`/`resolveCustomerUnconfirmedReason` は、現場管理者へ「同姓同名の
+ * 可能性があるので確認してください」を能動的に知らせるUI追加(2026-07-26)で新設。BE は
+ * 「マスター名1件 + 遅延Firestoreクエリ」、FE は「全件インメモリ(同期)」というデータ取得の
+ * 非対称があるため、判定順序と`customerConfirmed`優先のdual-read(真の重複ロジック)だけを
+ * `precheckCustomerIdentity` に共通化し、衝突真偽の取得方法(クエリ or Set照合)は呼出元に残す
+ * 2関数構成にした。単一関数に統合すると BE が短絡できるケースでも常に衝突クエリを撃つことになる
+ * ため。`isCustomerUnconfirmed`(functions/src/drive/customerAmbiguityGate.ts)はこれらへ委譲する
+ * 形にリファクタ済み、外部契約(戻り値boolean)は不変。
  */
 
 /**
  * 顧客名の sentinel 値。OCR 未マッチ・未判定状態を示すため、選択として無効扱いにする。
  */
 export const CUSTOMER_INVALID_SENTINELS: ReadonlySet<string> = new Set(['未判定', '不明顧客']);
+
+/**
+ * 顧客が未確定と判定された理由(現場管理者への通知UI・監査スクリプトの内訳集計で使う、
+ * 「同姓同名」プロアクティブ通知UI追加、2026-07-26)。
+ */
+export type CustomerUnconfirmedReason =
+  | 'invalid-name' // 顧客名未設定・空白のみ・sentinel値
+  | 'name-id-mismatch' // customerIdが指すマスター名とcustomerNameが乖離
+  | 'same-name-collision'; // 同名(完全一致)マスターが2件以上 + 人間の明示的確定なし
+
+/** `CustomerUnconfirmedReason` の日本語ラベル。`scripts/check-customer-master-integrity.js` の
+ * `UNCONFIRMED_REASON` と将来一本化する余地を残すため同一文言にする。 */
+export const CUSTOMER_UNCONFIRMED_REASON_LABELS: Readonly<Record<CustomerUnconfirmedReason, string>> = {
+  'invalid-name': '顧客名未設定/sentinel値',
+  'name-id-mismatch': 'customerId↔name乖離',
+  'same-name-collision': '同名衝突未確定',
+};
+
+/**
+ * 顧客未確定判定に必要なdocフィールドのみの構造的インターフェース。`shared/types.ts` の
+ * `Document` は構造的にこれを満たすため、呼出元は `Document` をそのまま渡せる。
+ */
+export interface CustomerIdentityDocFields {
+  customerName?: string | null;
+  customerConfirmed?: boolean;
+  needsManualCustomerSelection?: boolean;
+}
+
+/**
+ * 同名衝突の確認手前までの判定結果。BE(`functions/src/drive/customerAmbiguityGate.ts`)は
+ * `'needs-collision-check'` のときだけ Firestore へライブクエリを撃つ(短絡)。FE・監査スクリプトは
+ * インメモリの衝突集合と照合するため常に同期的に完結する(`resolveCustomerUnconfirmedReason`参照)。
+ */
+export type CustomerIdentityPrecheck =
+  | { outcome: 'unconfirmed'; reason: 'invalid-name' | 'name-id-mismatch' }
+  | { outcome: 'confirmed' }
+  | { outcome: 'needs-collision-check'; trimmedName: string };
+
+/**
+ * 同名衝突の確認手前まで(sentinel判定→name↔id乖離チェック→`customerConfirmed`優先のdual-read)を
+ * 判定する。判定順序・「両方undefinedのレガシーdocは未確定として扱う」という設計判断は
+ * `functions/src/drive/customerAmbiguityGate.ts` の旧実装からそのまま移設(挙動不変)。
+ *
+ * `opts.customerMasterName` が `null` の場合は name↔id 乖離チェックをスキップする(呼出元が
+ * `customerId` を持たない、またはマスターを未取得の場合)。
+ */
+export function precheckCustomerIdentity(
+  doc: CustomerIdentityDocFields,
+  opts: { customerMasterName: string | null }
+): CustomerIdentityPrecheck {
+  const name = (doc.customerName ?? '').trim();
+  if (!isValidCustomerSelection(name)) {
+    return { outcome: 'unconfirmed', reason: 'invalid-name' };
+  }
+
+  if (opts.customerMasterName !== null && opts.customerMasterName !== name) {
+    return { outcome: 'unconfirmed', reason: 'name-id-mismatch' };
+  }
+
+  const humanConfirmed = doc.customerConfirmed !== undefined
+    ? doc.customerConfirmed
+    : doc.needsManualCustomerSelection !== undefined
+      ? !doc.needsManualCustomerSelection
+      : false; // 両方未設定(レガシーdoc)は「未確定」として扱い、衝突チェックに委ねる
+  if (humanConfirmed) {
+    return { outcome: 'confirmed' };
+  }
+
+  return { outcome: 'needs-collision-check', trimmedName: name };
+}
+
+/**
+ * 顧客未確定の理由を同期的に解決する(FE・監査スクリプト用)。`opts.sameNameCollisionNames` は
+ * `findSameNameCollisionNames()` の戻り値をそのまま渡す想定。確定済みなら `null` を返す。
+ */
+export function resolveCustomerUnconfirmedReason(
+  doc: CustomerIdentityDocFields,
+  opts: { customerMasterName: string | null; sameNameCollisionNames: ReadonlySet<string> }
+): CustomerUnconfirmedReason | null {
+  const pre = precheckCustomerIdentity(doc, { customerMasterName: opts.customerMasterName });
+  if (pre.outcome === 'unconfirmed') {
+    return pre.reason;
+  }
+  if (pre.outcome === 'confirmed') {
+    return null;
+  }
+  return opts.sameNameCollisionNames.has(pre.trimmedName) ? 'same-name-collision' : null;
+}
 
 /**
  * 顧客名が「確定可能な有効値」かを判定する。
@@ -47,7 +144,12 @@ export function isValidCustomerSelection(name: string | null | undefined): boole
 export function findSameNameCollisionNames(customers: Array<{ name: string }>): Set<string> {
   const counts = new Map<string, number>();
   for (const c of customers) {
-    counts.set(c.name, (counts.get(c.name) ?? 0) + 1);
+    // BE(customerAmbiguityGate.ts)はtrim済みのdoc.customerNameで完全一致クエリするため、
+    // マスター名もtrimしてから集計しないと判定が食い違いうる(2026-07-26、本番マスターデータ
+    // (kanameone/cocoro双方)で前後空白付きnameが実在しないことは確認済み。addCustomer()の
+    // normalizeName()・import-masters.jsのCSVパースが書込み時に既にtrimしているため)。
+    const trimmed = c.name.trim();
+    counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
   }
   return new Set([...counts].filter(([, count]) => count > 1).map(([name]) => name));
 }


### PR DESCRIPTION
## Summary
- Drive誤配置ゲート(`customerAmbiguityGate.ts`)は処理をブロックする機能としては稼働していたが、現場管理者がその状態に気づける経路が存在しなかった問題への対応(承認済み計画: `~/.claude/plans/noble-booping-leaf.md`、Codex plan review反映済み)
- `shared/customerIdentity.ts`に共通判定関数(`precheckCustomerIdentity`/`resolveCustomerUnconfirmedReason`)を新設し、BEゲートとFEバッジ5箇所(書類一覧/担当CM別グループ/顧客サブグループ/処理履歴/詳細モーダル)が同一ロジックを共有
- 新規Cloud Function・Scheduler・Firestoreフィールドは追加しない(FEライブ判定+`useCustomers()`キャッシュ共有方式)

## Codex plan reviewの反映
- 「遅延ゼロ」表現を訂正(実際は5分キャッシュ)
- `findSameNameCollisionNames`へのtrim追加によるFE/BE canonicalization不一致リスクをkanameone/cocoro本番マスターで実測(前後空白付きname 0件)
- BE統合テスト(顧客未確定ゲート13ケース)・FE単体テストがいずれもCI未実行だったため`ci.yml`に追加
- `needsReview`合成(顧客+事業所)によるバッジ差し替えで事業所側要対応が隠れる問題をtitle属性への全理由列挙で対応
- 処理履歴の確定/未確定フィルターの不整合を解消
- エイリアス保存が同姓同名時に名前一致の先頭1件へ誤登録しうる隣接バグを同時修正

## Test plan
- [x] `functions`: unit 1943件 / BE統合テスト(emulator, 顧客未確定ゲート13ケース含む) 32件 / lint 0 errors / build成功
- [x] `frontend`: unit 501件(新規5件含む) / lint 0 errors・warnings / tsc clean / build成功
- [x] FAX複製・OCR回帰(`faxDuplication.test.ts`/`ocrProcessor.test.ts`) 112件
- [ ] Firebase Emulator + Playwright MCPで5箇所のバッジ/バナー実機確認(`ui-verified`ラベル取得、CLAUDE.md #193教訓)
- [ ] dev環境へのマージ後デプロイ確認 → kanameone/cocoro本番反映

## Scope note
UIコンポーネント変更を含むため、マージには「CI全PASS + `ui-verified`ラベル」の両方が必要(`ui-change-merge-check.sh` hook)。実コード13ファイル・新機能のため`/code-review high main...HEAD`の実行をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)