### PR TITLE
feat(audit): officeマスターcontamination検出をid===nameパターンにも拡張

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -54,6 +54,7 @@ on:
           - audit-short-office-masters
           - audit-short-office-masters --max-length 3
           - audit-short-office-masters --max-length 4
+          - audit-short-office-masters --fail-on-id-equals-name
           - delete-office-master --dry-run
           - delete-office-master --execute
           - reset-documents-by-office --dry-run

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -76,6 +76,14 @@ jobs:
           # #507 review Critical #2: --fail-on-collision を使うことで legitimate な
           # 短マスター ("ピース"・"わかば" 等) では false-positive Issue を抑制。
           # collision 検出 (PR #502 v2 と同じ判定) のみで通知発火する。
+          #
+          # 注意 (#707 調査結果): --fail-on-id-equals-name はここでは使わない。
+          # doc.id===name 単体は「CSV import 由来の汚染」の必要十分条件ではなく、
+          # scripts/samples/offices.csv 由来の正規サンプルマスター (dev環境に実在) 等
+          # legitimate なケースでも成立するため、自動fail条件に使うと false-positive
+          # Issue を量産する。手動調査用途では
+          # `node scripts/audit-short-office-masters.js --fail-on-id-equals-name`
+          # (run-ops-script.yml 経由) で検出結果を確認できる。
           NODE_PATH=./functions/node_modules \
             FIREBASE_PROJECT_ID="$PROJECT_ID" \
             node scripts/audit-short-office-masters.js \

--- a/functions/test/sharedValidation.test.ts
+++ b/functions/test/sharedValidation.test.ts
@@ -175,5 +175,18 @@ describe('#506 shared/officeMasterValidation', () => {
       const masters = [{ id: '', name: '' }];
       expect(computeIdEqualsNameMasters(masters).size).to.equal(0);
     });
+
+    it('複数件のid===nameマスターが混在する場合、全件をSetに蓄積する（ループ処理の回帰防止）', () => {
+      const masters = [
+        { id: 'かいと', name: 'かいと' },
+        { id: '福の里', name: '福の里' },
+        { id: 'auto-id-1', name: 'デイサービスさくら' },
+      ];
+      const result = computeIdEqualsNameMasters(masters);
+      expect(result.size).to.equal(2);
+      expect(result.has('かいと')).to.be.true;
+      expect(result.has('福の里')).to.be.true;
+      expect(result.has('auto-id-1')).to.be.false;
+    });
   });
 });

--- a/functions/test/sharedValidation.test.ts
+++ b/functions/test/sharedValidation.test.ts
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 import {
   validateOfficeMasterImport,
   computeCommonShortMasters,
+  computeIdEqualsNameMasters,
   normalizeForMatching as sharedNormalize,
   COMMON_SHORT_LENGTH_THRESHOLD,
   COMMON_SHORT_COLLISION_THRESHOLD,
@@ -139,6 +140,40 @@ describe('#506 shared/officeMasterValidation', () => {
       expect(common.has('bug-care')).to.be.true;
       expect(common.has('legit')).to.be.false;
       expect(common.has('long-1')).to.be.false;
+    });
+  });
+
+  describe('computeIdEqualsNameMasters (Issue #707)', () => {
+    it('id===name の短マスターを検出する', () => {
+      const masters = [
+        { id: 'かいと', name: 'かいと' },
+        { id: 'auto-id-1', name: 'デイサービスさくら' },
+      ];
+      const result = computeIdEqualsNameMasters(masters);
+      expect(result.has('かいと')).to.be.true;
+      expect(result.has('auto-id-1')).to.be.false;
+    });
+
+    it('name が7文字でもid===nameなら検出する（length<=3フィルタの網の穴対応）', () => {
+      const masters = [
+        { id: '訪問介護かいと', name: '訪問介護かいと' },
+        { id: '1a0zN2OehohAdvFo7kdH', name: '訪問介護さくら' },
+      ];
+      const result = computeIdEqualsNameMasters(masters);
+      expect(result.has('訪問介護かいと')).to.be.true;
+      expect(result.size).to.equal(1);
+    });
+
+    it('通常のauto-ID (id!==name) は検出しない', () => {
+      const masters = [
+        { id: '1a0zN2OehohAdvFo7kdH', name: 'デイサービスさくら' },
+      ];
+      expect(computeIdEqualsNameMasters(masters).size).to.equal(0);
+    });
+
+    it('name が空文字の場合は検出しない（id===""は通常発生しないが念のため除外）', () => {
+      const masters = [{ id: '', name: '' }];
+      expect(computeIdEqualsNameMasters(masters).size).to.equal(0);
     });
   });
 });

