### PR TITLE
fix(drive): sweepのrequeuedカウンタがclaim試行と実成功を混同する問題を修正

### DIFF
--- a/functions/src/drive/driveExportScheduled.ts
+++ b/functions/src/drive/driveExportScheduled.ts
@@ -64,7 +64,10 @@ export const DRIVE_EXPORT_ERROR_RETRY_THRESHOLD_MS = 60 * 60 * 1000;
 export const DRIVE_EXPORT_STUCK_EXPORTING_THRESHOLD_MS = 10 * 60 * 1000;
 
 export interface SweepResult {
+  /** exportDocument()が実際に成功しexportedへ遷移した件数(BATCH_SIZE上限の判定対象)。 */
   requeued: number;
+  /** claimには成功したがexportDocument()が失敗し再度errorへ戻った件数。 */
+  failed: number;
   skipped: number;
 }
 
@@ -88,7 +91,7 @@ export async function sweepStuckDriveExports(
   }
   const candidates = await query.get();
 
-  const result: SweepResult = { requeued: 0, skipped: 0 };
+  const result: SweepResult = { requeued: 0, failed: 0, skipped: 0 };
   if (candidates.empty) {
     // ページ末尾(または対象0件)。次回実行は先頭から周回する。
     if (cursor) {
@@ -126,10 +129,21 @@ export async function sweepStuckDriveExports(
     try {
       // eslint-disable-next-line no-await-in-loop
       const claimed = await executeDriveExport(firestore, docSnapshot.id, exportDeps, status);
-      if (claimed) {
+      if (!claimed) {
+        result.skipped++; // クレーム失敗(並行して他呼び出しが処理済み等)
+        continue;
+      }
+      // executeDriveExport()はexportDocument()が失敗してもclaim成立のみでtrueを返すため、
+      // claimed(試行)とexported(成功)を混同するとBATCH_SIZE上限が恒久的に失敗し続ける
+      // doc(顧客未確定等)だけで消費され、その先の正常docに永久に到達できない
+      // (starvation、kanameone本番でbackfillマーカー20件が滞留した実障害の根本原因)。
+      // requeuedは実際にexportedへ遷移した件数のみを数える。
+      // eslint-disable-next-line no-await-in-loop
+      const finalSnap = await docSnapshot.ref.get();
+      if (finalSnap.data()?.driveExportStatus === 'exported') {
         result.requeued++;
       } else {
-        result.skipped++; // クレーム失敗(並行して他呼び出しが処理済み等)
+        result.failed++;
       }
     } catch (error) {
       console.error(`[driveExportScheduled] requeue failed for ${docSnapshot.id}:`, error);
@@ -163,7 +177,7 @@ export const driveExportScheduled = onSchedule(
 
     const result = await sweepStuckDriveExports(db);
     console.log(
-      `[driveExportScheduled] completed: requeued=${result.requeued}, skipped=${result.skipped}`
+      `[driveExportScheduled] completed: requeued=${result.requeued}, failed=${result.failed}, skipped=${result.skipped}`
     );
   }
 );

--- a/functions/test/driveExportScheduledIntegration.test.ts
+++ b/functions/test/driveExportScheduledIntegration.test.ts
@@ -117,7 +117,7 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 1, skipped: 0 });
+    expect(result).to.deep.equal({ requeued: 1, failed: 0, skipped: 0 });
     expect(createCalls).to.have.lengthOf(2);
     const data = await getDoc(docId);
     expect(data.driveExportStatus).to.equal('exported');
@@ -140,7 +140,7 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 1, skipped: 0 });
+    expect(result).to.deep.equal({ requeued: 1, failed: 0, skipped: 0 });
     expect(createCalls).to.have.lengthOf(2);
     const data = await getDoc(docId);
     expect(data.driveExportStatus).to.equal('exported');
@@ -159,7 +159,7 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 0, skipped: 1 });
+    expect(result).to.deep.equal({ requeued: 0, failed: 0, skipped: 1 });
     expect(createCalls).to.have.lengthOf(0);
   });
 
@@ -177,7 +177,7 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 1, skipped: 0 });
+    expect(result).to.deep.equal({ requeued: 1, failed: 0, skipped: 0 });
     expect(createCalls).to.have.lengthOf(2);
     const data = await getDoc(docId);
     expect(data.driveExportStatus).to.equal('exported');
@@ -195,7 +195,7 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 0, skipped: 1 });
+    expect(result).to.deep.equal({ requeued: 0, failed: 0, skipped: 1 });
     expect(createCalls).to.have.lengthOf(0);
   });
 
@@ -212,7 +212,7 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 0, skipped: 0 });
+    expect(result).to.deep.equal({ requeued: 0, failed: 0, skipped: 0 });
     expect(createCalls).to.have.lengthOf(0);
   });
 
@@ -271,8 +271,66 @@ describe('sweepStuckDriveExports (ADR-0022 Phase 1 Task8)', () => {
       downloadFile: async () => Buffer.from('x'),
     });
 
-    expect(result).to.deep.equal({ requeued: 0, skipped: 0 });
+    expect(result).to.deep.equal({ requeued: 0, failed: 0, skipped: 0 });
     expect(createCalls).to.have.lengthOf(0);
