### PR TITLE
docs(ocr): Gemini 3.5 Flashのレート制限値を公式ドキュメントで再検証・修正

### DIFF
--- a/docs/context/gemini-rate-limiting.md
+++ b/docs/context/gemini-rate-limiting.md
@@ -2,23 +2,29 @@
 title: "Gemini APIレート制限設計"
 description: "Vertex AI Gemini 3.5 Flashのレート制限対策とコスト管理"
 status: completed
-updated: "2026-07-24"
+updated: "2026-08-02"
 ---
 
 # Gemini APIレート制限設計
 
 ## 1. Gemini 3.5 Flash レート制限
 
-### 1.1 制限値（2026年2月時点、Gemini 2.5 Flash運用時に策定。3.5移行後の再検証は未実施）
+### 1.1 制限値（2026-08-02、Vertex AI公式ドキュメント・モデルカードで再検証済み）
 
 | リソース | 制限 | 備考 |
 |---------|------|------|
-| RPM（Requests/分） | 1,000 | リージョン共通 |
-| TPM（Tokens/分） | 4,000,000 | 入力+出力 |
+| RPM（Requests/分） | **固定値なし（Dynamic Shared Quota）** | Gemini 2.0以降のモデルはDSQ化されており、旧来の固定RPM/TPM割り当ては廃止済み。全顧客で共有される容量プールから動的配分される（サービス品質は保証されない）。429発生時はリトライ／指数バックオフで対応（本ドキュメント§3） |
+| TPM（Tokens/分） | **固定値なし（Dynamic Shared Quota）** | 同上 |
 | TPD（Tokens/日） | 無制限 | 課金対象 |
-| 最大入力トークン | 1,048,576 | 約100万 |
-| 最大出力トークン | 8,192 | |
-| 最大画像サイズ | 20MB | PDF含む |
+| 最大入力トークン（コンテキストウィンドウ） | 1,048,576 | 約100万。Vertex AI公式モデルカードで確認済み、値に変更なし |
+| 最大出力トークン（モデル上限） | 65,536 | モデル自体の上限。旧記載の8,192はGemini 2.5 Flash時代の値の誤転記 |
+| 最大出力トークン（アプリ設定値） | **8,192**（`functions/src/utils/config.ts` `GEMINI_CONFIG.maxOutputTokens`） | モデル上限とは別に、Vertex AI暴走対策としてアプリ側で意図的に絞っている値（Issue #205）。上記モデル上限65,536とは目的が異なるため区別して管理する |
+| 最大ファイルサイズ（PDF、API/inlineData経由） | 50MB | doc-splitはページ単位でinlineData（`application/pdf`）送信（`functions/src/ocr/ocrProcessor.ts`）。旧記載の20MBは実際の制限値と不一致だった |
+| 最大ファイルサイズ（画像、inlineData経由） | 7MB | Cloud Storage経由の場合は30MB |
+
+> **出典**: [Vertex AI（Gemini Enterprise Agent Platform）Gemini 3.5 Flashモデルカード](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-5-flash)（2026-07-30更新）/ [割り当てとシステム上限](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/quotas) / [使用オプション](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/deploy/consumption-options)。2026-08-02にPlaywright実測で確認（`docs.cloud.google.com`はJSレンダリングのためWebFetch本文抽出不可、`tech-selection.md`の手順に従いブラウザ直接レンダリングで取得）。
+>
+> **未確定の注記**: 上記モデルカードの「サポートされるリージョン」表では、「標準従量課金（Standard PayGo）」の対応が `global` / `us` / `eu` のみ明記され、doc-split実運用リージョンの `asia-northeast1` が個別記載されていない。一方、kanameone/cocoro本番では `asia-northeast1` 固定（`functions/src/utils/config.ts` `GCP_CONFIG.location`）で日次OCR処理が現に稼働中であり、実害は確認されていない。表の記載意図（グローバルエンドポイント限定の話か、真にリージョナルStandard PayGo非対応かは不明）は二次情報のみで断定せず、次回の類似調査時に個別確認する。
 
 ### 1.2 OCR処理の想定トークン消費
 
@@ -38,10 +44,12 @@ updated: "2026-07-24"
 - 出力: 250 × 2,000 = 500,000 tokens
 - 合計: 2,000,000 tokens/日
 
