### PR TITLE
fix(frontend): 書類編集後にグループ表示キャッシュが更新されない問題を修正

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
@@ -225,6 +225,46 @@ describe('useDocumentEdit - careManager自動補完', () => {
     })
   })
 
+  describe('グループ表示キャッシュのinvalidate (Issue #793: 編集後にCM別・利用者別グループ表示から消える)', () => {
+    it('careManager変更を保存すると、documentGroups/groupDocuments/groupStatsもinvalidateされる', async () => {
+      const doc = makeDocument({ careManager: '板垣 亜紀子' })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('careManager', '長谷川 由紀'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const invalidatedKeys = mockInvalidateQueries.mock.calls.map(
+        (call) => (call[0] as { queryKey: unknown[] }).queryKey[0]
+      )
+      expect(invalidatedKeys).toContain('documentGroups')
+      expect(invalidatedKeys).toContain('groupDocuments')
+      expect(invalidatedKeys).toContain('groupStats')
+    })
+
+    it('customerName変更を保存すると、documentGroups/groupDocuments/groupStatsもinvalidateされる', async () => {
+      const doc = makeDocument({ customerName: '田村 勝義' })
+      const { result } = renderHook(() => useDocumentEdit(doc))
+
+      act(() => result.current.startEditing())
+      act(() => result.current.updateField('customerName', '鈴木 花子'))
+
+      await act(async () => {
+        await result.current.saveChanges()
+      })
+
+      const invalidatedKeys = mockInvalidateQueries.mock.calls.map(
+        (call) => (call[0] as { queryKey: unknown[] }).queryKey[0]
+      )
+      expect(invalidatedKeys).toContain('documentGroups')
+      expect(invalidatedKeys).toContain('groupDocuments')
+      expect(invalidatedKeys).toContain('groupStats')
+    })
+  })
+
   describe('ロールバック', () => {
     it('Firestore書き込み失敗時にcareManagerがロールバックされる', async () => {
       mockUpdateDoc.mockRejectedValueOnce(new Error('write failed'))

--- a/frontend/src/hooks/useDocumentEdit.ts
+++ b/frontend/src/hooks/useDocumentEdit.ts
@@ -456,6 +456,13 @@ export function useDocumentEdit(
       // サーバー確定値で同期
       queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['document', document.id] })
+      // customerName/careManager等グルーピングキーに使うフィールドが変わりうるため、
+      // グループ表示のキャッシュも合わせて無効化する(Issue #793: 編集後にCM別・利用者別
+      // グループ表示から書類が消えたように見える不具合対応。useReprocessDocumentの
+      // 既存パターン(useDocuments.ts)と同様だが、groupStatsが漏れていたため追加)
+      queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+      queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
+      queryClient.invalidateQueries({ queryKey: ['groupStats'] })
 
       setIsEditing(false)
       setEditedFields({})


### PR DESCRIPTION
## Summary
- `useDocumentEdit.ts`の`saveChanges()`が保存後に`['documentsInfinite']`と`['document', id]`のみinvalidateしており、担当CM別・利用者別グルーピング表示が使う`['documentGroups']`/`['groupDocuments']`/`['groupStats']`が漏れていた
- kanameoneからの報告「書類編集後に表示されていたファイルが消える/利用者の表示件数が変動する」(Issue #793)の仮説1(最有力)に対応
- `useReprocessDocument`(`useDocuments.ts`)の既存invalidateパターンに揃えて修正。ただし元のパターンでも`groupStats`が漏れていたため、今回追加した

## Test plan
- [x] TDD Red→Green: 新規テスト2件(careManager変更/customerName変更のいずれでも3クエリキーがinvalidateされること)を追加し、修正前にRed→修正後にGreenを確認
- [x] `frontend`テストスイート全体 519件PASS(回帰なし)
- [x] `tsc --noEmit` 0 errors
- [x] `eslint` 変更ファイル 0 errors
- [ ] kanameone実データでの動作確認(デプロイ後)

Refs #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated document editing so related document groups, documents, and statistics refresh automatically after changes to care manager or customer name.
  * Ensures users see current information immediately after saving edits.

* **Tests**
  * Added regression coverage to verify related data refreshes correctly after document updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->