### PR TITLE
feat(deploy): deploy-to-project.shにproject ID整合性検証を追加

### DIFF
--- a/scripts/deploy-to-project.sh
+++ b/scripts/deploy-to-project.sh
@@ -169,6 +169,31 @@ fi
 
 log_info "環境変数ファイル: $(basename $ENV_FILE)"
 
+# ===========================================
+# プロジェクトID整合性検証 (Issue #693)
+# ===========================================
+# $ENV_FILE の VITE_FIREBASE_PROJECT_ID が .firebaserc 由来の正しいプロジェクトID
+# ($PROJECT_ID)と一致するか、ビルド前に検証する。不一致のまま進めると、誤った
+# Firebase設定を埋め込んだUIが無警告でデプロイされる(import.meta.env.DEVは
+# ビルド時falseに固定されるため、devサーバー向けランタイムガードも本番ビルドでは
+# 効かない)。
+ENV_PROJECT_ID=$(grep -E '^VITE_FIREBASE_PROJECT_ID=' "$ENV_FILE" | head -1 | cut -d '=' -f2- | tr -d '[:space:]')
+if [ -z "$ENV_PROJECT_ID" ]; then
+    log_error "$(basename "$ENV_FILE") に VITE_FIREBASE_PROJECT_ID が見つかりません"
+    exit 1
+fi
+if [ "$ENV_PROJECT_ID" != "$PROJECT_ID" ]; then
+    log_error "プロジェクトID不整合を検出しました。デプロイを中止します。"
+    echo "  $(basename "$ENV_FILE") の VITE_FIREBASE_PROJECT_ID: $ENV_PROJECT_ID"
+    echo "  .firebaserc の '$PROJECT_ALIAS' エイリアス:          $PROJECT_ID"
+    echo ""
+    echo "誤ったプロジェクト向けのFirebase設定を埋め込んだままビルド・デプロイすると、"
+    echo "別クライアント向けUIが対象環境にデプロイされる危険があります。"
+    echo "$(basename "$ENV_FILE") の内容を確認してください。"
+    exit 1
+fi
+log_success "プロジェクトID整合性チェック通過 ($PROJECT_ALIAS: $ENV_PROJECT_ID)"
+
 # 現在の.env.localをバックアップ（元々存在しなかった場合は BACKUP_FILE="" のままとし、
 # デプロイ後に client 値の .env.local を残置しない。残置すると次の npm run dev が
 # 誤って本番プロジェクトを向くため: 恒久対策 #503系follow-up）


### PR DESCRIPTION
## Summary
- `scripts/deploy-to-project.sh`が、`.env.$PROJECT_ALIAS`（例: `frontend/.env.kanameone`）の中身を検証せずビルド・デプロイしていた問題を修正
- `.env.$PROJECT_ALIAS`の`VITE_FIREBASE_PROJECT_ID`と、`.firebaserc`由来の正しいプロジェクトID（既存の`$PROJECT_ID`変数）をビルド前に比較し、不一致なら即座にエラー終了するようにした
- これにより、`.env.kanameone`が何らかの理由で誤った値（dev値や他クライアントの値）になっていた場合に「無警告で誤ったFirebase設定を埋め込んだUIが本番デプロイされる」事故を防止する

## Test plan
- [x] `shellcheck scripts/deploy-to-project.sh` → 新規追加箇所に指摘なし（既存の指摘4件は今回の変更と無関係な既存行）
- [x] `bash -n scripts/deploy-to-project.sh` → 構文OK
- [x] 使い捨てエイリアス（`.firebaserc`に一時追加、作業後に復元）で意図的にproject ID不一致な`.env.*`を用意し、`./scripts/deploy-to-project.sh <alias>`実行 → エラーで即終了・`.env.local`未生成（ビルド前に安全停止すること）を確認
- [x] 実際のdev/kanameone/cocoro 3環境の`frontend/.env.*`について、追加した検証ロジックと同じ比較を実行 → 全て一致（誤検知なし）を確認

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)