### PR TITLE
fix(frontend): 書類グループ表示キャッシュのinvalidateを共通ヘルパーへ一本化

### DIFF
--- a/frontend/src/components/DocumentDetailModal.tsx
+++ b/frontend/src/components/DocumentDetailModal.tsx
@@ -30,7 +30,7 @@ import { PdfViewer } from '@/components/PdfViewer'
 import { PdfSplitModal } from '@/components/PdfSplitModal'
 import { MasterSelectField } from '@/components/MasterSelectField'
 import { ExtractionInfoPopover } from '@/components/ExtractionInfoPopover'
-import { useDocument, useDocumentDetail, useReprocessDocument, useDistributionSiblingCount, resolveDetailFields } from '@/hooks/useDocuments'
+import { useDocument, useDocumentDetail, useReprocessDocument, useDistributionSiblingCount, resolveDetailFields, invalidateGroupQueries } from '@/hooks/useDocuments'
 import { useDocumentEdit } from '@/hooks/useDocumentEdit'
 import { useCustomers, useOffices, useDocumentTypes, useCareManagers, useCustomerIdentityLookup } from '@/hooks/useMasters'
 import { resolveCustomerUnconfirmedReason, stripInternalSpaces } from '@shared/customerIdentity'
@@ -765,7 +765,9 @@ export function DocumentDetailModal({ documentId, open, onOpenChange }: Document
         }
       )
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
-      queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+      // documentGroupsだけでなくgroupDocuments/groupStatsも無効化する
+      // (2026-08-06、PR #802セカンドオピニオンレビューで発覚した漏れを解消)
+      invalidateGroupQueries(queryClient)
       setShowDeleteDialog(false)
       onOpenChange(false)
       toast.success('書類を削除しました')

--- a/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentEdit.test.ts
@@ -48,9 +48,16 @@ vi.mock('@tanstack/react-query', () => ({
   }),
 }))
 
-vi.mock('../useDocuments', () => ({
-  updateDocumentInListCache: vi.fn(),
-}))
+vi.mock('../useDocuments', async (importOriginal) => {
+  // invalidateDocumentAndGroupQueriesは実装をそのまま使う(モックでinvalidate対象キーの
+  // リストを重複定義すると、実装変更時にテストと実装が非同期にドリフトするため)。
+  // updateDocumentInListCacheのみ従来通りモック化する。
+  const actual = await importOriginal<typeof import('../useDocuments')>()
+  return {
+    ...actual,
+    updateDocumentInListCache: vi.fn(),
+  }
+})
 
 import { useDocumentEdit } from '../useDocumentEdit'
 

--- a/frontend/src/hooks/__tests__/useDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useDocuments.test.ts
@@ -5,7 +5,8 @@
  * - officeConfirmed / officeCandidates フィールドが正しく変換されること
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import type { QueryClient } from '@tanstack/react-query'
 import { deleteField, Timestamp } from 'firebase/firestore'
 import {
   firestoreToDocument,
@@ -15,6 +16,7 @@ import {
   getDriveExportClearFields,
   resolveDetailFields,
   applySearchTextFilter,
+  invalidateDocumentAndGroupQueries,
 } from '../useDocuments'
 import type { Document } from '@shared/types'
 
@@ -716,5 +718,24 @@ describe('applySearchTextFilter (ADR-0018 Phase D、Issue #547: ocrResult条件�
     })
     expect(() => applySearchTextFilter(docsWithoutOcrResult, '山田')).not.toThrow()
     expect(applySearchTextFilter(docsWithoutOcrResult, '山田')).toEqual([docsWithoutOcrResult[0]])
+  })
+})
+
+describe('invalidateDocumentAndGroupQueries (2026-08-06: useDocumentEdit/useReprocessDocument/useUpdateDocument/useReprocessErrorで独立に発生していたグループ表示キャッシュinvalidate漏れの一本化)', () => {
+  it('documentsInfinite/document本体/documentGroups/groupDocuments/groupStatsの5種類を全てinvalidateする', () => {
+    const invalidateQueries = vi.fn()
+    const queryClient = { invalidateQueries } as unknown as QueryClient
+
+    invalidateDocumentAndGroupQueries(queryClient, 'doc-123')
+
+    const invalidatedKeys = invalidateQueries.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    )
+    expect(invalidatedKeys).toContainEqual(['documentsInfinite'])
+    expect(invalidatedKeys).toContainEqual(['document', 'doc-123'])
+    expect(invalidatedKeys).toContainEqual(['documentGroups'])
+    expect(invalidatedKeys).toContainEqual(['groupDocuments'])
+    expect(invalidatedKeys).toContainEqual(['groupStats'])
+    expect(invalidateQueries).toHaveBeenCalledTimes(5)
   })
 })