-レート制限余裕:
-- RPM: 250 / (8h × 60min) = 0.5 RPM（余裕あり）
-- TPM: 2,000,000 / (8h × 60min) = 4,167 TPM（余裕あり）
+処理頻度の目安:
+- リクエスト数: 250 / (8h × 60min) ≈ 0.5 req/min
+- トークン量: 2,000,000 / (8h × 60min) ≈ 4,167 tokens/min
 ```
+
+> **注**: §1.1の通りRPM/TPMはDSQ化により固定値が存在しないため、上記は「レート制限に対する余裕」ではなく単純な処理頻度の参考値。実際のスロットリング要否は§2のトークンバケット実装とレスポンスの429エラー発生状況（`stats/gemini`の実測）で判断する。
 
 ## 2. スロットリング実装
 
@@ -347,6 +355,8 @@ interface GeminiLogEntry {
 
 ## 参照
 
-- Vertex AI Gemini Quotas: https://cloud.google.com/vertex-ai/generative-ai/docs/quotas
+- Vertex AI Gemini 3.5 Flash モデルカード: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-5-flash
+- Vertex AI 割り当てとシステム上限: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/quotas
+- Vertex AI 使用オプション（Dynamic Shared Quota概要含む）: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/deploy/consumption-options
 - エラーハンドリング: `context/error-handling-policy.md`
 - OCR処理: `functions/src/ocr/processOCR.ts`

--- a/functions/src/utils/rateLimiter.ts
+++ b/functions/src/utils/rateLimiter.ts
@@ -19,9 +19,15 @@ export interface RateLimiterConfig {
   minInterval: number; // リクエスト間の最小間隔（ms）
 }
 
-/** デフォルト設定（Gemini 2.5 Flash向け） */
+/**
+ * デフォルト設定
+ *
+ * Gemini 3.5 FlashはDynamic Shared Quota化により固定RPM/TPMが存在しない
+ * (docs/context/gemini-rate-limiting.md §1.1、2026-08-02公式再検証)。
+ * 以下は固定クォータの代替として、429を未然に防ぐための自主的な安全マージン。
+ */
 export const GEMINI_RATE_LIMIT_CONFIG: RateLimiterConfig = {
-  maxTokens: 100, // 安全マージンを持たせた値（実際は1000 RPM）
+  maxTokens: 100, // 安全マージンを持たせた値
   refillRate: 1.67, // 100/60秒
   minInterval: 600, // 最小600ms間隔
 };


### PR DESCRIPTION
## Summary
- `docs/context/gemini-rate-limiting.md` §1.1 の制限値をVertex AI公式ドキュメント（2026-08-02、Playwright実測でモデルカード・quotasページを直接確認）で再検証
  - RPM/TPM: Gemini 2.0以降はDynamic Shared Quota化されており固定値が存在しない旨に更新（旧「1,000 RPM / 4,000,000 TPM」は廃止済み構造）
  - 最大出力トークン: モデル上限は65,536（旧記載8,192はGemini 2.5 Flash時代の値の誤転記）。アプリ側の意図的な暴走対策キャップ8,192（Issue #205, `GEMINI_CONFIG.maxOutputTokens`）とは区別して記載
  - 最大ファイルサイズ: PDF(API/inlineData経由)は50MB（旧記載20MBは不一致）
- `functions/src/utils/rateLimiter.ts` のコメント「安全マージンを持たせた値（実際は1000 RPM）」を、DSQ化を踏まえた記述に修正（挙動不変、コメントのみ）

背景: `/catchup`で拾った積み残しタスク（GOAL.md起点、doc-audit 2026-08-01指摘）。Gemini 2.5→3.5 Flash移行（Issue #548, 2026-07-09）後、レート制限セクションの再検証が未実施だった。

## Test plan
- [x] `cd functions && npx tsc --noEmit -p .` PASS（コメントのみの変更で挙動影響なし）
- [x] 実コード変更が1ファイル・追加10行未満のため、`codex review`等のQuality Gate対象外（CLAUDE.md medium tier境界=実コード3ファイル以上 or 100行以上、未達）

🤖 Generated with [Claude Code](https://claude.com/claude-code)