### PR TITLE
perf(ocr): calculateKeywordMatchScoreのoverlapRatio判定を先行評価に変更(挙動不変)

### DIFF
--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -784,11 +784,15 @@ function calculateKeywordMatchScore(
       matchedLength += officeKw.length;
     } else {
       // 部分一致チェック（短すぎるサブストリングマッチを防ぐ）
+      // Issue #783 (H2): overlapRatio(長さ比較のみ、O(1))を先に判定し、falseなら
+      // 高コストなString#includes(O(文字列長))を評価せず次のocrKwへ進む。&&は元々
+      // 両条件が真の場合のみtrueになるため、判定順序を入れ替えても最終的なmatchedWeight/
+      // matchedLength/breakのタイミングは完全に不変(挙動不変、計算コストのみ削減)。
       for (const ocrKw of ocrKeywords) {
         const shorter = Math.min(ocrKw.length, officeKw.length);
         const longer = Math.max(ocrKw.length, officeKw.length);
         const overlapRatio = shorter / longer;
-        if ((ocrKw.includes(officeKw) || officeKw.includes(ocrKw)) && overlapRatio >= 0.65) {
+        if (overlapRatio >= 0.65 && (ocrKw.includes(officeKw) || officeKw.includes(ocrKw))) {
           matchedWeight += weight * 0.8;
           matchedLength += Math.min(ocrKw.length, officeKw.length);
           break;


### PR DESCRIPTION
## Summary
- Issue #783（calculateKeywordMatchScore内部のofficeごとループをさらに最適化(H2)）対応
- `functions/src/utils/extractors.ts` の部分一致チェックで、`&&`の左右を入れ替え、O(1)の`overlapRatio`判定を高コストな`String#includes`(O(文字列長)、最大2回)より先に評価するよう変更
- `&&`は両辺が真の場合のみtrueになるため、判定順序を入れ替えても最終的な`matchedWeight`/`matchedLength`/`break`のタイミングは完全に不変（挙動不変、計算コストのみ削減）

## 重要な追加調査結果（別Issueで起票予定）
本番相当データ（kanameone実測: 71ページ文書のOCR全文174,690文字 × 事業所マスター981件）でベンチマークしたところ、`calculateKeywordMatchScore`自体のコストは981回呼び出し合計**69.3ms**と、`extractOfficeCandidates`全体（約80,000ms）の**0.09%**に留まることが判明しました。Issue #783が想定していたボトルネック箇所は実測上ボトルネックではなく、真のボトルネックは別のステップ（ファジーマッチのスライディングウィンドウ、`extractOfficeCandidates`ステップ5）にあります。この点は別Issueとして起票します。

本PRの変更自体は数学的に完全等価な最適化であり、上記の発見とは独立して安全にマージ可能です。

## Test plan
- [x] `npx mocha --require ts-node/register --timeout 10000 'test/extractors.test.ts'` — 104 passing（変更前後で件数・内容とも同一）
- [x] `npx tsc --noEmit -p .` PASS
- [x] 実コード変更が1ファイル・追加5行のため、`codex review`等のQuality Gate対象外（CLAUDE.md medium tier境界=実コード3ファイル以上 or 100行以上、未達）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved keyword matching efficiency, reducing unnecessary processing while preserving existing matching behavior and scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->