--- a/frontend/src/hooks/__tests__/useErrorsReprocess.test.ts
+++ b/frontend/src/hooks/__tests__/useErrorsReprocess.test.ts
@@ -43,15 +43,27 @@ vi.mock('../../lib/firebase', () => ({
 }))
 
 const mockAppendReprocessClearToBatch = vi.fn().mockResolvedValue(undefined)
+const mockInvalidateDocumentAndGroupQueries = vi.fn()
 vi.mock('../useDocuments', () => ({
   appendReprocessClearToBatch: (...args: unknown[]) => mockAppendReprocessClearToBatch(...args),
+  invalidateDocumentAndGroupQueries: (...args: unknown[]) => mockInvalidateDocumentAndGroupQueries(...args),
 }))
 
 const mockInvalidateQueries = vi.fn()
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
-  useMutation: (opts: { mutationFn: (params: unknown) => Promise<unknown> }) => ({
-    mutateAsync: opts.mutationFn,
+  // 実際のreact-queryと同様、mutationFn成功後にonSuccessを呼ぶ(2026-08-06: onSuccessでの
+  // グループキャッシュinvalidate漏れ(useErrors.ts)を検証するため、旧実装のonSuccessバイパス
+  // を修正)
+  useMutation: (opts: {
+    mutationFn: (params: unknown) => Promise<unknown>
+    onSuccess?: (data: unknown) => void
+  }) => ({
+    mutateAsync: async (params: unknown) => {
+      const result = await opts.mutationFn(params)
+      opts.onSuccess?.(result)
+      return result
+    },
   }),
 }))
 
@@ -102,5 +114,31 @@ describe('useReprocessError / requestReprocess', () => {
     expect(mockAppendReprocessClearToBatch).not.toHaveBeenCalled()
     expect(mockBatchCommit).toHaveBeenCalledTimes(1)
     expect(response).toEqual({ documentId: null })
+  })
+
+  describe('グループ表示キャッシュのinvalidate (2026-08-06: useDocumentEdit/useReprocessDocumentと同型の漏れを解消)', () => {
+    it('documentIdが取得できた場合、document本体・グループ表示キャッシュ(documentGroups/groupDocuments/groupStats)もinvalidateされる', async () => {
+      mockGetDoc.mockResolvedValue({ exists: () => true })
+      const { result } = renderHook(() => useReprocessError())
+
+      await act(async () =>
+        result.current.mutateAsync({ errorId: 'err-1', fileId: 'shared-file-1', documentId: 'the-actual-doc' })
+      )
+
+      expect(mockInvalidateDocumentAndGroupQueries).toHaveBeenCalledWith(expect.anything(), 'the-actual-doc')
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['documentDetail', 'the-actual-doc'] })
+    })
+
+    it('documentIdが取得できない場合(doc削除済み等)、グループキャッシュのinvalidateは呼ばれない(documentsInfiniteのみ)', async () => {
+      mockGetDoc.mockResolvedValue({ exists: () => false })
+      const { result } = renderHook(() => useReprocessError())
+
+      await act(async () =>
+        result.current.mutateAsync({ errorId: 'err-3', fileId: 'shared-file-1', documentId: 'deleted-doc' })
+      )
+
+      expect(mockInvalidateDocumentAndGroupQueries).not.toHaveBeenCalled()
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
+    })
   })
 })

