### PR TITLE
docs(handoff): kanameone Drive OAuth不具合対応のセッションサマリーと中断点を記録

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -121,9 +121,19 @@ cocoro/kanameから、書類（ケアプラン・医療・介護保険証等）�
 
 ## 🔄 中断点（in-flight）
 
-なし。PR #752（利用者フォルダ名のスペース表記ゆれ正規化）は2026-07-28にマージ完了、kanameone・cocoro双方へFunctions反映済み（詳細は上記チェックリスト該当項目参照）。
+**対象タスク**: kanameone Drive連携OAuth不具合対応（2026-07-29、GOAL.md「進行中のtasks」該当項目参照）
 
-**次のアクション**: なし（このミッションは完了）。Phase C（kanameone/cocoroクライアント側Drive OAuth接続、外部依存）は引き続き先方実施待ち。将来ニーズとして「顧客マスター手動統合UI」が話題に上ったが、Drive Phase1がflag OFFの現状では実装の緊急性なし、Phase C/D完了後にDriveの実挙動を見てから設計する方針（実装は未着手・メモのみ）。
+**直前の状態**: kanameone担当者から「認証コードが無効または期限切れです」との不具合報告を受け調査、真因（`drive.googleapis.com`未有効化）を特定し、kanameone/cocoro/dev全3環境で`gcloud services enable drive.googleapis.com`を実行済み。dev環境では`seed-doc-0002`を使い実際にDriveエクスポートをトリガーし成功（`driveExportStatus:'exported'`）を実証済み。再発防止（PR #756）・GOAL.md教訓化（PR #757）・副次バグのIssue化（#755）は完了。**kanameone担当者へ再検証依頼文書（コピーボタン付きHTML、ローカル生成、リポジトリ非管理）を作成しdecision-makerが送付済み（2026-07-29）**。
+
+**次の一手**: kanameone担当者からの返信・再試行結果を待つ。返信が来たら以下の検証コマンドでCloud LoggingとFirestoreを確認し、実際に接続が成功したか（`settings/drive.authMode`/`connectedEmail`が新規に書き込まれているか）を実測で確認する。
+
+**検証コマンド**（再開時）:
+```bash
+gcloud functions logs read exchangeDriveAuthCode --project=docsplit-kanameone --account=hy.unimail.11@gmail.com --region=asia-northeast1 --gen2 --limit=20
+curl -s -X GET -H "Authorization: Bearer $(gcloud auth print-access-token --account=hy.unimail.11@gmail.com)" "https://firestore.googleapis.com/v1/projects/docsplit-kanameone/databases/(default)/documents/settings/drive"
+```
+
+**次のアクション**: 上記trigger（担当者からの返信）待ち。Phase C（kanameone/cocoroクライアント側Drive OAuth接続、外部依存）は引き続き先方実施待ち。将来ニーズとして「顧客マスター手動統合UI」が話題に上ったが、Drive Phase1がflag OFFの現状では実装の緊急性なし、Phase C/D完了後にDriveの実挙動を見てから設計する方針（実装は未着手・メモのみ）。
 
 **フォローアップ課題（Issue #753、P2・実害未確認）**: PR #752の`/code-review low`で「別人がスペース違いのみで同一漢字名の場合に誤って同一フォルダへ収束するリスク」が指摘された。既存の同姓同名衝突検知(`shared/customerIdentity.ts`の`findSameNameCollisionNames`)も同じくスペース非正規化のため元々検知できておらず、新規リスクではなく既存ギャップ。同関数はOCR紐付け(`ocrProcessor.ts`)・FAX重複検知(`faxDuplication.ts`)・同姓同名UIに跨る横断利用のため、拡張の要否は影響範囲評価込みで別Issueに切り出し済み。実例は現時点で未確認、着手判断はdecision-maker待ち。
 

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,6 +1,28 @@
 # ハンドオフメモ
 