--- a/scripts/audit-short-office-masters.js
+++ b/scripts/audit-short-office-masters.js
@@ -130,6 +130,13 @@ async function main() {
   console.log(`=== doc.id === name パターン (Issue #707): ${idEqualsNameIds.size}件 ===\n`);
   if (idEqualsNameIds.size === 0) {
     console.log('該当なし\n');
+  } else if (!failOnIdEqualsName) {
+    // --fail-on-id-equals-name 未指定時 (scheduled audit の日次実行はこちら) は
+    // legitimate なケース(サンプルマスター等)でも件数が出るため、関連 documents の
+    // count クエリを伴う詳細表示は省略し、件数のみ記録する (code-reviewer指摘対応:
+    // 無関係な運用コスト・ログノイズを削減)。詳細確認は
+    // `--fail-on-id-equals-name` 付きで手動実行すること。
+    console.log(`(詳細表示は --fail-on-id-equals-name 指定時のみ。件数のみ記録)\n`);
   } else {
     for (const id of idEqualsNameIds) {
       const data = masterById.get(id) || {};

--- a/scripts/audit-short-office-masters.js
+++ b/scripts/audit-short-office-masters.js
@@ -10,11 +10,23 @@
  *   FIREBASE_PROJECT_ID=<project-id> node scripts/audit-short-office-masters.js [--max-length N]
  *
  * オプション:
- *   --max-length N         name.length <= N のエントリを出力 (default: 3)
- *   --fail-on-detected     length<=N のエントリが 1件でも見つかれば exit 1 (legitimate 含む)
- *   --fail-on-collision    PR #507 review Critical #2 対応: legitimate 短マスター (collision なし)
- *                          を除外し、common short master (PR #502 v2 と同じ collision 判定)
- *                          のみで exit 1 する。scheduled audit から呼ぶ場合の推奨 flag。
+ *   --max-length N              name.length <= N のエントリを出力 (default: 3)
+ *   --fail-on-detected          length<=N のエントリが 1件でも見つかれば exit 1 (legitimate 含む)
+ *   --fail-on-collision         PR #507 review Critical #2 対応: legitimate 短マスター (collision なし)
+ *                               を除外し、common short master (PR #502 v2 と同じ collision 判定)
+ *                               のみで exit 1 する。scheduled audit から呼ぶ場合の推奨 flag。
+ *   --fail-on-id-equals-name    Issue #707: Firestore doc ID が name 文字列そのものになっている
+ *                               signature を、name の文字数に依存しない独立チェックとして検出し、
+ *                               1件でもあれば exit 1 する。--max-length の閾値では捕捉できない
+ *                               長い name (例:「訪問介護かいと」) の網の穴に対応する。
+ *
+ *                               注意: doc.id===name 単体は CSV import 由来の contamination の
+ *                               必要十分条件ではない (dev環境の scripts/samples/offices.csv 由来
+ *                               サンプルマスター等、legitimate なケースでも成立する)。実際に
+ *                               contamination と確定するには #704 のように「同一/類似名の
+ *                               正規 auto-ID マスターが別途存在するか」の手動確認が必要。
+ *                               このため scheduled audit の自動 fail 条件には使わず、本 flag は
+ *                               手動調査 (run-ops-script.yml 経由) 専用とする。
  */
 
 const admin = require('firebase-admin');
@@ -29,6 +41,7 @@ const args = process.argv.slice(2);
 let maxLength = 3;
 let failOnDetected = false;
 let failOnCollision = false;
+let failOnIdEqualsName = false;
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--max-length' && args[i + 1]) {
     const n = parseInt(args[i + 1], 10);
@@ -44,14 +57,27 @@ for (let i = 0; i < args.length; i++) {
   } else if (args[i] === '--fail-on-collision') {
     // #507 review Critical #2: legitimate (collision なし) を除外し、common short master のみで exit 1
     failOnCollision = true;
+  } else if (args[i] === '--fail-on-id-equals-name') {
+    // #707: id===name signature (length非依存) の独立チェック
+    failOnIdEqualsName = true;
   }
 }
 
-// shared collision 判定 (PR #502 v2 と同等)。Bridge 経由で ts-node から TS を require
-const { computeCommonShortMasters } = require('./lib/officeMasterValidationBridge');
+// shared collision 判定 (PR #502 v2 と同等) + id===name 判定 (#707)。Bridge 経由で ts-node から TS を require
+const { computeCommonShortMasters, computeIdEqualsNameMasters } = require('./lib/officeMasterValidationBridge');
 
 admin.initializeApp({ projectId });
 const db = admin.firestore();
+
+// 関連 documents の件数 (officeName 完全一致 / officeId 参照) を出力する共通ヘルパー
+async function printRelatedDocumentCounts(name, id) {
+  const [byName, byId] = await Promise.all([
+    db.collection('documents').where('officeName', '==', name).count().get(),
+    db.collection('documents').where('officeId', '==', id).count().get(),
+  ]);
+  console.log(`  関連 documents (officeName=="${name}"): ${byName.data().count}件`);
+  console.log(`  関連 documents (officeId=="${id}"): ${byId.data().count}件`);
+}
 
 async function main() {
   console.log(`プロジェクト: ${projectId}`);
@@ -59,6 +85,12 @@ async function main() {
 
   const snap = await db.collection('masters/offices/items').get();
   console.log(`masters/offices/items 全件: ${snap.size}\n`);
+
+  // #507 review Critical #2: collision 判定で legitimate と汚染を区別
+  const allMasters = snap.docs.map((doc) => ({
+    id: doc.id,
+    name: typeof doc.data().name === 'string' ? doc.data().name : '',
+  }));
 
   const short = [];
   for (const doc of snap.docs) {
@@ -75,37 +107,41 @@ async function main() {
 
   console.log(`=== name.length <= ${maxLength} のマスター: ${short.length}件 ===\n`);
   if (short.length === 0) {
-    console.log('該当なし');
-    // Issue #510: main().then(({ detectedCount, collisionCount }) => {}) で destructure するため、
-    // 0 件 case でも shape を維持して return する必要がある。
-    return { detectedCount: 0, collisionCount: 0 };
+    console.log('該当なし\n');
+  } else {
+    for (const entry of short) {
+      console.log(`id=${entry.id}`);
+      console.log(`  name="${entry.name}" (length=${entry.length})`);
+      console.log(`  shortName="${entry.data.shortName || ''}"`);
+      console.log(`  aliases=${JSON.stringify(entry.data.aliases || [])}`);
+      console.log(`  isDuplicate=${entry.data.isDuplicate ?? false}`);
+      console.log(`  notes="${entry.data.notes || ''}"`);
+      await printRelatedDocumentCounts(entry.name, entry.id);
+      console.log('');
+    }
   }
 
-  for (const entry of short) {
-    console.log(`id=${entry.id}`);
-    console.log(`  name="${entry.name}" (length=${entry.length})`);
-    console.log(`  shortName="${entry.data.shortName || ''}"`);
-    console.log(`  aliases=${JSON.stringify(entry.data.aliases || [])}`);
-    console.log(`  isDuplicate=${entry.data.isDuplicate ?? false}`);
-    console.log(`  notes="${entry.data.notes || ''}"`);
-
-    // 関連 documents の件数 (officeName 完全一致 / officeId 参照)
-    const [byName, byId] = await Promise.all([
-      db.collection('documents').where('officeName', '==', entry.name).count().get(),
-      db.collection('documents').where('officeId', '==', entry.id).count().get(),
-    ]);
-    console.log(`  関連 documents (officeName=="${entry.name}"): ${byName.data().count}件`);
-    console.log(`  関連 documents (officeId=="${entry.id}"): ${byId.data().count}件`);
-    console.log('');
-  }
-
-  // #507 review Critical #2: collision 判定で legitimate と汚染を区別
-  const allMasters = snap.docs.map((doc) => ({
-    id: doc.id,
-    name: typeof doc.data().name === 'string' ? doc.data().name : '',
-  }));
   const commonShortIds = computeCommonShortMasters(allMasters);
   const collisionDetected = short.filter((s) => commonShortIds.has(s.id));
+
+  // Issue #707: doc.id === name signature の独立チェック (name の文字数に依存しない)
+  const idEqualsNameIds = computeIdEqualsNameMasters(allMasters);
+  const masterById = new Map(snap.docs.map((doc) => [doc.id, doc.data()]));
+  console.log(`=== doc.id === name パターン (Issue #707): ${idEqualsNameIds.size}件 ===\n`);
+  if (idEqualsNameIds.size === 0) {
+    console.log('該当なし\n');
+  } else {
+    for (const id of idEqualsNameIds) {
+      const data = masterById.get(id) || {};
+      const name = typeof data.name === 'string' ? data.name : '';
+      console.log(`id=${id}`);
+      console.log(`  name="${name}" (length=${name.length})`);
+      console.log(`  shortName="${data.shortName || ''}"`);
+      console.log(`  isDuplicate=${data.isDuplicate ?? false}`);
+      await printRelatedDocumentCounts(name, id);
+      console.log('');
+    }
+  }
 
   console.log(`\n=== サマリー ===`);
   console.log(`プロジェクト: ${projectId}`);
@@ -118,16 +154,33 @@ async function main() {
       console.log(`  - ${c.id} (name="${c.name}")`);
     }
   }
-  return { detectedCount: short.length, collisionCount: collisionDetected.length };
+  console.log(`doc.id === name パターン: ${idEqualsNameIds.size}件`);
+  if (idEqualsNameIds.size > 0) {
+    console.log('id===name master id:');
+    for (const id of idEqualsNameIds) {
+      console.log(`  - ${id}`);
+    }
+  }
+  return {
+    detectedCount: short.length,
+    collisionCount: collisionDetected.length,
+    idEqualsNameCount: idEqualsNameIds.size,
+  };
 }
 
 main()
-  .then(({ detectedCount, collisionCount }) => {
+  .then(({ detectedCount, collisionCount, idEqualsNameCount }) => {
     // #507 review: --fail-on-collision (新規) を優先評価 → legitimate 短マスターでは
     // exit 0、bug pattern (collision 検出) でのみ exit 1。scheduled audit からは
     // 本 flag を使うことで false-positive Issue を抑制する。
     if (failOnCollision && collisionCount > 0) {
       console.error(`\n[FAIL] --fail-on-collision: common short master ${collisionCount}件が検出されたため exit 1`);
+      process.exit(1);
+    }
+    // #707: doc.id===name は legitimate なケース(サンプルデータ等)でも成立しうるため
+    // scheduled audit の自動 fail 条件には使わない。本 flag は手動調査専用。
+    if (failOnIdEqualsName && idEqualsNameCount > 0) {
+      console.error(`\n[FAIL] --fail-on-id-equals-name: id===name パターン ${idEqualsNameCount}件が検出されたため exit 1`);
       process.exit(1);
     }
     if (failOnDetected && detectedCount > 0) {

--- a/shared/officeMasterValidation.ts
+++ b/shared/officeMasterValidation.ts
@@ -47,6 +47,37 @@ export interface OfficeMasterLike {
 }
 
 /**
+ * Firestore doc ID が name 文字列そのものになっている「id===name」signature を
+ * 持つマスターの id 集合を返す (Issue #707)。
+ *
+ * CSV import 由来の contamination（kanameone環境の「かいと」「福の里」等、
+ * Issue #704/#699/#698 参照）は通常の auto-ID (`1a0zN2OehohAdvFo7kdH` 等) ではなく
+ * doc ID が name と一致する異常パターンを持つ。この signature は name の文字数に
+ * 依存せず発生しうるため（例: 7文字の「訪問介護かいと」）、
+ * computeCommonShortMasters の短マスター (length<4) 限定の collision 判定とは
+ * 独立したチェックとして提供する。
+ *
+ * 注意 (#707 調査結果): id===name は contamination の必要十分条件ではない。
+ * dev環境の scripts/samples/offices.csv 由来サンプルマスター等、legitimate な
+ * データでも同じ signature が成立しうることを実データで確認済み。実際の
+ * contamination 確定には #704 のように「同一/類似名の正規 auto-ID マスターが
+ * 別途存在するか」の手動確認が必要なため、本関数の出力は自動 fail 判定ではなく
+ * 手動調査の絞り込みに用いること。
+ *
+ * @param masters 全 office マスター (現状 Firestore データ)
+ * @returns id===name パターンに該当する master id の Set
+ */
+export function computeIdEqualsNameMasters(masters: OfficeMasterLike[]): Set<string> {
+  const ids = new Set<string>();
+  for (const master of masters) {
+    if (master.name.length > 0 && master.id === master.name) {
+      ids.add(master.id);
+    }
+  }
+  return ids;
+}
+
+/**
  * マスター name 同士の substring 衝突から「common short master」id 集合を返す。
  *
  * 短マスター (normalize 後 length < COMMON_SHORT_LENGTH_THRESHOLD) について、他マスター


### PR DESCRIPTION
## Summary
- Firestore doc IDがname文字列そのものになっている「id===name」signature（CSV import由来のcontamination、Issue #704/#699/#698参照）を、name文字数に依存しない独立チェックとして検出できるようにした
- `shared/officeMasterValidation.ts`に`computeIdEqualsNameMasters`を追加（既存の`computeCommonShortMasters`と独立、length非依存）
- `scripts/audit-short-office-masters.js`に`--fail-on-id-equals-name`フラグを追加（手動調査用）
- `run-ops-script.yml`に手動実行用オプションを追加

## スコープ縮小の経緯（重要）
実装後、`--fail-on-id-equals-name`をdev環境に対して実行したところ、10件検出されました。しかし中身は`scripts/samples/offices.csv`由来の正規サンプルマスター（「あおぞらデイサービス」等の正常な事業所名）で、Issue #707が前提とする「id===name = contamination」という判定は**単体では誤検知（false positive）を生む**ことが判明しました。

#704のコメントを読み直すと、実際に汚染と確定した「かいと」「福の里」は、id===nameに加えて「別途、正規のauto-IDマスターが重複して存在する」という追加条件があって初めて汚染と判定されていました。

この発見を踏まえ、`scheduled-audit.yml`への自動fail条件組み込みは見送り（false-positive Issueの自動生成を防ぐ）、`run-ops-script.yml`経由の**手動調査専用flag**としてスコープを縮小しました。将来的に「同一/類似名の正規auto-IDマスターとの重複」まで組み込んだ自動検出を実装する場合は、別Issueでの再設計が必要です。

## Test plan
- [x] `cd functions && npx mocha --require ts-node/register test/sharedValidation.test.ts` → 31 tests passed（新規4件含む）
- [x] `cd functions && npm test` → 1949 tests passed（回帰なし）
- [x] `npm run lint:functions` → 0 errors（既存warningのみ、変更ファイルへの新規指摘なし）
- [x] `npx tsc --noEmit -p functions` → エラーなし
- [x] `node -c scripts/audit-short-office-masters.js` → 構文OK
- [x] GitHub Actions "Run Operations Script"をこのブランチ(`--ref`指定)からdev環境に対して実行し、新フラグの実データ動作を確認（read-only、副作用なし）→ 上記の誤検知を発見し、設計を修正
- [x] YAML構文チェック（js-yaml）→ scheduled-audit.yml, run-ops-script.yml ともにOK

Refs #707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional audit mode to detect office masters whose IDs match their names.
  * Added the new audit option to manually triggered operations.
  * Enhanced audit output with matching entries and related document counts.

* **Bug Fixes**
  * Improved detection of ID/name matches, including edge cases and multiple matching records.

* **Documentation**
  * Clarified which failure checks are used by scheduled audits and which require manual investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->