### PR TITLE
perf(ocr): 事業所照合の重複計算とページ再パースをホイスト(挙動不変)

### DIFF
--- a/functions/src/ocr/ocrProcessor.ts
+++ b/functions/src/ocr/ocrProcessor.ts
@@ -260,7 +260,7 @@ export async function processDocument(
 
         console.log(`Processing page ${pageNumber}/${totalPages}`);
 
-        const pageBuffer = await extractPdfPage(buffer, i);
+        const pageBuffer = await extractPdfPage(pdfDoc, i);
         const result = await ocrWithGemini(pageBuffer, 'application/pdf', pageNumber);
 
         pageResults.push(buildPageResult(result, pageNumber, `Page ${pageNumber}/${totalPages}`));
@@ -938,9 +938,12 @@ export async function handleProcessingError(
 
 /**
  * PDFから単一ページを抽出
+ *
+ * PR3 (ADR-0023関連): 呼び出し元(processDocument)が既にページ数取得のためロード済みの
+ * PDFDocument を受け取る形に変更した(挙動不変)。旧実装はページごとに `PDFDocument.load()`
+ * でPDF全体を再パースしており、71ページなら71回のフルパースが発生していた。
  */
-async function extractPdfPage(pdfBuffer: Buffer, pageIndex: number): Promise<Buffer> {
-  const pdfDoc = await PDFDocument.load(pdfBuffer);
+async function extractPdfPage(pdfDoc: PDFDocument, pageIndex: number): Promise<Buffer> {
   const newPdf = await PDFDocument.create();
   const [copiedPage] = await newPdf.copyPages(pdfDoc, [pageIndex]);
   newPdf.addPage(copiedPage);

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -746,15 +746,23 @@ function extractKeywordsForMatching(text: string): string[] {
  * キーワードベースの類似度スコアを計算
  * マッチ率とマッチした文字数の両方を考慮
  *
- * @param ocrText OCRテキスト
+ * PR3 (ADR-0023関連, kanameone実測でofficeMatchMs=295秒/71ページ文書と判明): OCRテキスト側の
+ * キーワード抽出・正規化(extractKeywordsForMatching(ocrText) / normalizeForMatching(ocrText))は
+ * officeName に依存せず入力(ocrText)が同一である限り毎回同じ結果になるため、呼び出し元
+ * (extractOfficeCandidates)のループ外で1回だけ計算した値を受け取る形に変更した(挙動不変、
+ * 引数の受け渡し方法のみの変更)。旧実装は事業所マスター1件ごとにOCR全文(最大20万文字)への
+ * 正規化・キーワード抽出を再実行しており、マスター件数に比例してコストが増大する構造だった。
+ *
+ * @param ocrKeywords extractKeywordsForMatching(ocrText) の事前計算結果
+ * @param normalizedOcrText normalizeForMatching(ocrText) の事前計算結果
  * @param officeName 事業所名
  * @returns スコアオブジェクト
  */
 function calculateKeywordMatchScore(
-  ocrText: string,
+  ocrKeywords: string[],
+  normalizedOcrText: string,
   officeName: string
 ): { score: number; matchedLength: number } {
-  const ocrKeywords = extractKeywordsForMatching(ocrText);
   const officeKeywords = extractKeywordsForMatching(officeName);
 
   if (officeKeywords.length === 0) {
@@ -764,8 +772,6 @@ function calculateKeywordMatchScore(
   let matchedWeight = 0;
   let totalWeight = 0;
   let matchedLength = 0;
-
-  const normalizedOcrText = normalizeForMatching(ocrText);
 
   for (const officeKw of officeKeywords) {
     // キーワードの長さに応じた重み（長いキーワードほど重要）
@@ -839,6 +845,12 @@ export function extractOfficeCandidates(
   // exact match path から除外する (legitimate な短マスターは collision なしで通過する)
   const commonShortIds = computeCommonShortMasters(officeMasters);
 
+  // PR3 (ADR-0023関連): calculateKeywordMatchScore が事業所マスター1件ごとに再計算していた
+  // OCR全文側のキーワード抽出・正規化をループ外で1回だけ計算する(挙動不変)。ocrTextは
+  // このループ内で変化しないため、事業所間で完全に同一の値になる。
+  const ocrKeywordsForOfficeMatch = extractKeywordsForMatching(ocrText);
+  const normalizedOcrTextForOfficeMatch = normalizeForMatching(ocrText);
+
   // ファイル名プレフィックスの正規化（事業所名タイプの場合のみ使用）
   const useFilenameForMatching = filenameInfo && filenameInfo.prefixType === 'office_name';
   const filenamePrefix = useFilenameForMatching ? filenameInfo.normalizedPrefix : '';
@@ -904,7 +916,11 @@ export function extractOfficeCandidates(
 
     // 3. キーワードマッチング（事業所名の構成要素で照合）
     if (matchType === 'none') {
-      const keywordResult = calculateKeywordMatchScore(ocrText, office.name);
+      const keywordResult = calculateKeywordMatchScore(
+        ocrKeywordsForOfficeMatch,
+        normalizedOcrTextForOfficeMatch,
+        office.name
+      );
       if (keywordResult.score >= 70) {
         // キーワードマッチスコアをベースにして、マッチした文字数でボーナス
         // マッチした文字数が多いほど信頼度が高い

--- a/functions/test/ocrProcessorEarlyOwnershipCheckWiringContract.test.ts
+++ b/functions/test/ocrProcessorEarlyOwnershipCheckWiringContract.test.ts
@@ -63,7 +63,9 @@ describe('ocrProcessor PDFページOCRループ早期所有権チェック配線
 
   it('checkOcrRunStillOwned の呼出しが extractPdfPage / ocrWithGemini より前にある', () => {
     const checkCallIdx = pdfPageLoopBody.indexOf('await checkOcrRunStillOwned(');
-    const extractPdfPageIdx = pdfPageLoopBody.indexOf('await extractPdfPage(buffer, i)');
+    // PR3 (ADR-0023関連): extractPdfPage は毎ページ再パースを避けるため、bufferではなく
+    // ループ外で事前ロード済みの pdfDoc を受け取る形に変更した (挙動不変)。
+    const extractPdfPageIdx = pdfPageLoopBody.indexOf('await extractPdfPage(pdfDoc, i)');
     const ocrWithGeminiIdx = pdfPageLoopBody.indexOf("await ocrWithGemini(pageBuffer, 'application/pdf'");
     expect(checkCallIdx, 'checkOcrRunStillOwned呼出しが見つからない').to.be.greaterThan(-1);
     expect(extractPdfPageIdx, 'extractPdfPage呼出しが見つからない').to.be.greaterThan(checkCallIdx);


### PR DESCRIPTION
## Summary
- PR2(#781)デプロイ後のkanameone実機検証で、71ページ書類のOCR処理時に`officeMatchMs=295秒`(全体789秒の37%)が判明した。900秒予算に対し余裕がわずか111秒しかなく、マスター件数増加時の再発リスクが高いため、後処理の構造的なムダを削減する。
- `functions/src/utils/extractors.ts`: `calculateKeywordMatchScore`が事業所マスター1件ごと(kanameoneで981件)にOCR全文(最大20万文字)の正規化・キーワード抽出を再計算していた箇所を、`extractOfficeCandidates`のループ外で1回だけ計算する形にホイスト。`ocrText`はループ内で不変なため出力は完全に同一(挙動不変)。
- `functions/src/ocr/ocrProcessor.ts`: `extractPdfPage`がページごとにPDF全体を再パース(`PDFDocument.load`)していた箇所を、ループ冒頭で既にロード済みの`PDFDocument`を再利用する形に変更(71ページなら71回→1回のフルパースへ)。

いずれも純粋な引数受け渡し方法の変更のみ。

## Test plan
- [x] `cd functions && npm test` 全2008件PASS（`extractors.test.ts`のキーワードマッチング系列テスト・`#506`本番bugパターン回帰テスト含め無変更で全PASS = 挙動不変の証明）
- [x] 契約テスト`ocrProcessorEarlyOwnershipCheckWiringContract.test.ts`は新しい呼出しシグネチャ(`extractPdfPage(pdfDoc, i)`)に合わせて更新
- [x] dev環境にデプロイし、既存書類3件(3〜6ページ)を`seed-dev-data --force-pending`で再処理させ、`status: processed`・正しい`officeId`付与を確認(回帰なし)
- [ ] kanameone本番での`officeMatchMs`改善効果の実測確認は、マージ・デプロイ後に該当書類等で別途実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved PDF processing efficiency by avoiding repeated parsing during page-by-page OCR.
  * Optimized office matching to reduce repeated text processing while preserving existing results.
* **Tests**
  * Updated automated coverage to verify the optimized PDF OCR processing flow and validation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->