### PR TITLE
fix(customer-identity): 同姓同名衝突検知にスペース表記ゆれ正規化を追加 (#753)

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -33,7 +33,7 @@ import { ExtractionInfoPopover } from '@/components/ExtractionInfoPopover'
 import { useDocument, useDocumentDetail, useReprocessDocument, useDistributionSiblingCount, resolveDetailFields } from '@/hooks/useDocuments'
 import { useDocumentEdit } from '@/hooks/useDocumentEdit'
 import { useCustomers, useOffices, useDocumentTypes, useCareManagers, useCustomerIdentityLookup } from '@/hooks/useMasters'
-import { resolveCustomerUnconfirmedReason } from '@shared/customerIdentity'
+import { resolveCustomerUnconfirmedReason, stripInternalSpaces } from '@shared/customerIdentity'
 import { useMasterAlias } from '@/hooks/useMasterAlias'
 import { useAliasLearningHistory, useInvalidateAliasLearningHistory } from '@/hooks/useAliasLearningHistory'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
@@ -611,9 +611,16 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
   // typeof c.name === 'string'ガード: useCustomers()はFirestore生データをname: doc.data().name as stringで
   // castしており実行時保証がない。name欠損マスターが1件でもあるとc.name.trim()がTypeErrorでモーダル自体が
   // クラッシュする(shared/customerIdentity.tsのfindSameNameCollisionNamesと同種のregression、Codex
-  // review-diff plan mode指摘で発覚、2026-07-26)
+  // review-diff plan mode指摘で発覚、2026-07-26)。
+  // stripInternalSpaces正規化後で比較する(Issue #753対応、2026-08-01): isSameNameCollision
+  // (findSameNameCollisionNames経由)が内部スペース表記ゆれ(例:「鬼頭 京子」/「鬼頭京子」)も
+  // 衝突として検出するよう拡張されたため、ここも同じ正規化で揃えないと「バッジは点灯するが
+  // 候補一覧が空」という不整合UIになる。
   const collidingMasters = isSameNameCollision && document
-    ? (customers ?? []).filter(c => typeof c.name === 'string' && c.name.trim() === (document.customerName ?? '').trim())
+    ? (customers ?? []).filter(c =>
+        typeof c.name === 'string'
+        && stripInternalSpaces(c.name.trim()) === stripInternalSpaces((document.customerName ?? '').trim())
+      )
     : []
 
   // ドキュメントが変わったらdownloadUrlをリセット

--- a/functions/src/drive/folderPath.ts
+++ b/functions/src/drive/folderPath.ts
@@ -7,6 +7,7 @@
  */
 
 import { DriveFolderSegment, DriveFolderTemplate, DRIVE_SEGMENT_SEPARATOR_DEFAULT } from '../../../shared/types';
+import { stripInternalSpaces } from '../../../shared/customerIdentity';
 
 /**
  * フリガナ欠損時のフォールバック挙動(`DriveSettings.furiganaFallback`)。
@@ -94,18 +95,6 @@ function joinInitialAndName(
 ): string {
   const separatorChar = separator === 'full' ? '　' : ' ';
   return `${initial}${separatorChar}${name}`;
-}
-
-/**
- * 姓名間の全角/半角スペース有無・欠落表記ゆれ(実データ確認例: 「鬼頭 京子」/「鬼頭京子」)は
- * customerName/careManagerNameに残ったまま`findOrCreateFolder`の完全一致クエリに渡ると、
- * 表記の違うレコードが同一人物でも別々のフォルダとして黙って作成/参照されてしまう
- * (AmbiguousFolderErrorは同一の完全一致文字列が2件以上ヒットした場合にのみ発火するため、
- * この表記ゆれ自体は検知対象外)。フォルダ名解決の入力段階で内部の空白を除去し、
- * 表記ゆれのある同一人物が常に同じフォルダ名に解決されるようにする。
- */
-function stripInternalSpaces(name: string): string {
-  return name.replace(/[\s　]+/g, '');
 }
 
 function resolveCareManagerSegment(

--- a/functions/test/customerIdentity.test.ts
+++ b/functions/test/customerIdentity.test.ts
@@ -106,6 +106,44 @@ describe('findSameNameCollisionNames', () => {
     expect(() => findSameNameCollisionNames(malformed)).to.not.throw();
     expect([...findSameNameCollisionNames(malformed)]).to.deep.equal(['田中太郎']);
   });
+
+  it('内部スペース有無の表記ゆれ(例:「鬼頭 京子」/「鬼頭京子」)は正規化後に同名衝突とみなし、両方のraw表記を結果に含める(Issue #753対応、2026-08-01)', () => {
+    const result = findSameNameCollisionNames([
+      { name: '鬼頭 京子' },
+      { name: '鬼頭京子' },
+    ]);
+    expect([...result].sort()).to.deep.equal(['鬼頭京子', '鬼頭 京子'].sort());
+  });
+
+  it('全角スペースの表記ゆれも正規化後に同名衝突とみなす', () => {
+    const result = findSameNameCollisionNames([
+      { name: '鬼頭　京子' },
+      { name: '鬼頭京子' },
+    ]);
+    expect([...result].sort()).to.deep.equal(['鬼頭京子', '鬼頭　京子'].sort());
+  });
+
+  it('表記ゆれの相手が存在しない(1件のみ)場合は衝突扱いにしない', () => {
+    const result = findSameNameCollisionNames([{ name: '鬼頭 京子' }]);
+    expect(result.size).to.equal(0);
+  });
+
+  it('同一表記2件(従来ケース)は表記ゆれ拡張後も引き続き衝突として検出する(regression)', () => {
+    const result = findSameNameCollisionNames([
+      { name: '田中太郎' },
+      { name: '田中太郎' },
+    ]);
+    expect([...result]).to.deep.equal(['田中太郎']);
+  });
+
+  it('3表記混在(完全一致2件+表記ゆれ1件)は正規化キー配下の全variantを結果に含める', () => {
+    const result = findSameNameCollisionNames([
+      { name: '鬼頭 京子' },
+      { name: '鬼頭 京子' },
+      { name: '鬼頭京子' },
+    ]);
+    expect([...result].sort()).to.deep.equal(['鬼頭京子', '鬼頭 京子'].sort());
+  });
 });
 
 describe('precheckCustomerIdentity', () => {

--- a/shared/customerIdentity.ts
+++ b/shared/customerIdentity.ts
@@ -135,14 +135,33 @@ export function isValidCustomerSelection(name: string | null | undefined): boole
 }
 
 /**
- * 顧客マスター一覧から、同名(完全一致)が2件以上存在する名前の集合を返す。
+ * 姓名間の全角/半角スペース有無・欠落表記ゆれ(実データ確認例: 「鬼頭 京子」/「鬼頭京子」)を
+ * 除去する正規化。`functions/src/drive/folderPath.ts`のフォルダ名解決入力と
+ * `findSameNameCollisionNames`の同名衝突判定が同じ正規化を必要とするため(Issue #753、
+ * 2026-08-01)、重複実装を避けてここに集約する。folderPath.ts側はここからimportする。
+ */
+export function stripInternalSpaces(name: string): string {
+  return name.replace(/[\s　]+/g, '');
+}
+
+/**
+ * 顧客マスター一覧から、同名衝突(スペース表記ゆれを正規化した上で2件以上)が存在する
+ * 「生のtrimmed名」(表記ゆれのバリアント全て)の集合を返す。
  *
  * 「同姓同名の別人が同一 Drive フォルダへ合流するリスク」の判定に使う。マスターの
  * `isDuplicate` フラグ(登録時に自動付与されるが事後の追加・改名では更新されない)には
  * 依存せず、渡された一覧そのものから毎回数え直す。
+ *
+ * 戻り値は正規化後キーではなく生のtrimmed名を返す(Issue #753対応、2026-08-01):
+ * 呼出元(`useDocumentEdit.ts`/`faxDuplication.ts`/`resolveCustomerUnconfirmedReason`)は
+ * いずれも`.has(document.customerNameのtrimmed値)`という生の表記で照合するため、正規化後
+ * キーそのものを返しても照合に使えない。「鬼頭 京子」「鬼頭京子」のように内部スペースの
+ * 有無だけが異なる2件のマスターも同名衝突として検出できるよう、正規化キーでグルーピングした
+ * 上で、そのグループに属する全ての生表記(variant)を結果Setに含める。
  */
 export function findSameNameCollisionNames(customers: Array<{ name: string }>): Set<string> {
   const counts = new Map<string, number>();
+  const rawVariantsByKey = new Map<string, Set<string>>();
   for (const c of customers) {
     // 呼出元の型`Array<{ name: string }>`は実行時保証がない。Firestoreの生データを
     // `as string`でキャストして渡す呼出元(useMasters.tsのfetchCustomers等)があるため、
@@ -155,7 +174,19 @@ export function findSameNameCollisionNames(customers: Array<{ name: string }>): 
     // (kanameone/cocoro双方)で前後空白付きnameが実在しないことは確認済み。addCustomer()の
     // normalizeName()・import-masters.jsのCSVパースが書込み時に既にtrimしているため)。
     const trimmed = c.name.trim();
-    counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
+    // 正規化キー(内部スペース除去後)でグルーピングする。総件数(count)はdistinct variant数
+    // ではなく生の出現回数で数える必要がある(同一表記2件の従来ケースをdistinct=1で
+    // 見逃さないため)。
+    const key = stripInternalSpaces(trimmed);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (!rawVariantsByKey.has(key)) rawVariantsByKey.set(key, new Set());
+    rawVariantsByKey.get(key)!.add(trimmed);
   }
-  return new Set([...counts].filter(([, count]) => count > 1).map(([name]) => name));
+  const result = new Set<string>();
+  for (const [key, count] of counts) {
+    if (count > 1) {
+      for (const raw of rawVariantsByKey.get(key)!) result.add(raw);
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary
- `findSameNameCollisionNames`が姓名の内部スペース有無(例:「鬼頭 京子」/「鬼頭京子」)を別名扱いしており、表記ゆれだけの同姓同名衝突を見逃していた(Issue #753調査コメント参照)
- `functions/src/drive/folderPath.ts`にローカル定義されていた`stripInternalSpaces`を`shared/customerIdentity.ts`へ移設・export し、フォルダ名解決と同名衝突判定で正規化ロジックを共有する
- `findSameNameCollisionNames`を正規化キー(内部スペース除去後)でグルーピングし、キー配下の生表記(表記ゆれバリアント全て)を結果Setへ含める方式に変更。呼出し元は生のtrimmed文字列で照合するため、正規化キー自体ではなく全variantを返す設計
- `DocumentDetailModal.tsx`の候補一覧`collidingMasters`フィルタも同じ正規化に揃え、「バッジは点灯するが候補一覧が空」という不整合UIを防止(調査で発見した副次的なギャップ)

## スコープ外(Issue #753調査コメントで明記済み)
- `customerAmbiguityGate.ts`のBE Drive export gate側のライブクエリ(独立したFirestore完全一致クエリ)は本PRの対象外。実フォルダ衝突防止の観点では別Issueの論点

## Test plan
- [x] `cd functions && npm test -- --grep "findSameNameCollisionNames|resolveFolderSegments|precheckCustomerIdentity|resolveCustomerUnconfirmedReason|isValidCustomerSelection"` → 67件全PASS(新規表記ゆれケース5件含む)
- [x] `cd functions && npm test` → 2001件全PASS(regressionなし)
- [x] `cd functions && npx tsc --noEmit` → エラーなし
- [x] `cd frontend && npm test` → 33ファイル517件全PASS
- [x] `cd frontend && npm run typecheck` → エラーなし
- [x] ブラウザ確認(Playwright MCP、ローカルemulator+dev環境): 表記ゆれ2件(「鬼頭 京子」/「鬼頭京子」)のテスト顧客マスター+未確定書類を投入し、詳細モーダルで「同姓同名」バッジ点灯と候補一覧2名分(フリガナ・担当ケアマネ併記)の表示を確認

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate customer-name detection by treating half-width and full-width internal spaces consistently.
  * Updated collision results to include all matching name variants, improving accuracy in customer selection and document workflows.
  * Preserved valid handling for unique names and exact duplicates.

* **Tests**
  * Added coverage for spacing variations, mixed formatting, duplicate names, and single-entry names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->