+  });
+
+  it('claimに成功してもexportDocument()が失敗したdocはfailedとして数え、requeued(実成功件数)には含めない(sweepカウンタの成功/失敗混同によるstarvation回帰)', async () => {
+    const staleUpdatedAt = admin.firestore.Timestamp.fromMillis(
+      Date.now() - DRIVE_EXPORT_ERROR_RETRY_THRESHOLD_MS - BUFFER_MS
+    );
+    // documentIdの辞書順でfailingDocsがsuccessDocより必ず先に来るよう明示IDを使う。
+    const failingIds = Array.from({ length: DRIVE_EXPORT_SCHEDULED_BATCH_SIZE }, (_, i) => `a-fail-${i}`);
+    const successId = 'z-success';
+    const baseDoc = {
+      fileId: 'gmail-file-1',
+      fileName: 'original.pdf',
+      mimeType: 'application/pdf',
+      documentType: 'ケアプラン',
+      customerName: '鈴木花子',
+      officeName: '事業所A',
+      fileDate: admin.firestore.Timestamp.fromDate(new Date(2026, 0, 1)),
+      isDuplicateCustomer: false,
+      totalPages: 1,
+      targetPageNumber: 1,
+      status: 'processed',
+      careManager: '田中太郎',
+      customerId: 'customer-1',
+      verified: true,
+      driveExportStatus: 'error',
+      updatedAt: staleUpdatedAt,
+    };
+    await Promise.all(
+      failingIds.map((id) =>
+        db.doc(`documents/${id}`).set({
+          ...baseDoc,
+          fileUrl: 'gs://test-bucket/original/fail.pdf',
+          driveExportError: '恒久的に失敗するエラー(顧客未確定等を模擬)',
+        })
+      )
+    );
+    await db.doc(`documents/${successId}`).set({
+      ...baseDoc,
+      fileUrl: 'gs://test-bucket/original/success.pdf',
+      driveExportError: '[backfill] Feature Flag有効化前にverifiedされたdocumentの遡及エクスポート待ち',
+    });
+    const { drive } = makeFakeDrive();
+
+    const result = await sweepStuckDriveExports(db, {
+      drive,
+      downloadFile: async (fileUrl: string) => {
+        if (fileUrl.includes('fail')) {
+          throw new Error('恒久的に失敗するエラー(simulated)');
+        }
+        return Buffer.from('x');
+      },
+    });
+
+    // 修正前: claim成功時点でrequeued++するため、恒久失敗10件だけでBATCH_SIZE上限に
+    // 達しsuccessIdへ到達する前にbreakしていた(successIdはerrorのまま取り残される)。
+    expect((await getDoc(successId)).driveExportStatus).to.equal('exported');
+    expect(result.requeued).to.equal(1);
+    expect(result.failed).to.equal(DRIVE_EXPORT_SCHEDULED_BATCH_SIZE);
   });
 
   describe('ページネーション(code-review high指摘#44対応)', () => {


### PR DESCRIPTION
## Summary
- `sweepStuckDriveExports()`の`requeued`カウンタが「claimに成功した件数」を数えており、`exportDocument()`が失敗し再度`error`へ戻ったdocも同様にカウントしていた
- 恒久的に失敗し続けるdoc(顧客未確定・フォルダ名解決不可等)がdocumentId順で先行すると、毎回の実行(15分毎)がその10件だけでBATCH_SIZE上限に達し、後続の正常docへ永久に到達できないstarvationを引き起こしていた
- kanameone本番でbackfillマーカー20件が2026-07-31から3日以上滞留する実障害として顕在化。Firestore実測(driveExportSweepStateカーソル位置とerror/exporting全件のdocId順比較)・Cloud Logging(直近実行が毎回`requeued=10`固定で内訳が全て`Drive export failed`)で根本原因を確定した
- `requeued`は`exportDocument()`が実際に成功し`exported`へ遷移した件数のみを数えるよう変更し、claim成功かつexport失敗は新設の`failed`カウンタで別集計する(BATCH_SIZE上限判定にも`requeued`のみを使用)

## Test plan
- [x] TDD: 恒久失敗10件が先行してもBATCH_SIZE上限が実成功のみで判定され、同一ページ内の後続の正常docが処理されることを検証する回帰テストを追加(`functions/test/driveExportScheduledIntegration.test.ts`)。修正前コードで実行しRed確認済み
- [x] `driveExportScheduledIntegration.test.ts`全13件PASS(Firestoreエミュレータ実行)
- [x] `npm run build`(tsc)成功
- [x] `npm run lint`エラー0件(既存warningのみ)
- [x] `npm run test`(単体テスト一式)2023件PASS、既存回帰なし
- [ ] kanameone本番デプロイ後、backfillマーカー20件が解消されることをFirestoreで確認(このPRのマージ・デプロイ後に別途実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export batch reporting by distinguishing failed exports from successfully requeued documents.
  * Documents that fail during export are now counted accurately and do not reduce the number of successful exports processed.
  * Processing continues with later documents when an earlier export fails.
  * Completion logs now include the number of failed exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->