--- a/frontend/src/hooks/__tests__/usePdfSplit.test.tsx
+++ b/frontend/src/hooks/__tests__/usePdfSplit.test.tsx
@@ -60,6 +60,11 @@ describe('useSplitPdf - Issue #621 already-exists/aborted時のキャッシュ�
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['document'] })
+    // 2026-08-06: 分割元書類がグループ表示に含まれていた場合の表示崩れを防ぐため、
+    // グループ系キャッシュも合わせてinvalidateする(useDocumentEdit等と同型の漏れの予防)
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentGroups'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['groupDocuments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['groupStats'] })
   })
 
   it('aborted で失敗した場合、documentsInfinite/document を invalidate する', async () => {
@@ -75,6 +80,9 @@ describe('useSplitPdf - Issue #621 already-exists/aborted時のキャッシュ�
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['document'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentGroups'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['groupDocuments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['groupStats'] })
   })
 
   it('internal 等の他コードで失敗した場合は invalidate しない', async () => {
@@ -100,5 +108,8 @@ describe('useSplitPdf - Issue #621 already-exists/aborted時のキャッシュ�
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentsInfinite'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['document'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['documentGroups'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['groupDocuments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['groupStats'] })
   })
 })

--- a/frontend/src/hooks/__tests__/useReprocessDocumentAndUpdateDocument.test.tsx
+++ b/frontend/src/hooks/__tests__/useReprocessDocumentAndUpdateDocument.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * useReprocessDocument / useUpdateDocument 統合テスト (2026-08-06)
+ *
+ * PR #802のセカンドオピニオンレビュー(pr-test-analyzer)で、この2フックが
+ * invalidateDocumentAndGroupQueriesを実際に呼び出していることを検証するテストが
+ * 皆無(ヘルパー自体の単体テストのみ、useDocuments.test.ts参照)と指摘された。
+ * この2フックは本PRが解消したバグ(グループ表示キャッシュinvalidate漏れ)の
+ * 発生元そのものであり、ヘルパー呼び出しが将来のマージコンフリクト等で外れても
+ * 検知できない穴だったため追加する。
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+const mockGetDoc = vi.fn()
+const mockDoc = vi.fn((...args: unknown[]) => ({ __ref: args }))
+const mockBatchUpdate = vi.fn()
+const mockBatchCommit = vi.fn().mockResolvedValue(undefined)
+const mockWriteBatch = vi.fn().mockReturnValue({ update: mockBatchUpdate, commit: mockBatchCommit })
+const mockUpdateDoc = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('firebase/firestore', async () => {
+  const actual = await vi.importActual<typeof import('firebase/firestore')>('firebase/firestore')
+  return {
+    ...actual,
+    doc: (...args: unknown[]) => mockDoc(...args),
+    getDoc: (...args: unknown[]) => mockGetDoc(...args),
+    writeBatch: (...args: unknown[]) => mockWriteBatch(...args),
+    updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  }
+})
+
+vi.mock('../../lib/firebase', () => ({
+  db: { type: 'firestore' },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { useReprocessDocument, useUpdateDocument } from '../useDocuments'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return { wrapper, invalidateSpy }
+}
+
+function invalidatedKeysOf(spy: { mock: { calls: unknown[][] } }): unknown[][] {
+  return spy.mock.calls.map((call) => (call[0] as { queryKey: unknown[] }).queryKey)
+}
+
+describe('useReprocessDocument (2026-08-06回帰テスト: グループキャッシュinvalidate)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWriteBatch.mockReturnValue({ update: mockBatchUpdate, commit: mockBatchCommit })
+  })
+
+  it('再処理成功時、document本体・documentsInfinite・グループ系(documentGroups/groupDocuments/groupStats)を全てinvalidateする', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({}) }) // 親doc
+      .mockResolvedValueOnce({ exists: () => false }) // detail/main
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useReprocessDocument(), { wrapper })
+
+    const success = await act(async () => result.current.reprocess('doc-1'))
+
+    expect(success).toBe(true)
+    const invalidatedKeys = invalidatedKeysOf(invalidateSpy)
+    expect(invalidatedKeys).toContainEqual(['documentsInfinite'])
+    expect(invalidatedKeys).toContainEqual(['document', 'doc-1'])
+    expect(invalidatedKeys).toContainEqual(['documentDetail', 'doc-1'])
+    expect(invalidatedKeys).toContainEqual(['documentGroups'])
+    expect(invalidatedKeys).toContainEqual(['groupDocuments'])
+    expect(invalidatedKeys).toContainEqual(['groupStats'])
+  })
+
+  it('batch commit失敗時はグループキャッシュをinvalidateせずfalseを返す', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({ data: () => ({}) })
+      .mockResolvedValueOnce({ exists: () => false })
+    mockBatchCommit.mockRejectedValueOnce(new Error('commit failed'))
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useReprocessDocument(), { wrapper })
+
+    const success = await act(async () => result.current.reprocess('doc-err'))
+
+    expect(success).toBe(false)
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useUpdateDocument (2026-08-06回帰テスト: グループキャッシュinvalidate)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('更新成功時、document本体・documentsInfinite・グループ系を全てinvalidateする', async () => {
+    const { wrapper, invalidateSpy } = createWrapper()
+    const { result } = renderHook(() => useUpdateDocument(), { wrapper })
+
+    await act(async () =>
+      result.current.mutateAsync({ documentId: 'doc-2', updates: { fileName: 'renamed.pdf' } })
+    )
+
+    await waitFor(() => {
+      expect(invalidatedKeysOf(invalidateSpy)).toContainEqual(['documentGroups'])
+    })
+    const invalidatedKeys = invalidatedKeysOf(invalidateSpy)
+    expect(invalidatedKeys).toContainEqual(['documentsInfinite'])
+    expect(invalidatedKeys).toContainEqual(['document', 'doc-2'])
+    expect(invalidatedKeys).toContainEqual(['groupDocuments'])
+    expect(invalidatedKeys).toContainEqual(['groupStats'])
+  })
+})

