### PR TITLE
docs(handoff): Drive Phase D Stage E2着手・進行中状況をGOAL.mdに記録

### DIFF
--- a/docs/handoff/GOAL.md
+++ b/docs/handoff/GOAL.md
@@ -148,7 +148,14 @@ cocoro/kanameから、書類（ケアプラン・医療・介護保険証等）�
 - `backfill-drive-export --limit 10 --expected-count 10`実行（実書込み）→ マーク成功10件、manifest出力・artifact保存済み（run 30630425182、artifact ID 8793144475）
 - 定期スイープ（15分毎）による実処理を待機後、状態分布を再確認: **exported 10件（9件が本canary由来+既存Stage D control test分1件）、error(顧客未確定)1件（同姓同名リスク対応の既存ガード、顧客確定後に自動再試行される想定内の状態）、実エラー0件**。race-safe書込み・manifest出力・スイープ連携が本番で正しく機能することを実測確認
 
-**次の一手**: Stage E2（全展開、kanameone残り約866件相当・約22時間drain見込み）は別途番号単位の明示認可が必要（長時間・監視を要するため自動連鎖しない設計）。cocoro側はPhase C（クライアントOAuth接続）が未完了のため対象外、外部依存で待機継続。
+**Stage E2着手・進行中（kanameone全展開、2026-07-31、decision-maker「Stage E2に進める」で着手）**:
+- インフラギャップ追加発見・解消: `--limit`なし単独の`--expected-count`choiceがGHA未登録だったためPR #768で追加
+- `set-drive-allowlist --remove`実行 → allowlist制限解除（フィールド削除、Stage D/E1時点の制限を撤廃）
+- `backfill-drive-export --dry-run --expected-count 1276`で全走査し候補1,276件を確認（期待値と一致）
+- `backfill-drive-export --expected-count 1276`実行（実書込み）→ **マーク成功1,276件**、manifest出力・artifact保存済み（runId=1e11a81f-d527-4079-8fa3-dc610717dabc）
+- 初回スイープ後(約16分経過時点)のスポットチェック: exported 19件(単調増加を確認)、backfillマーカー残1,256件、error(顧客未確定)6件、**実エラー6件(比率0.5%、異常停止基準20%を大幅に下回り健全)**。実エラー6件の内訳を個別確認し、全て既存データ不備由来(顧客未確定・フリガナ未設定・ケアマネ名未設定・書類日付未設定)でDrive連携コード自体のバグやAmbiguousFolderError等の異常スパイクではないことを実測確認
+
+**次の一手（監視継続、番号単位の追加認可は不要・自然経過を見守る）**: 定期スイープ(15分毎・10件/回)により残り約1,256件が自動でdrainされる(残存ペースなら数十時間規模の見込み、876件想定のrunbook記載22時間より母数が多いため長め)。次回セッション/catchup時に`drive-export-status-report`で状態分布を再確認し、①exported数が単調増加しているか②実エラー比率が20%を超えていないか③`AmbiguousFolderError`/`AmbiguousFile Error`等のspikeがないかを確認する。異常時は`set-feature-flag --flag driveExport --value false`で新規停止(in-flightは完走、Drive PDFは自動削除されない)。cocoro側はPhase C（クライアントOAuth接続）が未完了のため対象外、外部依存で待機継続。
 
 **副次的に残る判断事項**:
 - PR-D4 Phase A（read-only監査）: genesis provenance実装により`processed/`配下の残課題（495件、Issue #432被害候補）の真の救済可能性を把握する価値は残るが、優先度は下がった（96%はgenesisで既に解消見込みのため）


### PR DESCRIPTION
## Summary
- kanameone向けStage E2（全展開）を開始。allowlist解除+残り1,276件の全件マークに成功
- 初回スイープ後のスポットチェックでexported数の単調増加・実エラー比率0.5%（異常停止基準20%を大幅に下回る）・エラー内訳が全て既存データ不備由来であることを確認
- 残りは定期スイープによる自然経過のdrainで次回セッション/catchup時に監視を引き継ぐ

## Test plan
- [x] docs-onlyのため構文確認のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)