### PR TITLE
fix: DocumentDetailModalのcollidingMasters計算にname型ガード追加

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -602,9 +602,13 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       })
     : null
   const isSameNameCollision = unconfirmedReason === 'same-name-collision'
-  // 同名衝突の候補一覧(フリガナ・担当ケアマネ併記、staleな`allCustomerCandidates`より情報量が多い)
+  // 同名衝突の候補一覧(フリガナ・担当ケアマネ併記、staleな`allCustomerCandidates`より情報量が多い)。
+  // typeof c.name === 'string'ガード: useCustomers()はFirestore生データをname: doc.data().name as stringで
+  // castしており実行時保証がない。name欠損マスターが1件でもあるとc.name.trim()がTypeErrorでモーダル自体が
+  // クラッシュする(shared/customerIdentity.tsのfindSameNameCollisionNamesと同種のregression、Codex
+  // review-diff plan mode指摘で発覚、2026-07-26)
   const collidingMasters = isSameNameCollision && document
-    ? (customers ?? []).filter(c => c.name.trim() === (document.customerName ?? '').trim())
+    ? (customers ?? []).filter(c => typeof c.name === 'string' && c.name.trim() === (document.customerName ?? '').trim())
     : []
 
   // ドキュメントが変わったらdownloadUrlをリセット


### PR DESCRIPTION
## Summary
- kanameone本番反映前のCodex plan reviewセカンドオピニオン(effort=high)で発覚したcrash riskを修正
- `shared/customerIdentity.ts`の`findSameNameCollisionNames()`には型ガードを追加済みだったが、同じ`c.name.trim()`パターンが`DocumentDetailModal.tsx`の`collidingMasters`計算にも存在し、そちらは未対応のままだった
- Firestore生データの`name`フィールドが実行時にstring型でない場合(欠損、過去に本番で実在確認済み)、同名衝突の書類詳細モーダルを開いた際にTypeErrorでクラッシュする経路が残っていた

## Test plan
- [x] `cd frontend && npx tsc --noEmit` → 0 errors
- [x] `cd frontend && npm test` → 504 tests all passing (回帰なし)
- [x] devローカル(実dev cloud project接続)でPlaywright MCPにより実機確認: 同名衝突doc(`seed_同姓同名レガシー_01.pdf`)の詳細モーダルを開き、`collidingMasters`が正しく2件(「黒田実(くろだみのる/担当:高橋誠)」「黒田実(くろだまこと/担当:森さくら)」)表示されクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)