### PR TITLE
feat(observability): sanitize drop に reason(invalid-type/empty-name)を付与

### DIFF
--- a/functions/src/utils/loadMasterData.ts
+++ b/functions/src/utils/loadMasterData.ts
@@ -17,6 +17,7 @@ import {
   sanitizeCustomerMasters,
   sanitizeDocumentMasters,
   sanitizeOfficeMasters,
+  type SanitizeDropEntry,
 } from './sanitizeMasterData';
 
 type RawDoc = FirebaseFirestore.DocumentData;
@@ -99,23 +100,35 @@ function isFirebaseFunctionsRuntime(): boolean {
  * Why always async:
  * 戻り値を `Promise<void>` 統一 (evaluator/silent-failure-hunter 指摘)。caller は常に await
  * で待機する契約で、将来 safeLogError が sync になっても型安全が崩れない。
+ *
+ * #503: id 一覧に加え reason (invalid-type/empty-name) ごとの内訳を summary に含める。
+ * SRE が `firestore export` なしで「なぜこの id が drop されたか」を判別できるようにする。
  */
 async function reportSanitizeDrops(
-  reports: Array<{ kind: 'documents' | 'customers' | 'offices'; rawCount: number; droppedIds: string[] }>,
+  reports: Array<{ kind: 'documents' | 'customers' | 'offices'; rawCount: number; droppedEntries: SanitizeDropEntry[] }>,
   context: { source: ErrorSource; functionName: string },
 ): Promise<void> {
-  const dropped = reports.filter((r) => r.droppedIds.length > 0);
+  const dropped = reports.filter((r) => r.droppedEntries.length > 0);
   if (dropped.length === 0) return;
 
-  const hasAllDroppedKind = dropped.some((r) => r.rawCount > 0 && r.rawCount === r.droppedIds.length);
-  // ログの可読性のため先頭 5 件のみ列挙、超過分は '...' で省略する (droppedIds.length > 5 の時のみ付与)。
-  // 全 droppedIds は fallback 時のデバッグ用に別途保持 (L87 allDroppedIds)。
+  const hasAllDroppedKind = dropped.some((r) => r.rawCount > 0 && r.rawCount === r.droppedEntries.length);
+  // ログの可読性のため id は先頭 5 件のみ列挙、超過分は '...' で省略する (5 件超過時のみ付与)。
+  // 全 id は fallback 時のデバッグ用に別途保持 (L87 allDroppedIds)。
   const summary = dropped
-    .map((r) => `${r.kind}: ${r.droppedIds.length}/${r.rawCount} (ids: ${r.droppedIds.slice(0, 5).join(', ')}${r.droppedIds.length > 5 ? ', ...' : ''})`)
+    .map((r) => {
+      const ids = r.droppedEntries.map((e) => e.id);
+      const reasonCounts = new Map<string, number>();
+      for (const entry of r.droppedEntries) {
+        reasonCounts.set(entry.reason, (reasonCounts.get(entry.reason) ?? 0) + 1);
+      }
+      const reasonSummary = [...reasonCounts.entries()].map(([reason, count]) => `${reason}: ${count}`).join(', ');
+      const idList = `${ids.slice(0, 5).join(', ')}${ids.length > 5 ? ', ...' : ''}`;
+      return `${r.kind}: ${ids.length}/${r.rawCount} (${reasonSummary}; ids: ${idList})`;
+    })
     .join('; ');
   const prefix = hasAllDroppedKind ? 'ALL RECORDS DROPPED' : 'Records dropped during sanitize';
   const message = `${prefix}: ${summary}`;
-  const allDroppedIds = dropped.flatMap((r) => r.droppedIds);
+  const allDroppedIds = dropped.flatMap((r) => r.droppedEntries.map((e) => e.id));
 
   console.warn(`[loadMasterData] ${message}`);
 
@@ -172,9 +185,9 @@ export async function loadMasterData(
 
   await reportSanitizeDrops(
     [
-      { kind: 'documents', rawCount: documentRaw.length, droppedIds: documentResult.droppedIds },
-      { kind: 'customers', rawCount: customerRaw.length, droppedIds: customerResult.droppedIds },
-      { kind: 'offices', rawCount: officeRaw.length, droppedIds: officeResult.droppedIds },
+      { kind: 'documents', rawCount: documentRaw.length, droppedEntries: documentResult.droppedEntries },
+      { kind: 'customers', rawCount: customerRaw.length, droppedEntries: customerResult.droppedEntries },
+      { kind: 'offices', rawCount: officeRaw.length, droppedEntries: officeResult.droppedEntries },
     ],
     { source, functionName },
   );

--- a/functions/src/utils/sanitizeMasterData.ts
+++ b/functions/src/utils/sanitizeMasterData.ts
@@ -8,14 +8,26 @@
  *
  * #344: silent drop を observable にするため、戻り値に droppedIds を含める。
  *       caller 側 (loadMasterData) が drop 件数に応じて safeLogError を発火する契約。
+ * #503: drop 理由 (型崩れ vs 空文字) を区別できるよう droppedEntries を追加。
+ *       droppedIds は droppedEntries から導出される後方互換フィールド (既存 caller 無改修)。
  */
 
 import type { CustomerMaster, OfficeMaster, DocumentMaster } from './extractors';
 
-/** サニタイズ結果 envelope (items + drop された id 一覧) */
+/** name が非文字列 (invalid-type) か空文字 (empty-name) かの drop 理由 */
+export type DropReason = 'invalid-type' | 'empty-name';
+
+/** drop されたレコードの id と理由 */
+export interface SanitizeDropEntry {
+  id: string;
+  reason: DropReason;
+}
+
+/** サニタイズ結果 envelope (items + drop された id 一覧 + drop 理由付き明細) */
 export interface SanitizeResult<T> {
   items: T[];
   droppedIds: string[];
+  droppedEntries: SanitizeDropEntry[];
 }
 
 /** 値が文字列であればそのまま、配列なら先頭要素、それ以外はundefined */
@@ -51,11 +63,16 @@ function safeId(raw: { id?: unknown }): string {
   return typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : '(unknown)';
 }
 
+/** name の drop 理由を判定する (空文字は empty-name、それ以外の非文字列は invalid-type) */
+function dropReasonForName(name: unknown): DropReason {
+  return name === '' ? 'empty-name' : 'invalid-type';
+}
+
 export function sanitizeCustomerMasters(
   raw: CustomerMaster[]
 ): SanitizeResult<CustomerMaster> {
   const items: CustomerMaster[] = [];
-  const droppedIds: string[] = [];
+  const droppedEntries: SanitizeDropEntry[] = [];
   for (const c of raw) {
     if (typeof c.name === 'string' && c.name.length > 0) {
       items.push({
@@ -67,17 +84,17 @@ export function sanitizeCustomerMasters(
         aliases: toOptionalStringArray(c.aliases),
       });
     } else {
-      droppedIds.push(safeId(c));
+      droppedEntries.push({ id: safeId(c), reason: dropReasonForName(c.name) });
     }
   }
-  return { items, droppedIds };
+  return { items, droppedIds: droppedEntries.map((e) => e.id), droppedEntries };
 }
 
 export function sanitizeOfficeMasters(
   raw: OfficeMaster[]
 ): SanitizeResult<OfficeMaster> {
   const items: OfficeMaster[] = [];
-  const droppedIds: string[] = [];
+  const droppedEntries: SanitizeDropEntry[] = [];
   for (const o of raw) {
     if (typeof o.name === 'string' && o.name.length > 0) {
       items.push({
@@ -88,17 +105,17 @@ export function sanitizeOfficeMasters(
         aliases: toOptionalStringArray(o.aliases),
       });
     } else {
-      droppedIds.push(safeId(o));
+      droppedEntries.push({ id: safeId(o), reason: dropReasonForName(o.name) });
     }
   }
-  return { items, droppedIds };
+  return { items, droppedIds: droppedEntries.map((e) => e.id), droppedEntries };
 }
 
 export function sanitizeDocumentMasters(
   raw: DocumentMaster[]
 ): SanitizeResult<DocumentMaster> {
   const items: DocumentMaster[] = [];
-  const droppedIds: string[] = [];
+  const droppedEntries: SanitizeDropEntry[] = [];
   for (const d of raw) {
     if (typeof d.name === 'string' && d.name.length > 0) {
       items.push({
@@ -110,8 +127,8 @@ export function sanitizeDocumentMasters(
         dateMarker: toOptionalNonEmptyString(d.dateMarker),
       });
     } else {
-      droppedIds.push(safeId(d));
+      droppedEntries.push({ id: safeId(d), reason: dropReasonForName(d.name) });
     }
   }
-  return { items, droppedIds };
+  return { items, droppedIds: droppedEntries.map((e) => e.id), droppedEntries };
 }

--- a/functions/test/loadMasterData.test.ts
+++ b/functions/test/loadMasterData.test.ts
@@ -167,6 +167,31 @@ describe('loadMasterData', () => {
     }
   });
 
+  it('drop 理由 (reason) の内訳が warn メッセージに含まれる (#503)', async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      const stub = createFirestoreStub({
+        'masters/documents/items': [],
+        'masters/customers/items': [],
+        'masters/offices/items': [
+          { id: 'o1', data: { name: '事業所A' } },
+          { id: 'o2', data: {} }, // name 欠落 → invalid-type
+          { id: 'o3', data: { name: '' } }, // name 空文字 → empty-name
+          { id: 'o4', data: { name: 123 } }, // name 型崩れ → invalid-type
+        ],
+      });
+      await loadMasterData(stub);
+      expect(warnings).to.have.length(1);
+      expect(warnings[0]).to.include('offices: 3/4');
+      expect(warnings[0]).to.include('invalid-type: 2');
+      expect(warnings[0]).to.include('empty-name: 1');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('全レコード drop のケースでは ALL RECORDS DROPPED prefix になる (#344)', async () => {
     const warnings: string[] = [];
     const originalWarn = console.warn;

--- a/functions/test/sanitizeMasterData.test.ts
+++ b/functions/test/sanitizeMasterData.test.ts
@@ -61,6 +61,23 @@ describe('sanitizeMasterData', () => {
       expect(result.droppedIds).to.deep.equal(['c1', 'c2']);
     });
 
+    it('droppedEntriesにdropの理由(reason)が付与される(#503)', () => {
+      const input = [
+        { id: 'c1', name: '' }, // 空文字 → empty-name
+        { id: 'c2', name: undefined as unknown as string }, // 欠落 → invalid-type
+        { id: 'c3', name: { text: '鈴木' } as unknown as string }, // オブジェクト → invalid-type
+        { id: 'c4', name: '鈴木一郎' },
+      ];
+      const result = sanitizeCustomerMasters(input);
+      expect(result.droppedEntries).to.deep.equal([
+        { id: 'c1', reason: 'empty-name' },
+        { id: 'c2', reason: 'invalid-type' },
+        { id: 'c3', reason: 'invalid-type' },
+      ]);
+      // droppedIds は droppedEntries から導出される後方互換フィールド
+      expect(result.droppedIds).to.deep.equal(result.droppedEntries.map((e) => e.id));
+    });
+
     it('aliasesが文字列の場合、配列に変換する', () => {
       const input = [{
         id: 'c1',
@@ -114,6 +131,19 @@ describe('sanitizeMasterData', () => {
       }];
       const result = sanitizeOfficeMasters(input);
       expect(result.items[0].shortName).to.equal('さくら');
+    });
+
+    it('droppedEntriesにdropの理由(reason)が付与される(#503)', () => {
+      const input = [
+        { id: 'o1', name: '' }, // 空文字 → empty-name
+        { id: 'o2', name: 123 as unknown as string }, // 数値 → invalid-type
+        { id: 'o3', name: 'デイサービスさくら' },
+      ];
+      const result = sanitizeOfficeMasters(input);
+      expect(result.droppedEntries).to.deep.equal([
+        { id: 'o1', reason: 'empty-name' },
+        { id: 'o2', reason: 'invalid-type' },
+      ]);
     });
 
   });
@@ -211,6 +241,19 @@ describe('sanitizeMasterData', () => {
       }];
       const result = sanitizeDocumentMasters(input);
       expect(result.items[0].dateMarker).to.be.undefined;
+    });
+
+    it('droppedEntriesにdropの理由(reason)が付与される(#503)', () => {
+      const input = [
+        { id: 'd1', name: '' }, // 空文字 → empty-name
+        { id: 'd2', name: ['介護保険証'] as unknown as string }, // 配列 → invalid-type
+        { id: 'd3', name: '介護保険証' },
+      ];
+      const result = sanitizeDocumentMasters(input);
+      expect(result.droppedEntries).to.deep.equal([
+        { id: 'd1', reason: 'empty-name' },
+        { id: 'd2', reason: 'invalid-type' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `sanitizeCustomerMasters`/`sanitizeOfficeMasters`/`sanitizeDocumentMasters`が`droppedEntries: {id, reason}[]`を返すよう拡張（reasonは`invalid-type`または`empty-name`）
- `loadMasterData.ts`の`reportSanitizeDrops`のwarn/safeLogErrorメッセージにreason内訳を追加（例: `offices: 3/450 (invalid-type: 1, empty-name: 2; ids: id1, id2, id3)`）
- 既存`droppedIds: string[]`は`droppedEntries`から導出する後方互換フィールドとして維持、既存caller（scripts/compare-*.ts等）は無改修

## Test plan
- [x] `functions/test/sanitizeMasterData.test.ts`: 3サニタイザそれぞれにdroppedEntries/reasonのテストケースを追加、全PASS
- [x] `functions/test/loadMasterData.test.ts`: reason内訳がwarnメッセージに含まれることを検証するテストを追加、全PASS
- [x] `npm test`（functions全体）: 2027 passing / 6 pending、回帰なし
- [x] `tsc --noEmit`: エラーなし
- [x] `eslint`（変更ファイル）: エラーなし（既存warning 1件は変更前から存在、無関係）
- [x] `codex review --base main -c model_reasoning_effort=medium`: findings 0件

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)