--- a/frontend/src/hooks/useDocumentEdit.ts
+++ b/frontend/src/hooks/useDocumentEdit.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { doc, updateDoc, collection, addDoc, serverTimestamp, Timestamp, deleteField } from 'firebase/firestore'
 import { useQueryClient } from '@tanstack/react-query'
 import { db, auth } from '../lib/firebase'
-import { updateDocumentInListCache } from './useDocuments'
+import { updateDocumentInListCache, invalidateDocumentAndGroupQueries } from './useDocuments'
 import { isValidCustomerSelection, isValidOfficeSelection, isValidDocumentTypeSelection } from '../lib/documentUtils'
 import { findSameNameCollisionNames } from '@shared/customerIdentity'
 import { generateDisplayFileName } from '@shared/generateDisplayFileName'
@@ -453,16 +453,10 @@ export function useDocumentEdit(
         })
       }
 
-      // サーバー確定値で同期
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      queryClient.invalidateQueries({ queryKey: ['document', document.id] })
-      // customerName/careManager等グルーピングキーに使うフィールドが変わりうるため、
-      // グループ表示のキャッシュも合わせて無効化する(Issue #793: 編集後にCM別・利用者別
-      // グループ表示から書類が消えたように見える不具合対応。useReprocessDocumentの
-      // 既存パターン(useDocuments.ts)と同様だが、groupStatsが漏れていたため追加)
-      queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
-      queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
-      queryClient.invalidateQueries({ queryKey: ['groupStats'] })
+      // サーバー確定値で同期(グループ表示キャッシュも含む、invalidateDocumentAndGroupQueries参照。
+      // Issue #793で本フックのgroupStats漏れが発覚した際、useReprocessDocumentにも同型の漏れが
+      // 独立に存在していたため、2026-08-06に共通ヘルパーへ一本化した)
+      invalidateDocumentAndGroupQueries(queryClient, document.id)
 
       setIsEditing(false)
       setEditedFields({})

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -278,11 +278,27 @@ export function updateDocumentInListCache(
 }
 
 /**
+ * 担当CM別・利用者別グループ表示が使う3種類のキャッシュ(documentGroups/groupDocuments/
+ * groupStats)を無効化する。customerName/careManagerName等グルーピングキーに使われる
+ * フィールドが変わりうる操作(単体編集・再処理・一括操作・削除)全てから共通で呼ぶ。
+ *
+ * 一覧の対象書類が1件に定まらない一括操作(一括再処理・一括削除、DocumentsPage.tsx)
+ * ではdocumentIdを持たないため、単体操作用の`invalidateDocumentAndGroupQueries`とは
+ * 別にこちらを直接呼ぶ(2026-08-06: PR #802のセカンドオピニオンレビューで、
+ * DocumentsPage.tsxの一括再処理・一括削除・DocumentDetailModal.tsxの個別削除が
+ * documentGroups等の一部または全部を無効化しておらず、単体編集/再処理と同型の
+ * 表示崩れが残っていたと判明したため分離・共通化)。
+ */
+export function invalidateGroupQueries(queryClient: QueryClient): void {
+  queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+  queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
+  queryClient.invalidateQueries({ queryKey: ['groupStats'] })
+}
+
+/**
  * 書類本体を更新する全mutation(編集保存/再処理/汎用更新)が共通で呼ぶキャッシュ
- * invalidateヘルパー。customerName/careManagerName等グルーピングキーに使われる
- * フィールドはどの更新経路でも変わりうるため、documentsInfinite/document本体だけでなく
- * documentGroups/groupDocuments/groupStats(担当CM別・利用者別グループ表示)も必ず
- * 合わせて無効化する。
+ * invalidateヘルパー。documentsInfinite/document本体に加え、上記`invalidateGroupQueries`
+ * も必ず合わせて無効化する。
  *
  * 各mutationが個別にinvalidateQueriesを手書きしていた旧実装では、useDocumentEdit.ts
  * (Issue #793)とuseReprocessDocument双方で独立にgroupStatsのinvalidate漏れが発生し、
@@ -292,9 +308,7 @@ export function updateDocumentInListCache(
 export function invalidateDocumentAndGroupQueries(queryClient: QueryClient, documentId: string): void {
   queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
   queryClient.invalidateQueries({ queryKey: ['document', documentId] })
-  queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
-  queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
-  queryClient.invalidateQueries({ queryKey: ['groupStats'] })
+  invalidateGroupQueries(queryClient)
 }
 
 // ============================================

--- a/frontend/src/hooks/useDocuments.ts
+++ b/frontend/src/hooks/useDocuments.ts
@@ -277,6 +277,26 @@ export function updateDocumentInListCache(
   )
 }
 
+/**
+ * 書類本体を更新する全mutation(編集保存/再処理/汎用更新)が共通で呼ぶキャッシュ
+ * invalidateヘルパー。customerName/careManagerName等グルーピングキーに使われる
+ * フィールドはどの更新経路でも変わりうるため、documentsInfinite/document本体だけでなく
+ * documentGroups/groupDocuments/groupStats(担当CM別・利用者別グループ表示)も必ず
+ * 合わせて無効化する。
+ *
+ * 各mutationが個別にinvalidateQueriesを手書きしていた旧実装では、useDocumentEdit.ts
+ * (Issue #793)とuseReprocessDocument双方で独立にgroupStatsのinvalidate漏れが発生し、
+ * さらにuseUpdateDocumentはグループ系キャッシュを一切invalidateしていなかった(2026-08-06
+ * 発見)。呼び出し箇所ごとに漏れが再発する構造的な問題だったため、一本化して解消する。
+ */
+export function invalidateDocumentAndGroupQueries(queryClient: QueryClient, documentId: string): void {
+  queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
+  queryClient.invalidateQueries({ queryKey: ['document', documentId] })
+  queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+  queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
+  queryClient.invalidateQueries({ queryKey: ['groupStats'] })
+}
+
 // ============================================
 // 再処理時クリアフィールド
 // ============================================
