### PR TITLE
debug(inspect-document): provenance/drive-export調査用フィールドを出力に追加

### DIFF
--- a/scripts/inspect-document.js
+++ b/scripts/inspect-document.js
@@ -4,7 +4,8 @@
  *
  * Storage 404 / fileUrl 不整合 / 孤児ドキュメント等の調査に使用する。
  * documents コレクションを fileName 完全一致で検索し、エラー原因究明に必要な
- * フィールド一式（status / fileUrl / parentDocumentId / splitFromPages / pageRotations 等）
+ * フィールド一式（status / fileUrl / parentDocumentId / splitFromPages / pageRotations /
+ * provenance / provenanceBackfill / provenanceOrigin / driveExportStatus 等）
  * を JSON で出力する。書き込みは一切行わない。
  *
  * 使用方法:
@@ -75,6 +76,19 @@ function summarize(doc) {
     lastErrorMessage: d.lastErrorMessage,
     confirmedBy: d.confirmedBy,
     confirmedAt: tsToIso(d.confirmedAt),
+    // ADR-0016 (Issue #445 PR-D4 / genesis provenance) rotate gate 調査用。
+    provenance: d.provenance,
+    provenanceBackfill: d.provenanceBackfill,
+    provenanceOrigin: d.provenanceOrigin,
+    // ADR-0022 (Drive export) 調査用。
+    verified: d.verified,
+    customerId: d.customerId,
+    officeId: d.officeId,
+    driveExportStatus: d.driveExportStatus,
+    driveFileId: d.driveFileId,
+    driveExportedAt: tsToIso(d.driveExportedAt),
+    driveExportError: d.driveExportError,
+    driveExportRunId: d.driveExportRunId,
   };
 }
 


### PR DESCRIPTION
## Summary
- kanameoneからの2件の問い合わせ(Drive export未作成/回転時provenance欠落エラー)の調査で、`scripts/inspect-document.js`の出力に`provenance`/`provenanceBackfill`/`provenanceOrigin`(ADR-0016)および`verified`/`driveExportStatus`等(ADR-0022)が含まれておらず、read-only調査ができなかったため追加した。
- 動作確認: GitHub Actions `Run Operations Script`(kanameone, `inspect-document --doc-id`)で本ブランチを対象に実行し、追加フィールドが正しく出力されることを確認済み(run 30673807377)。

## Test plan
- [x] `node --check scripts/inspect-document.js` (構文確認)
- [x] GitHub Actions経由でkanameone環境に対し実行し、追加フィールドの出力を確認
- 書き込みを一切行わないread-onlyスクリプトのため、他のテストは対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)