### PR TITLE
fix(drive): 利用者/ケアマネフォルダ名の姓名間スペース表記ゆれを正規化する

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -139,6 +139,7 @@ on:
           - audit-filename-pattern-issue686
           - backfill-drive-export --dry-run
           - backfill-drive-export
+          - audit-drive-folder-space-variants
       doc_id:
         description: 'Document ID (required when script contains --doc-id; ignored otherwise)'
         required: false

--- a/functions/src/drive/folderPath.ts
+++ b/functions/src/drive/folderPath.ts
@@ -96,6 +96,18 @@ function joinInitialAndName(
   return `${initial}${separatorChar}${name}`;
 }
 
+/**
+ * 姓名間の全角/半角スペース有無・欠落表記ゆれ(実データ確認例: 「鬼頭 京子」/「鬼頭京子」)は
+ * customerName/careManagerNameに残ったまま`findOrCreateFolder`の完全一致クエリに渡ると、
+ * 表記の違うレコードが同一人物でも別々のフォルダとして黙って作成/参照されてしまう
+ * (AmbiguousFolderErrorは同一の完全一致文字列が2件以上ヒットした場合にのみ発火するため、
+ * この表記ゆれ自体は検知対象外)。フォルダ名解決の入力段階で内部の空白を除去し、
+ * 表記ゆれのある同一人物が常に同じフォルダ名に解決されるようにする。
+ */
+function stripInternalSpaces(name: string): string {
+  return name.replace(/[\s　]+/g, '');
+}
+
 function resolveCareManagerSegment(
   doc: FolderPathDocInput,
   segment: Extract<DriveFolderSegment, { type: 'careManager' }>
@@ -104,7 +116,7 @@ function resolveCareManagerSegment(
   // untrimmedの careManagerName でガード判定した後もuntrimmedのまま使っていたため、
   // 先頭/末尾に空白のみを含む値(例:" 田中")がガードを通過しつつ空白始まりの
   // 壊れたフォルダ名を生成していた。
-  const careManagerName = doc.careManagerName.trim();
+  const careManagerName = stripInternalSpaces(doc.careManagerName.trim());
   if (!careManagerName) {
     throw new CareManagerMissingError();
   }
@@ -123,7 +135,7 @@ function resolveCustomerSegment(
   // customerName自体の空/空白チェック(code-review xhigh指摘#6対応、2026-07-22):
   // 元はfuriganaのみガードしておりcustomerNameが空文字/空白のみでも素通りしていた
   // (careManager/documentCategoryの同種ガードと非対称だった)。
-  const customerName = doc.customerName.trim();
+  const customerName = stripInternalSpaces(doc.customerName.trim());
   if (!customerName) {
     throw new CustomerNameMissingError();
   }

--- a/functions/test/folderPath.test.ts
+++ b/functions/test/folderPath.test.ts
@@ -193,4 +193,38 @@ describe('resolveFolderSegments', () => {
     const doc = makeDoc({ documentCategory: 'ケアプラン', fileDate: null });
     expect(() => resolveFolderSegments(doc, KANAME_TEMPLATE)).to.throw(FileDateMissingError);
   });
+
+  describe('姓名間スペースの表記ゆれ正規化(実データ確認例: 「鬼頭 京子」/「鬼頭京子」)', () => {
+    it('customerNameに半角スペースが含まれていてもnameOnly形式ではスペースなしの表記と同じフォルダ名になる', () => {
+      const withSpace = resolveFolderSegments(makeDoc({ customerName: '鬼頭 京子' }), COCORO_TEMPLATE);
+      const withoutSpace = resolveFolderSegments(makeDoc({ customerName: '鬼頭京子' }), COCORO_TEMPLATE);
+      expect(withSpace).to.deep.equal(withoutSpace);
+      expect(withSpace[2]).to.equal('鬼頭京子');
+    });
+
+    it('customerNameに全角スペースが含まれていてもnameOnly形式ではスペースなしの表記と同じフォルダ名になる', () => {
+      const withSpace = resolveFolderSegments(makeDoc({ customerName: '鬼頭　京子' }), COCORO_TEMPLATE);
+      const withoutSpace = resolveFolderSegments(makeDoc({ customerName: '鬼頭京子' }), COCORO_TEMPLATE);
+      expect(withSpace).to.deep.equal(withoutSpace);
+    });
+
+    it('customerNameのスペース表記ゆれはfuriganaInitialSpaceName形式でも吸収され同じフォルダ名になる', () => {
+      const withSpace = resolveFolderSegments(
+        makeDoc({ customerName: '藤 正義', customerFurigana: 'フジマサヨシ' }),
+        KANAME_TEMPLATE
+      );
+      const withoutSpace = resolveFolderSegments(
+        makeDoc({ customerName: '藤正義', customerFurigana: 'フジマサヨシ' }),
+        KANAME_TEMPLATE
+      );
+      expect(withSpace).to.deep.equal(withoutSpace);
+      expect(withSpace[2]).to.equal('フ　藤正義');
+    });
+
+    it('careManagerNameのスペース表記ゆれもnameOnly形式で吸収され同じフォルダ名になる', () => {
+      const withSpace = resolveFolderSegments(makeDoc({ careManagerName: '田中 太郎' }), COCORO_TEMPLATE);
+      const withoutSpace = resolveFolderSegments(makeDoc({ careManagerName: '田中太郎' }), COCORO_TEMPLATE);
+      expect(withSpace).to.deep.equal(withoutSpace);
+    });
+  });
 });

--- a/scripts/audit-drive-folder-space-variants.js
+++ b/scripts/audit-drive-folder-space-variants.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Drive連携済みdocumentの姓名スペース表記ゆれ監査スクリプト（read-only）
+ *
+ * PR #752(functions/src/drive/folderPath.ts)で、customerName/careManagerNameの
+ * 内部スペース(全角/半角)を除去してフォルダ名解決するよう修正した。この修正前に
+ * 既にdriveFileIdが書き込まれているdocumentの中に、正規化後は同一人物になるが
+ * 異なる表記(customerName/careManagerName)でフォルダが作成/参照されている組が
+ * 残っていないかを確認する。
+ *
+ * 使用方法:
+ *   FIREBASE_PROJECT_ID=<project-id> node scripts/audit-drive-folder-space-variants.js
+ */
+
+const admin = require('firebase-admin');
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+if (!projectId) {
+  console.error('FIREBASE_PROJECT_ID を設定してください');
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+function stripInternalSpaces(name) {
+  return (name || '').replace(/[\s　]+/g, '');
+}
+
+function reportVariants(label, snap, field) {
+  const byNormalized = new Map();
+  snap.forEach((doc) => {
+    const value = doc.data()[field];
+    if (!value) return;
+    const normalized = stripInternalSpaces(value);
+    if (!normalized) return;
+    if (!byNormalized.has(normalized)) byNormalized.set(normalized, new Set());
+    byNormalized.get(normalized).add(value);
+  });
+
+  let foundAny = false;
+  for (const [normalized, variants] of byNormalized.entries()) {
+    if (variants.size > 1) {
+      foundAny = true;
+      console.log(
+        `[${label}] 表記ゆれ検出: 正規化後="${normalized}" 実際の表記=${JSON.stringify([...variants])}`
+      );
+    }
+  }
+  if (!foundAny) {
+    console.log(`[${label}] OK: driveFileId設定済みdocument間で表記ゆれの重複は検出されませんでした`);
+  }
+}
+
+async function main() {
+  const snap = await db.collection('documents').get();
+  const exported = snap.docs.filter((doc) => !!doc.data().driveFileId);
+  console.log(`documents全件: ${snap.size} / driveFileId設定済み: ${exported.length}`);
+
+  reportVariants('customerName', exported, 'customerName');
+  reportVariants('careManagerName', exported, 'careManagerName');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## 背景

クライアントから「利用者フォルダの命名は、姓名間スペース(全角/半角/無し)の実データパターン次第でやってみないと分からないのでは」という懸念が寄せられた。

これを検証した結果、Drive連携のフォルダ検索(`findOrCreateFolder.ts`)はGoogle Drive APIへの完全一致クエリのため、`AmbiguousFolderError`は同一の完全一致文字列で2件以上ヒットした場合にのみ発火し、姓名間スペースの有無による表記ゆれ(実データ確認例: kanameoneの「鬼頭 京子」/「鬼頭京子」、PR #741で検出)は検知対象外だった。この場合エラーにはならず、同一人物に対して気づかれないまま別々のフォルダが作成/参照されうる状態だった。

## 変更内容

`resolveCustomerSegment`/`resolveCareManagerSegment`で、trim後に内部の空白(半角/全角)を除去し、表記ゆれのある同一人物が常に同じフォルダ名に解決されるようにした。

## Test plan

- [x] `functions/test/folderPath.test.ts`: 既存25件 + 新規4件(半角/全角スペース表記ゆれのcustomer/careManager両セグメントでの吸収)、計29件 PASS
- [x] `npm test`(functions unit test全体): 1969 passing / 0 failing
- [x] `firebase emulators:exec --only firestore` 経由でDrive関連integration test(exportDocumentIntegration/findOrCreateFolderIntegration/driveExportTriggerIntegration): 62 passing / 0 failing(回帰なし)
- [x] `npm run build`(tsc): エラーなし
- [x] dev環境実データ監査(`scripts/audit-drive-folder-space-variants.js`、GitHub Actions経由): driveFileId設定済み2件間で表記ゆれの重複なしを確認

Closes なし(現時点でIssue未起票、実データ監査・調査から直接着手)

## 既知のトレードオフ (/code-review low 指摘、2026-07-28)

内部スペースを除去して「同一人物の表記ゆれ」を同一フォルダに収束させる設計は、理論上「姓名の漢字表記が完全一致し、かつスペース有無だけが異なる別人2名」も同一フォルダ名に収束させてしまう(別人のフォルダが意図せず共有される)。

調査の結果、既存の同姓同名衝突検知(`shared/customerIdentity.ts`の`findSameNameCollisionNames`)も名前を`.trim()`のみで比較しており、このケースは元々検知できていなかった(今回の修正で新規に生まれたリスクではなく、修正前から潜在していたギャップ)。`findSameNameCollisionNames`はOCR顧客紐付け(`ocrProcessor.ts`)・FAX重複検知(`faxDuplication.ts`)・FEの同姓同名UI(`DocumentDetailModal.tsx`等)にまたがる横断利用のため、本PRの範囲でスペース正規化を拡張するのは影響範囲が広すぎると判断し見送った。実例は現時点で未確認(理論上のケース)。フォローアップは別Issueで追跡する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