@@ -502,13 +522,10 @@ export function useReprocessDocument() {
         verified: false,
         ...(hasDistributionId ? {} : { customerName: '', customerConfirmed: false }),
       })
-      queryClient.invalidateQueries({ queryKey: ['document', documentId] })
       // detail/main もクリア対象 (appendReprocessClearToBatch) のため、キャッシュ済み
       // detailの古いOCR内容がポーリング再開(3秒後)まで表示され続けるのを防ぐ
       queryClient.invalidateQueries({ queryKey: ['documentDetail', documentId] })
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
-      queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+      invalidateDocumentAndGroupQueries(queryClient, documentId)
       toast.success('再処理をリクエストしました。処理完了まで画面が自動更新されます。', { duration: 5000 })
       return true
     } catch (err) {
@@ -758,9 +775,8 @@ export function useUpdateDocument() {
   return useMutation({
     mutationFn: updateDocument,
     onSuccess: (_, { documentId }) => {
-      // 関連キャッシュを無効化
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      queryClient.invalidateQueries({ queryKey: ['document', documentId] })
+      // 関連キャッシュを無効化(グループ表示キャッシュも含む、invalidateDocumentAndGroupQueries参照)
+      invalidateDocumentAndGroupQueries(queryClient, documentId)
     },
   })
 }

--- a/frontend/src/hooks/useErrors.ts
+++ b/frontend/src/hooks/useErrors.ts
@@ -22,7 +22,7 @@ import {
   QueryConstraint,
 } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
-import { appendReprocessClearToBatch } from './useDocuments'
+import { appendReprocessClearToBatch, invalidateDocumentAndGroupQueries } from './useDocuments'
 import type { ErrorRecord, ErrorStatus, ErrorType } from '@shared/types'
 
 // ============================================
@@ -272,12 +272,18 @@ export function useReprocessError() {
     onSuccess: ({ documentId }) => {
       queryClient.invalidateQueries({ queryKey: ['errors'] })
       queryClient.invalidateQueries({ queryKey: ['errorStats'] })
-      queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
-      // detail/main もクリア対象 (appendReprocessClearToBatch) のため、キャッシュ済み
-      // documentDetailが古いOCR内容を残さないよう無効化する (useDocuments.ts
-      // useReprocessDocument と同じ理由、Issue #547)
       if (documentId) {
+        // detail/main もクリア対象 (appendReprocessClearToBatch) のため、キャッシュ済み
+        // documentDetailが古いOCR内容を残さないよう無効化する (useDocuments.ts
+        // useReprocessDocument と同じ理由、Issue #547)。
+        // document本体・グループ表示キャッシュも合わせて無効化する
+        // (invalidateDocumentAndGroupQueries参照。本フックはuseReprocessDocumentと同じ
+        // メタクリア(appendReprocessClearToBatch)を行うにもかかわらず、documentIdが
+        // 取得できた場合でもdocumentsInfinite以外を無効化していなかった漏れを2026-08-06に解消)
         queryClient.invalidateQueries({ queryKey: ['documentDetail', documentId] })
+        invalidateDocumentAndGroupQueries(queryClient, documentId)
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       }
     },
   })

