### PR TITLE
fix(oauth): 認証コード交換のリトライを無効化し誤ったエラー表示を防ぐ (#755)

### DIFF
--- a/frontend/src/lib/__tests__/callFunction.test.ts
+++ b/frontend/src/lib/__tests__/callFunction.test.ts
@@ -159,4 +159,31 @@ describe('callFunction - リトライ動作 (silent-failure-hunterレビュー�
     expect(mockGetIdToken).not.toHaveBeenCalled()
     expect(mockCallableImpl).toHaveBeenCalledTimes(1)
   })
+
+  describe('options.retryable=false (Issue #755: OAuth認証コード交換の誤リトライ防止)', () => {
+    it.each(['unauthenticated', 'deadline-exceeded', 'internal'])(
+      'code=%s でもretryable:falseならリトライせず元のエラーをthrowする',
+      async (code) => {
+        const err = makeFunctionsError(code, 'transient failure')
+        mockCallableImpl.mockRejectedValueOnce(err)
+
+        await expect(
+          callFunction('exchangeDriveAuthCode', {}, { retryable: false })
+        ).rejects.toBe(err)
+        expect(mockGetIdToken).not.toHaveBeenCalled()
+        expect(mockCallableImpl).toHaveBeenCalledTimes(1)
+      }
+    )
+
+    it('retryable省略時(デフォルト)は従来通りcode=internalでリトライする(後方互換)', async () => {
+      const err = makeFunctionsError('internal', 'network blip')
+      mockCallableImpl
+        .mockRejectedValueOnce(err)
+        .mockResolvedValueOnce({ data: { success: true } })
+
+      await expect(callFunction('splitPdf', {})).resolves.toEqual({ success: true })
+      expect(mockGetIdToken).toHaveBeenCalledWith(true)
+      expect(mockCallableImpl).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/frontend/src/lib/callFunction.ts
+++ b/frontend/src/lib/callFunction.ts
@@ -48,11 +48,17 @@ function isRetryableError(err: unknown): boolean {
  * @param name - Cloud Function名
  * @param data - リクエストデータ
  * @param options.timeout - クライアント側タイムアウト（ms）。Cloud Functions側と合わせること。
+ * @param options.retryable - false指定時は自動リトライを完全に無効化する（デフォルトtrue）。
+ *   Issue #755: OAuth認証コード交換(exchangeGmailAuthCode/exchangeDriveAuthCode)は
+ *   codeが1回しか使えないため、'internal'等リトライ対象コードで失敗した場合でも
+ *   同一codeでの再送は必ず`invalid_grant`となり、後続処理側の本来のエラー
+ *   (例: 対象APIが未有効化)を「認証コードが無効または期限切れです」という
+ *   誤ったメッセージで覆い隠してしまう。
  */
 export async function callFunction<TReq, TRes>(
   name: string,
   data: TReq,
-  options?: { timeout?: number }
+  options?: { timeout?: number; retryable?: boolean }
 ): Promise<TRes> {
   const callable = httpsCallable<TReq, TRes>(
     functions,
@@ -64,7 +70,7 @@ export async function callFunction<TReq, TRes>(
     const result = await callable(data)
     return result.data
   } catch (err) {
-    if (isRetryableError(err) && auth.currentUser) {
+    if (options?.retryable !== false && isRetryableError(err) && auth.currentUser) {
       // silent-failure-hunterレビュー指摘: リトライ後の呼び出しをtry/catchで
       // 包んで元のerrをthrowすると、getCallableErrorCode/onErrorベースの
       // 分岐(Issue #621)がリトライ後の真のコード(例: already-exists)を

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -580,7 +580,7 @@ function GmailOAuthConnect() {
           const result = await callFunction<
             { code: string },
             { success: boolean; email: string }
-          >('exchangeGmailAuthCode', { code: response.code })
+          >('exchangeGmailAuthCode', { code: response.code }, { retryable: false })
 
           setSuccessEmail(result.email)
           await refetch()
@@ -751,7 +751,7 @@ function GoogleDriveConnect() {
           const result = await callFunction<
             { code: string },
             { success: boolean; email: string }
-          >('exchangeDriveAuthCode', { code: response.code })
+          >('exchangeDriveAuthCode', { code: response.code }, { retryable: false })
 
           setSuccessEmail(result.email)
           queryClient.invalidateQueries({ queryKey: DRIVE_SETTINGS_QUERY_KEY })


### PR DESCRIPTION
## Summary
- `exchangeGmailAuthCode`/`exchangeDriveAuthCode`はOAuth認証コードが1回しか使えないため、`internal`等リトライ対象コードで失敗した場合の自動リトライは同一codeでの再送となり必ず`invalid_grant`で失敗する
- この2回目の失敗（「認証コードが無効または期限切れです」）が最終的にユーザーへ表示され、後続処理側の本来のエラー（例: 対象APIが未有効化）を覆い隠していた（2026-07-29のkanameone障害調査で実際に発生・特定に時間を要した）
- `callFunction`に`retryable`オプションを追加し、両OAuth呼び出しでのみ無効化（他の既存呼び出し元への影響なし）

## Test plan
- [x] `callFunction.test.ts`に新規テスト4件追加（retryable:false時にunauthenticated/deadline-exceeded/internalいずれもリトライしないこと、省略時は従来通りリトライすることの後方互換確認）
- [x] `cd frontend && npx vitest run` → 33ファイル/517件全PASS
- [x] `cd frontend && npx tsc --noEmit` → エラーなし
- [x] `codex review --base main -c model_reasoning_effort=medium` → 指摘0件

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to disable automatic retries for selected operations.
  - Existing retry behavior remains enabled by default.

- **Bug Fixes**
  - OAuth setup actions now avoid unnecessary token refreshes and retries when authentication or service errors occur.

- **Tests**
  - Added coverage for retry-disabled behavior and the default retry flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->