### PR TITLE
ci(ops-script): backfill-drive-export --expected-count単独choiceを追加

### DIFF
--- a/.github/workflows/run-ops-script.yml
+++ b/.github/workflows/run-ops-script.yml
@@ -154,6 +154,8 @@ on:
           - set-drive-allowlist --remove
           - backfill-drive-export --dry-run --limit --expected-count
           - backfill-drive-export --limit --expected-count
+          - backfill-drive-export --dry-run --expected-count
+          - backfill-drive-export --expected-count
       backfill_limit:
         description: 'backfill-drive-export --limit: canary実行時のマーク上限件数(数値のみ)'
         required: false


### PR DESCRIPTION
## Summary
- Stage E2全展開は`--limit`を付けず`--expected-count`のみで残り全件をマークする設計だが、PR #766で追加したchoiceは`--limit`必須の組み合わせのみだった
- Parse段階の`--expected-count`値注入ロジックは`--limit`有無に依存しないため、choice追加のみで対応可能

## Test plan
- [x] `actionlint`でYAML構文検証（新規error 0件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)