### PR TITLE
fix(pdf-split): PdfSplitModalのステップ1レイアウトをモバイル幅対応にする

### DIFF
--- a/frontend/src/components/PdfSplitModal.tsx
+++ b/frontend/src/components/PdfSplitModal.tsx
@@ -425,9 +425,9 @@ export function PdfSplitModal({
 
         {!isConfirmStep ? (
           // ステップ1: 分割ポイント設定
-          <div className="flex-1 overflow-hidden flex gap-4">
+          <div className="flex-1 overflow-y-auto flex flex-col sm:flex-row sm:overflow-hidden gap-4">
             {/* 左側: PDFプレビュー */}
-            <div className="w-1/2 flex flex-col min-h-[400px]">
+            <div className="w-full sm:w-1/2 flex flex-col min-h-[400px]">
               {/* 回転ボタン */}
               <div className="flex items-center justify-between mb-2">
                 <span className="text-sm font-medium text-gray-600">
@@ -496,7 +496,7 @@ export function PdfSplitModal({
             </div>
 
             {/* 右側: 分割ポイント一覧 */}
-            <div className="w-1/2 flex flex-col overflow-hidden">
+            <div className="w-full sm:w-1/2 flex flex-col overflow-hidden">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-sm font-medium">分割ポイント</span>
                 <Button

--- a/frontend/src/components/__tests__/PdfSplitModal.test.tsx
+++ b/frontend/src/components/__tests__/PdfSplitModal.test.tsx
@@ -509,3 +509,36 @@ describe('PdfSplitModal - splitPdfエラーハンドリング (Issue #621)', () 
     expect(lastToastErrorMessage()).toContain('Document has no updateTime')
   })
 })
+
+describe('PdfSplitModal - ステップ1レイアウトのモバイル対応 (Issue #744回帰防止)', () => {
+  it('左右カラムが固定w-1/2ではなく、sm未満で縦積みになるレスポンシブクラスを持つ', () => {
+    render(
+      <PdfSplitModal
+        document={makeDocument()}
+        isOpen={true}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        detailLoading={false}
+        detailError={false}
+      />
+    )
+
+    // 右カラム（「分割ポイント」見出しを含むdiv）
+    const splitPointsHeading = screen.getByText('分割ポイント')
+    const rightColumn = splitPointsHeading.parentElement?.parentElement
+    expect(rightColumn?.className).toContain('w-full')
+    expect(rightColumn?.className).toContain('sm:w-1/2')
+    expect(rightColumn?.className).not.toMatch(/(?<!sm:)\bw-1\/2\b/)
+
+    // 左カラム（サムネイル選択エリア）
+    const thumbnailLabel = screen.getByText('サムネイルをクリックでページ選択')
+    const leftColumn = thumbnailLabel.parentElement?.parentElement
+    expect(leftColumn?.className).toContain('w-full')
+    expect(leftColumn?.className).toContain('sm:w-1/2')
+
+    // 2カラムを包む親コンテナがsm未満でflex-col、sm以上でflex-row
+    const columnsContainer = rightColumn?.parentElement
+    expect(columnsContainer?.className).toContain('flex-col')
+    expect(columnsContainer?.className).toContain('sm:flex-row')
+  })
+})


### PR DESCRIPTION
## Summary
- `PdfSplitModal.tsx`のステップ1（分割ポイント設定）画面が固定`w-1/2`/`w-1/2`の2カラムで、モバイル幅（390px等）では「分割ポイント」ラベルが文字単位に折り返し、サムネイル表示も極端に圧縮されていた
- `flex gap-4` → `flex-col sm:flex-row gap-4`、`w-1/2` → `w-full sm:w-1/2`に変更し、sm未満（640px未満）では縦積み、sm以上では従来の2カラムレイアウトに切り替わるようにした
- 回帰防止のためコンポーネントテストを追加（左右カラム・親コンテナが期待するレスポンシブクラスを持つことを検証）

## Test plan
- [x] `npx vitest run src/components/__tests__/PdfSplitModal.test.tsx` → 14 tests passed（新規テスト含む）
- [x] `npx vitest run`（フロントエンド全体）→ 33 files / 505 tests passed（回帰なし）
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npm run lint` → エラーなし
- [x] Firebase Emulator + `vite --mode test`でdev環境相当の状態を用意し、Playwright MCPでiPhone 14相当（390×844）ビューポートにて実機確認: 修正前は「分割ポイント」ラベルが3行に折り返す崩れを確認、修正後は縦積みレイアウトで正常表示（スクリーンショット確認済み、検証用ファイルはコミット対象外）
- [x] デスクトップ幅（1280×900）でも従来の2カラムレイアウトが維持されることを確認（回帰なし）

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the PDF split dialog layout on small screens.
  * Enabled vertical scrolling and responsive column stacking for easier access to split-point controls on mobile devices.

* **Tests**
  * Added coverage to verify the responsive mobile layout and breakpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->