### PR TITLE
feat(ops): cocoro Hosting未反映検知をScheduled Master Auditに追加

### DIFF
--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -138,7 +138,7 @@ jobs:
     # 正規経路のため、frontend/ 変更の反映漏れをCIの外側で検知する手段がなかった (2026-07-28)。
     runs-on: ubuntu-latest
     outputs:
-      lag_detected: ${{ steps.check.outcome == 'failure' }}
+      lag_detected: ${{ steps.check.outputs.exit_code == '1' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -158,10 +158,21 @@ jobs:
 
       - name: Check cocoro Hosting reflection lag
         id: check
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/audit-cocoro-hosting-lag.js --threshold-hours 48
+        run: |
+          set +e
+          node scripts/audit-cocoro-hosting-lag.js --threshold-hours 48
+          code=$?
+          set -e
+          # スクリプトの exit code は 0=OK / 1=遅延検知 / 2=API障害等の実行エラー の3値。
+          # ここを区別しないと、GCP認証やGitHub APIの一時的なエラー(exit 2)まで
+          # 「遅延検知」(exit 1)と誤認して誤ったissueを量産してしまう(finder指摘)。
+          # exit 2 はissue化せずworkflow annotationとして可視化するに留める。
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" != "0" ] && [ "$code" != "1" ]; then
+            echo "::warning::cocoro-hosting-lag audit script failed unexpectedly (exit $code) — infra error, not a lag detection"
+          fi
 
   notify-cocoro-hosting-lag:
     needs: cocoro-hosting-lag

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -132,3 +132,86 @@ jobs:
             --title "[scheduled-audit] 短 office マスター検出 (${TODAY})" \
             --label "bug,P2" \
             --body "$BODY"
+
+  cocoro-hosting-lag:
+    # cocoro Hosting は deploy-hosting.yml 非対応(Secrets未登録)でローカル手動デプロイが
+    # 正規経路のため、frontend/ 変更の反映漏れをCIの外側で検知する手段がなかった (2026-07-28)。
+    runs-on: ubuntu-latest
+    outputs:
+      lag_detected: ${{ steps.check.outcome == 'failure' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Authenticate to Google Cloud (cocoro)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Check cocoro Hosting reflection lag
+        id: check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/audit-cocoro-hosting-lag.js --threshold-hours 48
+
+  notify-cocoro-hosting-lag:
+    needs: cocoro-hosting-lag
+    runs-on: ubuntu-latest
+    if: always() && needs.cocoro-hosting-lag.outputs.lag_detected == 'true'
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Skip if an open issue already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          COUNT=$(gh issue list --state open --json title \
+            --jq '[.[] | select(.title | startswith("[scheduled-audit] cocoro Hosting未反映"))] | length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Create issue for cocoro Hosting lag
+        if: steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TODAY=$(date -u +%Y-%m-%d)
+          BODY=$(cat <<EOF
+          ## cocoro Hosting反映が閾値(48時間)を超えて遅延
+
+          [Workflow run](${RUN_URL}) で、frontend/ の最新マージ済みcommitに対し
+          cocoroのFirebase Hosting反映が48時間以上遅延していることを検知しました。
+
+          ## 背景
+          cocoro Hostingは .github/workflows/deploy-hosting.yml の対象外
+          (VITE_FIREBASE_*_COCORO Secrets未登録)のため、ローカル手動
+          \`./scripts/switch-client.sh cocoro && ./scripts/deploy-to-project.sh cocoro\`
+          が正規デプロイ経路です。
+
+          ## 確認手順
+          1. workflow run ログでlag時間・commit時刻・release時刻を確認
+          2. 反映が必要なら上記コマンドでcocoro Hostingを手動デプロイ
+          3. 意図的な保留(リリース待ち等)なら本issueに理由を記載しpostponedラベルを付与
+          EOF
+          )
+          # shellcheck disable=SC2001
+          BODY=$(echo "$BODY" | sed 's/^          //')
+          gh issue create \
+            --title "[scheduled-audit] cocoro Hosting未反映 (${TODAY})" \
+            --label "bug,P2" \
+            --body "$BODY"

--- a/scripts/audit-cocoro-hosting-lag.js
+++ b/scripts/audit-cocoro-hosting-lag.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * cocoro Firebase Hosting 未反映検知スクリプト (read-only)
+ *
+ * cocoro の Hosting デプロイは .github/workflows/deploy-hosting.yml の対象外
+ * (VITE_FIREBASE_*_COCORO Secrets 未登録) で、ローカル手動
+ * `./scripts/deploy-to-project.sh cocoro` が正規デプロイ経路。このため
+ * frontend/ 変更のマージ漏れ検知が構造的にCIの外側にあった。
+ *
+ * frontend/ への最新マージ済みcommit時刻と、cocoro Hosting の最新release時刻を比較し、
+ * 閾値(デフォルト48時間)を超えて反映が遅延している場合に exit 1 する。
+ *
+ * 使用方法:
+ *   GH_TOKEN=<token> node scripts/audit-cocoro-hosting-lag.js [--threshold-hours 48]
+ *
+ * 前提:
+ *   - gh CLI が認証済み (GH_TOKEN or 既存 gh auth login)
+ *   - gcloud CLI が docsplit-cocoro 向けに認証済み
+ *     (CI: google-github-actions/auth@v2 + secrets.GCP_SA_KEY)
+ */
+
+const { execSync } = require('child_process');
+
+const REPO = 'yasushi-honda/doc-split';
+const SITE_ID = 'docsplit-cocoro';
+
+function parseThresholdHours(argv) {
+  let thresholdHours = 48;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--threshold-hours' && argv[i + 1]) {
+      const n = parseInt(argv[i + 1], 10);
+      if (!Number.isInteger(n) || n < 0) {
+        console.error(`--threshold-hours は非負整数を指定してください (got: ${argv[i + 1]})`);
+        process.exit(1);
+      }
+      thresholdHours = n;
+      i++;
+    }
+  }
+  return thresholdHours;
+}
+
+function getLatestFrontendCommitTime() {
+  const out = execSync(
+    `gh api "repos/${REPO}/commits?path=frontend&sha=main&per_page=1" --jq '.[0].commit.committer.date'`,
+    { encoding: 'utf8' }
+  ).trim();
+  if (!out) {
+    throw new Error('frontend/ の最新commit取得に失敗しました');
+  }
+  return new Date(out);
+}
+
+async function getLatestCocoroReleaseTime() {
+  const token = execSync('gcloud auth print-access-token', { encoding: 'utf8' }).trim();
+  const res = await fetch(
+    `https://firebasehosting.googleapis.com/v1beta1/sites/${SITE_ID}/releases?pageSize=1`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    throw new Error(`Firebase Hosting API error: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  const release = data.releases && data.releases[0];
+  if (!release) {
+    throw new Error('cocoro Hosting のrelease履歴が取得できませんでした');
+  }
+  return new Date(release.releaseTime);
+}
+
+async function main() {
+  const thresholdHours = parseThresholdHours(process.argv.slice(2));
+
+  const [commitTime, releaseTime] = await Promise.all([
+    Promise.resolve(getLatestFrontendCommitTime()),
+    getLatestCocoroReleaseTime(),
+  ]);
+
+  const lagHours = (commitTime.getTime() - releaseTime.getTime()) / (1000 * 60 * 60);
+
+  console.log(`frontend/ 最新commit: ${commitTime.toISOString()}`);
+  console.log(`cocoro Hosting 最新release: ${releaseTime.toISOString()}`);
+  console.log(`lag: ${lagHours.toFixed(1)}時間 (閾値: ${thresholdHours}時間)`);
+
+  if (lagHours > thresholdHours) {
+    console.error(
+      `cocoro Hosting反映が閾値を超えて遅延しています (${lagHours.toFixed(1)}h > ${thresholdHours}h)`
+    );
+    process.exit(1);
+  }
+
+  console.log('OK: 閾値内です');
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
- cocoro HostingはGitHub Actions非対応(`VITE_FIREBASE_*_COCORO` Secrets未登録)でローカル手動デプロイ(`deploy-to-project.sh cocoro`)が正規経路のため、frontend/変更の反映漏れを検知する仕組みがCIの外側にあった
- 既存の`Scheduled Master Audit`(#506)と同じcron/SA認証パターンで新ジョブ`cocoro-hosting-lag`を追加し、frontend/最新commit時刻とFirebase Hosting REST APIから取得したcocoro最新release時刻を比較、48時間超の遅延を検知したら`bug,P2`ラベルでissueを自動作成する(open issue重複防止つき)
- 閾値48時間はdecision-maker選定（AskUserQuestion）: 直近のkanameone/cocoroデプロイ実績上、翌日定期監査(06:00 JST)で確実に拾える幅かつ日中作業優先などの正常な遅延で誤検知しない値

## Test plan
- [x] `node scripts/audit-cocoro-hosting-lag.js --threshold-hours 48` をcocoro認証下でローカル実行 → `frontend/最新commit: 2026-07-28T02:36:33Z` / `cocoro release: 2026-07-28T03:17:32Z` / `lag: -0.7h` → `exit 0`（現状の正常系を正しく判定）
- [x] `actionlint .github/workflows/scheduled-audit.yml` → エラー0件
- [x] `node -c scripts/audit-cocoro-hosting-lag.js` → 構文OK
- [ ] マージ後、次回scheduled実行(06:00 JST)でジョブが正常完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)