-**更新日**: 2026-07-24（kanameone UXフィードバック①〜⑤対応 + セカンドオピニオン修正 + ヘルプ精度是正、Drive Phase1ミッションとは独立）
+**更新日**: 2026-07-29（kanameone Drive連携OAuth不具合対応・Phase B完了条件の教訓反映）
+
+## kanameone Drive連携OAuth不具合対応・Phase B完了条件の教訓反映（2026-07-29）
+
+kanameone担当者(katsumihiraide@kanameone.com)から「Google Driveと連携する」ボタン押下後「認証コードが無効または期限切れです」と表示され連携できない旨の実機スクリーンショット付き報告を受け調査した。
+
+**真因**: `drive.googleapis.com`（Google Drive API本体）がkanameone/cocoro/dev全3環境で未有効化だった。Phase Bで有効化していたのは`picker.googleapis.com`（フォルダ選択UI用）のみで、実データ操作用の本体APIが完了条件チェックリスト自体に含まれていなかった。
+
+**失敗メカニズム**（Cloud Loggingの実測ログで確認）: OAuth認可コード交換自体は成功するが、後続のDrive API疎通確認(`fetchConnectedEmail`)で`Google Drive API has not been used...or it is disabled`エラー発生→汎用`internal`エラーとしてFEに返る→`frontend/src/lib/callFunction.ts`の自動リトライが**使用済み認可コードで再送**→2回目は`invalid_grant`（非リトライ対象の`failed-precondition`）となりこれが最終的にユーザー画面へ表示、という2段階のエラー連鎖だった。
+
+**対処**: kanameone/cocoro/dev全3環境で`gcloud services enable drive.googleapis.com`を実行し解消（非破壊的操作）。dev環境では実際にFirestoreの`seed-doc-0002`を`verified:true`に更新してDriveエクスポートを実トリガーし、`driveExportStatus:'exported'`・`driveFileId`付与を確認、根本原因の解消をend-to-endで実証した。kanameone本番は担当者への再検証依頼文書（コピーボタン付きHTML、ローカル生成）を送付済み、実際の再試行結果は次回確認。
+
+**再発防止**: `scripts/setup-tenant.sh`のAPI有効化リストに`drive.googleapis.com`/`picker.googleapis.com`を追加（PR #756マージ済み）。GOAL.mdに教訓化したPhase B完了条件チェックリスト修正版を追記（PR #757マージ済み）。副次的に発見したリトライ設計課題（後続処理失敗時に使用済みOAuth codeで再送してしまう構造）はIssue #755として起票（P2、緊急性なし）。
+
+### Issue Net
+Net -1（Close 0件・起票1件(#755)）。#755は今回発見した副次的なリトライ設計課題の記録目的の起票で、triage基準（実バグ・再現条件明確）を満たす。本流の不具合対応自体は3環境のAPI有効化+dev環境でのend-to-end実証により完全に解決済みで、Net -1は品質改善の記録であり後退ではない。
+
+### 同根再発スキャン・対症療法判定（handoff §4.6/§4.7）
+- **同根候補を検出（STOP該当）**: 過去7日のアーカイブ(`docs/handoff/archive/2026-07-history.md:113`)に、2026-07-20のスパイクテスト時「GCP Console上でOAuth ClientへのlocalhostOrigin追加、**Drive API/Picker API有効化**、API Key制限へのAPI追加を実施」という記述がある。しかし今回の調査でdev環境は2026-07-29時点で`drive.googleapis.com`が未有効化だったと実測確認済みであり、この記述と矛盾する。
+- **真のroot causeの仮説（3つ以上）**: ①最も可能性が高い仮説: session137の「Drive API/Picker API有効化」という記述は実際には`picker.googleapis.com`のみを指す省略表現で、Drive API本体は最初から有効化されていなかった（＝今回発見した「2つのAPIの名前的混同」という認知パターンが、記録レベルで2026-07-20の時点から既に存在していた） ②2026-07-20のスパイクテスト後の後片付け（テストフォルダのゴミ箱移動等）の過程で誤ってAPI自体も無効化された ③プロジェクト請求先アカウント変更等でAPIが自動的にリセットされた（可能性は低い）
+- **もう1件同根が出るとしたらどの経路か**: 今回のPR #756でsetup-tenant.shに両API追加、PR #757でGOAL.mdにチェックリスト化したことで機械的な抜けは防止したが、手動のGCP Console操作（新規クライアントのPhase B相当作業やスパイク検証）に頼る限り、担当者が「Drive関連のAPI」を一括りに捉えて実際にはPicker APIしか有効化しない、という同じ認知パターンが再発しうる。GCP Console上でAPI名が似ているため、有効化直後の一覧確認（`gcloud services list --enabled | grep drive`）を都度実施する運用が必要
+- **対症療法判定**: 4基準（retry/fallback限定修正・外部要因調査欠如・過去30日同症状PR・smoke限定検証）いずれにも該当せず。修正は根本原因（プロジェクト単位のAPI有効化状態）を直接是正しており、検証もdev環境での実際のDrive書き込みend-to-end実証（smokeを超える水準）。「なぜ今起きたか」も、Phase C（kanameone担当者による実接続）が2026-07-29に初めて実施されたタイミングで初めてこのコードパスが本番相当条件で実行されたためと明確に説明できる
+- **結論**: 同根候補は「過去の記録の不正確さ」に起因するものであり、今回の対処（API有効化+チェックリスト化+スクリプト修正）で機械的な再発は防止済み。ただし手動オペレーション時の認知的混同リスクは完全には消えないため、次回同様のインフラ準備作業では`gcloud services list --enabled`での機械的突合を都度実施することを推奨する
 
 ## kanameone UXフィードバック①〜⑤対応 + セカンドオピニオン修正 + ヘルプページ精度是正（2026-07-24、Drive Phase1ミッションとは無関係の独立セッション）
 


### PR DESCRIPTION
## Summary
- LATEST.mdに本セッションの経緯（真因特定・3環境対処・dev実証・再発防止PR/Issue）を追記
- handoff §4.6同根再発スキャンで、2026-07-20のスパイクテスト時の記録（「Drive API/Picker API有効化」）と今回の実測（dev環境も未有効化だった）の矛盾を検出・記録。Picker API/Drive API混同という認知パターンが記録レベルで既に存在していた可能性を明記
- GOAL.mdの中断点を「kanameone担当者からの再試行結果待ち」に更新、再開時の検証コマンド（Cloud Logging・Firestore確認）を追記

## Test plan
- [x] docs onlyの変更のため実行確認は不要
- [x] Markdown構文上の崩れがないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)