--- a/frontend/src/hooks/usePdfSplit.ts
+++ b/frontend/src/hooks/usePdfSplit.ts
@@ -5,6 +5,7 @@
 
 import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { callFunction, getCallableErrorCode } from '@/lib/callFunction'
+import { invalidateGroupQueries } from './useDocuments'
 import type { SplitSuggestion, SplitSegment } from '@shared/types'
 
 // ============================================
@@ -124,10 +125,8 @@ function invalidateSplitQueries(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ['document'] })
   // 分割元書類がグループ表示(担当CM別・利用者別)に含まれていた場合、分割後は
   // 分割元が消え新規書類が現れるため、グループ系キャッシュも無効化する
-  // (useDocuments.tsのinvalidateDocumentAndGroupQueriesと同種の漏れを2026-08-06に予防的に解消)
-  queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
-  queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
-  queryClient.invalidateQueries({ queryKey: ['groupStats'] })
+  // (useDocuments.tsと同種の漏れを2026-08-06に予防的に解消)
+  invalidateGroupQueries(queryClient)
 }
 
 export function useSplitPdf() {

--- a/frontend/src/hooks/usePdfSplit.ts
+++ b/frontend/src/hooks/usePdfSplit.ts
@@ -122,6 +122,12 @@ async function splitPdf(request: SplitPdfRequest): Promise<SplitPdfResponse> {
 function invalidateSplitQueries(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
   queryClient.invalidateQueries({ queryKey: ['document'] })
+  // 分割元書類がグループ表示(担当CM別・利用者別)に含まれていた場合、分割後は
+  // 分割元が消え新規書類が現れるため、グループ系キャッシュも無効化する
+  // (useDocuments.tsのinvalidateDocumentAndGroupQueriesと同種の漏れを2026-08-06に予防的に解消)
+  queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+  queryClient.invalidateQueries({ queryKey: ['groupDocuments'] })
+  queryClient.invalidateQueries({ queryKey: ['groupStats'] })
 }
 
 export function useSplitPdf() {

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -51,7 +51,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { db } from '@/lib/firebase'
 import { callFunction } from '@/lib/callFunction'
 import { Checkbox } from '@/components/ui/checkbox'
-import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, appendReprocessClearToBatch, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
+import { useInfiniteDocuments, useDocumentStats, useDocumentMasters, appendReprocessClearToBatch, invalidateGroupQueries, type DocumentFilters, type SortField, type SortOrder } from '@/hooks/useDocuments'
 import { useCareManagers, useCustomerIdentityLookup, type CustomerIdentityLookup } from '@/hooks/useMasters'
 import { DateRangeFilter, type DateRange } from '@/components/DateRangeFilter'
 import { isCustomerConfirmed } from '@/hooks/useProcessingHistory'
@@ -563,6 +563,10 @@ export function DocumentsPage() {
       // 一覧をリフレッシュ (部分的成功分も反映)
       queryClient.invalidateQueries({ queryKey: ['documentsInfinite'] })
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
+      // customerName/careManagerName等をクリアするためグルーピングキーから外れる書類が
+      // 生じる。単体再処理(useReprocessDocument)と同じ理由でグループ表示キャッシュも
+      // 無効化する(2026-08-06、PR #802セカンドオピニオンレビューで発覚した漏れを解消)
+      invalidateGroupQueries(queryClient)
       setBulkOperation(null)
 
       // detail/main もクリア対象 (appendReprocessClearToBatch) のため、成功分の
@@ -654,7 +658,9 @@ export function DocumentsPage() {
       }
 
       queryClient.invalidateQueries({ queryKey: ['documentStats'] })
-      queryClient.invalidateQueries({ queryKey: ['documentGroups'] })
+      // documentGroupsだけでなくgroupDocuments/groupStatsも無効化する
+      // (2026-08-06、PR #802セカンドオピニオンレビューで発覚した漏れを解消)
+      invalidateGroupQueries(queryClient)
     } catch (error) {
       console.error('Bulk delete error:', error)
       toast.error('一括削除に失敗しました')


### PR DESCRIPTION
## Summary
- Issue #793対応(PR #796)後の調査で、同型のキャッシュinvalidate漏れが独立して現存していると判明。共通ヘルパー`invalidateDocumentAndGroupQueries`/`invalidateGroupQueries`を`useDocuments.ts`に新設し一本化した

### 修正箇所(計6箇所)
- `useReprocessDocument`: `groupStats`のinvalidateが欠落
- `useUpdateDocument`: `documentGroups`/`groupDocuments`/`groupStats`を一切invalidateしていない
- `useReprocessError`(エラー一覧からの再処理): `document`本体・グループ系キャッシュを一切invalidateしていない
- `usePdfSplit`: グループ系キャッシュを予防的に追加(以前は重複実装、今回共通ヘルパーへ統一)
- `DocumentsPage.tsx` `handleBulkReprocess`(一括再処理): グループ系キャッシュを一切invalidateしていない(**セカンドオピニオンレビューで追加発見、confidence 93**)
- `DocumentsPage.tsx` `handleBulkDelete`・`DocumentDetailModal.tsx` `handleDelete`: `documentGroups`のみでgroupDocuments/groupStatsが漏れ(**セカンドオピニオンレビューで追加発見、confidence 84**)

### 回帰テスト
- `useDocuments.test.ts`: 共通ヘルパー単体テスト
- `useReprocessDocumentAndUpdateDocument.test.tsx`(新規): `useReprocessDocument`/`useUpdateDocument`が実際にヘルパーを呼び出すことをrenderHookで検証(pr-test-analyzer指摘rating8を受けて追加)
- `useErrorsReprocess.test.ts`/`usePdfSplit.test.tsx`: 既存パターンに回帰テスト追加
- `DocumentsPage.tsx`/`DocumentDetailModal.tsx`はテストファイル自体が存在せず(既存の構造的ギャップ、本PRのスコープ外)、コード修正のみ

## Quality Gate
- [x] frontend全526件PASS、tsc/lint 0 errors
- [x] `codex review --base main -c model_reasoning_effort=medium`(初回コミット時点)指摘0件
- [x] `codex review --base main --strict-config -c model_reasoning_effort=high`(large tier、初回コミット)指摘0件
- [x] セカンドオピニオン: `pr-review-toolkit:code-reviewer`(sonnet)が上記2箇所の追加漏れを発見(confidence 93/84) → 修正済み
- [x] セカンドオピニオン: `pr-review-toolkit:pr-test-analyzer`(sonnet)が`useReprocessDocument`/`useUpdateDocument`のテスト欠如を指摘(rating 8) → 回帰テスト追加済み
- [x] `codex review --base main --strict-config -c model_reasoning_effort=high`(修正反映後、最終コミット)指摘0件

## Test plan
- [x] frontend全526件PASS
- [x] tsc --noEmit 0 errors
- [x] eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)