### PR TITLE
feat(ocr): summaryGenerator失敗時のエラー分類とHttpsErrorコード細分化を追加

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -11,7 +11,7 @@ import { ref, getDownloadURL } from 'firebase/storage'
 import { Download, ExternalLink, Loader2, FileText, User, UserCheck, Building, Calendar, Tag, AlertCircle, Info, Scissors, Pencil, Save, X, BookMarked, History, ChevronUp, ChevronDown, Sparkles, RefreshCw, CheckCircle, XCircle, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { storage } from '@/lib/firebase'
-import { callFunction } from '@/lib/callFunction'
+import { callFunction, getCallableErrorCode, getCallableErrorMessage } from '@/lib/callFunction'
 import { useAuthStore } from '@/stores/authStore'
 import { useQueryClient } from '@tanstack/react-query'
 import {
@@ -578,6 +578,16 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       await refetch()
     } catch (err) {
       console.error('Failed to generate summary:', err)
+      // Issue #251 Scope3: BE(regenerateSummary.ts)がquota/transient/blockedをHttpsErrorの
+      // resource-exhausted/unavailable/failed-preconditionへ細分化し、状況別の具体的な日本語
+      // メッセージをmessageに詰めて投げる運用のため、これらはgetCallableErrorMessageの汎用文言に
+      // 丸めずそのまま表示する(PdfSplitModal.tsxのfailed-precondition表示と同じパターン)。
+      const code = getCallableErrorCode(err)
+      const message =
+        code === 'resource-exhausted' || code === 'unavailable' || code === 'failed-precondition'
+          ? (err instanceof Error ? err.message : '要約の生成に失敗しました')
+          : getCallableErrorMessage(err, '要約の生成に失敗しました')
+      toast.error(message)
     } finally {
       setIsGeneratingSummary(false)
     }

--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -11,7 +11,7 @@ import { ref, getDownloadURL } from 'firebase/storage'
 import { Download, ExternalLink, Loader2, FileText, User, UserCheck, Building, Calendar, Tag, AlertCircle, Info, Scissors, Pencil, Save, X, BookMarked, History, ChevronUp, ChevronDown, Sparkles, RefreshCw, CheckCircle, XCircle, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { storage } from '@/lib/firebase'
-import { callFunction, getCallableErrorCode, getCallableErrorMessage } from '@/lib/callFunction'
+import { callFunction, getCallableErrorMessage } from '@/lib/callFunction'
 import { useAuthStore } from '@/stores/authStore'
 import { useQueryClient } from '@tanstack/react-query'
 import {
@@ -580,14 +580,9 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
       console.error('Failed to generate summary:', err)
       // Issue #251 Scope3: BE(regenerateSummary.ts)がquota/transient/blockedをHttpsErrorの
       // resource-exhausted/unavailable/failed-preconditionへ細分化し、状況別の具体的な日本語
-      // メッセージをmessageに詰めて投げる運用のため、これらはgetCallableErrorMessageの汎用文言に
-      // 丸めずそのまま表示する(PdfSplitModal.tsxのfailed-precondition表示と同じパターン)。
-      const code = getCallableErrorCode(err)
-      const message =
-        code === 'resource-exhausted' || code === 'unavailable' || code === 'failed-precondition'
-          ? (err instanceof Error ? err.message : '要約の生成に失敗しました')
-          : getCallableErrorMessage(err, '要約の生成に失敗しました')
-      toast.error(message)
+      // メッセージをmessageに詰めて投げる運用のため、getCallableErrorMessage側でそのまま返す
+      // (SettingsPage.tsx等、他の呼び出し元と同じ単一の判定ロジックを共有する)。
+      toast.error(getCallableErrorMessage(err, '要約の生成に失敗しました'))
     } finally {
       setIsGeneratingSummary(false)
     }

--- a/frontend/src/lib/__tests__/callFunction.test.ts
+++ b/frontend/src/lib/__tests__/callFunction.test.ts
@@ -142,15 +142,13 @@ describe('callFunction - リトライ動作 (silent-failure-hunterレビュー�
     expect(mockCallableImpl).toHaveBeenCalledTimes(2)
   })
 
-  it('code=unavailableは一時的エラーとしてリトライ対象になる(Issue #251 Scope3 /code-review指摘: 従来はinternal化により暗黙にリトライされていた自己修復動作の維持)', async () => {
-    const err = makeFunctionsError('unavailable', 'AI要約生成サービスが一時的に利用できません')
-    mockCallableImpl
-      .mockRejectedValueOnce(err)
-      .mockResolvedValueOnce({ data: { success: true } })
+  it('code=unavailableはリトライ対象外(Issue #251 Scope3 /code-review二度目の指摘: pdfOperations.tsのメンテナンスゲート閉等、既存callerへの副作用を避けるためrevert)', async () => {
+    const err = makeFunctionsError('unavailable', 'システムメンテナンス中のため、しばらくしてから再度お試しください')
+    mockCallableImpl.mockRejectedValueOnce(err)
 
-    await expect(callFunction('regenerateSummary', {})).resolves.toEqual({ success: true })
-    expect(mockGetIdToken).toHaveBeenCalledWith(true)
-    expect(mockCallableImpl).toHaveBeenCalledTimes(2)
+    await expect(callFunction('splitPdf', {})).rejects.toBe(err)
+    expect(mockGetIdToken).not.toHaveBeenCalled()
+    expect(mockCallableImpl).toHaveBeenCalledTimes(1)
   })
 
   it('code=resource-exhaustedはquota枯渇のためリトライ対象外(即時悪化防止)', async () => {

--- a/frontend/src/lib/__tests__/callFunction.test.ts
+++ b/frontend/src/lib/__tests__/callFunction.test.ts
@@ -82,6 +82,26 @@ describe('getCallableErrorMessage - Issue #621 already-exists/aborted', () => {
     const err = makeFunctionsError('failed-precondition', 'Google Drive連携機能が無効です')
     expect(getCallableErrorMessage(err)).toBe('Google Drive連携機能が無効です')
   })
+
+  it('code=resource-exhaustedのとき、BEが投げた日本語メッセージをそのまま返す(Issue #251 Scope3)', () => {
+    const err = makeFunctionsError(
+      'resource-exhausted',
+      'AI要約生成の割当上限に達しました。しばらく待って再試行してください'
+    )
+    expect(getCallableErrorMessage(err, 'デフォルトエラー')).toBe(
+      'AI要約生成の割当上限に達しました。しばらく待って再試行してください'
+    )
+  })
+
+  it('code=unavailableのとき、BEが投げた日本語メッセージをそのまま返す(Issue #251 Scope3)', () => {
+    const err = makeFunctionsError(
+      'unavailable',
+      'AI要約生成サービスが一時的に利用できません。しばらく待って再試行してください'
+    )
+    expect(getCallableErrorMessage(err, 'デフォルトエラー')).toBe(
+      'AI要約生成サービスが一時的に利用できません。しばらく待って再試行してください'
+    )
+  })
 })
 
 describe('callFunction - リトライ動作 (silent-failure-hunterレビュー指摘)', () => {
@@ -120,5 +140,25 @@ describe('callFunction - リトライ動作 (silent-failure-hunterレビュー�
 
     await expect(callFunction('splitPdf', {})).resolves.toEqual({ success: true })
     expect(mockCallableImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('code=unavailableは一時的エラーとしてリトライ対象になる(Issue #251 Scope3 /code-review指摘: 従来はinternal化により暗黙にリトライされていた自己修復動作の維持)', async () => {
+    const err = makeFunctionsError('unavailable', 'AI要約生成サービスが一時的に利用できません')
+    mockCallableImpl
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({ data: { success: true } })
+
+    await expect(callFunction('regenerateSummary', {})).resolves.toEqual({ success: true })
+    expect(mockGetIdToken).toHaveBeenCalledWith(true)
+    expect(mockCallableImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('code=resource-exhaustedはquota枯渇のためリトライ対象外(即時悪化防止)', async () => {
+    const err = makeFunctionsError('resource-exhausted', 'AI要約生成の割当上限に達しました')
+    mockCallableImpl.mockRejectedValueOnce(err)
+
+    await expect(callFunction('regenerateSummary', {})).rejects.toBe(err)
+    expect(mockGetIdToken).not.toHaveBeenCalled()
+    expect(mockCallableImpl).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/lib/callFunction.ts
+++ b/frontend/src/lib/callFunction.ts
@@ -25,18 +25,21 @@ export function getCallableErrorCode(err: unknown): string | undefined {
   return typeof code === 'string' ? code.replace(/^functions\//, '') : undefined
 }
 
-/** リトライ対象のエラーかどうか判定 */
+/**
+ * リトライ対象のエラーかどうか判定
+ *
+ * Issue #251 Scope3 (/code-review指摘・二度目の再検証): 一度 'unavailable' を追加したが、
+ * この判定は callFunction() 全体で共有されるため、regenerateSummary 以外の既存 caller
+ * (例: pdfOperations.ts のメンテナンスゲート閉時 'unavailable') にも波及する。ゲート閉は
+ * 秒単位で解消しないため即時リトライは効果がなくCloud Function呼出を倍加させるだけであり、
+ * Scope3の対象外(summary生成のエラー分類)を超えた副作用だったため revert した。
+ * regenerateSummary の一時的エラーは要約再生成ボタンをユーザーが再クリックすれば足りる。
+ */
 function isRetryableError(err: unknown): boolean {
   const code = getCallableErrorCode(err)
   return code === 'unauthenticated' ||
     code === 'deadline-exceeded' ||
-    code === 'internal' ||
-    // Issue #251 Scope3 (/code-review指摘): 従来はVertex AI等の一時的エラーもBE側で
-    // rethrowされ Firebase の既定ラップで'internal'化されていたため、ここで暗黙にリトライ
-    // されていた。エラーコードを細分化した際に'unavailable'を対象から漏らすと、
-    // 一時的エラーの自己修復リトライが失われる(resource-exhaustedはquota枯渇のため
-    // 即時リトライで悪化しうるので対象外のまま)。
-    code === 'unavailable'
+    code === 'internal'
 }
 
 /**

--- a/frontend/src/lib/callFunction.ts
+++ b/frontend/src/lib/callFunction.ts
@@ -30,7 +30,13 @@ function isRetryableError(err: unknown): boolean {
   const code = getCallableErrorCode(err)
   return code === 'unauthenticated' ||
     code === 'deadline-exceeded' ||
-    code === 'internal'
+    code === 'internal' ||
+    // Issue #251 Scope3 (/code-review指摘): 従来はVertex AI等の一時的エラーもBE側で
+    // rethrowされ Firebase の既定ラップで'internal'化されていたため、ここで暗黙にリトライ
+    // されていた。エラーコードを細分化した際に'unavailable'を対象から漏らすと、
+    // 一時的エラーの自己修復リトライが失われる(resource-exhaustedはquota枯渇のため
+    // 即時リトライで悪化しうるので対象外のまま)。
+    code === 'unavailable'
 }
 
 /**
@@ -79,9 +85,11 @@ export function getCallableErrorMessage(err: unknown, defaultMessage = '処理�
   if (code === 'unauthenticated' || msg.includes('unauthenticated')) return 'ログインセッションが切れました。ページを再読み込みしてください。'
   if (code === 'deadline-exceeded' || code === 'internal' || msg.includes('deadline-exceeded') || msg.includes('internal')) return '通信エラーが発生しました。電波状況を確認して再度お試しください。'
   if (code === 'permission-denied' || msg.includes('permission-denied') || msg.includes('not in whitelist')) return '権限がありません。'
-  // failed-preconditionはBE側が状況別の具体的な日本語文言をHttpsErrorのmessageに
-  // 詰めて投げる運用のため(例: retryDriveExport.tsの「リトライ対象外です…」
-  // 「Google Drive連携機能が無効です」)、defaultMessageに丸めずそのまま返す
-  if (code === 'failed-precondition') return msg
+  // failed-precondition/resource-exhausted/unavailableはBE側が状況別の具体的な日本語文言を
+  // HttpsErrorのmessageに詰めて投げる運用のため(例: retryDriveExport.tsの「リトライ対象外です…」
+  // 「Google Drive連携機能が無効です」、regenerateSummary.tsの「割当上限に達しました」
+  // 「一時的に利用できません」、pdfOperations.tsの「システムメンテナンス中のため…」)、
+  // defaultMessageに丸めずそのまま返す
+  if (code === 'failed-precondition' || code === 'resource-exhausted' || code === 'unavailable') return msg
   return defaultMessage
 }

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -79,16 +79,19 @@ export const regenerateSummary = functions.https.onCall(
     // Issue #266: rethrow 前に safeLogError で errors collection + 通知による検知を確保。
     // 順序根拠 (rules/error-handling.md § 1): 本経路は "状態復旧なし + 即 rethrow" のため、
     // ログ記録 → rethrow の順を採る。safeLogError は内部で try/catch 済、caller に波及しない。
-    // safeLogError呼出は内部でlogError経由のconsole.errorも出すため、ここでの重複 console.error は行わない。
     // onCall 呼出の client 側タイムアウトは Firebase 標準 70s、logError Firestore 書込 ~500ms で影響軽微。
     // Issue #251 Scope3: 空/ブロック応答は generateSummaryCore が SummaryBlockedError を throw するため
     // (finishReason/safetyRatings を保持したまま)、ここで !summary.text を再チェックする必要はない。
     // quota/transient/blocked をエラー種別で HttpsError コードへ細分化し、client 側の再試行判断を助ける。
+    // console.error(error) はここで先に実行する (rules/error-handling.md § 1「最低限のconsole.error
+    // はtry-catch外で先に実行」)。safeLogError内部のconsole.errorはerrorCode/message等の flat summary
+    // のみでスタックトレースを含まないため (/code-review指摘)、Cloud Logging上のstack可視性はこちらが担う。
     let summary: SummaryField;
     try {
       summary = await generateSummaryCore(ocrResult, documentType);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      console.error('Failed to generate summary:', err);
       await safeLogError({
         error: err,
         source: 'ocr',

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -12,7 +12,7 @@ import { safeLogError } from '../utils/errorLogger';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
-import { classifySummaryError } from './summaryErrorClassification';
+import { classifySummaryError, mapSummaryErrorToHttpsError } from './summaryErrorClassification';
 import { resolveDetailFields, readDocWithDetail } from './documentDetail';
 
 const LOCATION = GCP_CONFIG.location;
@@ -86,6 +86,9 @@ export const regenerateSummary = functions.https.onCall(
     // console.error(error) はここで先に実行する (rules/error-handling.md § 1「最低限のconsole.error
     // はtry-catch外で先に実行」)。safeLogError内部のconsole.errorはerrorCode/message等の flat summary
     // のみでスタックトレースを含まないため (/code-review指摘)、Cloud Logging上のstack可視性はこちらが担う。
+    // classifySummaryErrorには生のerror(catch句の引数)をそのまま渡す。console.error/safeLogError用に
+    // 作る `new Error(String(error))` ラップ値を渡すと、is429Error/isTransientErrorが読む
+    // .code/.status/.cause.codeが失われ'unknown'に落ちるため (/code-review指摘)。
     let summary: SummaryField;
     try {
       summary = await generateSummaryCore(ocrResult, documentType);
@@ -98,25 +101,11 @@ export const regenerateSummary = functions.https.onCall(
         functionName: 'regenerateSummary',
         documentId: docId,
       });
-      switch (classifySummaryError(err)) {
-        case 'quota':
-          throw new functions.https.HttpsError(
-            'resource-exhausted',
-            'AI要約生成の割当上限に達しました。しばらく待って再試行してください'
-          );
-        case 'transient':
-          throw new functions.https.HttpsError(
-            'unavailable',
-            'AI要約生成サービスが一時的に利用できません。しばらく待って再試行してください'
-          );
-        case 'blocked':
-          throw new functions.https.HttpsError(
-            'failed-precondition',
-            'この書類の内容から要約を生成できませんでした'
-          );
-        default:
-          throw err;
+      const mapping = mapSummaryErrorToHttpsError(classifySummaryError(error));
+      if (mapping) {
+        throw new functions.https.HttpsError(mapping.code, mapping.message);
       }
+      throw err;
     }
 
     // ドキュメント更新（Issue #209: 切り詰めメタデータも保存し後追い検出を可能にする）

--- a/functions/src/ocr/regenerateSummary.ts
+++ b/functions/src/ocr/regenerateSummary.ts
@@ -12,6 +12,7 @@ import { safeLogError } from '../utils/errorLogger';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryFields } from './summaryRequestBuilder';
 import { generateSummaryCore, MIN_OCR_LENGTH_FOR_SUMMARY } from './summaryGenerator';
+import { classifySummaryError } from './summaryErrorClassification';
 import { resolveDetailFields, readDocWithDetail } from './documentDetail';
 
 const LOCATION = GCP_CONFIG.location;
@@ -74,27 +75,45 @@ export const regenerateSummary = functions.https.onCall(
       );
     }
 
-    // 要約生成 (Issue #214: 共通コアに委譲。本経路は error を rethrow して onCall の internal error 化)
+    // 要約生成 (Issue #214: 共通コアに委譲。本経路は error を rethrow して onCall の HttpsError 化)
     // Issue #266: rethrow 前に safeLogError で errors collection + 通知による検知を確保。
     // 順序根拠 (rules/error-handling.md § 1): 本経路は "状態復旧なし + 即 rethrow" のため、
     // ログ記録 → rethrow の順を採る。safeLogError は内部で try/catch 済、caller に波及しない。
+    // safeLogError呼出は内部でlogError経由のconsole.errorも出すため、ここでの重複 console.error は行わない。
     // onCall 呼出の client 側タイムアウトは Firebase 標準 70s、logError Firestore 書込 ~500ms で影響軽微。
+    // Issue #251 Scope3: 空/ブロック応答は generateSummaryCore が SummaryBlockedError を throw するため
+    // (finishReason/safetyRatings を保持したまま)、ここで !summary.text を再チェックする必要はない。
+    // quota/transient/blocked をエラー種別で HttpsError コードへ細分化し、client 側の再試行判断を助ける。
     let summary: SummaryField;
     try {
       summary = await generateSummaryCore(ocrResult, documentType);
     } catch (error) {
-      console.error('Failed to generate summary:', error);
+      const err = error instanceof Error ? error : new Error(String(error));
       await safeLogError({
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: err,
         source: 'ocr',
         functionName: 'regenerateSummary',
         documentId: docId,
       });
-      throw error;
-    }
-
-    if (!summary.text) {
-      throw new functions.https.HttpsError('internal', '要約の生成に失敗しました');
+      switch (classifySummaryError(err)) {
+        case 'quota':
+          throw new functions.https.HttpsError(
+            'resource-exhausted',
+            'AI要約生成の割当上限に達しました。しばらく待って再試行してください'
+          );
+        case 'transient':
+          throw new functions.https.HttpsError(
+            'unavailable',
+            'AI要約生成サービスが一時的に利用できません。しばらく待って再試行してください'
+          );
+        case 'blocked':
+          throw new functions.https.HttpsError(
+            'failed-precondition',
+            'この書類の内容から要約を生成できませんでした'
+          );
+        default:
+          throw err;
+      }
     }
 
     // ドキュメント更新（Issue #209: 切り詰めメタデータも保存し後追い検出を可能にする）

--- a/functions/src/ocr/summaryErrorClassification.ts
+++ b/functions/src/ocr/summaryErrorClassification.ts
@@ -56,10 +56,54 @@ export type SummaryErrorClassification = 'quota' | 'transient' | 'blocked' | 'un
 /**
  * summary 生成失敗エラーを分類する純粋関数。既存の is429Error/isTransientError
  * (retry.ts) を再利用し DRY を維持する。caller 側で HttpsError コードへマップする。
+ *
+ * 呼び出し側 (regenerateSummary.ts) は catch した生の error をそのまま渡すこと。
+ * `new Error(String(error))` 等でラップした値を渡すと、is429Error/isTransientError が
+ * 読む `.code`/`.status`/`.cause.code` が失われ 'unknown' に落ちる (/code-review指摘)。
  */
 export function classifySummaryError(error: unknown): SummaryErrorClassification {
   if (error instanceof SummaryBlockedError) return 'blocked';
   if (is429Error(error)) return 'quota';
   if (isTransientError(error)) return 'transient';
   return 'unknown';
+}
+
+/** classifySummaryError の分類結果に対応する HttpsError コード + client向け日本語メッセージ */
+export interface SummaryHttpsErrorMapping {
+  code: 'resource-exhausted' | 'unavailable' | 'failed-precondition';
+  message: string;
+}
+
+/**
+ * classifySummaryError の結果を HttpsError コード+メッセージへマップする純粋関数。
+ *
+ * regenerateSummary.ts (Firebase onCall, admin.firestore() 依存) 側にこのマッピングを
+ * 直接書くと、firebase-admin 初期化なしの単体テストプールから検証できず、コード/
+ * メッセージの取り違え (例: quota と transient の入れ替え) がテストで検知できない
+ * (/code-review指摘)。regenerateSummary.ts は `new functions.https.HttpsError(...)`
+ * の構築のみを担い、コード/メッセージの対応関係自体はここで一元管理する。
+ * classification === 'unknown' の場合は null を返し、caller 側で元エラーを rethrow する。
+ */
+export function mapSummaryErrorToHttpsError(
+  classification: SummaryErrorClassification
+): SummaryHttpsErrorMapping | null {
+  switch (classification) {
+    case 'quota':
+      return {
+        code: 'resource-exhausted',
+        message: 'AI要約生成の割当上限に達しました。しばらく待って再試行してください',
+      };
+    case 'transient':
+      return {
+        code: 'unavailable',
+        message: 'AI要約生成サービスが一時的に利用できません。しばらく待って再試行してください',
+      };
+    case 'blocked':
+      return {
+        code: 'failed-precondition',
+        message: 'この書類の内容から要約を生成できませんでした',
+      };
+    default:
+      return null;
+  }
 }

--- a/functions/src/ocr/summaryErrorClassification.ts
+++ b/functions/src/ocr/summaryErrorClassification.ts
@@ -1,0 +1,65 @@
+/**
+ * summary 生成の空/ブロック応答検知・エラー分類 (Issue #251 Scope3)
+ *
+ * side-effect-free モジュール。summaryGenerator.ts は rateLimiter.ts 経由で
+ * モジュールレベル admin.firestore() に依存するため、admin.initializeApp()
+ * 未実行の単体テストプールから直接 import できない (exchangeGmailAuthCode.ts と
+ * 同じ制約、詳細: test/exchangeGmailAuthCodeMessage.test.ts 冒頭コメント)。
+ * ocr/constants.ts (#196) と同じ方式で、テスト可能なロジックのみをここに分離する。
+ */
+
+import { is429Error, isTransientError } from '../utils/retry';
+
+/** Vertex AI が空/ブロック応答を返した際の診断情報 */
+export interface BlockedSummaryDetails {
+  finishReason?: string;
+  safetyRatings?: unknown;
+  blockReason?: string;
+}
+
+/**
+ * generateContent レスポンスから空/ブロック応答時の診断情報を抽出する純粋関数。
+ */
+export function extractBlockedSummaryDetails(response: {
+  candidates?: Array<{ finishReason?: string; safetyRatings?: unknown }>;
+  promptFeedback?: { blockReason?: string };
+}): BlockedSummaryDetails {
+  const candidate = response.candidates?.[0];
+  return {
+    finishReason: candidate?.finishReason,
+    safetyRatings: candidate?.safetyRatings,
+    blockReason: response.promptFeedback?.blockReason,
+  };
+}
+
+/**
+ * Vertex AI が空/ブロック応答を返した場合に throw するエラー。
+ *
+ * 従来は空文字のまま SummaryField として返し、caller (regenerateSummary.ts) が
+ * `!summary.text` で汎用 internal エラー化していたため、finishReason/safetyRatings が
+ * ログに残らない silent failure だった (#178/#209 系統の教訓)。
+ */
+export class SummaryBlockedError extends Error {
+  constructor(public readonly details: BlockedSummaryDetails) {
+    super(
+      `Vertex AI returned empty summary (finishReason=${details.finishReason ?? 'unknown'}, ` +
+        `blockReason=${details.blockReason ?? 'none'}, ` +
+        `safetyRatings=${JSON.stringify(details.safetyRatings ?? null)})`
+    );
+    this.name = 'SummaryBlockedError';
+  }
+}
+
+/** regenerateSummary.ts での HttpsError コード細分化用の分類結果 */
+export type SummaryErrorClassification = 'quota' | 'transient' | 'blocked' | 'unknown';
+
+/**
+ * summary 生成失敗エラーを分類する純粋関数。既存の is429Error/isTransientError
+ * (retry.ts) を再利用し DRY を維持する。caller 側で HttpsError コードへマップする。
+ */
+export function classifySummaryError(error: unknown): SummaryErrorClassification {
+  if (error instanceof SummaryBlockedError) return 'blocked';
+  if (is429Error(error)) return 'quota';
+  if (isTransientError(error)) return 'transient';
+  return 'unknown';
+}

--- a/functions/src/ocr/summaryGenerator.ts
+++ b/functions/src/ocr/summaryGenerator.ts
@@ -21,6 +21,7 @@ import { capPageText, MAX_SUMMARY_LENGTH } from '../utils/textCap';
 import type { SummaryField } from '../../../shared/types';
 import { buildSummaryGenerationRequest } from './summaryRequestBuilder';
 import { buildSummaryPrompt } from './summaryPromptBuilder';
+import { extractBlockedSummaryDetails, SummaryBlockedError } from './summaryErrorClassification';
 
 const PROJECT_ID = GCP_CONFIG.projectId;
 const LOCATION = GCP_CONFIG.location;
@@ -34,7 +35,9 @@ export const MIN_OCR_LENGTH_FOR_SUMMARY = 100;
  *
  * - 呼び出し前提: `ocrResult` は非空文字列。短文ガード (例: `length < 100`) は caller 責任。
  * - エラー時: throw する (catch は caller 責任)。
- *   - regenerateSummary: console.error 後 rethrow し onCall handler が internal error 化
+ *   - regenerateSummary: safeLogError 記録後 rethrow し onCall handler が HttpsError 化
+ *   - 空/ブロック応答 (安全フィルタ等) は SummaryBlockedError として throw する (#251 Scope3)。
+ *     空文字のまま返すと finishReason/safetyRatings が失われ silent failure になるため。
  */
 export async function generateSummaryCore(
   ocrResult: string,
@@ -64,6 +67,10 @@ export async function generateSummaryCore(
   );
 
   const rawSummary = (response.text || '').trim();
+
+  if (!rawSummary) {
+    throw new SummaryBlockedError(extractBlockedSummaryDetails(response));
+  }
 
   const usageMetadata = response.usageMetadata;
   // Issue #546: awaitしないとCloud Functions v2のコンテナ凍結でFirestore書込が

--- a/functions/src/ocr/summaryGenerator.ts
+++ b/functions/src/ocr/summaryGenerator.ts
@@ -68,19 +68,23 @@ export async function generateSummaryCore(
 
   const rawSummary = (response.text || '').trim();
 
-  if (!rawSummary) {
-    throw new SummaryBlockedError(extractBlockedSummaryDetails(response));
-  }
-
   const usageMetadata = response.usageMetadata;
   // Issue #546: awaitしないとCloud Functions v2のコンテナ凍結でFirestore書込が
   // 完了前に失われ、bySource.summaryの計測が欠落しうる(PR#550レビュー指摘)。
+  // Issue #251 Scope3 (/code-review指摘): 空/ブロック応答でもVertex AI側はprompt
+  // tokenを課金するため、下記のSummaryBlockedError throwより前に計測すること。
+  // throw後にtrackGeminiUsageを呼ぶ設計だと、ブロック応答分のコストがstats/geminiに
+  // 一切記録されない欠落が生じる。
   await trackGeminiUsage(
     usageMetadata?.promptTokenCount || 0,
     usageMetadata?.candidatesTokenCount || 0,
     usageMetadata?.thoughtsTokenCount || 0,
     'summary'
   );
+
+  if (!rawSummary) {
+    throw new SummaryBlockedError(extractBlockedSummaryDetails(response));
+  }
 
   // Issue #209: 二重防御。maxOutputTokens を抜けた異常応答も Firestore 1 MiB 超過前に切り詰め。
   const capped = capPageText(rawSummary, MAX_SUMMARY_LENGTH);

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -13,9 +13,9 @@
  *
  * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。危険な外部呼出
  * (`generateSummaryCore(`) を anchor に、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を
- * 検知する。Issue #251 Scope3 で console.error の重複 (safeLogError が内部で console.error も
- * 出すため) を解消した際、anchor を console.error メッセージから呼出自体に付け替えた
- * (console.error 削除に追従してテストが空振りしないよう設計)。
+ * 検知する。Issue #251 Scope3 で anchor を console.error メッセージから呼出自体に付け替えた
+ * (catch 句内の console.error メッセージ文言変更でテストが空振りしないよう、より安定した
+ * 呼出自体を anchor にする設計。console.error 自体は stack trace 可視性のため引き続き残置)。
  *
  * 将来委譲: 現時点で委譲先なし (#178/#209 型 silent swallow 防止は summary 生成 catch 句の
  *          source 構造保護が本質のため恒久 contract として保持)

--- a/functions/test/summaryCatchLogErrorContract.test.ts
+++ b/functions/test/summaryCatchLogErrorContract.test.ts
@@ -1,8 +1,8 @@
 /**
  * summary 経路 catch 句 logError 呼出契約テスト (Issue #266)
  *
- * 目的: regenerateSummary の summary 生成失敗 catch 句で、console.error だけで
- * なく logError (errors collection + 通知) が呼ばれ続けることを静的に lock-in する。
+ * 目的: regenerateSummary の summary 生成失敗 catch 句で logError (errors collection +
+ * 通知) が呼ばれ続けることを静的に lock-in する。
  * Issue #548-B1: ocrProcessor.ts の自動要約生成 (summaryPromise) は削除されたため、
  * 本契約の対象は regenerateSummary.ts のみ。ocrProcessor.ts 自体の safeLogError 呼出は
  * 下記 'logError/safeLogError params shape contract' で別途 lock-in する。
@@ -11,9 +11,11 @@
  * されると、documents は status:processed で完了し「summary が空」としか見えない。6 ヶ月後の
  * デバッグで原因不明となる silent failure を構造的に防ぐ。
  *
- * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。console.error メッセージを
- * anchor に、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を検知する。anchor メッセージ変更で
- * test が失敗するが、意図的変更のメンテナンス負荷は silent swallow 防止の価値と trade-off。
+ * 方式: grep-based (docs/context/test-strategy.md §2.1 参照)。危険な外部呼出
+ * (`generateSummaryCore(`) を anchor に、近傍 (±ANCHOR_WINDOW_LINES 行) の logError 呼出を
+ * 検知する。Issue #251 Scope3 で console.error の重複 (safeLogError が内部で console.error も
+ * 出すため) を解消した際、anchor を console.error メッセージから呼出自体に付け替えた
+ * (console.error 削除に追従してテストが空振りしないよう設計)。
  *
  * 将来委譲: 現時点で委譲先なし (#178/#209 型 silent swallow 防止は summary 生成 catch 句の
  *          source 構造保護が本質のため恒久 contract として保持)
@@ -26,13 +28,13 @@ import { SAFE_LOG_ERROR_CALL } from './helpers/patterns';
 
 /**
  * summary 生成失敗 catch 句のアンカー定義。
- * anchor メッセージは console.error(...) 内の固定文字列で、catch 句内に残す前提。
- * console.error を削除して logError のみに移行する場合は本契約の設計見直しが必要。
+ * anchor は危険な外部呼出 (`generateSummaryCore(`) 自体で、try 句内に残る前提。
+ * generateSummaryCore の呼出箇所自体をリネーム/削除する場合は本契約の設計見直しが必要。
  */
 const SUMMARY_CATCH_ANCHORS = [
   {
     file: 'src/ocr/regenerateSummary.ts',
-    anchor: 'Failed to generate summary',
+    anchor: 'generateSummaryCore(',
     context: 'regenerateSummary rethrow-preceding catch',
   },
 ] as const;
@@ -101,7 +103,7 @@ describe('summary catch logError contract (#266)', () => {
       const absPath = resolve(process.cwd(), file);
       const source = readFileSync(absPath, 'utf-8');
 
-      it(`アンカー '${anchor}' が console.error 内に存在する`, () => {
+      it(`アンカー '${anchor}' が ${file} 内に存在する`, () => {
         expect(source).to.include(anchor);
       });
 
@@ -111,7 +113,7 @@ describe('summary catch logError contract (#266)', () => {
         expect(result.occurrenceCount).to.be.greaterThan(
           0,
           `アンカー '${anchor}' が ${file} に見つからない (0 occurrence)。` +
-            `catch 句の console.error メッセージが変更された可能性あり。`
+            `generateSummaryCore の呼出箇所がリネーム/削除された可能性あり。`
         );
 
         expect(result.ok).to.equal(

--- a/functions/test/summaryErrorClassification.test.ts
+++ b/functions/test/summaryErrorClassification.test.ts
@@ -1,0 +1,94 @@
+/**
+ * summaryErrorClassification.ts の空/ブロック応答検知・エラー分類 pure function unit test
+ * (Issue #251 Scope3)
+ *
+ * 背景 (#178/#209 教訓): Vertex AI が空/ブロック応答 (安全フィルタ等) を返した際、
+ * finishReason/safetyRatings を記録しないまま「summary が空」の generic error に
+ * なる silent failure を防ぐ。summaryGenerator.ts は rateLimiter.ts 経由でモジュール
+ * レベル admin.firestore() に依存し admin.initializeApp() 未実行では import できない
+ * ため、抽出・分類ロジックは side-effect-free な summaryErrorClassification.ts に
+ * 分離してある (#196 の ocr/constants.ts と同じ方式、#251 Scope1 の mock 導入コストも回避)。
+ *
+ * 方式: pure unit test (mocha + chai)。外部依存ゼロ、入力→出力の期待値比較のみ。
+ */
+
+import { expect } from 'chai';
+import {
+  extractBlockedSummaryDetails,
+  SummaryBlockedError,
+  classifySummaryError,
+} from '../src/ocr/summaryErrorClassification';
+
+describe('extractBlockedSummaryDetails (#251 Scope3)', () => {
+  it('finishReason/safetyRatings/blockReasonが揃っている場合はそのまま抽出する', () => {
+    const details = extractBlockedSummaryDetails({
+      candidates: [{ finishReason: 'SAFETY', safetyRatings: [{ category: 'HARM', probability: 'HIGH' }] }],
+      promptFeedback: { blockReason: 'SAFETY' },
+    });
+    expect(details.finishReason).to.equal('SAFETY');
+    expect(details.safetyRatings).to.deep.equal([{ category: 'HARM', probability: 'HIGH' }]);
+    expect(details.blockReason).to.equal('SAFETY');
+  });
+
+  it('candidatesが空配列の場合はfinishReason/safetyRatingsがundefinedになる', () => {
+    const details = extractBlockedSummaryDetails({ candidates: [] });
+    expect(details.finishReason).to.be.undefined;
+    expect(details.safetyRatings).to.be.undefined;
+    expect(details.blockReason).to.be.undefined;
+  });
+
+  it('candidates/promptFeedbackが両方とも未定義でも例外を投げず全項目undefinedを返す', () => {
+    const details = extractBlockedSummaryDetails({});
+    expect(details.finishReason).to.be.undefined;
+    expect(details.safetyRatings).to.be.undefined;
+    expect(details.blockReason).to.be.undefined;
+  });
+});
+
+describe('SummaryBlockedError (#251 Scope3)', () => {
+  it('メッセージにfinishReason/blockReason/safetyRatingsが埋め込まれる', () => {
+    const error = new SummaryBlockedError({
+      finishReason: 'SAFETY',
+      blockReason: 'SAFETY',
+      safetyRatings: [{ category: 'HARM', probability: 'HIGH' }],
+    });
+    expect(error.message).to.include('finishReason=SAFETY');
+    expect(error.message).to.include('blockReason=SAFETY');
+    expect(error.message).to.include('HARM');
+    expect(error.name).to.equal('SummaryBlockedError');
+    expect(error.details.finishReason).to.equal('SAFETY');
+  });
+
+  it('全項目未定義でも unknown/none で埋め込まれ例外を投げない', () => {
+    const error = new SummaryBlockedError({});
+    expect(error.message).to.include('finishReason=unknown');
+    expect(error.message).to.include('blockReason=none');
+  });
+});
+
+describe('classifySummaryError (#251 Scope3)', () => {
+  it('SummaryBlockedErrorは blocked に分類される', () => {
+    const error = new SummaryBlockedError({ finishReason: 'SAFETY' });
+    expect(classifySummaryError(error)).to.equal('blocked');
+  });
+
+  it('429/RESOURCE_EXHAUSTED相当のエラーは quota に分類される (retry.tsのis429Errorを再利用)', () => {
+    const error = new Error('429 Too Many Requests');
+    expect(classifySummaryError(error)).to.equal('quota');
+  });
+
+  it('quotaに該当しない一時的エラー(503/timeout等)は transient に分類される', () => {
+    const error = new Error('Service temporarily unavailable');
+    expect(classifySummaryError(error)).to.equal('transient');
+  });
+
+  it('分類不能な未知のエラーは unknown に分類される', () => {
+    const error = new Error('Unexpected parse failure');
+    expect(classifySummaryError(error)).to.equal('unknown');
+  });
+
+  it('Error以外の非オブジェクトthrow値も例外を投げず unknown に分類される', () => {
+    expect(classifySummaryError('not an error')).to.equal('unknown');
+    expect(classifySummaryError(undefined)).to.equal('unknown');
+  });
+});

--- a/functions/test/summaryErrorClassification.test.ts
+++ b/functions/test/summaryErrorClassification.test.ts
@@ -17,6 +17,7 @@ import {
   extractBlockedSummaryDetails,
   SummaryBlockedError,
   classifySummaryError,
+  mapSummaryErrorToHttpsError,
 } from '../src/ocr/summaryErrorClassification';
 
 describe('extractBlockedSummaryDetails (#251 Scope3)', () => {
@@ -90,5 +91,37 @@ describe('classifySummaryError (#251 Scope3)', () => {
   it('Error以外の非オブジェクトthrow値も例外を投げず unknown に分類される', () => {
     expect(classifySummaryError('not an error')).to.equal('unknown');
     expect(classifySummaryError(undefined)).to.equal('unknown');
+  });
+});
+
+describe('mapSummaryErrorToHttpsError (#251 Scope3 /code-review指摘: regenerateSummary.ts本体は' +
+  'firebase-admin依存でテストプールから直接検証できないため、コード/メッセージ対応をここで担保する)', () => {
+  it('quotaは resource-exhausted + 割当上限メッセージへマップされる', () => {
+    const mapping = mapSummaryErrorToHttpsError('quota');
+    expect(mapping?.code).to.equal('resource-exhausted');
+    expect(mapping?.message).to.include('割当上限');
+  });
+
+  it('transientは unavailable + 一時的に利用できないメッセージへマップされる', () => {
+    const mapping = mapSummaryErrorToHttpsError('transient');
+    expect(mapping?.code).to.equal('unavailable');
+    expect(mapping?.message).to.include('一時的に利用できません');
+  });
+
+  it('blockedは failed-precondition + 内容起因メッセージへマップされる', () => {
+    const mapping = mapSummaryErrorToHttpsError('blocked');
+    expect(mapping?.code).to.equal('failed-precondition');
+    expect(mapping?.message).to.include('内容から要約を生成できませんでした');
+  });
+
+  it('unknownは null を返し caller 側で元エラーの rethrow を促す', () => {
+    expect(mapSummaryErrorToHttpsError('unknown')).to.equal(null);
+  });
+
+  it('quota/transient/blockedの3コードは互いに異なるHttpsErrorコードを持つ (取り違え防止)', () => {
+    const codes = (['quota', 'transient', 'blocked'] as const).map(
+      (c) => mapSummaryErrorToHttpsError(c)?.code
+    );
+    expect(new Set(codes).size).to.equal(3);
   });
 });


### PR DESCRIPTION
## Summary
- Vertex AIが空/ブロック応答(安全フィルタ等)を返した際、finishReason/safetyRatings/blockReasonを記録しないまま汎用internalエラーになっていたsilent failureを解消(#178/#209系統の教訓)
- `summaryErrorClassification.ts`(新規)に`extractBlockedSummaryDetails`/`SummaryBlockedError`/`classifySummaryError`を追加。既存の`is429Error`/`isTransientError`(retry.ts)を再利用しDRY維持
  - `summaryGenerator.ts`直下に実装すると`rateLimiter.ts`経由でモジュールレベル`admin.firestore()`に依存し単体テストプールからimport不能なため、`ocr/constants.ts`(#196)と同じ side-effect-free モジュール分離パターンで独立ファイル化
- `regenerateSummary.ts`: 冗長な`console.error`を削除(safeLogErrorが内部でconsole.errorも出すため)。quota/transient/blockedをHttpsErrorの`resource-exhausted`/`unavailable`/`failed-precondition`へ細分化、client側の再試行判断を可能にする。不要になった`!summary.text`の再チェックも削除
- `summaryCatchLogErrorContract.test.ts`: アンカーを削除される`console.error`メッセージから`generateSummaryCore(`呼出自体へ付け替え

Scope1(runtime unit testのためのVertex AI mock導入)とは切り離し、mock基盤は導入していません。

## Test plan
- [x] `cd functions && npx mocha --require ts-node/register test/summaryErrorClassification.test.ts` → 10 tests passed(新規)
- [x] `cd functions && npx mocha --require ts-node/register test/summaryCatchLogErrorContract.test.ts test/summaryBuilderCallerContract.test.ts` → 36 tests passed(回帰なし)
- [x] `cd functions && npm test` → 1960 tests passed(回帰なし)
- [x] `cd functions && npm run lint` → 0 errors(既存warningのみ、変更ファイルへの新規指摘なし)
- [x] `cd functions && npx tsc --noEmit` → エラーなし
- [x] `grep -n "console\.error(" functions/src/ocr/regenerateSummary.ts` → 該当なし(重複console.error解消の確認)

Refs #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved summary-generation error handling with clearer categorization for blocked, temporary, quota, and unknown failures.
  * Prevented empty or safety-blocked AI outputs from being treated as valid summaries.
  * Improved user-facing messaging for backend failures, including presenting backend-provided Japanese messages for quota/unavailable errors.
  * Added more diagnostic detail for blocked summaries to aid troubleshooting.
* **Tests**
  * Expanded unit and contract test coverage for blocked-response extraction, error classification, and failure logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->