### PR TITLE
perf(ocr): extractCustomerCandidates/extractOfficeNameEnhancedのファジーマッチをbestFuzzyWindowScoreへ水平展開

### DIFF
--- a/functions/src/utils/extractors.ts
+++ b/functions/src/utils/extractors.ts
@@ -435,16 +435,15 @@ export function extractOfficeNameEnhanced(
     }
 
     // ファジーマッチ
+    // Issue #789: extractOfficeCandidates(Issue #787/PR #788)と同一構造のボトルネックのため
+    // bestFuzzyWindowScoreへ置き換え。floorはこの時点でscoreが常に0(matchType==='none')であり、
+    // 下流の唯一の観測点が「score>=minScoreならbestResult更新」であることに基づく
+    // (minScore未満のfuzzyScoreはどんな値でもbestResult更新に寄与しないため区別不要)。
     if (matchType === 'none') {
-      // スライディングウィンドウで最良マッチを探す
-      const windowSize = Math.min(normalizedOfficeName.length + 5, matchingText.length);
-      for (let i = 0; i <= matchingText.length - windowSize; i++) {
-        const window = matchingText.slice(i, i + windowSize);
-        const fuzzyScore = similarityScore(window, normalizedOfficeName);
-        if (fuzzyScore > score && fuzzyScore >= minScore) {
-          score = fuzzyScore;
-          matchType = 'fuzzy';
-        }
+      const fuzzyScore = bestFuzzyWindowScore(matchingText, normalizedOfficeName, 5, minScore);
+      if (fuzzyScore > 0) {
+        score = fuzzyScore;
+        matchType = 'fuzzy';
       }
     }
 
@@ -544,15 +543,15 @@ export function extractCustomerCandidates(
 
     // 3. ファジーマッチ（類似度検索）
     // GAS版と同様：完全一致・ふりがな一致がない場合のみ類似度で判定
+    // Issue #789: extractOfficeCandidates(Issue #787/PR #788)と同一構造のボトルネックのため
+    // bestFuzzyWindowScoreへ置き換え。floorはこの時点でscoreが常に0(matchType==='none')であり、
+    // 下流の唯一の観測点が後段の「score>=minScoreならcandidates.push」であることに基づく
+    // (minScore未満のfuzzyScoreはどんな値でもpush判定に寄与しないため区別不要、ブースト分岐なし)。
     if (matchType === 'none') {
-      const windowSize = Math.min(normalizedName.length + 3, matchingText.length);
-      for (let i = 0; i <= matchingText.length - windowSize; i++) {
-        const window = matchingText.slice(i, i + windowSize);
-        const fuzzyScore = similarityScore(window, normalizedName);
-        if (fuzzyScore > score) {
-          score = fuzzyScore;
-          matchType = 'fuzzy';
-        }
+      const fuzzyScore = bestFuzzyWindowScore(matchingText, normalizedName, 3, minScore);
+      if (fuzzyScore > 0) {
+        score = fuzzyScore;
+        matchType = 'fuzzy';
       }
     }
 


### PR DESCRIPTION
## Summary
- Issue #787/PR #788（`extractOfficeCandidates`ステップ5のファジーマッチ最適化）と全く同一構造のO(テキスト長)スライディングウィンドウ+毎回フルLevenshtein計算が、`extractCustomerCandidates`（顧客照合、kanameone1,352件）と`extractOfficeNameEnhanced`（事業所照合旧版、981件）にも存在していたため、既に数学的等価性を証明済みの`bestFuzzyWindowScore`（bag distance branch-and-bound、`functions/src/utils/similarity.ts`）へ置き換え
- floorは両関数とも「`matchType==='none'`到達時点でscoreは常に0」「下流の唯一の観測点はminScore以上かどうかの判定のみ」という条件から`minScore`として導出（`extractOfficeCandidates`のようなブースト分岐は両関数とも存在しないため単純）
- 挙動不変（`bestFuzzyWindowScore`はPR #788で6000件超の差分テストにより素朴な実装と完全等価であることを証明済み）

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npx mocha test/extractors.test.ts` 107件全PASS（`extractOfficeNameEnhanced`/`extractCustomerCandidates`のケース含む）
- [x] `npx mocha test/similarityFuzzyWindow.test.ts` 8件全PASS（`bestFuzzyWindowScore`自体の等価性証明）
- [x] `npm test`（functions全体unit）2021件全PASS
- [x] 合成ベンチマーク（顧客1,352件/事業所981件×OCR全文174,690文字相当、ランダム日本語テキスト）でfuzzy段のみ比較: 顧客照合7.6倍・事業所照合12.7倍の高速化を確認（ローカル使い捨てスクリプトで実施、リポジトリには含めず）。本番実データでは文字列類似度分布の違いによりPR #788（officeMatchMs実測805倍）によりに近い効果も見込まれるが、正確な`customerMatchMs`改善幅はデプロイ後にkanameone本番ログで確認予定（Issue #789本文の推奨手順）

Refs #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching accuracy when identifying office names and customer candidates.
  * Reduced incorrect fuzzy matches by applying minimum confidence thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->