### PR TITLE
fix(setup): 新規テナントセットアップにDrive/Picker API有効化を追加

### DIFF
--- a/scripts/setup-tenant.sh
+++ b/scripts/setup-tenant.sh
@@ -327,6 +327,8 @@ APIS=(
     "cloudscheduler.googleapis.com"
     "cloudbuild.googleapis.com"
     "identitytoolkit.googleapis.com"
+    "drive.googleapis.com"
+    "picker.googleapis.com"
 )
 
 for api in "${APIS[@]}"; do


### PR DESCRIPTION
## Summary
- kanameone環境でGoogle Drive連携のOAuth認証が`invalid_grant`エラーで失敗する不具合が発生(2026-07-29)。真因は`drive.googleapis.com`がkanameone/cocoro/dev全環境で未有効化だったこと(既存3環境は`gcloud services enable`で個別対応済み、本PRは対象外)
- `setup-tenant.sh`のAPI有効化リストに`picker.googleapis.com`のみあり`drive.googleapis.com`本体が漏れていたため、今後の新規テナント展開で同じ抜けが起きないよう追記

## Test plan
- [x] `bash -n scripts/setup-tenant.sh` で構文チェックPASS
- [ ] 次回の新規テナントセットアップ実行時に、Drive/Picker両APIが有効化されることを確認(doc/scriptのみの変更のため実機実行は次回セットアップ機会に委ねる)

Refs #755(関連する副次バグのIssue、本PRの対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Setup now enables Google Drive and Google Picker APIs automatically during project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->