### PR TITLE
perf(ocr): extractOfficeCandidatesのファジーマッチをbag distance branch-and-boundで最適化

### DIFF
--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -23,7 +23,7 @@ import {
   formatDateString,
   DateCandidate,
 } from './textNormalizer';
-import { similarityScore, SIMILARITY_THRESHOLDS } from './similarity';
+import { similarityScore, bestFuzzyWindowScore, SIMILARITY_THRESHOLDS } from './similarity';
 
 // Re-export for use in other modules
 export { normalizeForMatching } from './textNormalizer';
@@ -951,15 +951,20 @@ export function extractOfficeCandidates(
     }
 
     // 5. ファジーマッチ
+    // Issue #787: 素朴なスライディングウィンドウ実装は事業所981件×OCR全文15万文字超の
+    // 本番相当データで実測99.86%のコストを占めるボトルネックだった。bestFuzzyWindowScore
+    // (bag distanceによるbranch-and-bound + 静的floorスキップ、functions/src/utils/similarity.ts)
+    // に置き換える。floorは後段2つの観測点(下記ブースト分岐・candidates push分岐)未満の
+    // スコアが一切外部から観測されないことに基づく(この時点でscoreは常に0、
+    // filenameBoost>0ならminScore-10未満、そうでなければminScore未満のスコアは
+    // どちらの分岐にも到達しないため、floor未満として扱ってよい)。差分テストで
+    // 素朴な実装との完全一致を6000ケースで検証済み(similarityFuzzyWindow.test.ts)。
     if (matchType === 'none') {
-      const windowSize = Math.min(normalizedOfficeName.length + 5, matchingText.length);
-      for (let i = 0; i <= matchingText.length - windowSize; i++) {
-        const window = matchingText.slice(i, i + windowSize);
-        const fuzzyScore = similarityScore(window, normalizedOfficeName);
-        if (fuzzyScore > score) {
-          score = fuzzyScore;
-          matchType = 'fuzzy';
-        }
+      const floor = filenameBoost > 0 ? minScore - 10 : minScore;
+      const fuzzyScore = bestFuzzyWindowScore(matchingText, normalizedOfficeName, 5, floor);
+      if (fuzzyScore > 0) {
+        score = fuzzyScore;
+        matchType = 'fuzzy';
       }
     }
 

--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -970,12 +970,15 @@ export function extractOfficeCandidates(
 
     // ファイル名ボーナスを適用（スコアが閾値以上の場合のみ）
     // ファイル名だけでのマッチは避け、OCRでもある程度マッチした場合にブーストする
+    // (Issue #787: この `minScore - 10` は上記ステップ5のfloor算出根拠でもある。
+    //  ここを変更する場合はステップ5の`floor`算出ロジックも合わせて見直すこと)
     if (score >= minScore - 10 && filenameBoost > 0) {
       score = Math.min(100, score + filenameBoost);
       // ファイル名ブーストでスコアが閾値を超えた場合のみ候補に
     }
 
     // 閾値以上の場合、候補に追加
+    // (Issue #787: この `minScore` も上記ステップ5のfloor算出根拠。同上)
     if (score >= minScore) {
       candidates.push({
         id: office.id,

--- a/functions/src/utils/similarity.ts
+++ b/functions/src/utils/similarity.ts
@@ -26,37 +26,49 @@ export const SIMILARITY_THRESHOLDS = {
  * レーベンシュタイン距離を計算
  *
  * 2つの文字列間の編集距離を計算
+ *
+ * Issue #787: DPの漸化式は直前の1行しか参照しないため、O(a.length×b.length)の
+ * 2次元配列(行列)をO(min(a.length,b.length))の2行バッファに縮小した(rolling row)。
+ * 編集距離は対称(ed(a,b)=ed(b,a)。挿入と削除が互いに逆操作、置換は自己対称なため、
+ * 編集スクリプトを反転すれば同じコストの逆向きスクリプトになる)なので、短い方を
+ * バッファ長に使うため必要なら入れ替える。戻り値は旧実装と数学的に完全に同一。
  */
 export function levenshteinDistance(a: string, b: string): number {
   if (a.length === 0) return b.length;
   if (b.length === 0) return a.length;
 
-  const matrix: number[][] = [];
-
-  // 行列を初期化
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i];
+  // 対称性より、短い方をバッファ長(内側次元)にする
+  if (a.length > b.length) {
+    const tmp = a;
+    a = b;
+    b = tmp;
   }
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0]![j] = j;
-  }
+  const n = a.length; // n <= b.length
 
-  // 行列を埋める
+  let prev = new Int32Array(n + 1);
+  let cur = new Int32Array(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+
   for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      if (b.charAt(i - 1) === a.charAt(j - 1)) {
-        matrix[i]![j] = matrix[i - 1]![j - 1]!;
+    cur[0] = i;
+    const bChar = b.charCodeAt(i - 1);
+    for (let j = 1; j <= n; j++) {
+      if (bChar === a.charCodeAt(j - 1)) {
+        cur[j] = prev[j - 1]!;
       } else {
-        matrix[i]![j] = Math.min(
-          matrix[i - 1]![j - 1]! + 1, // 置換
-          matrix[i]![j - 1]! + 1, // 挿入
-          matrix[i - 1]![j]! + 1 // 削除
+        cur[j] = Math.min(
+          prev[j - 1]! + 1, // 置換
+          cur[j - 1]! + 1, // 挿入
+          prev[j]! + 1 // 削除
         );
       }
     }
+    const swap = prev;
+    prev = cur;
+    cur = swap;
   }
 
-  return matrix[b.length]![a.length]!;
+  return prev[n]!;
 }
 
 /**
@@ -71,6 +83,117 @@ export function similarityScore(a: string, b: string): number {
   const distance = levenshteinDistance(a, b);
   const maxLength = Math.max(a.length, b.length);
   return Math.round((1 - distance / maxLength) * 100);
+}
+
+/**
+ * テキスト中の固定幅スライディングウィンドウについて、needleとの最良ファジーマッチ
+ * スコアを探索する(Issue #787)。
+ *
+ * 素朴な実装(各ウィンドウ位置でtext.slice()して毎回similarityScore()を呼ぶ)と
+ * 数学的に完全に同一の結果を返す。等価性の根拠:
+ *
+ * 1. windowSize = min(needle.length + windowPad, text.length) はneedleごとに一定。
+ *    M = max(windowSize, needle.length) も一定であり、window(常にwindowSize文字)と
+ *    needleの類似度スコアは score(d) = round((1 - d/M) * 100) (d=編集距離) という
+ *    dについて単調非増加な関数になる(similarityScoreと同一式)。
+ * 2. bag distance(文字多重集合差分の下界) bag(window,needle) は編集距離の厳密な下界
+ *    (bag <= d が常に成立。1回の編集操作で文字の多重集合差分は高々1しか縮まらないため)。
+ *    windowの文字数は一定(windowSize)なので P-N(=文字超過数-文字不足数)は
+ *    windowSize-needle.lengthで一定となり、bag = N + max(windowSize-needle.length, 0)
+ *    (N=needleの文字のうちwindowに含まれない文字数)としてNだけを追跡すれば十分。
+ * 3. bagから決まるscoreの上界がこれまでの最良スコアを超えられないウィンドウは、
+ *    フルLevenshtein計算を行っても最良スコアを更新し得ない(scoreはdについて単調
+ *    非増加、bag<=dより score(bag)>=score(d))。よってこれらはスキップしてよい。
+ *
+ * @param text 探索対象の正規化済みテキスト
+ * @param needle 探索する正規化済み文字列(事業所名・顧客名等)
+ * @param windowPad ウィンドウ幅 = needle.length + windowPad (元実装のスライディング窓幅)
+ * @param minAcceptableScore この値未満のスコアは0として扱ってよい場合に指定する
+ *   (呼び出し元でその範囲のスコアが観測不可能であることを呼び出し元が保証すること)。
+ *   既定0は完全等価モード(素朴な実装と1件も違わない、needle自体が空の場合や
+ *   text.length<windowSizeとなる退化ケースも含めて元の`similarityScore`の特別扱いと
+ *   一致する)。
+ * @returns 最良スコア(0-100)。マッチなし、またはminAcceptableScore未満の場合は0
+ */
+export function bestFuzzyWindowScore(
+  text: string,
+  needle: string,
+  windowPad: number,
+  minAcceptableScore = 0
+): number {
+  const windowSize = Math.min(needle.length + windowPad, text.length);
+
+  // 元実装のfor条件 `i <= text.length - windowSize` が1回も回らないケース
+  if (windowSize > text.length) return 0;
+
+  // 退化ケース: ウィンドウが空文字列(このときi=0の1回のみ)。M=0でのゼロ除算を避けるため
+  // similarityScoreの特別扱い(a===b等)にそのまま委譲する。
+  if (windowSize === 0) {
+    const s = similarityScore('', needle);
+    return s > 0 ? s : 0;
+  }
+
+  const L = needle.length;
+  const M = Math.max(windowSize, L);
+
+  // 距離→スコアの変換テーブル。similarityScoreと同一式で丸めの一致を保証する。
+  const scoreByDist = new Int32Array(M + 1);
+  for (let d = 0; d <= M; d++) {
+    scoreByDist[d] = Math.round((1 - d / M) * 100);
+  }
+
+  let best = Math.max(0, minAcceptableScore - 1);
+  let updated = false;
+
+  // needleの文字ヒストグラム(needleに含まれる文字コードのみ追跡)
+  const needleCount = new Map<number, number>();
+  for (let k = 0; k < L; k++) {
+    const c = needle.charCodeAt(k);
+    needleCount.set(c, (needleCount.get(c) ?? 0) + 1);
+  }
+  // delta[c] = (windowでのcの出現数) - (needleでのcの出現数)。needleに出現する文字のみ管理。
+  const delta = new Map<number, number>();
+  for (const [c, cnt] of needleCount) delta.set(c, -cnt);
+  let n = L; // ウィンドウ未構築時点では全文字が不足 → N = L
+
+  const addChar = (c: number): void => {
+    if (!needleCount.has(c)) return;
+    const before = delta.get(c) ?? 0;
+    delta.set(c, before + 1);
+    if (before < 0) n--;
+  };
+  const removeChar = (c: number): void => {
+    if (!needleCount.has(c)) return;
+    const before = delta.get(c) ?? 0;
+    delta.set(c, before - 1);
+    if (before <= 0) n++;
+  };
+
+  // 初期ウィンドウ [0, windowSize) を構築
+  for (let k = 0; k < windowSize; k++) addChar(text.charCodeAt(k));
+
+  const wMinusL = Math.max(windowSize - L, 0);
+  const lastStart = text.length - windowSize;
+
+  for (let i = 0; i <= lastStart; i++) {
+    if (i > 0) {
+      removeChar(text.charCodeAt(i - 1));
+      addChar(text.charCodeAt(i + windowSize - 1));
+    }
+    const bag = n + wMinusL; // 常に 0 <= bag <= M (証明はコメント冒頭参照)
+    const upperBoundScore = scoreByDist[bag]!;
+    if (upperBoundScore > best) {
+      const window = text.slice(i, i + windowSize);
+      const d = levenshteinDistance(window, needle);
+      const s = scoreByDist[d]!;
+      if (s > best) {
+        best = s;
+        updated = true;
+      }
+    }
+  }
+
+  return updated ? best : 0;
 }
 
 /**

--- a/functions/src/utils/similarity.ts
+++ b/functions/src/utils/similarity.ts
@@ -123,7 +123,8 @@ export function bestFuzzyWindowScore(
 ): number {
   const windowSize = Math.min(needle.length + windowPad, text.length);
 
-  // 元実装のfor条件 `i <= text.length - windowSize` が1回も回らないケース
+  // 元実装のfor条件 `i <= text.length - windowSize` が1回も回らないケース。
+  // windowSize = Math.min(..., text.length) により通常は到達不能(防御的コード)。
   if (windowSize > text.length) return 0;
 
   // 退化ケース: ウィンドウが空文字列(このときi=0の1回のみ)。M=0でのゼロ除算を避けるため

--- a/functions/test/extractors.test.ts
+++ b/functions/test/extractors.test.ts
@@ -695,6 +695,65 @@ TEL: 052-509-2292
     }
   });
 
+  // Issue #787: ステップ5(ファジーマッチ)を実際に経由するcharacterization test。
+  // リポジトリ全体を検索してもこの経路(完全一致・キーワード一致・部分一致の全てに失敗し、
+  // スライディングウィンドウ+Levenshtein距離のみでマッチする経路)を実行するテストが
+  // 存在しなかったため、性能最適化(bag distance枝刈り等)着手前の安全網として追加する。
+  // スコアはgreaterThanではなく実測した具体的な数値で固定し、丸め・枝刈り境界のズレを検出する。
+  describe('Issue #787: ファジーマッチ(ステップ5)経由の候補抽出', () => {
+    it('1文字誤り(OCR誤読)でも閾値を超えてfuzzyマッチする(陽性ケース)', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'o1', name: '社会福祉法人みどり会介護老人保健施設あおばの丘', isDuplicate: false },
+      ];
+      // 「人」→「八」の1文字誤り。完全一致・キーワード一致・部分一致のいずれにも該当しない
+      const ocrText = '送付先: 社会福祉法人みどり会介護老八保健施設あおばの丘 様';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      expect(result.bestMatch).to.not.be.null;
+      expect(result.bestMatch!.id).to.equal('o1');
+      expect(result.bestMatch!.score).to.equal(79);
+      expect(result.bestMatch!.matchType).to.equal('fuzzy');
+    });
+
+    it('短い事業所名は誤読があってもファジーマッチの閾値に届かない(陰性ケース)', () => {
+      const testMasters: OfficeMaster[] = [
+        { id: 'o1', name: '特別養護老人ホームさくらのさと', isDuplicate: false },
+      ];
+      const ocrText = '当該書類の送付先は 特別養護老八ホームさくらのさと 御中 です';
+      const result = extractOfficeCandidates(ocrText, testMasters);
+
+      expect(result.candidates).to.have.lengthOf(0);
+      expect(result.bestMatch).to.be.null;
+    });
+
+    it('ファジーマッチ単体では閾値未満だが、filenameInfoブーストで閾値を超えて候補になる', () => {
+      const officeName = '介護支援センターさくら';
+      const testMasters: OfficeMaster[] = [{ id: 'o1', name: officeName, isDuplicate: false }];
+      const ocrText = 'A介語支援センタ差くらB';
+
+      // ブーストなし: 閾値(70)未満のため候補なし
+      const withoutBoost = extractOfficeCandidates(ocrText, testMasters);
+      expect(withoutBoost.candidates).to.have.lengthOf(0);
+
+      // ブーストあり: filenamePrefixが事業所名を包含 → filenameBoost=15
+      // 元スコア(62) + 15 = 77 で閾値を超える。この境界(score>=minScore-10でのみブースト適用)は
+      // ステップ5をヘルパ化する際、floorをminScoreではなくminScore-10にする実装ミスを検出する
+      // 唯一のテストケースであるため重要。
+      const withBoost = extractOfficeCandidates(ocrText, testMasters, {
+        filenameInfo: {
+          prefix: officeName,
+          prefixType: 'office_name',
+          normalizedPrefix: officeName,
+          originalFilename: `${officeName}-L1-20260101120000.pdf`,
+        },
+      });
+      expect(withBoost.bestMatch).to.not.be.null;
+      expect(withBoost.bestMatch!.id).to.equal('o1');
+      expect(withBoost.bestMatch!.score).to.equal(77);
+      expect(withBoost.bestMatch!.matchType).to.equal('fuzzy');
+    });
+  });
+
   // #501 v2: 短文字列マスター ("ケア" / "ニック" 等) が長マスター name の substring に
   // 頻出する場合 (collision >= 2) は「common short master」と判定し exact match から除外。
   // length 単独でなく collision 数で動的判定するため legitimate 短マスター ("ピース" "てらす"

--- a/functions/test/similarityFuzzyWindow.test.ts
+++ b/functions/test/similarityFuzzyWindow.test.ts
@@ -1,0 +1,129 @@
+/**
+ * bestFuzzyWindowScore のオラクル差分テスト (Issue #787)
+ *
+ * 素朴なスライディングウィンドウ実装(オラクル)との出力比較により、
+ * bag distance branch-and-bound + 静的floorスキップが元の挙動と
+ * 完全に等価であることを機械的に検証する。
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { bestFuzzyWindowScore, similarityScore } from '../src/utils/similarity';
+
+// 素朴な実装(素朴なスライディングウィンドウ + 毎回similarityScore呼び出し)。
+// extractors.ts のステップ5・extractCustomerCandidates 等の元実装と同一のロジック。
+function naiveBestFuzzyWindowScore(text: string, needle: string, windowPad: number): number {
+  const windowSize = Math.min(needle.length + windowPad, text.length);
+  let best = 0;
+  for (let i = 0; i <= text.length - windowSize; i++) {
+    const window = text.slice(i, i + windowSize);
+    const s = similarityScore(window, needle);
+    if (s > best) best = s;
+  }
+  return best;
+}
+
+// 線形合同法(LCG)による決定的疑似乱数。Math.randomは使わない(再現性のため)。
+function makeLcg(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+function randomString(rand: () => number, alphabet: string, maxLen: number): string {
+  const len = Math.floor(rand() * (maxLen + 1));
+  let s = '';
+  for (let i = 0; i < len; i++) {
+    s += alphabet[Math.floor(rand() * alphabet.length)];
+  }
+  return s;
+}
+
+describe('bestFuzzyWindowScore', () => {
+  describe('完全等価モード(minAcceptableScore=0)', () => {
+    it('ランダムなtext/needleペア4000件でオラクルと完全一致する', () => {
+      const rand = makeLcg(20260803);
+      // アルファベットは小さく保ち、近似一致(fuzzy経路への到達)頻度を上げる
+      const alphabet = 'abcあいう介護支援センターさくら';
+      for (let i = 0; i < 4000; i++) {
+        const text = randomString(rand, alphabet, 60);
+        const needle = randomString(rand, alphabet, 20);
+        const pad = [0, 3, 5][Math.floor(rand() * 3)]!;
+        const expected = naiveBestFuzzyWindowScore(text, needle, pad);
+        const actual = bestFuzzyWindowScore(text, needle, pad, 0);
+        expect(actual, `text=${JSON.stringify(text)} needle=${JSON.stringify(needle)} pad=${pad}`).to.equal(
+          expected
+        );
+      }
+    });
+
+    it('needleが空文字列の場合は常に0(オラクルと一致)', () => {
+      expect(bestFuzzyWindowScore('何らかのテキスト', '', 5)).to.equal(
+        naiveBestFuzzyWindowScore('何らかのテキスト', '', 5)
+      );
+      expect(bestFuzzyWindowScore('何らかのテキスト', '', 5)).to.equal(0);
+    });
+
+    it('textが空文字列の場合(退化ケース)もオラクルと一致する', () => {
+      expect(bestFuzzyWindowScore('', '', 5)).to.equal(naiveBestFuzzyWindowScore('', '', 5));
+      expect(bestFuzzyWindowScore('', 'なにか', 5)).to.equal(naiveBestFuzzyWindowScore('', 'なにか', 5));
+    });
+
+    it('textがwindowSizeより短い場合(ループ0回)もオラクルと一致する', () => {
+      const text = 'あ';
+      const needle = '介護支援センターさくら';
+      expect(bestFuzzyWindowScore(text, needle, 5)).to.equal(naiveBestFuzzyWindowScore(text, needle, 5));
+      expect(bestFuzzyWindowScore(text, needle, 5)).to.equal(0);
+    });
+
+    it('サロゲートペアを含む文字列でもオラクルと一致する', () => {
+      const cases: Array<[string, string, number]> = [
+        ['送付先は𠮷田太郎様です', '𠮷田太郎', 5],
+        ['送付先は吉田太郎様です', '𠮷田太郎', 5],
+        ['𠮷𠮷𠮷𠮷𠮷', '𠮷𠮷𠮷', 3],
+      ];
+      for (const [text, needle, pad] of cases) {
+        expect(bestFuzzyWindowScore(text, needle, pad)).to.equal(naiveBestFuzzyWindowScore(text, needle, pad));
+      }
+    });
+
+    it('windowPad=0でneedleと完全一致するウィンドウがあれば100を返す', () => {
+      // windowSize = needle.length + windowPad なので、pad>0だと窓が常にneedleより
+      // 長くなり完全一致(距離0)にはなり得ない。pad=0の場合のみdistance=0が実現しうる。
+      const needle = '株式会社テストケア';
+      const text = `送付先${needle}御中`;
+      expect(bestFuzzyWindowScore(text, needle, 0)).to.equal(100);
+    });
+  });
+
+  describe('floorモード(minAcceptableScore>0)', () => {
+    it('ランダムなtext/needleペア2000件で「floor以上ならオラクルと同値、未満なら0」を満たす', () => {
+      const rand = makeLcg(78120260803);
+      const alphabet = 'abcあいう介護支援センターさくら';
+      for (let i = 0; i < 2000; i++) {
+        const text = randomString(rand, alphabet, 60);
+        const needle = randomString(rand, alphabet, 20);
+        const pad = [0, 3, 5][Math.floor(rand() * 3)]!;
+        const floor = 50 + Math.floor(rand() * 40); // 50-89
+        const oracle = naiveBestFuzzyWindowScore(text, needle, pad);
+        const expected = oracle >= floor ? oracle : 0;
+        const actual = bestFuzzyWindowScore(text, needle, pad, floor);
+        expect(
+          actual,
+          `text=${JSON.stringify(text)} needle=${JSON.stringify(needle)} pad=${pad} floor=${floor} oracle=${oracle}`
+        ).to.equal(expected);
+      }
+    });
+
+    it('floorちょうどのスコアは含まれる(境界off-by-oneの検出)', () => {
+      // 事前に発見した実際の境界ケース: 62点(ブーストなしでは非マッチ)のペア
+      const needle = '介護支援センターさくら';
+      const text = 'A介語支援センタ差くらB';
+      const oracle = naiveBestFuzzyWindowScore(text, needle, 5);
+      expect(bestFuzzyWindowScore(text, needle, 5, oracle)).to.equal(oracle); // floor=oracleちょうど → 含まれる
+      expect(bestFuzzyWindowScore(text, needle, 5, oracle + 1)).to.equal(0); // floor=oracle+1 → 除外される
+    });
+  });
+});

--- a/functions/test/utils.test.ts
+++ b/functions/test/utils.test.ts
@@ -33,6 +33,77 @@ describe('Similarity Utilities', () => {
     it('日本語も正しく計算', () => {
       expect(levenshteinDistance('山田太郎', '山田次郎')).to.equal(1);
     });
+
+    // Issue #787: rolling row化(O(min(n,m))バッファ)への置換に伴うオラクル差分テスト。
+    // 旧実装(フルO(n×m)行列)の逐語コピーを比較対象とし、決定的PRNG(線形合同法)で
+    // 生成した多数のランダム文字列ペアで戻り値が完全一致することを確認する。
+    describe('rolling row実装のオラクル差分テスト', () => {
+      function naiveLevenshteinDistance(a: string, b: string): number {
+        if (a.length === 0) return b.length;
+        if (b.length === 0) return a.length;
+        const matrix: number[][] = [];
+        for (let i = 0; i <= b.length; i++) matrix[i] = [i];
+        for (let j = 0; j <= a.length; j++) matrix[0]![j] = j;
+        for (let i = 1; i <= b.length; i++) {
+          for (let j = 1; j <= a.length; j++) {
+            if (b.charAt(i - 1) === a.charAt(j - 1)) {
+              matrix[i]![j] = matrix[i - 1]![j - 1]!;
+            } else {
+              matrix[i]![j] = Math.min(
+                matrix[i - 1]![j - 1]! + 1,
+                matrix[i]![j - 1]! + 1,
+                matrix[i - 1]![j]! + 1
+              );
+            }
+          }
+        }
+        return matrix[b.length]![a.length]!;
+      }
+
+      // 線形合同法(LCG)による決定的疑似乱数。テスト実行環境間で再現性を持たせるため
+      // Math.randomは使わない。
+      function makeLcg(seed: number): () => number {
+        let state = seed >>> 0;
+        return () => {
+          state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+          return state / 0xffffffff;
+        };
+      }
+
+      function randomString(rand: () => number, alphabet: string, maxLen: number): string {
+        const len = Math.floor(rand() * (maxLen + 1));
+        let s = '';
+        for (let i = 0; i < len; i++) {
+          s += alphabet[Math.floor(rand() * alphabet.length)];
+        }
+        return s;
+      }
+
+      it('ランダム文字列ペア4000件で旧実装(オラクル)と完全一致する', () => {
+        const rand = makeLcg(20260803);
+        // アルファベットは小さく保ち、近似一致(部分的に共通する文字列)の発生頻度を上げる
+        const alphabet = 'abcあいう';
+        for (let i = 0; i < 4000; i++) {
+          const a = randomString(rand, alphabet, 20);
+          const b = randomString(rand, alphabet, 20);
+          expect(levenshteinDistance(a, b), `a=${JSON.stringify(a)} b=${JSON.stringify(b)}`).to.equal(
+            naiveLevenshteinDistance(a, b)
+          );
+        }
+      });
+
+      it('サロゲートペアを含む文字列でも旧実装と完全一致する', () => {
+        const cases: Array<[string, string]> = [
+          ['𠮷田太郎', '吉田太郎'],
+          ['𠮷野家', '𠮷野家'],
+          ['a𠮷b', 'a吉b'],
+          ['𠮷𠮷𠮷', ''],
+        ];
+        for (const [a, b] of cases) {
+          expect(levenshteinDistance(a, b)).to.equal(naiveLevenshteinDistance(a, b));
+        }
+      });
+    });
   });
 
   describe('similarityScore', () => {

--- a/scripts/bench-office-matching.ts
+++ b/scripts/bench-office-matching.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env ts-node
+/**
+ * extractOfficeCandidates 性能ベンチマーク (Issue #787)
+ *
+ * ファジーマッチ(ステップ5)最適化(bestFuzzyWindowScore、bag distance branch-and-bound)の
+ * 効果を、本番相当スケールの合成データで計測する。本番データ・ネットワーク・認証には
+ * 一切依存しない(シード固定PRNGで決定的に生成)。npm testには組み込まない
+ * (壁時計時間のassertはCIでflakyになるため、実行と数値確認は手動)。
+ *
+ * 使用方法:
+ *   npx ts-node scripts/bench-office-matching.ts
+ */
+
+import { extractOfficeCandidates, OfficeMaster } from '../functions/src/utils/extractors';
+
+function makeLcg(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+const PREFECTURES = ['東京', '大阪', '名古屋', '横浜', '福岡', '札幌', '仙台', '広島', '京都', '神戸'];
+const FACILITY_TYPES = [
+  '介護老人保健施設',
+  '特別養護老人ホーム',
+  '訪問看護ステーション',
+  '居宅介護支援事業所',
+  'デイサービスセンター',
+];
+const BRANDS = ['サンライズ', 'ひまわり', 'すみれ', 'グリーンヒル', 'ノーブル', 'フォレスト', 'メイプル', 'ローズ', 'ラベンダー', 'オアシス'];
+
+// kanameone実測値(2026-08-02時点): 事業所マスター981件、71ページ文書のOCR全文174,690文字相当
+function buildOfficeMasters(count: number): OfficeMaster[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `office-${i}`,
+    name: `${PREFECTURES[i % PREFECTURES.length]}${BRANDS[i % BRANDS.length]}${FACILITY_TYPES[i % FACILITY_TYPES.length]}第${i}`,
+  }));
+}
+
+function buildSyntheticOcrText(rand: () => number, chunkCount: number): string {
+  const chunks: string[] = [];
+  for (let i = 0; i < chunkCount; i++) {
+    const pref = PREFECTURES[Math.floor(rand() * PREFECTURES.length)];
+    const type = FACILITY_TYPES[Math.floor(rand() * FACILITY_TYPES.length)];
+    const brand = BRANDS[Math.floor(rand() * BRANDS.length)];
+    chunks.push(`${pref}${brand}${type}のサービス利用に関する記録その${i}。利用者氏名、生年月日、要介護度等の情報を含む。`);
+  }
+  return chunks.join('');
+}
+
+function main(): void {
+  const rand = makeLcg(20260802);
+  const officeMasters = buildOfficeMasters(981);
+  const ocrText = buildSyntheticOcrText(rand, 3000);
+
+  console.log(`OCR text length: ${ocrText.length} chars, officeMasters: ${officeMasters.length}`);
+
+  const iterations = 5;
+  const durations: number[] = [];
+  let lastCandidateCount = -1;
+  for (let i = 0; i < iterations; i++) {
+    const start = process.hrtime.bigint();
+    const result = extractOfficeCandidates(ocrText, officeMasters);
+    const end = process.hrtime.bigint();
+    const ms = Number(end - start) / 1e6;
+    durations.push(ms);
+    lastCandidateCount = result.candidates.length;
+    console.log(`run ${i + 1}: ${ms.toFixed(1)}ms, candidates=${result.candidates.length}`);
+  }
+  const avg = durations.reduce((a, b) => a + b, 0) / durations.length;
+  console.log(`avg: ${avg.toFixed(1)}ms (candidates=${lastCandidateCount})`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Issue #787対応。事業所照合(`extractOfficeCandidates`)のステップ5「ファジーマッチ」は、OCR全文(15万文字超)に対する1文字刻みスライディングウィンドウ+毎回フルLevenshtein計算という構造で、本番相当データ(kanameone実測: 71ページ文書=OCR全文174,690文字×事業所981件)で実測**99.86%(79,454ms)**のコストを占めるボトルネックだった。

3層の最適化を実施(承認済みplan: すべて数学的に完全等価、挙動不変):

- **L1**: `levenshteinDistance`(`similarity.ts`)をO(min(n,m))空間のInt32Array rolling row化(フルO(n×m)行列allocationを廃止、戻り値は数学的に完全同一)
- **L0+L2**: `bestFuzzyWindowScore`(`similarity.ts`、新規)を追加。bag distance(文字多重集合差分)が編集距離の厳密な下界であることを利用し、現在のベストスコアを超えられないウィンドウのフルLevenshtein計算をスキップするbranch-and-bound、および観測不能な閾値未満スコアをO(1)でスキップする静的floorを実装。数学的根拠はコード内JSDocコメント参照
- `extractOfficeCandidates`(`extractors.ts`)のステップ5を`bestFuzzyWindowScore`呼び出しに差し替え

## 効果

本番相当スケール(OCR全文17万文字×事業所981件)のベンチマーク実測:

| | before | after | 倍率 |
|---|---|---|---|
| `extractOfficeCandidates` 所要時間 | 79,864.6ms | 99.2ms | **約805倍** |

BEFORE/AFTER実装で同一入力に対する候補リスト(id/score/matchType)が**完全一致**することも直接比較で確認済み(diff結果は差分なし)。

## 安全網

- 変更前に`extractOfficeCandidates`がステップ5に実際到達するcharacterization testを新規追加(陽性/陰性/filenameBoost閾値越えの3ケース、スコアを`greaterThan`ではなく具体的な数値で固定)
- `bestFuzzyWindowScore`/`levenshteinDistance`それぞれに、素朴な実装をオラクルとした決定的PRNG(線形合同法)差分テストを追加(計6000+ケース、サロゲートペア含め不一致0件)
- `scripts/bench-office-matching.ts`を恒久ベンチマークスクリプトとして追加(シード固定PRNGで本番非依存、`npm test`には非組込み)

## スコープ外(followup Issue化を推奨)

調査の過程で、`extractCustomerCandidates`(顧客照合、マスター1,352件)と旧`extractOfficeNameEnhanced`系にも全く同一構造のO(テキスト長)スライディングウィンドウが存在することを確認した。同じ`bestFuzzyWindowScore`ヘルパで解決可能で、顧客照合側の影響は事業所照合と同等以上の可能性がある。本PRは事業所照合に閉じたスコープとし、範囲拡大は別Issueとして提案する。

## Test plan

- [x] `cd functions && npm test`(type-check含む)— 2021 passing, 6 pending(既存分、無関係)
- [x] characterization test 3件・差分テスト計6000+ケース 全PASS
- [x] `scripts/bench-office-matching.ts`実測: 79,864.6ms → 99.2ms(約805倍)
- [x] BEFORE/AFTER実装での候補リスト直接比較: 完全一致
- [x] `codex review --base main -c model_reasoning_effort=high` 実行、**findings 0件**（要約: 「ファジーウィンドウ最適化は呼び出し元に対するスコアリング挙動を保持しており、rolling-row Levenshtein実装も等価。対象の型チェック・テストはPASS」。レビュー内でcodex自身が本ベンチマークスクリプトを独立実行し101.8ms平均を確認済み）

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fuzzy matching for office names, including OCR errors and filename-based matching.
  * Preserved accurate candidate classification while reducing unnecessary comparisons.
  * Improved handling of short, empty, and edge-case text inputs.

* **Performance**
  * Fuzzy matching and text similarity calculations are now faster, especially for larger inputs.

* **Tests**
  * Added extensive coverage for fuzzy matching, OCR variations, thresholds, Unicode text, and similarity calculations.
  * Added benchmarking to measure office-matching performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->